### PR TITLE
[WIP][P2] Copycat, Mirror Move, Metronome fixes

### DIFF
--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -569,7 +569,7 @@ export function initMoves() {
       .target(MoveTarget.USER)
       .unimplemented(),
     new SelfStatusMove(Moves.METRONOME, Type.NORMAL, -1, 10, -1, 0, 1).attr(RandomMoveAttr).ignoresVirtual(),
-    new StatusMove(Moves.MIRROR_MOVE, Type.FLYING, -1, 20, -1, 0, 1).attr(CopyMoveAttr).ignoresVirtual(),
+    new StatusMove(Moves.MIRROR_MOVE, Type.FLYING, -1, 20, -1, 0, 1).attr(CopyMoveAttr, true).ignoresVirtual(),
     new AttackMove(Moves.SELF_DESTRUCT, Type.NORMAL, MoveCategory.PHYSICAL, 200, 100, 5, -1, 0, 1)
       .attr(SacrificialAttr)
       .makesContact(false)

--- a/src/data/move-attrs/copy-move-attr.ts
+++ b/src/data/move-attrs/copy-move-attr.ts
@@ -5,11 +5,38 @@ import { type Move, getMoveTargets } from "#app/data/move";
 import { OverrideMoveEffectAttr } from "#app/data/move-attrs/override-move-effect-attr";
 import { lastMoveCopiableCondition, type MoveConditionFunc } from "../move-conditions";
 
+/**
+ * Attr used for Copycat and Mirror Move
+ */
 export class CopyMoveAttr extends OverrideMoveEffectAttr {
+  /**
+   * Mirror move requires the user to be targeted last and can hit allies
+   */
+  private isMirrorMove: boolean;
+
+  constructor(isMirrorMove: boolean = false) {
+    super();
+
+    this.isMirrorMove = isMirrorMove;
+  }
+
   override apply(user: Pokemon, target: Pokemon, _move: Move, _args: any[]): boolean {
     const lastMove = globalScene.currentBattle.lastMove;
 
+    /**
+     * WIP
+     * mirror move only works if the user was the last target
+     * if (this.isMirrorMove && lastMove.target !== user) return false
+     */
+
     const moveTargets = getMoveTargets(user, lastMove);
+
+    // Copycat cannot target one's ally
+    if (!this.isMirrorMove) {
+      const allyBattlerIndex = user.getAlly()?.getBattlerIndex();
+      moveTargets.targets = moveTargets.targets.filter((bi) => bi !== allyBattlerIndex);
+    }
+
     if (!moveTargets.targets.length) {
       return false;
     }

--- a/src/data/move-attrs/random-move-attr.ts
+++ b/src/data/move-attrs/random-move-attr.ts
@@ -9,6 +9,9 @@ import { type Move, getMoveTargets } from "#app/data/move";
 import { allMoves } from "#app/data/all-moves";
 import { OverrideMoveEffectAttr } from "#app/data/move-attrs/override-move-effect-attr";
 
+/**
+ * Uses a random move. Used for Metronome
+ */
 export class RandomMoveAttr extends OverrideMoveEffectAttr {
   /**
    * This function exists solely to allow tests to override the randomly selected move by mocking this function.
@@ -24,6 +27,10 @@ export class RandomMoveAttr extends OverrideMoveEffectAttr {
     const moveId = this.getMoveOverride() ?? moveIds[user.randSeedInt(moveIds.length)];
 
     const moveTargets = getMoveTargets(user, moveId);
+    // Metronome cannot target one's ally
+    const allyBattlerIndex = user.getAlly()?.getBattlerIndex();
+    moveTargets.targets = moveTargets.targets.filter((bi) => bi !== allyBattlerIndex);
+
     if (!moveTargets.targets.length) {
       return false;
     }


### PR DESCRIPTION
## What are the changes the user will see?

- [ ] Mirror move requires the user to be the last target
- [x] Copycat can no longer target allies
- [x] Metronome can no longer target allies

## Why am I making these changes?

PR#3874

## What are the changes from a developer perspective?

* Added a new variable in CopyMoveAttr since mirror move and copycat are not the same functionality
* Added filtering for ally slot targeting for copycat and metronome

## Screenshots/Videos

n/a

## How to test the changes?

n/a

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
