### PR TITLE
[P3] Add message when smacking down a Pokemon

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -2227,7 +2227,7 @@ export class GroundedTag extends BattlerTag {
 
     if (isSmackDownOrThousandArrows && wasNotGrounded) {
       globalScene.queueMessage(
-        i18next.t("battlerTags:smackDown", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
+        i18next.t("battlerTags:groundedSmackDown", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       );
     }
   }


### PR DESCRIPTION
## What are the changes the user will see?

Smack Down and Thousand Arrows now display a message when knocking a Pokemon down

## Why am I making these changes?

PR issue #5027

## What are the changes from a developer perspective?
* Added an onAdd to the GroundedTag that checks if the source move was smack down or thousand arrows and the target Pokemon was not grounded

## Screenshots/Videos

![](https://cdn.discordapp.com/attachments/1312660001952632942/1320625003141529610/image.png?ex=676a4760&is=6768f5e0&hm=2fe8b1930b9ae91531a2e32d5cb8656f48ed44343e68b99df423b5ab2eedadd4&)

## How to test the changes?

```ts
const overrides = {
  OPP_SPECIES_OVERRIDE: Species.BULBASAUR,
  OPP_MOVESET_OVERRIDE: [Moves.SPLASH],
  OPP_LEVEL_OVERRIDE: 100,
  MOVESET_OVERRIDE: [Moves.SMACK_DOWN],

} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [x] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/Despair-Games/poketernity-locales/pull/8
- [ ] Has the translation team been contacted for proofreading/translation?
