### PR TITLE
[P2] Moody fix

### DIFF
--- a/src/data/ab-attrs/moody-ab-attr.ts
+++ b/src/data/ab-attrs/moody-ab-attr.ts
@@ -28,7 +28,7 @@ export class MoodyAbAttr extends PostTurnAbAttr {
     if (!simulated) {
       if (canRaise.length > 0) {
         const raisedStat = canRaise[pokemon.randSeedInt(canRaise.length)];
-        canLower = EFFECTIVE_STATS.filter((s) => s !== raisedStat);
+        canLower = canLower.filter((s) => s !== raisedStat);
         globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [raisedStat], 2));
       }
       if (canLower.length > 0) {


### PR DESCRIPTION
## What are the changes the user will see?

Moody can now lower stats at +6 properly

## Why am I making these changes?

PR#5000

## What are the changes from a developer perspective?

There was a typo in the original implementation. `canLower` should be filtering out `raisedStat` from itself but it was filtering it from `canRaise`

## Screenshots/Videos

n/a

## How to test the changes?

const overrides = {
  MOVESET_OVERRIDE: [Moves.QUIVER_DANCE],
  ABILITY_OVERRIDE: Abilities.MOODY
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
