### PR TITLE
[Move] Fully implement Ally Switch

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -9404,8 +9404,9 @@ export function initMoves() {
       .attr(AddArenaTagAttr, ArenaTagType.QUICK_GUARD, 1, true, true)
       .condition(failIfLastCondition),
     new SelfStatusMove(Moves.ALLY_SWITCH, Type.PSYCHIC, -1, 15, -1, 2, 5)
-      .ignoresProtect()
-      .unimplemented(),
+      .attr(AllySwitchAttr)
+      .condition(failIfSingleBattle)
+      .ignoresProtect(),
     new AttackMove(Moves.SCALD, Type.WATER, MoveCategory.SPECIAL, 80, 100, 15, 30, 0, 5)
       .attr(HealStatusEffectAttr, false, StatusEffect.FREEZE)
       .attr(HealStatusEffectAttr, true, StatusEffect.FREEZE)


### PR DESCRIPTION
## What are the changes the user will see?
The user can now use Ally Switch in battle. 

## Why am I making these changes?
Shareholder value up. 

## What are the changes from a developer perspective?
New AllySwitchAttr (child of MoveEffectAttr)
Will add a test. 

### Screenshots/Videos

https://github.com/user-attachments/assets/2d4bea48-e642-49b7-8575-a239fac2161c

## How to test the changes?
1. Go into a doubles battle and use Ally Swap. 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I considered writing automated tests for the issue?
- [x] If I have text, did I make it translatable and add a key in the English locale file(s)?
- [x] Have I tested the changes (manually)?
    - [x] Are all unit tests still passing? (`npm run test`)
- [x] Are the changes visual?
  - [x] Have I provided screenshots/videos of the changes?
