### PR TITLE
[Bug] Prevent crashes from interactions with delayed attacks

### DIFF
--- a/src/data/ab-attrs/post-faint-hp-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-hp-damage-ab-attr.ts
@@ -19,7 +19,11 @@ export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
     _hitResult?: HitResult,
     ..._args: any[]
   ): boolean {
-    if (move !== undefined && attacker !== undefined && !simulated) {
+    if (!move || !attacker || !attacker.isOnField()) {
+      return false;
+    }
+
+    if (!simulated) {
       //If the mon didn't die to indirect damage
       const damage = pokemon.turnData.attacksReceived[0].damage;
       attacker.damageAndUpdate(damage, HitResult.OTHER);

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -776,18 +776,16 @@ export class DestinyBondTag extends BattlerTag {
    *
    * @param pokemon Pokemon that is attacking the Destiny Bond user.
    * @param lapseType CUSTOM or PRE_MOVE
-   * @returns false if the tag source fainted or one turn has passed since the application
+   * @returns `false` if the tag source fainted or one turn has passed since the application
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType !== BattlerTagLapseType.CUSTOM) {
       return super.lapse(pokemon, lapseType);
     }
-    const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
-    if (!source?.isFainted()) {
-      return true;
-    }
 
-    if (source?.getAlly() === pokemon) {
+    const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
+
+    if (!source || !source.isFainted() || !pokemon.isOnField() || source.getAlly() === pokemon) {
       return false;
     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/237aa9a8-4f48-496b-b274-10c79b29652b)
![image](https://github.com/user-attachments/assets/48344913-ff62-4065-a1e1-ffad65a057c8)

## What are the changes the user will see?
If a Future Sight attack from an off-field Pokémon faints a Pokémon that used Destiny Bond or a Pokémon that has Innards Out, the game will no longer crash.

## Why am I making these changes?
Crashes are bad.

## What are the changes from a developer perspective?
`PostFaintHPDamageAbAttr` (Innards Out) and `DestinyBondTag` (Destiny Bond) now have a check for the target being on the field.

## How to test the changes?
`npm run test future_sight`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?