### PR TITLE
[P2] getWeight now returns correct weight including form

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1862,7 +1862,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       weightRemoved = 100 * autotomizedTag!.autotomizeCount;
     }
     const minWeight = 0.1;
-    const weight = new NumberHolder(this.species.weight - weightRemoved);
+    const weight = new NumberHolder(this.getSpeciesForm().weight - weightRemoved);
 
     // This will trigger the ability overlay so only call this function when necessary
     applyAbAttrs(WeightMultiplierAbAttr, this, null, false, weight);


### PR DESCRIPTION
## What are the changes the user will see?

Pokemon in alternate forms will now have the correct weight

## Why am I making these changes?

PR#4987

## What are the changes from a developer perspective?

Changed `this.species.weight` to `this.getSpeciesForm().weight`

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/159ca888-71d9-4fcc-8998-2f4b3bbde942)

I added a console.log in `getWeight`
```
current weight: pokemon.ts:1865:12
305 pokemon.ts:1866:12
current weight: pokemon.ts:1865:12
21.2 pokemon.ts:1866:12
base damage 29.855483870967742 Heat Crash 120 257 930 pokemon.ts:3164:14
damage 28 Heat Crash

current weight: pokemon.ts:1865:12
610 pokemon.ts:1866:12
current weight: pokemon.ts:1865:12
21.2 pokemon.ts:1866:12
base damage 113.42193548387097 Heat Crash 120 1028 930 pokemon.ts:3164:14
damage 113 Heat Crash
```

## How to test the changes?

```ts
// Form 0 zygarde does not transform
const overrides = {
  STARTER_SPECIES_OVERRIDE: Species.ZYGARDE,
  STARTER_FORM_OVERRIDES: {[Species.ZYGARDE]: 2},
  ABILITY_OVERRIDE: Abilities.POWER_CONSTRUCT,
  MOVESET_OVERRIDE: [Moves.HEAT_CRASH, Moves.BELLY_DRUM, Moves.TAKE_DOWN],
  OPP_MOVESET_OVERRIDE: [Moves.SPLASH, Moves.SONIC_BOOM],
  STARTING_LEVEL_OVERRIDE: 100,
  OPP_LEVEL_OVERRIDE: 1000
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
