### PR TITLE
[Bug] Prevent crashes from Future Sight

### DIFF
--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -4263,9 +4263,13 @@ export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
   }
 
   applyPostFaint(pokemon: Pokemon, passive: boolean, simulated: boolean, attacker?: Pokemon, move?: Move, hitResult?: HitResult, ...args: any[]): boolean {
-    if (move !== undefined && attacker !== undefined && !simulated) { //If the mon didn't die to indirect damage
+    if (!move || !attacker || !attacker.isOnField()) {
+      return false;
+    }
+
+    if (!simulated) {
       const damage = pokemon.turnData.attacksReceived[0].damage;
-      attacker.damageAndUpdate((damage), HitResult.OTHER);
+      attacker.damageAndUpdate(damage, HitResult.OTHER);
       attacker.turnData.damageTaken += damage;
     }
     return true;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -692,20 +692,18 @@ export class DestinyBondTag extends BattlerTag {
    * or after receiving fatal damage. When the damage is fatal,
    * the attacking Pokemon is taken down as well, unless it's a boss.
    *
-   * @param {Pokemon} pokemon Pokemon that is attacking the Destiny Bond user.
-   * @param {BattlerTagLapseType} lapseType CUSTOM or PRE_MOVE
-   * @returns false if the tag source fainted or one turn has passed since the application
+   * @param pokemon Pokemon that is attacking the Destiny Bond user.
+   * @param lapseType CUSTOM or PRE_MOVE
+   * @returns `false` if the tag source fainted or one turn has passed since the application
    */
   lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType !== BattlerTagLapseType.CUSTOM) {
       return super.lapse(pokemon, lapseType);
     }
-    const source = this.sourceId ? pokemon.scene.getPokemonById(this.sourceId) : null;
-    if (!source?.isFainted()) {
-      return true;
-    }
 
-    if (source?.getAlly() === pokemon) {
+    const source = this.sourceId ? pokemon.scene.getPokemonById(this.sourceId) : null;
+
+    if (!source || !source.isFainted() || !pokemon.isOnField() || source.getAlly() === pokemon) {
       return false;
     }
 

--- a/src/test/moves/future_sight.test.ts
+++ b/src/test/moves/future_sight.test.ts
@@ -42,4 +42,46 @@ describe("Moves - Future Sight", () => {
 
     expect(game.scene.getEnemyPokemon()!.isFullHp()).toBe(false);
   });
+
+  it("doesn't crash if the user leaves the field and the hit triggers Destiny Bond", async () => {
+    game.override
+      .enemyMoveset([ Moves.DESTINY_BOND, Moves.SPLASH ])
+      .enemyAbility(Abilities.BALL_FETCH)
+      .startingLevel(100);
+    await game.classicMode.startBattle([ Species.FEEBAS, Species.MILOTIC ]);
+
+    game.move.select(Moves.FUTURE_SIGHT);
+    await game.forceEnemyMove(Moves.SPLASH);
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.forceEnemyMove(Moves.SPLASH);
+    await game.toNextTurn();
+    game.move.select(Moves.SPLASH);
+    await game.forceEnemyMove(Moves.DESTINY_BOND);
+    await game.phaseInterceptor.to("SelectModifierPhase", false);
+
+    const milotic = game.scene.getPlayerPokemon()!;
+
+    expect(milotic.species.speciesId).toBe(Species.MILOTIC);
+    expect(milotic.isFullHp()).toBe(true);
+  });
+
+  it("doesn't crash if the user leaves the field and the hit triggers Innards Out", async () => {
+    game.override
+      .enemyAbility(Abilities.INNARDS_OUT)
+      .startingLevel(100);
+    await game.classicMode.startBattle([ Species.FEEBAS, Species.MILOTIC ]);
+
+    game.move.select(Moves.FUTURE_SIGHT);
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+    game.move.select(Moves.SPLASH);
+    await game.phaseInterceptor.to("SelectModifierPhase", false);
+
+    const milotic = game.scene.getPlayerPokemon()!;
+
+    expect(milotic.species.speciesId).toBe(Species.MILOTIC);
+    expect(milotic.isFullHp()).toBe(true);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
If a Future Sight attack from an off-field Pokémon faints a Pokémon that used Destiny Bond or a Pokémon that has Innards Out, the game will no longer crash from trying to target an off-field Pokémon.

## Why am I making these changes?
Fixes a crash.

## What are the changes from a developer perspective?
Checks for the attacker being on the field are added to the Innards Out ability attr and the Destiny Bond battler tag.

## How to test the changes?
`npm run test future_sight`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- ~[ ] Have I provided screenshots/videos of the changes (if applicable)?~
  - ~[ ] Have I made sure that any UI change works for both UI themes (default and legacy)?~