### PR TITLE
[P2] Shedinja will now be genderless upon evolution

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5203,6 +5203,7 @@ export class PlayerPokemon extends Pokemon {
         newPokemon.moveset = this.moveset.slice();
         newPokemon.moveset = this.copyMoveset();
         newPokemon.luck = this.luck;
+        newPokemon.gender = Gender.GENDERLESS;
         newPokemon.metLevel = this.metLevel;
         newPokemon.metBiome = this.metBiome;
         newPokemon.metSpecies = this.metSpecies;

--- a/test/pokemon/evolution.test.ts
+++ b/test/pokemon/evolution.test.ts
@@ -10,6 +10,7 @@ import * as Utils from "#app/utils";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Gender } from "#enums/gender";
 
 describe("Evolution", () => {
   let phaserGame: Phaser.Game;
@@ -82,12 +83,15 @@ describe("Evolution", () => {
     const nincada = game.scene.getPlayerPokemon()!;
     nincada.abilityIndex = 2;
     nincada.metBiome = -1;
+    nincada.gender = Gender.FEMALE;
 
     nincada.evolve(pokemonEvolutions[Species.NINCADA][0], nincada.getSpeciesForm());
     const ninjask = game.scene.getPlayerParty()[0];
     const shedinja = game.scene.getPlayerParty()[1];
     expect(ninjask.abilityIndex).toBe(2);
     expect(shedinja.abilityIndex).toBe(1);
+    expect(ninjask.gender).toBe(Gender.FEMALE);
+    expect(shedinja.gender).toBe(Gender.GENDERLESS);
     // Regression test
     expect(shedinja.metBiome).toBe(-1);
   });


### PR DESCRIPTION
Co-authored-by: asukakuwahara

Original PR: pokerogue/pull/5039

## What are the changes the user will see?

Shedinja will be genderless instead of the gender that the Nincada was

## Why am I making these changes?

PR#5038

## What are the changes from a developer perspective?

Added a `newPokemon.gender = Gender.GENDERLESS;` in the special nincada evolution case

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/c56ba4c6-e790-4f59-acb2-a603cba8ee6c)

## How to test the changes?

`npm run test evolution`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
