### PR TITLE
[Refactor][Misc] Removed 'species'/'category' string from pokemonSpecies declaration and moved it into localization

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -768,7 +768,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
   }
 
   localize(): void {
-    this.name = i18next.t(`pokemon:${Species[this.speciesId].toLowerCase()}.name`);
+    this.name = i18next.t(`pokemon:${Species[this.speciesId].toLowerCase()}`);
   }
 
   getWildSpeciesForLevel(level: number, allowEvolving: boolean, isBoss: boolean, gameMode: GameMode): Species {


### PR DESCRIPTION
## What are the changes the user will see?
None.

## Why am I making these changes?

This PR is part of an effort to clean up pokemon-species and the associated allSpecies object. For some reason, species categories were included as part of the PokemonSpecies constructor and these strings were hardcoded in English. At the moment, these strings are not used in the game, but we may want to use them for Pokedex related purposes.
There is a sibling PR but there will be no changes to the localization key used in-game until the sibling PR is cleaned up and translated categories have been added. A separate PR will be made to change the localization key once the sibling PR is ready.

https://github.com/Despair-Games/poketernity-locales/pull/3

## Screenshots/Videos

https://github.com/user-attachments/assets/906f6743-d186-4a1e-85c5-0bc4a6b2fa2f

## How to test the changes?
Pokemon names should be still readable with the correct localization.

