### PR TITLE
[Ability][Checkup][Bug] Fixed Long Reach interaction and added tests/documentation for Gooey/Tangling Hair

### DIFF
--- a/src/data/ab-attrs/post-defend-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-stat-stage-change-ab-attr.ts
@@ -6,6 +6,20 @@ import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 import type { BattleStat } from "#enums/stat";
 import { PostDefendAbAttr } from "./post-defend-ab-attr";
 
+/**
+ * Activates after receiving an attack and if certain conditions are met, changes the effective stats
+ * These abilities use this attribute:
+ * - Weak Armor
+ * - Justified
+ * - Rattled
+ * - Gooey
+ * - Stamina
+ * - Water Compaction
+ * - Tangling Hair
+ * - Cotton Down
+ * - Steam Engine
+ * - Thermal Exchange
+ */
 export class PostDefendStatStageChangeAbAttr extends PostDefendAbAttr {
   private readonly condition: PokemonDefendCondition;
   private readonly stat: BattleStat;

--- a/src/data/abilities.ts
+++ b/src/data/abilities.ts
@@ -966,7 +966,7 @@ export function initAbilities() {
     ),
     new Ability(Abilities.GOOEY, 6).attr(
       PostDefendStatStageChangeAbAttr,
-      (_target, _user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT),
+      (target, user, move) => move.checkFlag(MoveFlags.MAKES_CONTACT, user, target),
       Stat.SPD,
       -1,
       false,
@@ -1205,7 +1205,7 @@ export function initAbilities() {
     new Ability(Abilities.SOUL_HEART, 7).attr(PostKnockOutStatStageChangeAbAttr, Stat.SPATK, 1),
     new Ability(Abilities.TANGLING_HAIR, 7).attr(
       PostDefendStatStageChangeAbAttr,
-      (_target, _user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT),
+      (target, user, move) => move.checkFlag(MoveFlags.MAKES_CONTACT, user, target),
       Stat.SPD,
       -1,
       false,

--- a/test/abilities/gooey.test.ts
+++ b/test/abilities/gooey.test.ts
@@ -1,0 +1,104 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { allMoves } from "#app/data/all-moves";
+import { MoveFlags } from "#enums/move-flags";
+
+describe("Abilities - Gooey/Tangling Hair", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.TACKLE, Moves.EMBER, Moves.DOUBLE_IRON_BASH])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it.each([
+    { abilityName: "Gooey", ability: Abilities.GOOEY },
+    { abilityName: "Tangling Hair", ability: Abilities.TANGLING_HAIR },
+  ])(
+    "$abilityName should decrease the attacker's speed by 1 stage if the attacker uses a contact move",
+    async ({ ability }) => {
+      game.override.enemyAbility(ability);
+      await game.classicMode.startBattle([Species.FEEBAS]);
+      const pokemon = game.scene.getPlayerPokemon()!;
+
+      game.move.select(Moves.TACKLE);
+      await game.phaseInterceptor.to("BerryPhase");
+
+      expect(allMoves[Moves.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+      expect(pokemon.getStatStage(Stat.SPD)).toBe(-1);
+    },
+  );
+
+  it.each([
+    { abilityName: "Gooey", ability: Abilities.GOOEY },
+    { abilityName: "Tangling Hair", ability: Abilities.TANGLING_HAIR },
+  ])(
+    "$abilityName should not activate if the attacker has the ability Long Reach and uses a contact move",
+    async ({ ability }) => {
+      game.override.ability(Abilities.LONG_REACH).enemyAbility(ability);
+      await game.classicMode.startBattle([Species.FEEBAS]);
+      const pokemon = game.scene.getPlayerPokemon()!;
+
+      game.move.select(Moves.TACKLE);
+      await game.phaseInterceptor.to("BerryPhase");
+
+      expect(allMoves[Moves.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+      expect(pokemon.getStatStage(Stat.SPD)).toBe(0);
+    },
+  );
+
+  it.each([
+    { abilityName: "Gooey", ability: Abilities.GOOEY },
+    { abilityName: "Tangling Hair", ability: Abilities.TANGLING_HAIR },
+  ])(
+    "$abilityName should not affect the attacker's speed if the attacker does not use a contact move",
+    async ({ ability }) => {
+      game.override.enemyAbility(ability);
+      await game.classicMode.startBattle([Species.FEEBAS]);
+      const pokemon = game.scene.getPlayerPokemon()!;
+
+      game.move.select(Moves.EMBER);
+      await game.phaseInterceptor.to("BerryPhase");
+
+      expect(allMoves[Moves.EMBER].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(false);
+      expect(pokemon.getStatStage(Stat.SPD)).toBe(0);
+    },
+  );
+
+  it.each([
+    { abilityName: "Gooey", ability: Abilities.GOOEY },
+    { abilityName: "Tangling Hair", ability: Abilities.TANGLING_HAIR },
+  ])("$abilityName should activate per hit of a contact-making multi-strike move", async ({ ability }) => {
+    game.override.enemyAbility(ability);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const pokemon = game.scene.getPlayerPokemon()!;
+
+    game.move.select(Moves.DOUBLE_IRON_BASH);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(allMoves[Moves.DOUBLE_IRON_BASH].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+    expect(pokemon.getStatStage(Stat.SPD)).toBe(-2);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

Gooey/Tangling Hair should not activate if the user has long reach and uses a contact move. 

## Why am I making these changes?

Abilities... yay....

## What are the changes from a developer perspective?

Both abilities now check for move.checkFlag(MoveFlag.MAKES_CONTACT, user, target) iinstead of move.hasFlag(MoveFlag.MAKES_CONTACT)

Tests have been written. 

## How to test the changes?

`npm run test gooey`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
