### PR TITLE
[Bug][Move] Updated Heal Block behavior to its Gen VI+ version

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2615,10 +2615,10 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
   /**
    * Checks if a move is disabled under Heal Block
    * @param move {@linkcode Moves} the move ID
-   * @returns `true` if the move has a TRIAGE_MOVE flag and is a status move
+   * @returns `true` if the move has a TRIAGE_MOVE flag
    */
   override isMoveRestricted(move: Moves): boolean {
-    if (allMoves[move].hasFlag(MoveFlags.TRIAGE_MOVE) && allMoves[move].category === MoveCategory.STATUS) {
+    if (allMoves[move].hasFlag(MoveFlags.TRIAGE_MOVE)) {
       return true;
     }
     return false;

--- a/test/moves/heal_block.test.ts
+++ b/test/moves/heal_block.test.ts
@@ -36,7 +36,7 @@ describe("Moves - Heal Block", () => {
       .disableCrits();
   });
 
-  it("shouldn't stop damage from HP-drain attacks, just HP restoration", async () => {
+  it("should block the usage of damaging moves that heal the user", async () => {
     await game.classicMode.startBattle([Species.CHARIZARD]);
 
     const player = game.scene.getPlayerPokemon()!;
@@ -48,24 +48,8 @@ describe("Moves - Heal Block", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(player.hp).toBe(1);
-    expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
-  });
-
-  it("shouldn't stop Liquid Ooze from dealing damage", async () => {
-    game.override.enemyAbility(Abilities.LIQUID_OOZE);
-
-    await game.classicMode.startBattle([Species.CHARIZARD]);
-
-    const player = game.scene.getPlayerPokemon()!;
-    const enemy = game.scene.getEnemyPokemon()!;
-
-    game.move.select(Moves.ABSORB);
-    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-    await game.phaseInterceptor.to("TurnEndPhase");
-
-    expect(player.isFullHp()).toBe(false);
-    expect(enemy.isFullHp()).toBe(false);
+    const lastPlayerMove = player.getLastXMoves(1)[0];
+    expect(lastPlayerMove.move).toBe(Moves.NONE);
   });
 
   it("should stop delayed heals, such as from Wish", async () => {


### PR DESCRIPTION
## What are the changes the user will see?

Heal Block / Psychic Noise will prevent the use of all healing moves, including attacking moves that heal the user. 

## Why am I making these changes?

When I implemented Heal Block / Psychic Noise, I was under the impression that healing from moves like absorb, etc. was prevented by heal block but those moves still could be used. However, Bulbapedia was recently updated to clarify these cases.
![image](https://github.com/user-attachments/assets/63a6163a-7b17-4ba4-aefb-ec10b2ab33e5)
This change updates Heal Block/Psychic Noise behavior to reflect its latest version. 

## What are the changes from a developer perspective?
The Heal Block tag no longer checks if a triage move is a status move before applying a restriction on it. 

## How to test the changes?
npm run test heal_block

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
