### PR TITLE
[Balance] Revert Multi-Lens boosting spread moves

### DIFF
--- a/src/data/ab-attrs/add-second-strike-ab-attr.ts
+++ b/src/data/ab-attrs/add-second-strike-ab-attr.ts
@@ -38,7 +38,7 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
     const hitCount = args[0] as NumberHolder;
     const multiplier = args[1] as NumberHolder;
 
-    if (move.canBeMultiStrikeEnhanced(pokemon, true)) {
+    if (move.canBeMultiStrikeEnhanced(pokemon)) {
       this.showAbility = !!hitCount?.value;
       if (hitCount?.value) {
         hitCount.value += 1;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -818,10 +818,8 @@ export abstract class Move implements Localizable {
    * Currently used for {@link https://bulbapedia.bulbagarden.net/wiki/Parental_Bond_(Ability) | Parental Bond}
    * and {@linkcode PokemonMultiHitModifier | Multi-Lens}.
    * @param user The {@linkcode Pokemon} using the move
-   * @param restrictSpread `true` if the enhancing effect
-   * should not affect multi-target moves (default `false`)
    */
-  canBeMultiStrikeEnhanced(user: Pokemon, restrictSpread: boolean = false): boolean {
+  canBeMultiStrikeEnhanced(user: Pokemon): boolean {
     // Multi-strike enhancers...
 
     // ...cannot enhance moves that hit multiple targets
@@ -835,7 +833,7 @@ export abstract class Move implements Localizable {
     const exceptMoves: Moves[] = [Moves.FLING, Moves.UPROAR, Moves.ROLLOUT, Moves.ICE_BALL, Moves.ENDEAVOR];
 
     return (
-      (!restrictSpread || !isMultiTarget)
+      !isMultiTarget
       && !this.isChargingMove()
       && !exceptAttrs.some((attr) => this.hasAttr(attr))
       && !exceptMoves.some((id) => this.id === id)

--- a/test/items/multi_lens.test.ts
+++ b/test/items/multi_lens.test.ts
@@ -98,7 +98,7 @@ describe("Items - Multi Lens", () => {
     expect(playerPokemon.turnData.hitCount).toBe(2);
   });
 
-  it("should enhance multi-target moves", async () => {
+  it("should not enhance multi-target moves", async () => {
     game.override.battleType("double").moveset([Moves.SWIFT, Moves.SPLASH]);
 
     await game.classicMode.startBattle([Species.MAGIKARP, Species.FEEBAS]);
@@ -112,7 +112,7 @@ describe("Items - Multi Lens", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
 
-    expect(magikarp.turnData.hitCount).toBe(2);
+    expect(magikarp.turnData.hitCount).toBe(1);
   });
 
   it("should enhance fixed-damage moves while also applying damage reduction", async () => {


### PR DESCRIPTION
## What are the changes the user will see?

Multi-Lens no longer boosts spread moves unless they only hit 1 target.

## Why am I making these changes?

When Multi-Lens was reworked, it initially was given the same restrictions on what moves were boosted as Parental Bond. However, following backlash from Endless players, the restriction on spread moves (when hitting more than 1 target) was lifted. With a major rework to Endless planned, that's not a concern anymore, and adding back the restriction is the cleaner, more stable option from a dev perspective.

## What are the changes from a developer perspective?

- Removed the `restrictSpread` option from `Move#canBeMultiStrikeEnhanced`. This function now always treats spread moves as restricted from multi-strike enhancement.
- Changed a test case in `multi_lens.test.ts` to "should *not* enhance multi-target moves".

## Screenshots/Videos

## How to test the changes?

`npm run test multi_lens`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?
