### PR TITLE
[Refactor] Clean up turn count logic in `SwitchSummonPhase.onEnd`

### DIFF
--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -55,8 +55,7 @@ export class SummonPhase extends PartyMemberPokemonPhase {
         console.error("All available Pokemon were fainted or illegal!");
         globalScene.clearPhaseQueue();
         globalScene.unshiftPhase(new GameOverPhase());
-        this.end();
-        return;
+        return this.end();
       }
 
       // Swaps the fainted Pokemon and the first non-fainted legal Pokemon in the party


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

Checking `SwitchType` for conditions instead of checking move and ability attributes reduces circular imports.

## What are the changes from a developer perspective?

- `SwitchSummonPhase.onEnd` currently determines whether or not it should decrement the switched in Pokemon's turn counters by checking the Pokemon's turn command and/or it meets conditions for a forced switch-out, either from a move or Wimp Out/Emergency Exit. This changes the code to check the phase's `SwitchType` instead.
- New tests in `fake_out.test.ts` to ensure Fake Out is usable after the user is switched in via force switch-out moves and Wimp Out.

## How to test the changes?

`npm run test fake_out`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?
