### PR TITLE
[Bug][Move] Photon Geyser should ignore abilities

### DIFF
--- a/src/data/move-attrs/photon-geyser-category-attr.ts
+++ b/src/data/move-attrs/photon-geyser-category-attr.ts
@@ -9,7 +9,7 @@ export class PhotonGeyserCategoryAttr extends VariableMoveCategoryAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, args: any[]): boolean {
     const category = args[0] as NumberHolder;
 
-    if (user.getEffectiveStat(Stat.ATK, target, move) > user.getEffectiveStat(Stat.SPATK, target, move)) {
+    if (user.getEffectiveStat(Stat.ATK, target, move, true) > user.getEffectiveStat(Stat.SPATK, target, move, true)) {
       category.value = MoveCategory.PHYSICAL;
       return true;
     }

--- a/test/moves/photon_geyser.test.ts
+++ b/test/moves/photon_geyser.test.ts
@@ -1,0 +1,56 @@
+import { allMoves } from "#app/data/all-moves";
+import { PhotonGeyserCategoryAttr } from "#app/data/move-attrs/photon-geyser-category-attr";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Photon Geyser", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  const photonGeyserAttr = allMoves[Moves.PHOTON_GEYSER].getAttrs(PhotonGeyserCategoryAttr)[0];
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.PHOTON_GEYSER])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+
+    vi.spyOn(photonGeyserAttr, "apply");
+  });
+
+  it("should be special if the user's Special Attack is higher", async () => {
+    await game.classicMode.startBattle([Species.CHANDELURE]);
+
+    game.move.select(Moves.PHOTON_GEYSER);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(photonGeyserAttr.apply).toHaveReturnedWith(false);
+  });
+
+  it("should be physical if the user's Attack is higher", async () => {
+    await game.classicMode.startBattle([Species.KARTANA]);
+
+    game.move.select(Moves.PHOTON_GEYSER);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(photonGeyserAttr.apply).toHaveReturnedWith(true);
+  });
+});


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6ee54844-fe8e-4886-b4d2-20a0a2f9afdb)
![image](https://github.com/user-attachments/assets/93d7c365-2814-499b-8afc-af79cbf7b6b4)

## What are the changes the user will see?
Photon Geyser's category change effect will now properly ignore abilities.

## Why am I making these changes?
Photon Geyser is supposed to ignore abilities.
Also incidentally fixes an infinite recursion crash when the AI is simulating its moves (uses of `.getEffectiveStat()` need a full look-over later).

## What are the changes from a developer perspective?
`true` is passed to the `ignoreAbilities` param of `.getEffectiveStat()` in `PhotonGeyserCategoryAttr`

## How to test the changes?
`npm run test photon_geyser`
For the crash: use Photon Geyser against a Pokémon with an ability like Torrent.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?