### PR TITLE
[Fix] some bgm loop point errors

### DIFF
--- a/src/data/bgm-loop-point.ts
+++ b/src/data/bgm-loop-point.ts
@@ -164,7 +164,7 @@ export const bgmLoopPoint = {
   /** SWSH Trainer Battle */
   battle_macro_grunt: 11.56,
   /** SV Team Star Battle */
-  battle_star_grunt: 0.362,
+  battle_star_grunt: 133.362,
   /** BDSP Team Galactic Admin*/
   battle_galactic_admin: 11.997,
   /** SM Team Skull Admin*/
@@ -178,7 +178,7 @@ export const bgmLoopPoint = {
   /** ORAS Archie & Maxie Battle */
   battle_aqua_magma_boss: 14.847,
   /** BDSP Cyrus Battle */
-  battle_galactic_boss: 0.962,
+  battle_galactic_boss: 106.962,
   /** B2W2 Ghetsis Battle */
   battle_plasma_boss: 25.624,
   /** XY Lysandre Battle */


### PR DESCRIPTION
- battle_galar_elite: `0.069` -> `162.069`
- battle_galar_gym: `0.262` -> `171.262`
- battle_paldea_gym: `0.489` -> `127.489`
- battle_star_grunt: `0.362` -> `133.362`
- battle_galactic_boss: `0.962` -> `106.962`

Fix missed errors from #51 
