### PR TITLE
[P3] Healer no longer tries to activate on fainted Pokemon

### DIFF
--- a/src/data/abilities.ts
+++ b/src/data/abilities.ts
@@ -756,7 +756,7 @@ export function initAbilities() {
       .condition((pokemon) => pokemon.getHpRatio() <= 0.5),
     new Ability(Abilities.CURSED_BODY, 5).attr(PostDefendMoveDisableAbAttr, 30).bypassFaint(),
     new Ability(Abilities.HEALER, 5).conditionalAttr(
-      (pokemon) => pokemon.getAlly() && randSeedInt(10) < 3,
+      (pokemon) => pokemon.getAlly() && pokemon.getAlly().status?.effect !== StatusEffect.FAINT && randSeedInt(10) < 3,
       PostTurnResetStatusAbAttr,
       true,
     ),


### PR DESCRIPTION
## What are the changes the user will see?

Healer will no longer make `none.heal` messages when trying to activate on a fainted ally

## Why am I making these changes?

PR#4981

## What are the changes from a developer perspective?

Added an extra `pokemon.getAlly().status?.effect !== StatusEffect.FAINT` check in Healer

## Screenshots/Videos

n/a

## How to test the changes?
Modify healer to always proc
```ts
    new Ability(Abilities.HEALER, 5).conditionalAttr(
      (pokemon) => pokemon.getAlly() && pokemon.getAlly().status?.effect !== StatusEffect.FAINT && randSeedInt(10) < 30,
      PostTurnResetStatusAbAttr,
      true,
    ),
```

```ts
const overrides = {
  BATTLE_TYPE_OVERRIDE: "double",
  MOVESET_OVERRIDE: [Moves.MEMENTO, Moves.SPLASH],
  OPP_SPECIES_OVERRIDE: Species.AUDINO,
  OPP_MOVESET_OVERRIDE: [Moves.SPLASH]
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
