### PR TITLE
[UI][Temporary] Moved addWindow and addTextObject into class functions of SceneBase

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -50,7 +50,7 @@ import type { Phase } from "#app/phase";
 import { initGameSpeed } from "#app/system/game-speed";
 import { Arena, ArenaBase } from "#app/field/arena";
 import { GameData } from "#app/system/game-data";
-import { addTextObject, getTextColor, TextStyle } from "#app/ui/text";
+import { getTextColor, TextStyle } from "#app/ui/text";
 import { allMoves } from "#app/data/all-moves";
 import { MusicPreference } from "#app/system/settings/settings";
 import {
@@ -598,7 +598,7 @@ export default class BattleScene extends SceneBase {
     this.candyBar.setup();
     this.fieldUI.add(this.candyBar);
 
-    this.biomeWaveText = addTextObject(
+    this.biomeWaveText = globalScene.addTextObject(
       this.game.canvas.width / 6 - 2,
       0,
       startingWave.toString(),
@@ -608,23 +608,27 @@ export default class BattleScene extends SceneBase {
     this.biomeWaveText.setOrigin(1, 0.5);
     this.fieldUI.add(this.biomeWaveText);
 
-    this.moneyText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.MONEY);
+    this.moneyText = globalScene.addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.MONEY);
     this.moneyText.setName("text-money");
     this.moneyText.setOrigin(1, 0.5);
     this.fieldUI.add(this.moneyText);
 
-    this.scoreText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, { fontSize: "54px" });
+    this.scoreText = globalScene.addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, {
+      fontSize: "54px",
+    });
     this.scoreText.setName("text-score");
     this.scoreText.setOrigin(1, 0.5);
     this.fieldUI.add(this.scoreText);
 
-    this.luckText = addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, { fontSize: "54px" });
+    this.luckText = globalScene.addTextObject(this.game.canvas.width / 6 - 2, 0, "", TextStyle.PARTY, {
+      fontSize: "54px",
+    });
     this.luckText.setName("text-luck");
     this.luckText.setOrigin(1, 0.5);
     this.luckText.setVisible(false);
     this.fieldUI.add(this.luckText);
 
-    this.luckLabelText = addTextObject(
+    this.luckLabelText = globalScene.addTextObject(
       this.game.canvas.width / 6 - 2,
       0,
       i18next.t("common:luckIndicator"),

--- a/src/field/damage-number-handler.ts
+++ b/src/field/damage-number-handler.ts
@@ -1,4 +1,4 @@
-import { TextStyle, addTextObject } from "../ui/text";
+import { TextStyle } from "../ui/text";
 import type { DamageResult } from "./pokemon";
 import type { Pokemon } from "./pokemon";
 import { HitResult } from "./pokemon";
@@ -27,7 +27,7 @@ export default class DamageNumberHandler {
 
     const battlerIndex = target.getBattlerIndex();
     const baseScale = target.getSpriteScale() / 6;
-    const damageNumber = addTextObject(
+    const damageNumber = globalScene.addTextObject(
       target.x,
       -(globalScene.game.canvas.height / 6) + target.y - target.getSprite().height / 2,
       formatStat(amount, true),

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -20,7 +20,7 @@ import { PokemonHealPhase } from "#app/phases/pokemon-heal-phase";
 import { achvs } from "#app/system/achv";
 import type { VoucherType } from "#app/system/voucher";
 import { Command } from "#app/ui/command-ui-handler";
-import { addTextObject, TextStyle } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import { BooleanHolder, hslToHex, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { BerryType } from "#enums/berry-type";
@@ -411,7 +411,7 @@ export abstract class LapsingPersistentModifier extends PersistentModifier {
     const typeHex = hslToHex(hue, 0.5, 0.9);
     const strokeHex = hslToHex(hue, 0.7, 0.3);
 
-    const battleCountText = addTextObject(27, 0, this.battleCount.toString(), TextStyle.PARTY, {
+    const battleCountText = globalScene.addTextObject(27, 0, this.battleCount.toString(), TextStyle.PARTY, {
       fontSize: "66px",
       color: typeHex,
     });
@@ -813,7 +813,7 @@ export abstract class LapsingPokemonHeldItemModifier extends PokemonHeldItemModi
     const container = super.getIcon(forSummary);
 
     if (this.getPokemon()?.isPlayer()) {
-      const battleCountText = addTextObject(27, 0, this.battlesLeft.toString(), TextStyle.PARTY, {
+      const battleCountText = globalScene.addTextObject(27, 0, this.battlesLeft.toString(), TextStyle.PARTY, {
         fontSize: "66px",
         color: Color.PINK,
       });

--- a/src/phases/end-card-phase.ts
+++ b/src/phases/end-card-phase.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { PlayerGender } from "#app/enums/player-gender";
 import { Phase } from "#app/phase";
-import { addTextObject, TextStyle } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import i18next from "i18next";
 
 export class EndCardPhase extends Phase {
@@ -27,7 +27,7 @@ export class EndCardPhase extends Phase {
     this.endCard.setScale(0.5);
     globalScene.field.add(this.endCard);
 
-    this.text = addTextObject(
+    this.text = globalScene.addTextObject(
       globalScene.game.canvas.width / 12,
       globalScene.game.canvas.height / 6 - 16,
       i18next.t("battle:congratulations"),

--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { TextStyle, addTextObject } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import type { nil } from "#app/utils";
 import i18next from "i18next";
 
@@ -135,7 +135,7 @@ export class TimedEventDisplay extends Phaser.GameObjects.Container {
       this.banner.setOrigin(0.5, 1);
       this.banner.setScale(this.event.scale ?? 0.18);
       if (showTimer) {
-        this.eventTimerText = addTextObject(
+        this.eventTimerText = globalScene.addTextObject(
           this.banner.x,
           this.banner.y + 2,
           this.timeToGo(this.event.endDate),

--- a/src/ui/ability-bar.ts
+++ b/src/ui/ability-bar.ts
@@ -1,7 +1,7 @@
 import { getPokemonNameWithAffix } from "#app/messages";
 import { globalScene } from "#app/global-scene";
 import type { Pokemon } from "../field/pokemon";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import i18next from "i18next";
 
 const hiddenX = -118;
@@ -27,7 +27,7 @@ export default class AbilityBar extends Phaser.GameObjects.Container {
 
     this.add(this.bg);
 
-    this.abilityBarText = addTextObject(15, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
+    this.abilityBarText = globalScene.addTextObject(15, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
     this.abilityBarText.setOrigin(0, 0);
     this.abilityBarText.setWordWrapWidth(600, true);
     this.add(this.abilityBarText);

--- a/src/ui/abstact-option-select-ui-handler.ts
+++ b/src/ui/abstact-option-select-ui-handler.ts
@@ -1,8 +1,7 @@
 import { globalScene } from "#app/global-scene";
-import { TextStyle, addTextObject, getTextStyleOptions } from "./text";
+import { TextStyle, getTextStyleOptions } from "./text";
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
-import { addWindow } from "./ui-theme";
 import { rgbHexToRgba, fixedInt } from "#app/utils";
 import { argbFromRgba } from "@material/material-color-utilities";
 import { Button } from "#enums/buttons";
@@ -64,7 +63,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
     this.optionSelectContainer.setVisible(false);
     ui.add(this.optionSelectContainer);
 
-    this.optionSelectBg = addWindow(0, 0, this.getWindowWidth(), this.getWindowHeight());
+    this.optionSelectBg = globalScene.addWindow(0, 0, this.getWindowWidth(), this.getWindowHeight());
     this.optionSelectBg.setName("option-select-bg");
     this.optionSelectBg.setOrigin(1, 1);
     this.optionSelectContainer.add(this.optionSelectBg);
@@ -107,7 +106,7 @@ export default abstract class AbstractOptionSelectUiHandler extends UiHandler {
       this.optionSelectIcons.splice(0, this.optionSelectIcons.length);
     }
 
-    this.optionSelectText = addTextObject(
+    this.optionSelectText = globalScene.addTextObject(
       0,
       0,
       options.map((o) => (o.item ? `    ${o.label}` : o.label)).join("\n"),

--- a/src/ui/achv-bar.ts
+++ b/src/ui/achv-bar.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { Achv, getAchievementDescription } from "../system/achv";
 import { Voucher } from "../system/voucher";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import type { PlayerGender } from "#enums/player-gender";
 
 export default class AchvBar extends Phaser.GameObjects.Container {
@@ -48,15 +48,15 @@ export default class AchvBar extends Phaser.GameObjects.Container {
     this.icon.setOrigin(0, 0);
     this.add(this.icon);
 
-    this.titleText = addTextObject(40, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
+    this.titleText = globalScene.addTextObject(40, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
     this.titleText.setOrigin(0, 0);
     this.add(this.titleText);
 
-    this.scoreText = addTextObject(150, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
+    this.scoreText = globalScene.addTextObject(150, 3, "", TextStyle.MESSAGE, { fontSize: "72px" });
     this.scoreText.setOrigin(1, 0);
     this.add(this.scoreText);
 
-    this.descriptionText = addTextObject(43, 16, "", TextStyle.WINDOW_ALT, { fontSize: "72px" });
+    this.descriptionText = globalScene.addTextObject(43, 16, "", TextStyle.WINDOW_ALT, { fontSize: "72px" });
     this.descriptionText.setOrigin(0, 0);
     this.add(this.descriptionText);
 

--- a/src/ui/achvs-ui-handler.ts
+++ b/src/ui/achvs-ui-handler.ts
@@ -5,9 +5,8 @@ import { achvs, getAchievementDescription } from "#app/system/achv";
 import type { Voucher } from "#app/system/voucher";
 import { getVoucherTypeIcon, getVoucherTypeName, vouchers } from "#app/system/voucher";
 import MessageUiHandler from "#app/ui/message-ui-handler";
-import { addTextObject, TextStyle } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import type { Mode } from "#app/ui/ui";
-import { addWindow } from "#app/ui/ui-theme";
 import { ScrollBar } from "#app/ui/scroll-bar";
 import { PlayerGender } from "#enums/player-gender";
 import { globalScene } from "#app/global-scene";
@@ -77,16 +76,16 @@ export default class AchvsUiHandler extends MessageUiHandler {
       Phaser.Geom.Rectangle.Contains,
     );
 
-    this.headerBg = addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
+    this.headerBg = globalScene.addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
     this.headerBg.setOrigin(0, 0);
 
-    this.headerText = addTextObject(0, 0, "", TextStyle.SETTINGS_LABEL);
+    this.headerText = globalScene.addTextObject(0, 0, "", TextStyle.SETTINGS_LABEL);
     this.headerText.setOrigin(0, 0);
     this.headerText.setPositionRelative(this.headerBg, 8, 4);
     this.headerActionButton = new Phaser.GameObjects.Sprite(globalScene, 0, 0, "keyboard", "ACTION.png");
     this.headerActionButton.setOrigin(0, 0);
     this.headerActionButton.setPositionRelative(this.headerBg, 236, 6);
-    this.headerActionText = addTextObject(0, 0, "", TextStyle.WINDOW, { fontSize: "60px" });
+    this.headerActionText = globalScene.addTextObject(0, 0, "", TextStyle.WINDOW, { fontSize: "60px" });
     this.headerActionText.setOrigin(0, 0);
     this.headerActionText.setPositionRelative(this.headerBg, 264, 8);
 
@@ -97,7 +96,7 @@ export default class AchvsUiHandler extends MessageUiHandler {
     this.achvsName = i18next.t("achv:Achievements.name", { context: genderStr });
     this.vouchersName = i18next.t("voucher:vouchers");
 
-    this.iconsBg = addWindow(
+    this.iconsBg = globalScene.addWindow(
       0,
       this.headerBg.height,
       globalScene.game.canvas.width / 6 - 2,
@@ -130,11 +129,11 @@ export default class AchvsUiHandler extends MessageUiHandler {
       this.iconsContainer.add(icon);
     }
 
-    const titleBg = addWindow(0, this.headerBg.height + this.iconsBg.height, 174, 24);
+    const titleBg = globalScene.addWindow(0, this.headerBg.height + this.iconsBg.height, 174, 24);
     titleBg.setOrigin(0, 0);
     this.titleBg = titleBg;
 
-    this.titleText = addTextObject(0, 0, "", TextStyle.WINDOW);
+    this.titleText = globalScene.addTextObject(0, 0, "", TextStyle.WINDOW);
     const textSize = languageSettings[i18next.language]?.TextSize ?? this.titleText.style.fontSize;
     this.titleText.setFontSize(textSize);
     const titleBgCenterX = titleBg.x + titleBg.width / 2;
@@ -143,25 +142,30 @@ export default class AchvsUiHandler extends MessageUiHandler {
     this.titleText.setPosition(titleBgCenterX, titleBgCenterY);
 
     this.scoreContainer = globalScene.add.container(titleBg.x + titleBg.width, titleBg.y);
-    const scoreBg = addWindow(0, 0, 46, 24);
+    const scoreBg = globalScene.addWindow(0, 0, 46, 24);
     scoreBg.setOrigin(0, 0);
     this.scoreContainer.add(scoreBg);
 
-    this.scoreText = addTextObject(scoreBg.width / 2, scoreBg.height / 2, "", TextStyle.WINDOW);
+    this.scoreText = globalScene.addTextObject(scoreBg.width / 2, scoreBg.height / 2, "", TextStyle.WINDOW);
     this.scoreText.setOrigin(0.5, 0.5);
     this.scoreContainer.add(this.scoreText);
 
-    const unlockBg = addWindow(this.scoreContainer.x + scoreBg.width, titleBg.y, 98, 24);
+    const unlockBg = globalScene.addWindow(this.scoreContainer.x + scoreBg.width, titleBg.y, 98, 24);
     unlockBg.setOrigin(0, 0);
 
-    this.unlockText = addTextObject(0, 0, "", TextStyle.WINDOW);
+    this.unlockText = globalScene.addTextObject(0, 0, "", TextStyle.WINDOW);
     this.unlockText.setOrigin(0.5, 0.5);
     this.unlockText.setPositionRelative(unlockBg, unlockBg.width / 2, unlockBg.height / 2);
 
-    const descriptionBg = addWindow(0, titleBg.y + titleBg.height, globalScene.game.canvas.width / 6 - 2, 42);
+    const descriptionBg = globalScene.addWindow(
+      0,
+      titleBg.y + titleBg.height,
+      globalScene.game.canvas.width / 6 - 2,
+      42,
+    );
     descriptionBg.setOrigin(0, 0);
 
-    const descriptionText = addTextObject(0, 0, "", TextStyle.WINDOW, { maxLines: 2 });
+    const descriptionText = globalScene.addTextObject(0, 0, "", TextStyle.WINDOW, { maxLines: 2 });
     descriptionText.setWordWrapWidth(1870);
     descriptionText.setOrigin(0, 0);
     descriptionText.setPositionRelative(descriptionBg, 8, 4);

--- a/src/ui/arena-flyout.ts
+++ b/src/ui/arena-flyout.ts
@@ -1,9 +1,9 @@
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import { globalScene } from "#app/global-scene";
 import { ArenaTagSide, ArenaTrapTag } from "#app/data/arena-tag";
 import { WeatherType } from "#enums/weather-type";
 import { TerrainType } from "#enums/terrain-type";
-import { addWindow, WindowVariant } from "./ui-theme";
+import { WindowVariant } from "./ui-theme";
 import type { ArenaEvent } from "#app/events/arena";
 import {
   ArenaEventType,
@@ -119,10 +119,20 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
     this.flyoutContainer = globalScene.add.container(0, 0);
     this.flyoutParent.add(this.flyoutContainer);
 
-    this.flyoutWindow = addWindow(0, 0, this.flyoutWidth, this.flyoutHeight, false, false, 0, 0, WindowVariant.THIN);
+    this.flyoutWindow = globalScene.addWindow(
+      0,
+      0,
+      this.flyoutWidth,
+      this.flyoutHeight,
+      false,
+      false,
+      0,
+      0,
+      WindowVariant.THIN,
+    );
     this.flyoutContainer.add(this.flyoutWindow);
 
-    this.flyoutWindowHeader = addWindow(
+    this.flyoutWindowHeader = globalScene.addWindow(
       this.flyoutWidth / 2,
       0,
       this.flyoutWidth / 2,
@@ -137,7 +147,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
     this.flyoutContainer.add(this.flyoutWindowHeader);
 
-    this.flyoutTextHeader = addTextObject(
+    this.flyoutTextHeader = globalScene.addTextObject(
       this.flyoutWidth / 2,
       0,
       i18next.t("arenaFlyout:activeBattleEffects"),
@@ -152,14 +162,19 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
     this.timeOfDayWidget = new TimeOfDayWidget(this.flyoutWidth / 2 + this.flyoutWindowHeader.displayWidth / 2);
     this.flyoutContainer.add(this.timeOfDayWidget);
 
-    this.flyoutTextHeaderPlayer = addTextObject(6, 5, i18next.t("arenaFlyout:player"), TextStyle.SUMMARY_BLUE);
+    this.flyoutTextHeaderPlayer = globalScene.addTextObject(
+      6,
+      5,
+      i18next.t("arenaFlyout:player"),
+      TextStyle.SUMMARY_BLUE,
+    );
     this.flyoutTextHeaderPlayer.setFontSize(54);
     this.flyoutTextHeaderPlayer.setAlign("left");
     this.flyoutTextHeaderPlayer.setOrigin(0, 0);
 
     this.flyoutContainer.add(this.flyoutTextHeaderPlayer);
 
-    this.flyoutTextHeaderField = addTextObject(
+    this.flyoutTextHeaderField = globalScene.addTextObject(
       this.flyoutWidth / 2,
       5,
       i18next.t("arenaFlyout:neutral"),
@@ -171,7 +186,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
     this.flyoutContainer.add(this.flyoutTextHeaderField);
 
-    this.flyoutTextHeaderEnemy = addTextObject(
+    this.flyoutTextHeaderEnemy = globalScene.addTextObject(
       this.flyoutWidth - 6,
       5,
       i18next.t("arenaFlyout:enemy"),
@@ -183,7 +198,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
     this.flyoutContainer.add(this.flyoutTextHeaderEnemy);
 
-    this.flyoutTextPlayer = addTextObject(6, 13, "", TextStyle.BATTLE_INFO);
+    this.flyoutTextPlayer = globalScene.addTextObject(6, 13, "", TextStyle.BATTLE_INFO);
     this.flyoutTextPlayer.setLineSpacing(-1);
     this.flyoutTextPlayer.setFontSize(48);
     this.flyoutTextPlayer.setAlign("left");
@@ -191,7 +206,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
     this.flyoutContainer.add(this.flyoutTextPlayer);
 
-    this.flyoutTextField = addTextObject(this.flyoutWidth / 2, 13, "", TextStyle.BATTLE_INFO);
+    this.flyoutTextField = globalScene.addTextObject(this.flyoutWidth / 2, 13, "", TextStyle.BATTLE_INFO);
     this.flyoutTextField.setLineSpacing(-1);
     this.flyoutTextField.setFontSize(48);
     this.flyoutTextField.setAlign("center");
@@ -199,7 +214,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
 
     this.flyoutContainer.add(this.flyoutTextField);
 
-    this.flyoutTextEnemy = addTextObject(this.flyoutWidth - 6, 13, "", TextStyle.BATTLE_INFO);
+    this.flyoutTextEnemy = globalScene.addTextObject(this.flyoutWidth - 6, 13, "", TextStyle.BATTLE_INFO);
     this.flyoutTextEnemy.setLineSpacing(-1);
     this.flyoutTextEnemy.setFontSize(48);
     this.flyoutTextEnemy.setAlign("right");

--- a/src/ui/ball-ui-handler.ts
+++ b/src/ui/ball-ui-handler.ts
@@ -1,9 +1,8 @@
 import { getPokeballName } from "../data/pokeball";
-import { addTextObject, getTextStyleOptions, TextStyle } from "./text";
+import { getTextStyleOptions, TextStyle } from "./text";
 import { Command } from "./command-ui-handler";
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
-import { addWindow } from "./ui-theme";
 import { Button } from "#enums/buttons";
 import type { CommandPhase } from "#app/phases/command-phase";
 import { globalScene } from "#app/global-scene";
@@ -34,7 +33,10 @@ export default class BallUiHandler extends UiHandler {
       optionsTextContent += `${getPokeballName(pb)}\n`;
     }
     optionsTextContent += "Cancel";
-    const optionsText = addTextObject(0, 0, optionsTextContent, TextStyle.WINDOW, { align: "right", maxLines: 6 });
+    const optionsText = globalScene.addTextObject(0, 0, optionsTextContent, TextStyle.WINDOW, {
+      align: "right",
+      maxLines: 6,
+    });
     const optionsTextWidth = optionsText.displayWidth;
     this.pokeballSelectContainer = globalScene.add.container(
       globalScene.game.canvas.width / 6 - 51 - Math.max(64, optionsTextWidth),
@@ -43,7 +45,7 @@ export default class BallUiHandler extends UiHandler {
     this.pokeballSelectContainer.setVisible(false);
     ui.add(this.pokeballSelectContainer);
 
-    this.pokeballSelectBg = addWindow(
+    this.pokeballSelectBg = globalScene.addWindow(
       0,
       0,
       50 + Math.max(64, optionsTextWidth),
@@ -56,7 +58,7 @@ export default class BallUiHandler extends UiHandler {
     optionsText.setPositionRelative(this.pokeballSelectBg, 42, 9);
     optionsText.setLineSpacing(this.scale * 72);
 
-    this.countsText = addTextObject(0, 0, "", TextStyle.WINDOW, { maxLines: 5 });
+    this.countsText = globalScene.addTextObject(0, 0, "", TextStyle.WINDOW, { maxLines: 5 });
     this.countsText.setPositionRelative(this.pokeballSelectBg, 18, 9);
     this.countsText.setLineSpacing(this.scale * 72);
     this.pokeballSelectContainer.add(this.countsText);

--- a/src/ui/battle-flyout.ts
+++ b/src/ui/battle-flyout.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "../field/pokemon";
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import { fixedInt } from "#app/utils";
 import { globalScene } from "#app/global-scene";
 import type { Move } from "#app/data/move";
@@ -86,7 +86,7 @@ export default class BattleFlyout extends Phaser.GameObjects.Container {
 
     // Loops through and sets the position of each text object according to the width and height of the flyout
     for (let i = 0; i < 4; i++) {
-      this.flyoutText[i] = addTextObject(
+      this.flyoutText[i] = globalScene.addTextObject(
         this.flyoutWidth / 4 + (this.flyoutWidth / 2) * (i % 2),
         this.flyoutHeight / 4 + (this.flyoutHeight / 2) * (i < 2 ? 0 : 1),
         "???",

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -1,7 +1,7 @@
 import type { EnemyPokemon, Pokemon } from "../field/pokemon";
 import { getLevelTotalExp, getLevelRelExp } from "../data/exp";
 import { getLocalizedSpriteKey, fixedInt } from "#app/utils";
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import { getGenderSymbol, getGenderColor } from "#app/data/gender";
 import { Gender } from "#enums/gender";
 import { StatusEffect } from "#enums/status-effect";
@@ -11,7 +11,7 @@ import { Type } from "#enums/type";
 import { getVariantTint } from "#app/data/variant";
 import { Stat } from "#enums/stat";
 import BattleFlyout from "./battle-flyout";
-import { WindowVariant, addWindow } from "./ui-theme";
+import { WindowVariant } from "./ui-theme";
 import i18next from "i18next";
 import { ExpGainsSpeed } from "#app/enums/exp-gains-speed";
 
@@ -102,12 +102,12 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.box.setOrigin(1, 0.5);
     this.add(this.box);
 
-    this.nameText = addTextObject(player ? -115 : -124, player ? -15.2 : -11.2, "", TextStyle.BATTLE_INFO);
+    this.nameText = globalScene.addTextObject(player ? -115 : -124, player ? -15.2 : -11.2, "", TextStyle.BATTLE_INFO);
     this.nameText.setName("text_name");
     this.nameText.setOrigin(0, 0);
     this.add(this.nameText);
 
-    this.genderText = addTextObject(0, 0, "", TextStyle.BATTLE_INFO);
+    this.genderText = globalScene.addTextObject(0, 0, "", TextStyle.BATTLE_INFO);
     this.genderText.setName("text_gender");
     this.genderText.setOrigin(0, 0);
     this.genderText.setPositionRelative(this.nameText, 0, 2);
@@ -316,8 +316,18 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
       this.effectivenessContainer.setVisible(false);
       this.add(this.effectivenessContainer);
 
-      this.effectivenessText = addTextObject(5, 4.5, "", TextStyle.BATTLE_INFO);
-      this.effectivenessWindow = addWindow(0, 0, 0, 20, undefined, false, undefined, undefined, WindowVariant.XTHIN);
+      this.effectivenessText = globalScene.addTextObject(5, 4.5, "", TextStyle.BATTLE_INFO);
+      this.effectivenessWindow = globalScene.addWindow(
+        0,
+        0,
+        0,
+        20,
+        undefined,
+        false,
+        undefined,
+        undefined,
+        WindowVariant.XTHIN,
+      );
 
       this.effectivenessContainer.add(this.effectivenessWindow);
       this.effectivenessContainer.add(this.effectivenessText);
@@ -772,7 +782,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     let displayName = pokemon.getNameToRender().replace(/[♂♀]/g, "");
     let nameTextWidth: number;
 
-    const nameSizeTest = addTextObject(0, 0, displayName, TextStyle.BATTLE_INFO);
+    const nameSizeTest = globalScene.addTextObject(0, 0, displayName, TextStyle.BATTLE_INFO);
     nameTextWidth = nameSizeTest.displayWidth;
 
     while (

--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -1,8 +1,7 @@
 import { globalScene } from "#app/global-scene";
-import { addBBCodeTextObject, addTextObject, getTextColor, TextStyle } from "./text";
+import { addBBCodeTextObject, getTextColor, TextStyle } from "./text";
 import { Mode } from "./ui";
 import MessageUiHandler from "./message-ui-handler";
-import { addWindow } from "./ui-theme";
 import type BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import { Button } from "#enums/buttons";
 import i18next from "i18next";
@@ -38,7 +37,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     this.bg.setOrigin(0, 1);
     ui.add(this.bg);
 
-    this.commandWindow = addWindow(202, 0, 118, 48);
+    this.commandWindow = globalScene.addWindow(202, 0, 118, 48);
     this.commandWindow.setName("window-command");
     this.commandWindow.setOrigin(0, 1);
     this.commandWindow.setVisible(false);
@@ -48,11 +47,11 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     this.movesWindowContainer.setName("moves-bg");
     this.movesWindowContainer.setVisible(false);
 
-    const movesWindow = addWindow(0, 0, 243, 48);
+    const movesWindow = globalScene.addWindow(0, 0, 243, 48);
     movesWindow.setName("moves-window");
     movesWindow.setOrigin(0, 1);
 
-    const moveDetailsWindow = addWindow(240, 0, 80, 48, false, false, -1, 132);
+    const moveDetailsWindow = globalScene.addWindow(240, 0, 80, 48, false, false, -1, 132);
     moveDetailsWindow.setName("move-details-window");
     moveDetailsWindow.setOrigin(0, 1);
 
@@ -62,7 +61,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     const messageContainer = globalScene.add.container(12, -39);
     ui.add(messageContainer);
 
-    const message = addTextObject(0, 0, "", TextStyle.MESSAGE, {
+    const message = globalScene.addTextObject(0, 0, "", TextStyle.MESSAGE, {
       maxLines: 2,
       wordWrap: {
         width: this.wordWrapWidth,
@@ -78,7 +77,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     this.nameBox = globalScene.add.nineslice(0, 0, "namebox", globalScene.windowType, 72, 16, 8, 8, 5, 5);
     this.nameBox.setOrigin(0, 0);
 
-    this.nameText = addTextObject(8, 0, "Rival", TextStyle.MESSAGE, { maxLines: 1 });
+    this.nameText = globalScene.addTextObject(8, 0, "Rival", TextStyle.MESSAGE, { maxLines: 1 });
 
     this.nameBoxContainer.add(this.nameBox);
     this.nameBoxContainer.add(this.nameText);
@@ -92,9 +91,15 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
 
     this.levelUpStatsContainer = levelUpStatsContainer;
 
-    const levelUpStatsLabelsContent = addTextObject(globalScene.game.canvas.width / 6 - 73, -94, "", TextStyle.WINDOW, {
-      maxLines: 6,
-    });
+    const levelUpStatsLabelsContent = globalScene.addTextObject(
+      globalScene.game.canvas.width / 6 - 73,
+      -94,
+      "",
+      TextStyle.WINDOW,
+      {
+        maxLines: 6,
+      },
+    );
     levelUpStatsLabelsContent.setLineSpacing(i18next.resolvedLanguage === "ja" ? 25 : 5);
     let levelUpStatsLabelText = "";
 
@@ -104,7 +109,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
     levelUpStatsLabelsContent.text = levelUpStatsLabelText;
     levelUpStatsLabelsContent.x -= levelUpStatsLabelsContent.displayWidth;
 
-    const levelUpStatsBg = addWindow(
+    const levelUpStatsBg = globalScene.addWindow(
       globalScene.game.canvas.width / 6,
       -100,
       80 + levelUpStatsLabelsContent.displayWidth,
@@ -115,7 +120,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
 
     levelUpStatsContainer.add(levelUpStatsLabelsContent);
 
-    const levelUpStatsIncrContent = addTextObject(
+    const levelUpStatsIncrContent = globalScene.addTextObject(
       globalScene.game.canvas.width / 6 - 50,
       -94,
       "+\n+\n+\n+\n+\n+",

--- a/src/ui/bgm-bar.ts
+++ b/src/ui/bgm-bar.ts
@@ -1,4 +1,4 @@
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import i18next from "i18next";
 import { formatText } from "#app/utils";
 import { globalScene } from "#app/global-scene";
@@ -40,7 +40,7 @@ export default class BgmBar extends Phaser.GameObjects.Container {
 
     this.add(this.bg);
 
-    this.musicText = addTextObject(5, 5, "", TextStyle.BGM_BAR);
+    this.musicText = globalScene.addTextObject(5, 5, "", TextStyle.BGM_BAR);
     this.musicText.setOrigin(0, 0);
     this.musicText.setWordWrapWidth(650, true);
 

--- a/src/ui/candy-bar.ts
+++ b/src/ui/candy-bar.ts
@@ -1,6 +1,6 @@
 import { starterColors } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import { argbFromRgba } from "@material/material-color-utilities";
 import { rgbHexToRgba } from "#app/utils";
 import type { Species } from "#enums/species";
@@ -39,7 +39,7 @@ export default class CandyBar extends Phaser.GameObjects.Container {
 
     this.add(this.candyOverlayIcon);
 
-    this.countText = addTextObject(22, 4, "", TextStyle.BATTLE_INFO);
+    this.countText = globalScene.addTextObject(22, 4, "", TextStyle.BATTLE_INFO);
     this.countText.setOrigin(0, 0);
     this.add(this.countText);
 

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -1,7 +1,6 @@
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import type { Mode } from "./ui";
 import UiHandler from "./ui-handler";
-import { addWindow } from "./ui-theme";
 import { Button } from "#enums/buttons";
 import i18next from "i18next";
 import type { Challenge } from "#app/data/challenge";
@@ -80,17 +79,17 @@ export default class GameChallengesUiHandler extends UiHandler {
     this.challengesContainer.add(bgOverlay);
 
     // TODO: Change this back to /9 when adding in difficulty
-    const headerBg = addWindow(0, 0, globalScene.game.canvas.width / 6, 24);
+    const headerBg = globalScene.addWindow(0, 0, globalScene.game.canvas.width / 6, 24);
     headerBg.setName("window-header-bg");
     headerBg.setOrigin(0, 0);
 
-    const headerText = addTextObject(0, 0, i18next.t("challenges:title"), TextStyle.SETTINGS_LABEL);
+    const headerText = globalScene.addTextObject(0, 0, i18next.t("challenges:title"), TextStyle.SETTINGS_LABEL);
     headerText.setName("text-header");
     headerText.setOrigin(0, 0);
     headerText.setPositionRelative(headerBg, 8, 4);
 
     this.optionsWidth = globalScene.scaledCanvas.width * 0.6;
-    this.optionsBg = addWindow(
+    this.optionsBg = globalScene.addWindow(
       0,
       headerBg.height,
       this.optionsWidth,
@@ -99,7 +98,7 @@ export default class GameChallengesUiHandler extends UiHandler {
     this.optionsBg.setName("window-options-bg");
     this.optionsBg.setOrigin(0, 0);
 
-    const descriptionBg = addWindow(
+    const descriptionBg = globalScene.addWindow(
       0,
       headerBg.height,
       globalScene.scaledCanvas.width - this.optionsWidth,
@@ -127,12 +126,12 @@ export default class GameChallengesUiHandler extends UiHandler {
     this.descriptionText.setShadow(4, 5, ShadowColor.ORANGE);
     this.descriptionText.setOrigin(0, 0);
 
-    this.startBg = addWindow(0, 0, descriptionBg.width, 24);
+    this.startBg = globalScene.addWindow(0, 0, descriptionBg.width, 24);
     this.startBg.setName("window-start-bg");
     this.startBg.setOrigin(0, 0);
     this.startBg.setPositionRelative(descriptionBg, 0, descriptionBg.height);
 
-    this.startText = addTextObject(0, 0, i18next.t("challenges:noneSelected"), TextStyle.SETTINGS_LABEL);
+    this.startText = globalScene.addTextObject(0, 0, i18next.t("challenges:noneSelected"), TextStyle.SETTINGS_LABEL);
     this.startText.setName("text-start");
     this.startText.setOrigin(0, 0);
     this.startText.setPositionRelative(this.startBg, (this.startBg.width - this.startText.displayWidth) / 2, 4);
@@ -160,7 +159,7 @@ export default class GameChallengesUiHandler extends UiHandler {
     this.challengeLabels = [];
 
     for (let i = 0; i < 9; i++) {
-      const label = addTextObject(8, 28 + i * 16, "", TextStyle.SETTINGS_LABEL);
+      const label = globalScene.addTextObject(8, 28 + i * 16, "", TextStyle.SETTINGS_LABEL);
       label.setName(`text-challenge-label-${i}`);
       label.setOrigin(0, 0);
 
@@ -180,7 +179,7 @@ export default class GameChallengesUiHandler extends UiHandler {
       rightArrow.setVisible(false);
       this.valuesContainer.add(rightArrow);
 
-      const value = addTextObject(0, 28 + i * 16, "", TextStyle.SETTINGS_LABEL);
+      const value = globalScene.addTextObject(0, 28 + i * 16, "", TextStyle.SETTINGS_LABEL);
       value.setName(`challenge-value-text-${i}`);
       value.setPositionRelative(label, 100, 0);
       this.valuesContainer.add(value);
@@ -242,7 +241,7 @@ export default class GameChallengesUiHandler extends UiHandler {
         this.challengeLabels[i].leftArrow.setVisible(true);
         this.challengeLabels[i].rightArrow.setVisible(true);
 
-        const tempText = addTextObject(0, 0, "", TextStyle.SETTINGS_LABEL); // this is added here to get the widest text object for this language, which will be used for the arrow placement
+        const tempText = globalScene.addTextObject(0, 0, "", TextStyle.SETTINGS_LABEL); // this is added here to get the widest text object for this language, which will be used for the arrow placement
 
         for (let j = 0; j <= globalScene.gameMode.challenges[i].maxValue; j++) {
           // this goes through each challenge's value to find out what the max width will be

--- a/src/ui/command-ui-handler.ts
+++ b/src/ui/command-ui-handler.ts
@@ -1,4 +1,4 @@
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import PartyUiHandler, { PartyUiMode } from "./party-ui-handler";
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
@@ -41,7 +41,12 @@ export default class CommandUiHandler extends UiHandler {
     ui.add(this.commandsContainer);
 
     for (let c = 0; c < commands.length; c++) {
-      const commandText = addTextObject(c % 2 === 0 ? 0 : 55.8, c < 2 ? 0 : 16, commands[c], TextStyle.WINDOW);
+      const commandText = globalScene.addTextObject(
+        c % 2 === 0 ? 0 : 55.8,
+        c < 2 ? 0 : 16,
+        commands[c],
+        TextStyle.WINDOW,
+      );
       commandText.setName(commands[c]);
       this.commandsContainer.add(commandText);
     }

--- a/src/ui/daily-run-scoreboard.ts
+++ b/src/ui/daily-run-scoreboard.ts
@@ -1,8 +1,8 @@
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
 import { getEnumKeys, executeIf } from "#app/utils";
-import { TextStyle, addTextObject } from "./text";
-import { WindowVariant, addWindow } from "./ui-theme";
+import { TextStyle } from "./text";
+import { WindowVariant } from "./ui-theme";
 import { api } from "#app/plugins/api/api";
 
 export interface RankingEntry {
@@ -60,10 +60,10 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
   }
 
   setup() {
-    const titleWindow = addWindow(0, 0, 114, 18, false, false, undefined, undefined, WindowVariant.THIN);
+    const titleWindow = globalScene.addWindow(0, 0, 114, 18, false, false, undefined, undefined, WindowVariant.THIN);
     this.add(titleWindow);
 
-    this.titleLabel = addTextObject(
+    this.titleLabel = globalScene.addTextObject(
       titleWindow.displayWidth / 2,
       titleWindow.displayHeight / 2,
       i18next.t("menu:loading"),
@@ -73,13 +73,18 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
     this.titleLabel.setOrigin(0.5, 0.5);
     this.add(this.titleLabel);
 
-    const window = addWindow(0, 17, 114, 118, false, false, undefined, undefined, WindowVariant.THIN);
+    const window = globalScene.addWindow(0, 17, 114, 118, false, false, undefined, undefined, WindowVariant.THIN);
     this.add(window);
 
     this.rankingsContainer = globalScene.add.container(6, 21);
     this.add(this.rankingsContainer);
 
-    this.loadingLabel = addTextObject(window.displayWidth / 2, window.displayHeight / 2 + 16, "", TextStyle.WINDOW);
+    this.loadingLabel = globalScene.addTextObject(
+      window.displayWidth / 2,
+      window.displayHeight / 2 + 16,
+      "",
+      TextStyle.WINDOW,
+    );
     this.loadingLabel.setOrigin(0.5, 0.5);
     this.loadingLabel.setVisible(false);
 
@@ -117,7 +122,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
       }
     });
 
-    this.pageNumberLabel = addTextObject(
+    this.pageNumberLabel = globalScene.addTextObject(
       window.displayWidth / 2,
       titleWindow.displayHeight + window.displayHeight - 16,
       "1",
@@ -153,18 +158,18 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
     const getEntry = (rank: string, username: string, score: string, wave: string) => {
       const entryContainer = globalScene.add.container(0, 0);
 
-      const rankLabel = addTextObject(0, 0, rank, TextStyle.WINDOW, { fontSize: "54px" });
+      const rankLabel = globalScene.addTextObject(0, 0, rank, TextStyle.WINDOW, { fontSize: "54px" });
       entryContainer.add(rankLabel);
 
-      const usernameLabel = addTextObject(12, 0, username, TextStyle.WINDOW, { fontSize: "54px" });
+      const usernameLabel = globalScene.addTextObject(12, 0, username, TextStyle.WINDOW, { fontSize: "54px" });
       entryContainer.add(usernameLabel);
 
-      const scoreLabel = addTextObject(84, 0, score, TextStyle.WINDOW, { fontSize: "54px" });
+      const scoreLabel = globalScene.addTextObject(84, 0, score, TextStyle.WINDOW, { fontSize: "54px" });
       entryContainer.add(scoreLabel);
 
       switch (this.category) {
         case ScoreboardCategory.DAILY:
-          const waveLabel = addTextObject(68, 0, wave, TextStyle.WINDOW, { fontSize: "54px" });
+          const waveLabel = globalScene.addTextObject(68, 0, wave, TextStyle.WINDOW, { fontSize: "54px" });
           entryContainer.add(waveLabel);
           break;
         case ScoreboardCategory.WEEKLY:

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
-import { addTextObject, TextStyle } from "./text";
-import { addWindow, WindowVariant } from "./ui-theme";
+import { TextStyle } from "./text";
+import { WindowVariant } from "./ui-theme";
 import i18next from "i18next";
 
 export enum DropDownState {
@@ -68,7 +68,7 @@ export class DropDownOption extends Phaser.GameObjects.Container {
     const currentLabel = this.labels[this.currentLabelIndex];
 
     this.state = currentLabel.state;
-    this.text = addTextObject(0, 0, currentLabel.text || "", TextStyle.TOOLTIP_CONTENT);
+    this.text = globalScene.addTextObject(0, 0, currentLabel.text || "", TextStyle.TOOLTIP_CONTENT);
     this.text.setOrigin(0, 0.5);
     this.add(this.text);
 
@@ -338,7 +338,7 @@ export class DropDown extends Phaser.GameObjects.Container {
       }
     });
 
-    this.window = addWindow(
+    this.window = globalScene.addWindow(
       0,
       0,
       optionWidth,

--- a/src/ui/egg-counter-container.ts
+++ b/src/ui/egg-counter-container.ts
@@ -1,6 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { addWindow } from "./ui-theme";
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import type { EggCountChangedEvent } from "#app/events/egg";
 import { EggEventType } from "#app/events/egg";
 import type EggHatchSceneHandler from "./egg-hatch-scene-handler";
@@ -38,7 +37,7 @@ export default class EggCounterContainer extends Phaser.GameObjects.Container {
   private setup(): void {
     const windowWidth = this.eggCount > 9 ? this.WINDOW_MEDIUM_WIDTH : this.WINDOW_DEFAULT_WIDTH;
 
-    this.eggCountWindow = addWindow(5, 5, windowWidth, this.WINDOW_HEIGHT);
+    this.eggCountWindow = globalScene.addWindow(5, 5, windowWidth, this.WINDOW_HEIGHT);
     this.setVisible(this.eggCount > 1);
 
     this.add(this.eggCountWindow);
@@ -46,7 +45,7 @@ export default class EggCounterContainer extends Phaser.GameObjects.Container {
     const eggSprite = globalScene.add.sprite(19, 18, "egg", "egg_0");
     eggSprite.setScale(0.32);
 
-    this.eggCountText = addTextObject(28, 13, `${this.eggCount}`, TextStyle.MESSAGE, { fontSize: "66px" });
+    this.eggCountText = globalScene.addTextObject(28, 13, `${this.eggCount}`, TextStyle.MESSAGE, { fontSize: "66px" });
     this.eggCountText.setName("text-egg-count");
 
     this.add(eggSprite);

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -1,12 +1,11 @@
 import { Mode } from "./ui";
-import { TextStyle, addTextObject, getEggTierTextTint, getTextStyleOptions } from "./text";
+import { TextStyle, getEggTierTextTint, getTextStyleOptions } from "./text";
 import MessageUiHandler from "./message-ui-handler";
 import { getEnumValues, getEnumKeys, fixedInt, randSeedShuffle } from "#app/utils";
 import type { IEggOptions } from "../data/egg";
 import { Egg, getLegendaryGachaSpeciesForTimestamp } from "../data/egg";
 import { VoucherType, getVoucherTypeIcon } from "../system/voucher";
 import { getPokemonSpecies } from "../data/pokemon-species";
-import { addWindow } from "./ui-theme";
 import { Tutorial, handleTutorial } from "../tutorial";
 import { Button } from "#enums/buttons";
 import Overrides from "#app/overrides";
@@ -123,7 +122,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
         legendaryLabelY = 0;
       }
 
-      const gachaUpLabel = addTextObject(gachaX, gachaY, i18next.t("egg:legendaryUPGacha"), gachaTextStyle);
+      const gachaUpLabel = globalScene.addTextObject(gachaX, gachaY, i18next.t("egg:legendaryUPGacha"), gachaTextStyle);
       gachaUpLabel.setOrigin(0, 0);
       gachaInfoContainer.add(gachaUpLabel);
 
@@ -206,7 +205,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
     this.eggGachaOptionsContainer = globalScene.add.container(globalScene.game.canvas.width / 6, 148);
     this.eggGachaContainer.add(this.eggGachaOptionsContainer);
 
-    this.eggGachaOptionSelectBg = addWindow(0, 0, 96, 16 + 576 * this.scale);
+    this.eggGachaOptionSelectBg = globalScene.addWindow(0, 0, 96, 16 + 576 * this.scale);
     this.eggGachaOptionSelectBg.setOrigin(1, 1);
     this.eggGachaOptionsContainer.add(this.eggGachaOptionSelectBg);
 
@@ -254,7 +253,12 @@ export default class EggGachaUiHandler extends MessageUiHandler {
       })
       .join("\n");
 
-    const optionText = addTextObject(0, 0, `${pullOptionsText}\n${i18next.t("menu:cancel")}`, TextStyle.WINDOW);
+    const optionText = globalScene.addTextObject(
+      0,
+      0,
+      `${pullOptionsText}\n${i18next.t("menu:cancel")}`,
+      TextStyle.WINDOW,
+    );
 
     optionText.setLineSpacing(28);
     optionText.setFontSize("80px");
@@ -275,11 +279,11 @@ export default class EggGachaUiHandler extends MessageUiHandler {
     new Array(getEnumKeys(VoucherType).length).fill(null).map((_, i) => {
       const container = globalScene.add.container(globalScene.game.canvas.width / 6 - 56 * i, 0);
 
-      const bg = addWindow(0, 0, 56, 22);
+      const bg = globalScene.addWindow(0, 0, 56, 22);
       bg.setOrigin(1, 0);
       container.add(bg);
 
-      const countLabel = addTextObject(-48, 3, "0", TextStyle.WINDOW);
+      const countLabel = globalScene.addTextObject(-48, 3, "0", TextStyle.WINDOW);
       countLabel.setOrigin(0, 0);
       container.add(countLabel);
 
@@ -307,13 +311,13 @@ export default class EggGachaUiHandler extends MessageUiHandler {
 
     const gachaMessageBoxContainer = globalScene.add.container(0, 148);
 
-    const gachaMessageBox = addWindow(0, 0, 320, 32);
+    const gachaMessageBox = globalScene.addWindow(0, 0, 320, 32);
     gachaMessageBox.setOrigin(0, 0);
     gachaMessageBoxContainer.add(gachaMessageBox);
 
     this.eggGachaMessageBox = gachaMessageBox;
 
-    const gachaMessageText = addTextObject(8, 8, "", TextStyle.WINDOW, { maxLines: 2 });
+    const gachaMessageText = globalScene.addTextObject(8, 8, "", TextStyle.WINDOW, { maxLines: 2 });
     gachaMessageText.setOrigin(0, 0);
     gachaMessageBoxContainer.add(gachaMessageText);
 
@@ -537,7 +541,9 @@ export default class EggGachaUiHandler extends MessageUiHandler {
           const eggSprite = globalScene.add.sprite(0, 0, "egg", `egg_${egg.getKey()}`);
           ret.add(eggSprite);
 
-          const eggText = addTextObject(0, 14, egg.getEggDescriptor(), TextStyle.PARTY, { align: "center" });
+          const eggText = globalScene.addTextObject(0, 14, egg.getEggDescriptor(), TextStyle.PARTY, {
+            align: "center",
+          });
           eggText.setOrigin(0.5, 0);
           eggText.setTint(getEggTierTextTint(!egg.isManaphyEgg() ? egg.tier : EggTier.EPIC));
           ret.add(eggText);

--- a/src/ui/egg-list-ui-handler.ts
+++ b/src/ui/egg-list-ui-handler.ts
@@ -1,8 +1,7 @@
 import { Mode } from "#app/ui/ui";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "#app/ui/pokemon-icon-anim-handler";
-import { TextStyle, addTextObject } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import MessageUiHandler from "#app/ui/message-ui-handler";
-import { addWindow } from "#app/ui/ui-theme";
 import { Button } from "#enums/buttons";
 import i18next from "i18next";
 import ScrollableGridUiHandler from "#app/ui/scrollable-grid-handler";
@@ -53,26 +52,26 @@ export default class EggListUiHandler extends MessageUiHandler {
     eggListBg.setOrigin(0, 0);
     this.eggListContainer.add(eggListBg);
 
-    this.eggListContainer.add(addWindow(1, 85, 106, 22));
-    this.eggListContainer.add(addWindow(1, 102, 106, 50, true));
-    this.eggListContainer.add(addWindow(1, 147, 106, 32, true));
-    this.eggListContainer.add(addWindow(107, 1, 212, 178));
+    this.eggListContainer.add(globalScene.addWindow(1, 85, 106, 22));
+    this.eggListContainer.add(globalScene.addWindow(1, 102, 106, 50, true));
+    this.eggListContainer.add(globalScene.addWindow(1, 147, 106, 32, true));
+    this.eggListContainer.add(globalScene.addWindow(107, 1, 212, 178));
 
     this.iconAnimHandler = new PokemonIconAnimHandler();
     this.iconAnimHandler.setup();
 
-    this.eggNameText = addTextObject(8, 68, "", TextStyle.SUMMARY);
+    this.eggNameText = globalScene.addTextObject(8, 68, "", TextStyle.SUMMARY);
     this.eggNameText.setOrigin(0, 0);
     this.eggListContainer.add(this.eggNameText);
 
-    this.eggDateText = addTextObject(8, 91, "", TextStyle.TOOLTIP_CONTENT);
+    this.eggDateText = globalScene.addTextObject(8, 91, "", TextStyle.TOOLTIP_CONTENT);
     this.eggListContainer.add(this.eggDateText);
 
-    this.eggHatchWavesText = addTextObject(8, 108, "", TextStyle.TOOLTIP_CONTENT);
+    this.eggHatchWavesText = globalScene.addTextObject(8, 108, "", TextStyle.TOOLTIP_CONTENT);
     this.eggHatchWavesText.setWordWrapWidth(540);
     this.eggListContainer.add(this.eggHatchWavesText);
 
-    this.eggGachaInfoText = addTextObject(8, 152, "", TextStyle.TOOLTIP_CONTENT);
+    this.eggGachaInfoText = globalScene.addTextObject(8, 152, "", TextStyle.TOOLTIP_CONTENT);
     this.eggGachaInfoText.setWordWrapWidth(540);
     this.eggListContainer.add(this.eggGachaInfoText);
 
@@ -98,11 +97,11 @@ export default class EggListUiHandler extends MessageUiHandler {
     this.eggListMessageBoxContainer.setVisible(false);
     this.eggListContainer.add(this.eggListMessageBoxContainer);
 
-    const eggListMessageBox = addWindow(1, -1, 318, 28);
+    const eggListMessageBox = globalScene.addWindow(1, -1, 318, 28);
     eggListMessageBox.setOrigin(0, 1);
     this.eggListMessageBoxContainer.add(eggListMessageBox);
 
-    this.message = addTextObject(8, -8, "", TextStyle.WINDOW, { maxLines: 1 });
+    this.message = globalScene.addTextObject(8, -8, "", TextStyle.WINDOW, { maxLines: 1 });
     this.message.setOrigin(0, 1);
     this.eggListMessageBoxContainer.add(this.message);
 

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -1,6 +1,6 @@
 import type { InfoToggle } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import { getTypeDamageMultiplierColor } from "#app/data/type";
 import { Type } from "#enums/type";
 import { Command } from "./command-ui-handler";
@@ -63,35 +63,65 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     this.moveCategoryIcon.setVisible(false);
     this.moveInfoContainer.add(this.moveCategoryIcon);
 
-    this.ppLabel = addTextObject(globalScene.scaledCanvas.width - 70, -26, "PP", TextStyle.MOVE_INFO_CONTENT);
+    this.ppLabel = globalScene.addTextObject(
+      globalScene.scaledCanvas.width - 70,
+      -26,
+      "PP",
+      TextStyle.MOVE_INFO_CONTENT,
+    );
     this.ppLabel.setOrigin(0.0, 0.5);
     this.ppLabel.setVisible(false);
     this.ppLabel.setText(i18next.t("fightUiHandler:pp"));
     this.moveInfoContainer.add(this.ppLabel);
 
-    this.ppText = addTextObject(globalScene.scaledCanvas.width - 12, -26, "--/--", TextStyle.MOVE_INFO_CONTENT);
+    this.ppText = globalScene.addTextObject(
+      globalScene.scaledCanvas.width - 12,
+      -26,
+      "--/--",
+      TextStyle.MOVE_INFO_CONTENT,
+    );
     this.ppText.setOrigin(1, 0.5);
     this.ppText.setVisible(false);
     this.moveInfoContainer.add(this.ppText);
 
-    this.powerLabel = addTextObject(globalScene.scaledCanvas.width - 70, -18, "POWER", TextStyle.MOVE_INFO_CONTENT);
+    this.powerLabel = globalScene.addTextObject(
+      globalScene.scaledCanvas.width - 70,
+      -18,
+      "POWER",
+      TextStyle.MOVE_INFO_CONTENT,
+    );
     this.powerLabel.setOrigin(0.0, 0.5);
     this.powerLabel.setVisible(false);
     this.powerLabel.setText(i18next.t("fightUiHandler:power"));
     this.moveInfoContainer.add(this.powerLabel);
 
-    this.powerText = addTextObject(globalScene.scaledCanvas.width - 12, -18, "---", TextStyle.MOVE_INFO_CONTENT);
+    this.powerText = globalScene.addTextObject(
+      globalScene.scaledCanvas.width - 12,
+      -18,
+      "---",
+      TextStyle.MOVE_INFO_CONTENT,
+    );
     this.powerText.setOrigin(1, 0.5);
     this.powerText.setVisible(false);
     this.moveInfoContainer.add(this.powerText);
 
-    this.accuracyLabel = addTextObject(globalScene.scaledCanvas.width - 70, -10, "ACC", TextStyle.MOVE_INFO_CONTENT);
+    this.accuracyLabel = globalScene.addTextObject(
+      globalScene.scaledCanvas.width - 70,
+      -10,
+      "ACC",
+      TextStyle.MOVE_INFO_CONTENT,
+    );
     this.accuracyLabel.setOrigin(0.0, 0.5);
     this.accuracyLabel.setVisible(false);
     this.accuracyLabel.setText(i18next.t("fightUiHandler:accuracy"));
     this.moveInfoContainer.add(this.accuracyLabel);
 
-    this.accuracyText = addTextObject(globalScene.scaledCanvas.width - 12, -10, "---", TextStyle.MOVE_INFO_CONTENT);
+    this.accuracyText = globalScene.addTextObject(
+      globalScene.scaledCanvas.width - 12,
+      -10,
+      "---",
+      TextStyle.MOVE_INFO_CONTENT,
+    );
     this.accuracyText.setOrigin(1, 0.5);
     this.accuracyText.setVisible(false);
     this.moveInfoContainer.add(this.accuracyText);
@@ -315,7 +345,12 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     const moveset = pokemon.getMoveset();
 
     for (let moveIndex = 0; moveIndex < 4; moveIndex++) {
-      const moveText = addTextObject(moveIndex % 2 === 0 ? 0 : 100, moveIndex < 2 ? 0 : 16, "-", TextStyle.WINDOW);
+      const moveText = globalScene.addTextObject(
+        moveIndex % 2 === 0 ? 0 : 100,
+        moveIndex < 2 ? 0 : 16,
+        "-",
+        TextStyle.WINDOW,
+      );
       moveText.setName("text-empty-move");
 
       if (moveIndex < moveset.length) {

--- a/src/ui/filter-bar.ts
+++ b/src/ui/filter-bar.ts
@@ -1,9 +1,9 @@
 import type { DropDown } from "./dropdown";
 import { DropDownType } from "./dropdown";
 import type { StarterContainer } from "./starter-container";
-import { addTextObject, getTextColor, TextStyle } from "./text";
+import { getTextColor, TextStyle } from "./text";
 import type { UiTheme } from "#enums/ui-theme";
-import { addWindow, WindowVariant } from "./ui-theme";
+import { WindowVariant } from "./ui-theme";
 import { globalScene } from "#app/global-scene";
 
 export enum DropDownColumn {
@@ -32,7 +32,7 @@ export class FilterBar extends Phaser.GameObjects.Container {
     this.width = width;
     this.height = height;
 
-    this.window = addWindow(0, 0, width, height, false, false, undefined, undefined, WindowVariant.THIN);
+    this.window = globalScene.addWindow(0, 0, width, height, false, false, undefined, undefined, WindowVariant.THIN);
     this.add(this.window);
 
     this.cursorObj = globalScene.add.image(1, 1, "cursor");
@@ -59,7 +59,7 @@ export class FilterBar extends Phaser.GameObjects.Container {
 
     this.columns.push(column);
 
-    const filterTypesLabel = addTextObject(0, 3, title, TextStyle.TOOLTIP_CONTENT);
+    const filterTypesLabel = globalScene.addTextObject(0, 3, title, TextStyle.TOOLTIP_CONTENT);
     this.labels.push(filterTypesLabel);
     this.add(filterTypesLabel);
     this.dropDowns.push(dropDown);

--- a/src/ui/form-change-scene-handler.ts
+++ b/src/ui/form-change-scene-handler.ts
@@ -1,5 +1,5 @@
 import MessageUiHandler from "./message-ui-handler";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import { Mode } from "./ui";
 import { Button } from "#enums/buttons";
 import { globalScene } from "#app/global-scene";
@@ -39,7 +39,7 @@ export default class FormChangeSceneHandler extends MessageUiHandler {
     this.messageContainer.setVisible(false);
     ui.add(this.messageContainer);
 
-    const message = addTextObject(0, 0, "", TextStyle.MESSAGE, {
+    const message = globalScene.addTextObject(0, 0, "", TextStyle.MESSAGE, {
       maxLines: 2,
       wordWrap: {
         width: 1780,

--- a/src/ui/form-modal-ui-handler.ts
+++ b/src/ui/form-modal-ui-handler.ts
@@ -1,8 +1,8 @@
 import type { ModalConfig } from "./modal-ui-handler";
 import { ModalUiHandler } from "./modal-ui-handler";
 import type { Mode } from "./ui";
-import { TextStyle, addTextInputObject, addTextObject } from "./text";
-import { WindowVariant, addWindow } from "./ui-theme";
+import { TextStyle, addTextInputObject } from "./text";
+import { WindowVariant } from "./ui-theme";
 import type InputText from "phaser3-rex-plugins/plugins/inputtext";
 import { fixedInt } from "#app/utils";
 import { Button } from "#enums/buttons";
@@ -66,7 +66,7 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
       this.updateFields(config, hasTitle);
     }
 
-    this.errorMessage = addTextObject(
+    this.errorMessage = globalScene.addTextObject(
       10,
       (hasTitle ? 31 : 5) + 20 * (config.length - 1) + 16 + this.getButtonTopMargin(),
       "",
@@ -83,7 +83,12 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
     this.inputs = [];
     this.formLabels = [];
     fieldsConfig.forEach((config, f) => {
-      const label = addTextObject(10, (hasTitle ? 31 : 5) + 20 * f, config.label, TextStyle.TOOLTIP_CONTENT);
+      const label = globalScene.addTextObject(
+        10,
+        (hasTitle ? 31 : 5) + 20 * f,
+        config.label,
+        TextStyle.TOOLTIP_CONTENT,
+      );
       label.name = "formLabel" + f;
 
       this.formLabels.push(label);
@@ -92,7 +97,7 @@ export abstract class FormModalUiHandler extends ModalUiHandler {
       const inputContainer = globalScene.add.container(70, (hasTitle ? 28 : 2) + 20 * f);
       inputContainer.setVisible(false);
 
-      const inputBg = addWindow(0, 0, 80, 16, false, false, 0, 0, WindowVariant.XTHIN);
+      const inputBg = globalScene.addWindow(0, 0, 80, 16, false, false, 0, 0, WindowVariant.XTHIN);
 
       const isPassword = config?.isPassword;
       const isReadOnly = config?.isReadOnly;

--- a/src/ui/game-stats-ui-handler.ts
+++ b/src/ui/game-stats-ui-handler.ts
@@ -1,8 +1,7 @@
 import Phaser from "phaser";
-import { TextStyle, addTextObject } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import type { Mode } from "#app/ui/ui";
 import UiHandler from "#app/ui/ui-handler";
-import { addWindow } from "#app/ui/ui-theme";
 import { getPlayTimeString, formatFancyLargeNumber, toReadableString } from "#app/utils";
 import type { GameData } from "#app/system/game-data";
 import { DexAttr } from "#app/data/dex-attributes";
@@ -240,10 +239,10 @@ export default class GameStatsUiHandler extends UiHandler {
       Phaser.Geom.Rectangle.Contains,
     );
 
-    const headerBg = addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
+    const headerBg = globalScene.addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
     headerBg.setOrigin(0, 0);
 
-    const headerText = addTextObject(0, 0, i18next.t("gameStatsUiHandler:stats"), TextStyle.SETTINGS_LABEL);
+    const headerText = globalScene.addTextObject(0, 0, i18next.t("gameStatsUiHandler:stats"), TextStyle.SETTINGS_LABEL);
     headerText.setOrigin(0, 0);
     headerText.setPositionRelative(headerBg, 8, 4);
 
@@ -251,7 +250,7 @@ export default class GameStatsUiHandler extends UiHandler {
     const [statsBgLeft, statsBgRight] = new Array(2).fill(null).map((_, i) => {
       const width = statsBgWidth + 2;
       const height = Math.floor(globalScene.game.canvas.height / 6 - headerBg.height - 2);
-      const statsBg = addWindow(
+      const statsBg = globalScene.addWindow(
         (statsBgWidth - 2) * i,
         headerBg.height,
         width,
@@ -268,7 +267,7 @@ export default class GameStatsUiHandler extends UiHandler {
     this.statsContainer = globalScene.add.container(0, 0);
 
     new Array(18).fill(null).map((_, s) => {
-      const statLabel = addTextObject(
+      const statLabel = globalScene.addTextObject(
         8 + (s % 2 === 1 ? statsBgWidth : 0),
         28 + Math.floor(s / 2) * 16,
         "",
@@ -278,7 +277,12 @@ export default class GameStatsUiHandler extends UiHandler {
       this.statsContainer.add(statLabel);
       this.statLabels.push(statLabel);
 
-      const statValue = addTextObject(statsBgWidth * ((s % 2) + 1) - 8, statLabel.y, "", TextStyle.STATS_VALUE);
+      const statValue = globalScene.addTextObject(
+        statsBgWidth * ((s % 2) + 1) - 8,
+        statLabel.y,
+        "",
+        TextStyle.STATS_VALUE,
+      );
       statValue.setOrigin(1, 0);
       this.statsContainer.add(statValue);
       this.statValues.push(statValue);

--- a/src/ui/loading-modal-ui-handler.ts
+++ b/src/ui/loading-modal-ui-handler.ts
@@ -1,6 +1,7 @@
 import i18next from "i18next";
 import { ModalUiHandler } from "./modal-ui-handler";
-import { addTextObject, TextStyle } from "./text";
+import { globalScene } from "#app/global-scene";
+import { TextStyle } from "./text";
 import type { Mode } from "./ui";
 
 export default class LoadingModalUiHandler extends ModalUiHandler {
@@ -31,7 +32,12 @@ export default class LoadingModalUiHandler extends ModalUiHandler {
   override setup(): void {
     super.setup();
 
-    const label = addTextObject(this.getWidth() / 2, this.getHeight() / 2, i18next.t("menu:loading"), TextStyle.WINDOW);
+    const label = globalScene.addTextObject(
+      this.getWidth() / 2,
+      this.getHeight() / 2,
+      i18next.t("menu:loading"),
+      TextStyle.WINDOW,
+    );
     label.setOrigin(0.5, 0.5);
 
     this.modalContainer.add(label);

--- a/src/ui/login-form-ui-handler.ts
+++ b/src/ui/login-form-ui-handler.ts
@@ -4,8 +4,7 @@ import type { ModalConfig } from "./modal-ui-handler";
 import { fixedInt } from "#app/utils";
 import { Mode } from "./ui";
 import i18next from "i18next";
-import { addTextObject, TextStyle } from "./text";
-import { addWindow } from "./ui-theme";
+import { TextStyle } from "./text";
 import type { OptionSelectItem } from "#app/ui/abstact-option-select-ui-handler";
 import { api } from "#app/plugins/api/api";
 import { globalScene } from "#app/global-scene";
@@ -68,9 +67,9 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
       new Phaser.Geom.Rectangle(0, 0, globalScene.game.canvas.width / 12, globalScene.game.canvas.height / 12),
       Phaser.Geom.Rectangle.Contains,
     );
-    this.externalPartyTitle = addTextObject(0, 4, "", TextStyle.SETTINGS_LABEL);
+    this.externalPartyTitle = globalScene.addTextObject(0, 4, "", TextStyle.SETTINGS_LABEL);
     this.externalPartyTitle.setOrigin(0.5, 0);
-    this.externalPartyBg = addWindow(0, 0, 0, 0);
+    this.externalPartyBg = globalScene.addWindow(0, 0, 0, 0);
     this.externalPartyContainer.add(this.externalPartyBg);
     this.externalPartyContainer.add(this.externalPartyTitle);
 

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -14,9 +14,9 @@ import type { OptionSelectConfig, OptionSelectItem } from "./abstact-option-sele
 import { AdminMode, getAdminModeName } from "./admin-ui-handler";
 import type AwaitableUiHandler from "./awaitable-ui-handler";
 import MessageUiHandler from "./message-ui-handler";
-import { TextStyle, addTextObject, getTextStyleOptions } from "./text";
+import { TextStyle, getTextStyleOptions } from "./text";
 import { Mode } from "./ui";
-import { WindowVariant, addWindow } from "./ui-theme";
+import { WindowVariant } from "./ui-theme";
 
 enum MenuOptions {
   GAME_SETTINGS,
@@ -128,7 +128,7 @@ export default class MenuUiHandler extends MessageUiHandler {
         return !this.excludedMenus().some((exclusion) => exclusion.condition && exclusion.options.includes(m));
       });
 
-    this.optionSelectText = addTextObject(
+    this.optionSelectText = globalScene.addTextObject(
       0,
       0,
       this.menuOptions.map((o) => `${i18next.t(`menuUiHandler:${MenuOptions[o]}`)}`).join("\n"),
@@ -138,7 +138,7 @@ export default class MenuUiHandler extends MessageUiHandler {
     this.optionSelectText.setLineSpacing(12);
 
     this.scale = getTextStyleOptions(TextStyle.WINDOW, globalScene.uiTheme).scale;
-    this.menuBg = addWindow(
+    this.menuBg = globalScene.addWindow(
       globalScene.game.canvas.width / 6 - (this.optionSelectText.displayWidth + 25),
       0,
       this.optionSelectText.displayWidth + 19 + 24 * this.scale,
@@ -159,12 +159,12 @@ export default class MenuUiHandler extends MessageUiHandler {
     this.menuMessageBoxContainer.setVisible(false);
 
     // Window for general messages
-    this.menuMessageBox = addWindow(0, 0, this.defaultMessageBoxWidth, 48);
+    this.menuMessageBox = globalScene.addWindow(0, 0, this.defaultMessageBoxWidth, 48);
     this.menuMessageBox.setOrigin(0, 0);
     this.menuMessageBoxContainer.add(this.menuMessageBox);
 
     // Full-width window used for testing dialog messages in debug mode
-    this.dialogueMessageBox = addWindow(
+    this.dialogueMessageBox = globalScene.addWindow(
       -this.textPadding,
       0,
       globalScene.game.canvas.width / 6 + this.textPadding * 2,
@@ -178,7 +178,9 @@ export default class MenuUiHandler extends MessageUiHandler {
     this.dialogueMessageBox.setOrigin(0, 0);
     this.menuMessageBoxContainer.add(this.dialogueMessageBox);
 
-    const menuMessageText = addTextObject(this.textPadding, this.textPadding, "", TextStyle.WINDOW, { maxLines: 2 });
+    const menuMessageText = globalScene.addTextObject(this.textPadding, this.textPadding, "", TextStyle.WINDOW, {
+      maxLines: 2,
+    });
     menuMessageText.setName("menu-message");
     menuMessageText.setOrigin(0, 0);
     this.menuMessageBoxContainer.add(menuMessageText);

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -1,7 +1,7 @@
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import type { Mode } from "./ui";
 import UiHandler from "./ui-handler";
-import { WindowVariant, addWindow } from "./ui-theme";
+import { WindowVariant } from "./ui-theme";
 import type { Button } from "#enums/buttons";
 import { globalScene } from "#app/global-scene";
 
@@ -49,11 +49,11 @@ export abstract class ModalUiHandler extends UiHandler {
       Phaser.Geom.Rectangle.Contains,
     );
 
-    this.modalBg = addWindow(0, 0, 0, 0);
+    this.modalBg = globalScene.addWindow(0, 0, 0, 0);
 
     this.modalContainer.add(this.modalBg);
 
-    this.titleText = addTextObject(0, 4, "", TextStyle.SETTINGS_LABEL);
+    this.titleText = globalScene.addTextObject(0, 4, "", TextStyle.SETTINGS_LABEL);
     this.titleText.setOrigin(0.5, 0);
 
     this.modalContainer.add(this.titleText);
@@ -71,10 +71,20 @@ export abstract class ModalUiHandler extends UiHandler {
 
   private addButton(label: string) {
     const buttonTopMargin = this.getButtonTopMargin();
-    const buttonLabel = addTextObject(0, 8, label, TextStyle.TOOLTIP_CONTENT);
+    const buttonLabel = globalScene.addTextObject(0, 8, label, TextStyle.TOOLTIP_CONTENT);
     buttonLabel.setOrigin(0.5, 0.5);
 
-    const buttonBg = addWindow(0, 0, buttonLabel.getBounds().width + 8, 16, false, false, 0, 0, WindowVariant.THIN);
+    const buttonBg = globalScene.addWindow(
+      0,
+      0,
+      buttonLabel.getBounds().width + 8,
+      16,
+      false,
+      false,
+      0,
+      0,
+      WindowVariant.THIN,
+    );
     buttonBg.setOrigin(0.5, 0);
     buttonBg.setInteractive(
       new Phaser.Geom.Rectangle(0, 0, buttonBg.width, buttonBg.height),

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import type { ModifierTypeOption } from "../modifier/modifier-type";
 import { getPlayerShopModifierTypeOptionsForWave, TmModifierType } from "../modifier/modifier-type";
 import { getPokeballAtlasKey } from "#app/data/pokeball";
-import { addTextObject, getTextStyleOptions, getModifierTierTextTint, getTextColor, TextStyle } from "./text";
+import { getTextStyleOptions, getModifierTierTextTint, getTextColor, TextStyle } from "./text";
 import AwaitableUiHandler from "./awaitable-ui-handler";
 import { Mode } from "./ui";
 import { LockModifierTiersModifier, PokemonHeldItemModifier, HealShopCostModifier } from "../modifier/modifier";
@@ -81,7 +81,12 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.transferButtonContainer.setVisible(false);
     ui.add(this.transferButtonContainer);
 
-    const transferButtonText = addTextObject(-4, -2, i18next.t("modifierSelectUiHandler:transfer"), TextStyle.PARTY);
+    const transferButtonText = globalScene.addTextObject(
+      -4,
+      -2,
+      i18next.t("modifierSelectUiHandler:transfer"),
+      TextStyle.PARTY,
+    );
     transferButtonText.setName("text-transfer-btn");
     transferButtonText.setOrigin(1, 0);
     this.transferButtonContainer.add(transferButtonText);
@@ -94,7 +99,12 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.checkButtonContainer.setVisible(false);
     ui.add(this.checkButtonContainer);
 
-    const checkButtonText = addTextObject(-4, -2, i18next.t("modifierSelectUiHandler:checkTeam"), TextStyle.PARTY);
+    const checkButtonText = globalScene.addTextObject(
+      -4,
+      -2,
+      i18next.t("modifierSelectUiHandler:checkTeam"),
+      TextStyle.PARTY,
+    );
     checkButtonText.setName("text-use-btn");
     checkButtonText.setOrigin(1, 0);
     this.checkButtonContainer.add(checkButtonText);
@@ -104,12 +114,17 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.rerollButtonContainer.setVisible(false);
     ui.add(this.rerollButtonContainer);
 
-    const rerollButtonText = addTextObject(-4, -2, i18next.t("modifierSelectUiHandler:reroll"), TextStyle.PARTY);
+    const rerollButtonText = globalScene.addTextObject(
+      -4,
+      -2,
+      i18next.t("modifierSelectUiHandler:reroll"),
+      TextStyle.PARTY,
+    );
     rerollButtonText.setName("text-reroll-btn");
     rerollButtonText.setOrigin(0, 0);
     this.rerollButtonContainer.add(rerollButtonText);
 
-    this.rerollCostText = addTextObject(0, 0, "", TextStyle.MONEY);
+    this.rerollCostText = globalScene.addTextObject(0, 0, "", TextStyle.MONEY);
     this.rerollCostText.setName("text-reroll-cost");
     this.rerollCostText.setOrigin(0, 0);
     this.rerollCostText.setPositionRelative(rerollButtonText, rerollButtonText.displayWidth + 5, 1);
@@ -119,7 +134,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     this.lockRarityButtonContainer.setVisible(false);
     ui.add(this.lockRarityButtonContainer);
 
-    this.lockRarityButtonText = addTextObject(
+    this.lockRarityButtonText = globalScene.addTextObject(
       -4,
       -2,
       i18next.t("modifierSelectUiHandler:lockRarities"),
@@ -136,7 +151,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
     ui.add(this.continueButtonContainer);
 
     // Create continue button
-    const continueButtonText = addTextObject(
+    const continueButtonText = globalScene.addTextObject(
       -24,
       5,
       i18next.t("modifierSelectUiHandler:continueNextWaveButton"),
@@ -755,7 +770,9 @@ class ModifierOption extends Phaser.GameObjects.Container {
       this.itemContainer.add(this.itemTint);
     }
 
-    this.itemText = addTextObject(0, 35, this.modifierTypeOption.type?.name!, TextStyle.PARTY, { align: "center" }); // TODO: is this bang correct?
+    this.itemText = globalScene.addTextObject(0, 35, this.modifierTypeOption.type?.name!, TextStyle.PARTY, {
+      align: "center",
+    }); // TODO: is this bang correct?
     this.itemText.setOrigin(0.5, 0);
     this.itemText.setAlpha(0);
     this.itemText.setTint(
@@ -764,7 +781,7 @@ class ModifierOption extends Phaser.GameObjects.Container {
     this.add(this.itemText);
 
     if (this.modifierTypeOption.cost) {
-      this.itemCostText = addTextObject(0, 45, "", TextStyle.MONEY, { align: "center" });
+      this.itemCostText = globalScene.addTextObject(0, 45, "", TextStyle.MONEY, { align: "center" });
 
       this.itemCostText.setOrigin(0.5, 0);
       this.itemCostText.setAlpha(0);

--- a/src/ui/move-info-overlay.ts
+++ b/src/ui/move-info-overlay.ts
@@ -1,7 +1,6 @@
 import type { InfoToggle } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
-import { TextStyle, addTextObject } from "./text";
-import { addWindow } from "./ui-theme";
+import { TextStyle } from "./text";
 import { getLocalizedSpriteKey, fixedInt } from "#app/utils";
 import type { Move } from "../data/move";
 import { MoveCategory } from "#app/enums/move-category";
@@ -59,7 +58,7 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
 
     // prepare the description box
     const width = (options?.width || MoveInfoOverlay.getWidth(scale)) / scale; // divide by scale as we always want this to be half a window wide
-    this.descBg = addWindow(
+    this.descBg = globalScene.addWindow(
       options?.onSide && !options?.right ? EFF_WIDTH : 0,
       options?.top ? EFF_HEIGHT : 0,
       width - (options?.onSide ? EFF_WIDTH : 0),
@@ -69,7 +68,7 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
     this.add(this.descBg);
 
     // set up the description; wordWrap uses true pixels, unaffected by any scaling, while other values are affected
-    this.desc = addTextObject(
+    this.desc = globalScene.addTextObject(
       (options?.onSide && !options?.right ? EFF_WIDTH : 0) + BORDER,
       (options?.top ? EFF_HEIGHT : 0) + BORDER - 2,
       "",
@@ -112,7 +111,7 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
     );
     this.add(this.val);
 
-    const valuesBg = addWindow(0, 0, EFF_WIDTH, EFF_HEIGHT);
+    const valuesBg = globalScene.addWindow(0, 0, EFF_WIDTH, EFF_HEIGHT);
     valuesBg.setOrigin(0, 0);
     this.val.add(valuesBg);
 
@@ -123,30 +122,30 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
     this.cat = globalScene.add.sprite(57, EFF_HEIGHT - 35, "categories", "physical");
     this.val.add(this.cat);
 
-    const ppTxt = addTextObject(12, EFF_HEIGHT - 25, "PP", TextStyle.MOVE_INFO_CONTENT);
+    const ppTxt = globalScene.addTextObject(12, EFF_HEIGHT - 25, "PP", TextStyle.MOVE_INFO_CONTENT);
     ppTxt.setOrigin(0.0, 0.5);
     ppTxt.setText(i18next.t("fightUiHandler:pp"));
     this.val.add(ppTxt);
 
-    this.pp = addTextObject(70, EFF_HEIGHT - 25, "--", TextStyle.MOVE_INFO_CONTENT);
+    this.pp = globalScene.addTextObject(70, EFF_HEIGHT - 25, "--", TextStyle.MOVE_INFO_CONTENT);
     this.pp.setOrigin(1, 0.5);
     this.val.add(this.pp);
 
-    const powTxt = addTextObject(12, EFF_HEIGHT - 17, "POWER", TextStyle.MOVE_INFO_CONTENT);
+    const powTxt = globalScene.addTextObject(12, EFF_HEIGHT - 17, "POWER", TextStyle.MOVE_INFO_CONTENT);
     powTxt.setOrigin(0.0, 0.5);
     powTxt.setText(i18next.t("fightUiHandler:power"));
     this.val.add(powTxt);
 
-    this.pow = addTextObject(70, EFF_HEIGHT - 17, "---", TextStyle.MOVE_INFO_CONTENT);
+    this.pow = globalScene.addTextObject(70, EFF_HEIGHT - 17, "---", TextStyle.MOVE_INFO_CONTENT);
     this.pow.setOrigin(1, 0.5);
     this.val.add(this.pow);
 
-    const accTxt = addTextObject(12, EFF_HEIGHT - 9, "ACC", TextStyle.MOVE_INFO_CONTENT);
+    const accTxt = globalScene.addTextObject(12, EFF_HEIGHT - 9, "ACC", TextStyle.MOVE_INFO_CONTENT);
     accTxt.setOrigin(0.0, 0.5);
     accTxt.setText(i18next.t("fightUiHandler:accuracy"));
     this.val.add(accTxt);
 
-    this.acc = addTextObject(70, EFF_HEIGHT - 9, "---", TextStyle.MOVE_INFO_CONTENT);
+    this.acc = globalScene.addTextObject(70, EFF_HEIGHT - 9, "---", TextStyle.MOVE_INFO_CONTENT);
     this.acc.setOrigin(1, 0.5);
     this.val.add(this.acc);
 

--- a/src/ui/mystery-encounter-ui-handler.ts
+++ b/src/ui/mystery-encounter-ui-handler.ts
@@ -2,7 +2,7 @@ import { addBBCodeTextObject, getBBCodeFrag, TextStyle } from "./text";
 import { Mode } from "./ui";
 import UiHandler from "./ui-handler";
 import { Button } from "#enums/buttons";
-import { addWindow, WindowVariant } from "./ui-theme";
+import { WindowVariant } from "./ui-theme";
 import type { MysteryEncounterPhase } from "../phases/mystery-encounter-phases";
 import { PartyUiMode } from "./party-ui-handler";
 import type MysteryEncounterOption from "#app/data/mystery-encounters/mystery-encounter-option";
@@ -71,13 +71,13 @@ export default class MysteryEncounterUiHandler extends UiHandler {
 
     this.setCursor(this.getCursor());
 
-    this.descriptionWindow = addWindow(0, 0, 150, 105, false, false, 0, 0, WindowVariant.THIN);
+    this.descriptionWindow = globalScene.addWindow(0, 0, 150, 105, false, false, 0, 0, WindowVariant.THIN);
     this.descriptionContainer.add(this.descriptionWindow);
 
-    this.tooltipWindow = addWindow(0, 0, 110, 48, false, false, 0, 0, WindowVariant.THIN);
+    this.tooltipWindow = globalScene.addWindow(0, 0, 110, 48, false, false, 0, 0, WindowVariant.THIN);
     this.tooltipContainer.add(this.tooltipWindow);
 
-    this.dexProgressWindow = addWindow(0, 0, 24, 28, false, false, 0, 0, WindowVariant.THIN);
+    this.dexProgressWindow = globalScene.addWindow(0, 0, 24, 28, false, false, 0, 0, WindowVariant.THIN);
     this.dexProgressContainer.add(this.dexProgressWindow);
 
     this.rarityBall = globalScene.add.sprite(141, 9, "pb");

--- a/src/ui/party-exp-bar.ts
+++ b/src/ui/party-exp-bar.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import type { Pokemon } from "../field/pokemon";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 
 export default class PartyExpBar extends Phaser.GameObjects.Container {
   private bg: Phaser.GameObjects.NineSlice;
@@ -21,7 +21,7 @@ export default class PartyExpBar extends Phaser.GameObjects.Container {
 
     this.add(this.bg);
 
-    this.expText = addTextObject(22, 4, "", TextStyle.BATTLE_INFO);
+    this.expText = globalScene.addTextObject(22, 4, "", TextStyle.BATTLE_INFO);
     this.expText.setOrigin(0, 0);
     this.add(this.expText);
 

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -1,7 +1,7 @@
 import type { PlayerPokemon, PokemonMove } from "#app/field/pokemon";
 import type { Pokemon } from "#app/field/pokemon";
 import { MoveResult } from "#app/field/pokemon";
-import { addBBCodeTextObject, addTextObject, getTextColor, TextStyle } from "#app/ui/text";
+import { addBBCodeTextObject, getTextColor, TextStyle } from "#app/ui/text";
 import { Command } from "#app/ui/command-ui-handler";
 import MessageUiHandler from "#app/ui/message-ui-handler";
 import { Mode } from "#app/ui/ui";
@@ -16,7 +16,6 @@ import { getGenderColor, getGenderShadowColor, getGenderSymbol } from "#app/data
 import { StatusEffect } from "#enums/status-effect";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "#app/ui/pokemon-icon-anim-handler";
 import { pokemonEvolutions } from "#app/data/balance/pokemon-evolutions";
-import { addWindow } from "#app/ui/ui-theme";
 import { SpeciesFormChangeItemTrigger, FormChangeItem } from "#app/data/pokemon-forms";
 import { getVariantTint } from "#app/data/variant";
 import { Button } from "#enums/buttons";
@@ -280,14 +279,14 @@ export default class PartyUiHandler extends MessageUiHandler {
     partyMessageBoxContainer.setName("party-msg-box");
     partyContainer.add(partyMessageBoxContainer);
 
-    const partyMessageBox = addWindow(1, 31, 262, 30);
+    const partyMessageBox = globalScene.addWindow(1, 31, 262, 30);
     partyMessageBox.setName("window-party-msg-box");
     partyMessageBox.setOrigin(0, 1);
     partyMessageBoxContainer.add(partyMessageBox);
 
     this.partyMessageBox = partyMessageBox;
 
-    const partyMessageText = addTextObject(10, 8, defaultMessage, TextStyle.WINDOW, { maxLines: 2 });
+    const partyMessageText = globalScene.addTextObject(10, 8, defaultMessage, TextStyle.WINDOW, { maxLines: 2 });
     partyMessageText.setName("text-party-msg");
 
     partyMessageText.setOrigin(0, 0);
@@ -1119,7 +1118,7 @@ export default class PartyUiHandler extends MessageUiHandler {
 
     this.options.push(PartyOption.CANCEL);
 
-    this.optionsBg = addWindow(0, 0, 0, 16 * this.options.length + 13);
+    this.optionsBg = globalScene.addWindow(0, 0, 0, 16 * this.options.length + 13);
     this.optionsBg.setOrigin(1, 1);
 
     this.optionsContainer.add(this.optionsBg);
@@ -1444,7 +1443,7 @@ class PartySlot extends Phaser.GameObjects.Container {
     let displayName = this.pokemon.getNameToRender();
     let nameTextWidth: number;
 
-    const nameSizeTest = addTextObject(0, 0, displayName, TextStyle.PARTY);
+    const nameSizeTest = globalScene.addTextObject(0, 0, displayName, TextStyle.PARTY);
     nameTextWidth = nameSizeTest.displayWidth;
 
     while (nameTextWidth > (this.slotIndex >= battlerCount ? 52 : 76 - (this.pokemon.fusionSpecies ? 8 : 0))) {
@@ -1455,7 +1454,7 @@ class PartySlot extends Phaser.GameObjects.Container {
 
     nameSizeTest.destroy();
 
-    this.slotName = addTextObject(0, 0, displayName, TextStyle.PARTY);
+    this.slotName = globalScene.addTextObject(0, 0, displayName, TextStyle.PARTY);
     this.slotName.setPositionRelative(
       slotBg,
       this.slotIndex >= battlerCount ? 21 : 24,
@@ -1467,7 +1466,7 @@ class PartySlot extends Phaser.GameObjects.Container {
     slotLevelLabel.setPositionRelative(this.slotName, 8, 12);
     slotLevelLabel.setOrigin(0, 0);
 
-    const slotLevelText = addTextObject(
+    const slotLevelText = globalScene.addTextObject(
       0,
       0,
       this.pokemon.level.toString(),
@@ -1481,7 +1480,7 @@ class PartySlot extends Phaser.GameObjects.Container {
     const genderSymbol = getGenderSymbol(this.pokemon.getGender(true));
 
     if (genderSymbol) {
-      const slotGenderText = addTextObject(0, 0, genderSymbol, TextStyle.PARTY);
+      const slotGenderText = globalScene.addTextObject(0, 0, genderSymbol, TextStyle.PARTY);
       slotGenderText.setColor(getGenderColor(this.pokemon.getGender(true)));
       slotGenderText.setShadowColor(getGenderShadowColor(this.pokemon.getGender(true)));
       if (this.slotIndex >= battlerCount) {
@@ -1558,12 +1557,12 @@ class PartySlot extends Phaser.GameObjects.Container {
     this.slotHpOverlay.setScale(hpRatio, 1);
     this.slotHpOverlay.setVisible(false);
 
-    this.slotHpText = addTextObject(0, 0, `${this.pokemon.hp}/${this.pokemon.getMaxHp()}`, TextStyle.PARTY);
+    this.slotHpText = globalScene.addTextObject(0, 0, `${this.pokemon.hp}/${this.pokemon.getMaxHp()}`, TextStyle.PARTY);
     this.slotHpText.setPositionRelative(this.slotHpBar, this.slotHpBar.width - 3, this.slotHpBar.height - 2);
     this.slotHpText.setOrigin(1, 0);
     this.slotHpText.setVisible(false);
 
-    this.slotDescriptionLabel = addTextObject(0, 0, "", TextStyle.MESSAGE);
+    this.slotDescriptionLabel = globalScene.addTextObject(0, 0, "", TextStyle.MESSAGE);
     this.slotDescriptionLabel.setPositionRelative(
       slotBg,
       this.slotIndex >= battlerCount ? 94 : 32,
@@ -1663,7 +1662,7 @@ class PartyCancelButton extends Phaser.GameObjects.Container {
 
     this.partyCancelPb = partyCancelPb;
 
-    const partyCancelText = addTextObject(-8, -7, i18next.t("partyUiHandler:cancel"), TextStyle.PARTY);
+    const partyCancelText = globalScene.addTextObject(-8, -7, i18next.t("partyUiHandler:cancel"), TextStyle.PARTY);
     this.add(partyCancelText);
   }
 

--- a/src/ui/pokemon-hatch-info-container.ts
+++ b/src/ui/pokemon-hatch-info-container.ts
@@ -2,7 +2,7 @@ import PokemonInfoContainer from "#app/ui/pokemon-info-container";
 import { Gender } from "#enums/gender";
 import { Type } from "#enums/type";
 import { rgbHexToRgba, padInt } from "#app/utils";
-import { TextStyle, addTextObject } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { allMoves } from "#app/data/all-moves";
 import { Species } from "#enums/species";
@@ -49,11 +49,11 @@ export default class PokemonHatchInfoContainer extends PokemonInfoContainer {
     this.pokemonListContainer.add(this.currentPokemonSprite);
 
     // setup name and number
-    this.pokemonNumberText = addTextObject(80, 107.5, "0000", TextStyle.SUMMARY, { fontSize: 74 });
+    this.pokemonNumberText = globalScene.addTextObject(80, 107.5, "0000", TextStyle.SUMMARY, { fontSize: 74 });
     this.pokemonNumberText.setOrigin(0, 0);
     this.pokemonListContainer.add(this.pokemonNumberText);
 
-    this.pokemonNameText = addTextObject(7, 107.5, "", TextStyle.SUMMARY, { fontSize: 74 });
+    this.pokemonNameText = globalScene.addTextObject(7, 107.5, "", TextStyle.SUMMARY, { fontSize: 74 });
     this.pokemonNameText.setOrigin(0, 0);
     this.pokemonListContainer.add(this.pokemonNameText);
 
@@ -73,7 +73,7 @@ export default class PokemonHatchInfoContainer extends PokemonInfoContainer {
     this.pokemonCandyOverlayIcon.setOrigin(0, 0);
     this.pokemonListContainer.add(this.pokemonCandyOverlayIcon);
 
-    this.pokemonCandyCountText = addTextObject(14, 40, "x0", TextStyle.SUMMARY, { fontSize: "56px" });
+    this.pokemonCandyCountText = globalScene.addTextObject(14, 40, "x0", TextStyle.SUMMARY, { fontSize: "56px" });
     this.pokemonCandyCountText.setOrigin(0, 0);
     this.pokemonListContainer.add(this.pokemonCandyCountText);
 
@@ -91,7 +91,7 @@ export default class PokemonHatchInfoContainer extends PokemonInfoContainer {
       const eggMoveBg = globalScene.add.nineslice(70, 0, "type_bgs", "unknown", 92, 14, 2, 2, 2, 2);
       eggMoveBg.setOrigin(1, 0);
 
-      const eggMoveLabel = addTextObject(70 - eggMoveBg.width / 2, 0, "???", TextStyle.PARTY);
+      const eggMoveLabel = globalScene.addTextObject(70 - eggMoveBg.width / 2, 0, "???", TextStyle.PARTY);
       eggMoveLabel.setOrigin(0.5, 0);
 
       this.pokemonEggMoveBgs.push(eggMoveBg);

--- a/src/ui/pokemon-info-container.ts
+++ b/src/ui/pokemon-info-container.ts
@@ -13,8 +13,7 @@ import type { StarterDataEntry } from "#app/@types/StarterData";
 import { capitalizeString, fixedInt } from "#app/utils";
 import ConfirmUiHandler from "./confirm-ui-handler";
 import { StatsContainer } from "./stats-container";
-import { TextStyle, addBBCodeTextObject, addTextObject, getTextColor } from "./text";
-import { addWindow } from "./ui-theme";
+import { TextStyle, addBBCodeTextObject, getTextColor } from "./text";
 import { Species } from "#enums/species";
 
 interface LanguageSetting {
@@ -70,7 +69,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     const currentLanguage = i18next.resolvedLanguage!; // TODO: is this bang correct?
     const langSettingKey = Object.keys(languageSettings).find((lang) => currentLanguage?.includes(lang))!; // TODO: is this bang correct?
     const textSettings = languageSettings[langSettingKey];
-    this.infoBg = addWindow(0, 0, this.infoWindowWidth, 132);
+    this.infoBg = globalScene.addWindow(0, 0, this.infoWindowWidth, 132);
     this.infoBg.setOrigin(0.5, 0.5);
     this.infoBg.setName("window-info-bg");
 
@@ -83,12 +82,12 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     this.pokemonMoveBgs = [];
     this.pokemonMoveLabels = [];
 
-    const movesBg = addWindow(0, 0, 58, 52);
+    const movesBg = globalScene.addWindow(0, 0, 58, 52);
     movesBg.setOrigin(1, 0);
     movesBg.setName("window-moves-bg");
     this.pokemonMovesContainer.add(movesBg);
 
-    const movesLabel = addTextObject(
+    const movesLabel = globalScene.addTextObject(
       -movesBg.width / 2,
       6,
       i18next.t("pokemonInfoContainer:moveset"),
@@ -108,7 +107,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
       moveBg.setOrigin(1, 0);
       moveBg.setName("nineslice-move-bg");
 
-      const moveLabel = addTextObject(-moveBg.width / 2, 0, "-", TextStyle.PARTY);
+      const moveLabel = globalScene.addTextObject(-moveBg.width / 2, 0, "-", TextStyle.PARTY);
       moveLabel.setOrigin(0.5, 0);
       moveLabel.setName("text-move-label");
 
@@ -136,7 +135,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     // The font size should be set by language
     const infoContainerTextSize = textSettings?.infoContainerTextSize || "64px";
 
-    this.pokemonFormLabelText = addTextObject(
+    this.pokemonFormLabelText = globalScene.addTextObject(
       infoContainerLabelXPos,
       19,
       i18next.t("pokemonInfoContainer:form"),
@@ -147,26 +146,28 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     this.pokemonFormLabelText.setVisible(false);
     this.add(this.pokemonFormLabelText);
 
-    this.pokemonFormText = addTextObject(infoContainerTextXPos, 19, "", TextStyle.WINDOW, {
+    this.pokemonFormText = globalScene.addTextObject(infoContainerTextXPos, 19, "", TextStyle.WINDOW, {
       fontSize: infoContainerTextSize,
     });
     this.pokemonFormText.setOrigin(0, 0);
     this.pokemonFormText.setVisible(false);
     this.add(this.pokemonFormText);
 
-    this.pokemonGenderText = addTextObject(-42, -61, "", TextStyle.WINDOW, { fontSize: infoContainerTextSize });
+    this.pokemonGenderText = globalScene.addTextObject(-42, -61, "", TextStyle.WINDOW, {
+      fontSize: infoContainerTextSize,
+    });
     this.pokemonGenderText.setOrigin(0, 0);
     this.pokemonGenderText.setVisible(false);
     this.pokemonGenderText.setName("text-pkmn-gender");
     this.add(this.pokemonGenderText);
 
-    this.pokemonGenderNewText = addTextObject(-36, -61, "", TextStyle.WINDOW, { fontSize: "64px" });
+    this.pokemonGenderNewText = globalScene.addTextObject(-36, -61, "", TextStyle.WINDOW, { fontSize: "64px" });
     this.pokemonGenderNewText.setOrigin(0, 0);
     this.pokemonGenderNewText.setVisible(false);
     this.pokemonGenderNewText.setName("text-pkmn-new-gender");
     this.add(this.pokemonGenderNewText);
 
-    this.pokemonAbilityLabelText = addTextObject(
+    this.pokemonAbilityLabelText = globalScene.addTextObject(
       infoContainerLabelXPos,
       29,
       i18next.t("pokemonInfoContainer:ability"),
@@ -177,14 +178,14 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     this.pokemonAbilityLabelText.setName("text-pkmn-ability-label");
     this.add(this.pokemonAbilityLabelText);
 
-    this.pokemonAbilityText = addTextObject(infoContainerTextXPos, 29, "", TextStyle.WINDOW, {
+    this.pokemonAbilityText = globalScene.addTextObject(infoContainerTextXPos, 29, "", TextStyle.WINDOW, {
       fontSize: infoContainerTextSize,
     });
     this.pokemonAbilityText.setOrigin(0, 0);
     this.pokemonAbilityText.setName("text-pkmn-ability");
     this.add(this.pokemonAbilityText);
 
-    this.pokemonNatureLabelText = addTextObject(
+    this.pokemonNatureLabelText = globalScene.addTextObject(
       infoContainerLabelXPos,
       39,
       i18next.t("pokemonInfoContainer:nature"),
@@ -211,7 +212,7 @@ export default class PokemonInfoContainer extends Phaser.GameObjects.Container {
     this.pokemonShinyIcon.setName("img-pkmn-shiny-icon");
     this.add(this.pokemonShinyIcon);
 
-    this.pokemonShinyNewIcon = addTextObject(
+    this.pokemonShinyNewIcon = globalScene.addTextObject(
       this.pokemonShinyIcon.x + 12,
       this.pokemonShinyIcon.y,
       "",

--- a/src/ui/registration-form-ui-handler.ts
+++ b/src/ui/registration-form-ui-handler.ts
@@ -2,7 +2,7 @@ import type { InputFieldConfig } from "./form-modal-ui-handler";
 import { FormModalUiHandler } from "./form-modal-ui-handler";
 import type { ModalConfig } from "./modal-ui-handler";
 import { Mode } from "./ui";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import i18next from "i18next";
 import { api } from "#app/plugins/api/api";
 import { globalScene } from "#app/global-scene";
@@ -79,9 +79,15 @@ export default class RegistrationFormUiHandler extends FormModalUiHandler {
     });
 
     const warningMessageFontSize = languageSettings[i18next.resolvedLanguage!]?.warningMessageFontSize ?? "42px";
-    const label = addTextObject(10, 87, i18next.t("menu:registrationAgeWarning"), TextStyle.TOOLTIP_CONTENT, {
-      fontSize: warningMessageFontSize,
-    });
+    const label = globalScene.addTextObject(
+      10,
+      87,
+      i18next.t("menu:registrationAgeWarning"),
+      TextStyle.TOOLTIP_CONTENT,
+      {
+        fontSize: warningMessageFontSize,
+      },
+    );
 
     this.modalContainer.add(label);
   }

--- a/src/ui/run-history-ui-handler.ts
+++ b/src/ui/run-history-ui-handler.ts
@@ -1,8 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { GameModes } from "../game-mode";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import { Mode } from "./ui";
-import { addWindow } from "./ui-theme";
 import { fixedInt, formatLargeNumber, isNullOrUndefined } from "#app/utils";
 import type PokemonData from "../system/pokemon-data";
 import MessageUiHandler from "./message-ui-handler";
@@ -188,10 +187,10 @@ export default class RunHistoryUiHandler extends MessageUiHandler {
    * If the player has no runs saved so far, this creates a giant window labeled empty instead.
    */
   private async showEmpty() {
-    const emptyWindow = addWindow(0, 0, 304, 165);
+    const emptyWindow = globalScene.addWindow(0, 0, 304, 165);
     this.runsContainer.add(emptyWindow);
     const emptyWindowCoordinates = emptyWindow.getCenter();
-    const emptyText = addTextObject(0, 0, i18next.t("saveSlotSelectUiHandler:empty"), TextStyle.WINDOW, {
+    const emptyText = globalScene.addTextObject(0, 0, i18next.t("saveSlotSelectUiHandler:empty"), TextStyle.WINDOW, {
       fontSize: "128px",
     });
     emptyText.setPosition(emptyWindowCoordinates.x - 18, emptyWindowCoordinates.y - 15);
@@ -284,12 +283,12 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
     const victory = run.isVictory;
     const data = globalScene.gameData.parseSessionData(JSON.stringify(run.entry));
 
-    const slotWindow = addWindow(0, 0, 304, 52);
+    const slotWindow = globalScene.addWindow(0, 0, 304, 52);
     this.add(slotWindow);
 
     // Run Result: Victory
     if (victory) {
-      const gameOutcomeLabel = addTextObject(8, 5, `${i18next.t("runHistory:victory")}`, TextStyle.WINDOW);
+      const gameOutcomeLabel = globalScene.addTextObject(8, 5, `${i18next.t("runHistory:victory")}`, TextStyle.WINDOW);
       this.add(gameOutcomeLabel);
     } else {
       // Run Result: Defeats
@@ -298,7 +297,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
       // Defeats from wild Pokemon battles will show the Pokemon responsible by the text of the run result.
       if (data.battleType === BattleType.WILD || (data.battleType === BattleType.MYSTERY_ENCOUNTER && !data.trainer)) {
         const enemyContainer = globalScene.add.container(8, 5);
-        const gameOutcomeLabel = addTextObject(
+        const gameOutcomeLabel = globalScene.addTextObject(
           0,
           0,
           `${i18next.t("runHistory:defeatedWild", { context: genderStr })}`,
@@ -312,7 +311,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
           enemyData["player"] = true;
           const enemy = enemyData.toPokemon();
           const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
-          const enemyLevel = addTextObject(
+          const enemyLevel = globalScene.addTextObject(
             32,
             20,
             `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
@@ -338,7 +337,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
         const RIVAL_TRAINER_ID_THRESHOLD = 375;
         if (data.trainer.trainerType >= RIVAL_TRAINER_ID_THRESHOLD) {
           const rivalName = tObj.variant === TrainerVariant.FEMALE ? "trainerNames:rival_female" : "trainerNames:rival";
-          const gameOutcomeLabel = addTextObject(
+          const gameOutcomeLabel = globalScene.addTextObject(
             8,
             5,
             `${i18next.t("runHistory:defeatedRival", { context: genderStr })} ${i18next.t(rivalName)}`,
@@ -346,7 +345,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
           );
           this.add(gameOutcomeLabel);
         } else {
-          const gameOutcomeLabel = addTextObject(
+          const gameOutcomeLabel = globalScene.addTextObject(
             8,
             5,
             `${i18next.t("runHistory:defeatedTrainer", { context: genderStr })}${tObj.getName(0, true)}`,
@@ -360,7 +359,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
     // Game Mode + Waves
     // Because Endless (Spliced) tends to have the longest name across languages, the line tends to spill into the party icons.
     // To fix this, the Spliced icon is used to indicate an Endless Spliced run
-    const gameModeLabel = addTextObject(8, 19, "", TextStyle.WINDOW);
+    const gameModeLabel = globalScene.addTextObject(8, 19, "", TextStyle.WINDOW);
     let mode = "";
     switch (data.gameMode) {
       case GameModes.DAILY:
@@ -392,7 +391,12 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
     gameModeLabel.appendText(i18next.t("saveSlotSelectUiHandler:wave") + " " + data.waveIndex, false);
     this.add(gameModeLabel);
 
-    const timestampLabel = addTextObject(8, 33, new Date(data.timestamp).toLocaleString(), TextStyle.WINDOW);
+    const timestampLabel = globalScene.addTextObject(
+      8,
+      33,
+      new Date(data.timestamp).toLocaleString(),
+      TextStyle.WINDOW,
+    );
     this.add(timestampLabel);
 
     // pokemonIconsContainer holds the run's party Pokemon icons and levels
@@ -406,7 +410,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
       const pokemon = p.toPokemon();
       const icon = globalScene.addPokemonIcon(pokemon, 0, 0, 0, 0);
 
-      const text = addTextObject(
+      const text = globalScene.addTextObject(
         32,
         20,
         `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(pokemon.level, 1000)}`,

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -1,9 +1,8 @@
 import { GameModes } from "../game-mode";
 import UiHandler from "./ui-handler";
 import type { SessionSaveData } from "#app/@types/SessionData";
-import { TextStyle, addTextObject, addBBCodeTextObject, getTextColor } from "./text";
+import { TextStyle, addBBCodeTextObject, getTextColor } from "./text";
 import { Mode } from "./ui";
-import { addWindow } from "./ui-theme";
 import { getPokeballAtlasKey } from "#app/data/pokeball";
 import {
   formatLargeNumber,
@@ -128,7 +127,7 @@ export default class RunInfoUiHandler extends UiHandler {
 
     // Creates Run Result Container
     this.runResultContainer = globalScene.add.container(0, 24);
-    const runResultWindow = addWindow(0, 0, this.statsBgWidth - 11, 65);
+    const runResultWindow = globalScene.addWindow(0, 0, this.statsBgWidth - 11, 65);
     runResultWindow.setOrigin(0, 0);
     runResultWindow.setName("Run_Result_Window");
     this.runResultContainer.add(runResultWindow);
@@ -140,7 +139,7 @@ export default class RunInfoUiHandler extends UiHandler {
 
     // Creates Run Info Container
     this.runInfoContainer = globalScene.add.container(0, 89);
-    const runInfoWindow = addWindow(0, 0, this.statsBgWidth - 11, 90);
+    const runInfoWindow = globalScene.addWindow(0, 0, this.statsBgWidth - 11, 90);
     const runInfoWindowCoords = runInfoWindow.getBottomRight();
     this.runInfoContainer.add(runInfoWindow);
     this.parseRunInfo(runInfoWindowCoords.x, runInfoWindowCoords.y);
@@ -178,15 +177,21 @@ export default class RunInfoUiHandler extends UiHandler {
    * It does not check if the run has any PokemonHeldItemModifiers though.
    */
   private addHeader() {
-    const headerBg = addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
+    const headerBg = globalScene.addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
     headerBg.setOrigin(0, 0);
     this.runContainer.add(headerBg);
     if (this.runInfo.modifiers.length !== 0) {
       const headerBgCoords = headerBg.getTopRight();
       const abilityButtonContainer = globalScene.add.container(0, 0);
-      const abilityButtonText = addTextObject(8, 0, i18next.t("runHistory:viewHeldItems"), TextStyle.WINDOW, {
-        fontSize: "34px",
-      });
+      const abilityButtonText = globalScene.addTextObject(
+        8,
+        0,
+        i18next.t("runHistory:viewHeldItems"),
+        TextStyle.WINDOW,
+        {
+          fontSize: "34px",
+        },
+      );
       const gamepadType = this.getUi().getGamepadType();
       let abilityButtonElement: Phaser.GameObjects.Sprite;
       if (gamepadType === "touch") {
@@ -207,7 +212,7 @@ export default class RunInfoUiHandler extends UiHandler {
       );
       this.runContainer.add(abilityButtonContainer);
     }
-    const headerText = addTextObject(0, 0, i18next.t("runHistory:runInfo"), TextStyle.SETTINGS_LABEL);
+    const headerText = globalScene.addTextObject(0, 0, i18next.t("runHistory:runInfo"), TextStyle.SETTINGS_LABEL);
     headerText.setOrigin(0, 0);
     headerText.setPositionRelative(headerBg, 8, 4);
     this.runContainer.add(headerText);
@@ -228,7 +233,7 @@ export default class RunInfoUiHandler extends UiHandler {
     const runResultTitle = this.isVictory
       ? i18next.t("runHistory:victory")
       : i18next.t("runHistory:defeated", { context: genderStr });
-    const runResultText = addTextObject(
+    const runResultText = globalScene.addTextObject(
       6,
       5,
       `${runResultTitle} - ${i18next.t("saveSlotSelectUiHandler:wave")} ${this.runInfo.waveIndex}`,
@@ -238,12 +243,24 @@ export default class RunInfoUiHandler extends UiHandler {
 
     if (this.isVictory) {
       const hallofFameInstructionContainer = globalScene.add.container(0, 0);
-      const shinyButtonText = addTextObject(8, 0, i18next.t("runHistory:viewHallOfFame"), TextStyle.WINDOW, {
-        fontSize: "65px",
-      });
-      const formButtonText = addTextObject(8, 12, i18next.t("runHistory:viewEndingSplash"), TextStyle.WINDOW, {
-        fontSize: "65px",
-      });
+      const shinyButtonText = globalScene.addTextObject(
+        8,
+        0,
+        i18next.t("runHistory:viewHallOfFame"),
+        TextStyle.WINDOW,
+        {
+          fontSize: "65px",
+        },
+      );
+      const formButtonText = globalScene.addTextObject(
+        8,
+        12,
+        i18next.t("runHistory:viewEndingSplash"),
+        TextStyle.WINDOW,
+        {
+          fontSize: "65px",
+        },
+      );
       const gamepadType = this.getUi().getGamepadType();
       let shinyButtonElement: Phaser.GameObjects.Sprite;
       let formButtonElement: Phaser.GameObjects.Sprite;
@@ -346,7 +363,10 @@ export default class RunInfoUiHandler extends UiHandler {
         })
         .replace(/\n/g, " ");
       const descContainer = globalScene.add.container(0, 0);
-      const textBox = addTextObject(0, 0, boxString, TextStyle.WINDOW, { fontSize: "35px", wordWrap: { width: 200 } });
+      const textBox = globalScene.addTextObject(0, 0, boxString, TextStyle.WINDOW, {
+        fontSize: "35px",
+        wordWrap: { width: 200 },
+      });
       descContainer.add(textBox);
       descContainer.setPosition(55, 32);
       this.runResultContainer.add(descContainer);
@@ -362,7 +382,7 @@ export default class RunInfoUiHandler extends UiHandler {
           + ":title",
       );
       const descContainer = globalScene.add.container(0, 0);
-      const textBox = addTextObject(0, 0, mysteryEncounterTitle, TextStyle.WINDOW, {
+      const textBox = globalScene.addTextObject(0, 0, mysteryEncounterTitle, TextStyle.WINDOW, {
         fontSize: "45px",
         wordWrap: { width: 160 },
       });
@@ -375,7 +395,7 @@ export default class RunInfoUiHandler extends UiHandler {
     const windowCenterX = runResultWindow.getTopCenter().x;
     const windowBottomY = runResultWindow.getBottomCenter().y;
 
-    const runStatusText = addTextObject(
+    const runStatusText = globalScene.addTextObject(
       windowCenterX,
       5,
       `${i18next.t("saveSlotSelectUiHandler:wave")} ${this.runInfo.waveIndex}`,
@@ -384,7 +404,7 @@ export default class RunInfoUiHandler extends UiHandler {
     );
     runStatusText.setOrigin(0.5, 0);
 
-    const currentBiomeText = addTextObject(
+    const currentBiomeText = globalScene.addTextObject(
       windowCenterX,
       windowBottomY - 5,
       `${getBiomeName(this.runInfo.arena.biome)}`,
@@ -411,7 +431,7 @@ export default class RunInfoUiHandler extends UiHandler {
     const enemy = enemyData.toPokemon();
     const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
     const enemyLevelStyle = bossStatus ? TextStyle.PARTY_RED : TextStyle.PARTY;
-    const enemyLevel = addTextObject(
+    const enemyLevel = globalScene.addTextObject(
       36,
       26,
       `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
@@ -441,7 +461,7 @@ export default class RunInfoUiHandler extends UiHandler {
       enemyData["player"] = true;
       const enemy = enemyData.toPokemon();
       const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
-      const enemyLevel = addTextObject(
+      const enemyLevel = globalScene.addTextObject(
         36,
         26,
         `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
@@ -555,7 +575,7 @@ export default class RunInfoUiHandler extends UiHandler {
         }
       }
       enemyIcon.setPosition(39 * (e % 3) + 5, 35 * pokemonRowHeight);
-      const enemyLevel = addTextObject(
+      const enemyLevel = globalScene.addTextObject(
         43 * (e % 3),
         27 * (pokemonRowHeight + 1),
         `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
@@ -683,7 +703,7 @@ export default class RunInfoUiHandler extends UiHandler {
         }
 
         if (++visibleModifierIndex === 20) {
-          const maxItems = addTextObject(45, 90, "+", TextStyle.WINDOW);
+          const maxItems = globalScene.addTextObject(45, 90, "+", TextStyle.WINDOW);
           maxItems.setPositionRelative(modifierIconsContainer, 70, 45);
           this.runInfoContainer.add(maxItems);
           break;
@@ -885,7 +905,7 @@ export default class RunInfoUiHandler extends UiHandler {
         moveContainer.setScale(0.5);
         const moveBg = globalScene.add.nineslice(0, 0, "type_bgs", "unknown", 85, 15, 2, 2, 2, 2);
         moveBg.setOrigin(1, 0);
-        const moveLabel = addTextObject(-moveBg.width / 2, 2, "-", TextStyle.PARTY);
+        const moveLabel = globalScene.addTextObject(-moveBg.width / 2, 2, "-", TextStyle.PARTY);
         moveLabel.setOrigin(0.5, 0);
         moveLabel.setName("text-move-label");
         pokemonMoveBgs.push(moveBg);
@@ -917,7 +937,7 @@ export default class RunInfoUiHandler extends UiHandler {
           let row = 0;
           for (const [index, item] of heldItemsList.entries()) {
             if (index > 36) {
-              const overflowIcon = addTextObject(182, 4, "+", TextStyle.WINDOW);
+              const overflowIcon = globalScene.addTextObject(182, 4, "+", TextStyle.WINDOW);
               heldItemsContainer.add(overflowIcon);
               break;
             }
@@ -988,7 +1008,7 @@ export default class RunInfoUiHandler extends UiHandler {
     const endCard = globalScene.add.image(0, 0, `end_${isFemale ? "f" : "m"}`);
     endCard.setOrigin(0);
     endCard.setScale(0.5);
-    const text = addTextObject(
+    const text = globalScene.addTextObject(
       globalScene.game.canvas.width / 12,
       globalScene.game.canvas.height / 6 - 16,
       i18next.t("battle:congratulations"),
@@ -1025,7 +1045,7 @@ export default class RunInfoUiHandler extends UiHandler {
     this.hallofFameContainer.add(endCard);
     this.hallofFameContainer.add(hallofFameBg);
 
-    const hallofFameText = addTextObject(
+    const hallofFameText = globalScene.addTextObject(
       0,
       0,
       i18next.t("runHistory:hallofFameText", { context: genderStr }),

--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -7,9 +7,8 @@ import type { SessionSaveData } from "#app/@types/SessionData";
 import type PokemonData from "../system/pokemon-data";
 import { isNullOrUndefined, fixedInt, getPlayTimeString, formatLargeNumber } from "#app/utils";
 import MessageUiHandler from "./message-ui-handler";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import { Mode } from "./ui";
-import { addWindow } from "./ui-theme";
 import { RunDisplayMode } from "#app/ui/run-info-ui-handler";
 
 const SESSION_SLOTS_COUNT = 5;
@@ -68,11 +67,11 @@ export default class SaveSlotSelectUiHandler extends MessageUiHandler {
     this.saveSlotSelectMessageBoxContainer.setVisible(false);
     this.saveSlotSelectContainer.add(this.saveSlotSelectMessageBoxContainer);
 
-    this.saveSlotSelectMessageBox = addWindow(1, -1, 318, 28);
+    this.saveSlotSelectMessageBox = globalScene.addWindow(1, -1, 318, 28);
     this.saveSlotSelectMessageBox.setOrigin(0, 1);
     this.saveSlotSelectMessageBoxContainer.add(this.saveSlotSelectMessageBox);
 
-    this.message = addTextObject(8, 8, "", TextStyle.WINDOW, { maxLines: 2 });
+    this.message = globalScene.addTextObject(8, 8, "", TextStyle.WINDOW, { maxLines: 2 });
     this.message.setOrigin(0, 0);
     this.saveSlotSelectMessageBoxContainer.add(this.message);
 
@@ -370,10 +369,15 @@ class SessionSlot extends Phaser.GameObjects.Container {
   }
 
   setup() {
-    const slotWindow = addWindow(0, 0, 304, 52);
+    const slotWindow = globalScene.addWindow(0, 0, 304, 52);
     this.add(slotWindow);
 
-    this.loadingLabel = addTextObject(152, 26, i18next.t("saveSlotSelectUiHandler:loading"), TextStyle.WINDOW);
+    this.loadingLabel = globalScene.addTextObject(
+      152,
+      26,
+      i18next.t("saveSlotSelectUiHandler:loading"),
+      TextStyle.WINDOW,
+    );
     this.loadingLabel.setOrigin(0.5, 0.5);
     this.add(this.loadingLabel);
   }
@@ -381,7 +385,7 @@ class SessionSlot extends Phaser.GameObjects.Container {
   async setupWithData(data: SessionSaveData) {
     this.remove(this.loadingLabel, true);
 
-    const gameModeLabel = addTextObject(
+    const gameModeLabel = globalScene.addTextObject(
       8,
       5,
       `${GameMode.getModeName(data.gameMode) || i18next.t("gameMode:unkown")} - ${i18next.t("saveSlotSelectUiHandler:wave")} ${data.waveIndex}`,
@@ -389,10 +393,15 @@ class SessionSlot extends Phaser.GameObjects.Container {
     );
     this.add(gameModeLabel);
 
-    const timestampLabel = addTextObject(8, 19, new Date(data.timestamp).toLocaleString(), TextStyle.WINDOW);
+    const timestampLabel = globalScene.addTextObject(
+      8,
+      19,
+      new Date(data.timestamp).toLocaleString(),
+      TextStyle.WINDOW,
+    );
     this.add(timestampLabel);
 
-    const playTimeLabel = addTextObject(8, 33, getPlayTimeString(data.playTime), TextStyle.WINDOW);
+    const playTimeLabel = globalScene.addTextObject(8, 33, getPlayTimeString(data.playTime), TextStyle.WINDOW);
     this.add(playTimeLabel);
 
     const pokemonIconsContainer = globalScene.add.container(144, 4);
@@ -403,7 +412,7 @@ class SessionSlot extends Phaser.GameObjects.Container {
       const pokemon = p.toPokemon();
       const icon = globalScene.addPokemonIcon(pokemon, 0, 0, 0, 0);
 
-      const text = addTextObject(
+      const text = globalScene.addTextObject(
         32,
         20,
         `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(pokemon.level, 1000)}`,

--- a/src/ui/session-reload-modal-ui-handler.ts
+++ b/src/ui/session-reload-modal-ui-handler.ts
@@ -1,6 +1,7 @@
 import type { ModalConfig } from "./modal-ui-handler";
 import { ModalUiHandler } from "./modal-ui-handler";
-import { addTextObject, TextStyle } from "./text";
+import { globalScene } from "#app/global-scene";
+import { TextStyle } from "./text";
 import type { Mode } from "./ui";
 
 export default class SessionReloadModalUiHandler extends ModalUiHandler {
@@ -31,7 +32,7 @@ export default class SessionReloadModalUiHandler extends ModalUiHandler {
   override setup(): void {
     super.setup();
 
-    const label = addTextObject(
+    const label = globalScene.addTextObject(
       this.getWidth() / 2,
       this.getHeight() / 2,
       "Your session is out of date.\nYour data will be reloaded…",

--- a/src/ui/settings/abstract-binding-ui-handler.ts
+++ b/src/ui/settings/abstract-binding-ui-handler.ts
@@ -1,7 +1,6 @@
 import UiHandler from "../ui-handler";
 import type { Mode } from "../ui";
-import { addWindow } from "../ui-theme";
-import { addTextObject, TextStyle } from "../text";
+import { TextStyle } from "../text";
 import { Button } from "#enums/buttons";
 import { NavigationManager } from "#app/ui/settings/navigationMenu";
 import i18next from "i18next";
@@ -71,7 +70,7 @@ export default abstract class AbstractBindingUiHandler extends UiHandler {
     ui.add(this.actionsContainer);
 
     // Setup backgrounds and text objects for UI.
-    this.titleBg = addWindow(
+    this.titleBg = globalScene.addWindow(
       globalScene.game.canvas.width / 6 - this.getWindowWidth(),
       -(globalScene.game.canvas.height / 6) + 28 + 21,
       this.getWindowWidth(),
@@ -80,7 +79,7 @@ export default abstract class AbstractBindingUiHandler extends UiHandler {
     this.titleBg.setOrigin(0.5);
     this.optionSelectContainer.add(this.titleBg);
 
-    this.actionBg = addWindow(
+    this.actionBg = globalScene.addWindow(
       globalScene.game.canvas.width / 6 - this.getWindowWidth(),
       -(globalScene.game.canvas.height / 6) + this.getWindowHeight() + 28 + 21 + 21,
       this.getWindowWidth(),
@@ -90,17 +89,17 @@ export default abstract class AbstractBindingUiHandler extends UiHandler {
     this.actionsContainer.add(this.actionBg);
 
     // Text prompts and instructions for the user.
-    this.unlockText = addTextObject(0, 0, i18next.t("settings:pressButton"), TextStyle.WINDOW);
+    this.unlockText = globalScene.addTextObject(0, 0, i18next.t("settings:pressButton"), TextStyle.WINDOW);
     this.unlockText.setOrigin(0, 0);
     this.unlockText.setPositionRelative(this.titleBg, 36, 4);
     this.optionSelectContainer.add(this.unlockText);
 
-    this.timerText = addTextObject(0, 0, "(5)", TextStyle.WINDOW);
+    this.timerText = globalScene.addTextObject(0, 0, "(5)", TextStyle.WINDOW);
     this.timerText.setOrigin(0, 0);
     this.timerText.setPositionRelative(this.unlockText, this.unlockText.width / 6 + 5, 0);
     this.optionSelectContainer.add(this.timerText);
 
-    this.optionSelectBg = addWindow(
+    this.optionSelectBg = globalScene.addWindow(
       globalScene.game.canvas.width / 6 - this.getWindowWidth(),
       -(globalScene.game.canvas.height / 6) + this.getWindowHeight() + 28,
       this.getWindowWidth(),
@@ -109,7 +108,7 @@ export default abstract class AbstractBindingUiHandler extends UiHandler {
     this.optionSelectBg.setOrigin(0.5);
     this.optionSelectContainer.add(this.optionSelectBg);
 
-    this.cancelLabel = addTextObject(0, 0, i18next.t("settings:back"), TextStyle.SETTINGS_LABEL);
+    this.cancelLabel = globalScene.addTextObject(0, 0, i18next.t("settings:back"), TextStyle.SETTINGS_LABEL);
     this.cancelLabel.setOrigin(0, 0.5);
     this.cancelLabel.setPositionRelative(this.actionBg, 10, this.actionBg.height / 2);
     this.actionsContainer.add(this.cancelLabel);

--- a/src/ui/settings/abstract-control-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-control-settings-ui-handler.ts
@@ -1,8 +1,7 @@
 import UiHandler from "#app/ui/ui-handler";
 import type { Mode } from "#app/ui/ui";
 import type { InterfaceConfig } from "#app/inputs-controller";
-import { addWindow } from "#app/ui/ui-theme";
-import { addTextObject, TextStyle } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import { ScrollBar } from "#app/ui/scroll-bar";
 import { getIconWithSettingName } from "#app/configs/inputs/configHandler";
 import NavigationMenu, { NavigationManager } from "#app/ui/settings/navigationMenu";
@@ -112,7 +111,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
 
     this.navigationContainer = new NavigationMenu(0, 0);
 
-    this.optionsBg = addWindow(
+    this.optionsBg = globalScene.addWindow(
       0,
       this.navigationContainer.height,
       globalScene.game.canvas.width / 6 - 2,
@@ -120,7 +119,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
     );
     this.optionsBg.setOrigin(0, 0);
 
-    this.actionsBg = addWindow(
+    this.actionsBg = globalScene.addWindow(
       0,
       globalScene.game.canvas.height / 6 - this.navigationContainer.height,
       globalScene.game.canvas.width / 6 - 2,
@@ -133,7 +132,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
     iconAction.setPositionRelative(this.actionsBg, this.navigationContainer.width - 32, 4);
     this.navigationIcons["BUTTON_ACTION"] = iconAction;
 
-    const actionText = addTextObject(0, 0, i18next.t("settings:action"), TextStyle.SETTINGS_LABEL);
+    const actionText = globalScene.addTextObject(0, 0, i18next.t("settings:action"), TextStyle.SETTINGS_LABEL);
     actionText.setOrigin(0, 0.15);
     actionText.setPositionRelative(iconAction, -actionText.width / 6 - 2, 0);
 
@@ -142,7 +141,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
     iconCancel.setPositionRelative(this.actionsBg, this.navigationContainer.width - 100, 4);
     this.navigationIcons["BUTTON_CANCEL"] = iconCancel;
 
-    const cancelText = addTextObject(0, 0, i18next.t("settings:back"), TextStyle.SETTINGS_LABEL);
+    const cancelText = globalScene.addTextObject(0, 0, i18next.t("settings:back"), TextStyle.SETTINGS_LABEL);
     cancelText.setOrigin(0, 0.15);
     cancelText.setPositionRelative(iconCancel, -cancelText.width / 6 - 2, 0);
 
@@ -151,7 +150,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
     iconReset.setPositionRelative(this.actionsBg, this.navigationContainer.width - 180, 4);
     this.navigationIcons["BUTTON_HOME"] = iconReset;
 
-    const resetText = addTextObject(0, 0, i18next.t("settings:reset"), TextStyle.SETTINGS_LABEL);
+    const resetText = globalScene.addTextObject(0, 0, i18next.t("settings:reset"), TextStyle.SETTINGS_LABEL);
     resetText.setOrigin(0, 0.15);
     resetText.setPositionRelative(iconReset, -resetText.width / 6 - 2, 0);
 
@@ -218,7 +217,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
         } else {
           labelText = i18next.t(`settings:${i18nKey}`);
         }
-        settingLabels[s] = addTextObject(8, 28 + s * 16, labelText, labelStyle);
+        settingLabels[s] = globalScene.addTextObject(8, 28 + s * 16, labelText, labelStyle);
         settingLabels[s].setOrigin(0, 0);
         optionsContainer.add(settingLabels[s]);
 
@@ -231,7 +230,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
           if (bindingSettings.includes(this.setting[setting])) {
             // Create a label for non-null options, typically indicating actionable options like 'change'.
             if (o) {
-              const valueLabel = addTextObject(0, 0, isLock ? "" : option, TextStyle.WINDOW);
+              const valueLabel = globalScene.addTextObject(0, 0, isLock ? "" : option, TextStyle.WINDOW);
               valueLabel.setOrigin(0, 0);
               optionsContainer.add(valueLabel);
               valueLabels.push(valueLabel);
@@ -246,7 +245,7 @@ export default abstract class AbstractControlSettingsUiHandler extends UiHandler
             continue;
           }
           // For regular settings like 'Gamepad support', create a label and determine if it is selected.
-          const valueLabel = addTextObject(
+          const valueLabel = globalScene.addTextObject(
             0,
             0,
             option,

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -1,7 +1,6 @@
-import { TextStyle, addTextObject } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import { Mode } from "#app/ui/ui";
 import MessageUiHandler from "#app/ui/message-ui-handler";
-import { addWindow } from "#app/ui/ui-theme";
 import { ScrollBar } from "#app/ui/scroll-bar";
 import { Button } from "#enums/buttons";
 import type { InputsIcons } from "#app/ui/settings/abstract-control-settings-ui-handler";
@@ -66,7 +65,7 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
 
     this.navigationContainer = new NavigationMenu(0, 0);
 
-    this.optionsBg = addWindow(
+    this.optionsBg = globalScene.addWindow(
       0,
       this.navigationContainer.height,
       globalScene.game.canvas.width / 6 - 2,
@@ -75,7 +74,7 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
     this.optionsBg.setName("window-options-bg");
     this.optionsBg.setOrigin(0, 0);
 
-    const actionsBg = addWindow(
+    const actionsBg = globalScene.addWindow(
       0,
       globalScene.game.canvas.height / 6 - this.navigationContainer.height,
       globalScene.game.canvas.width / 6 - 2,
@@ -88,7 +87,7 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
     iconAction.setPositionRelative(actionsBg, this.navigationContainer.width - 32, 4);
     this.navigationIcons["BUTTON_ACTION"] = iconAction;
 
-    const actionText = addTextObject(0, 0, i18next.t("settings:action"), TextStyle.SETTINGS_LABEL);
+    const actionText = globalScene.addTextObject(0, 0, i18next.t("settings:action"), TextStyle.SETTINGS_LABEL);
     actionText.setOrigin(0, 0.15);
     actionText.setPositionRelative(iconAction, -actionText.width / 6 - 2, 0);
 
@@ -97,7 +96,7 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
     iconCancel.setPositionRelative(actionsBg, this.navigationContainer.width - 100, 4);
     this.navigationIcons["BUTTON_CANCEL"] = iconCancel;
 
-    const cancelText = addTextObject(0, 0, i18next.t("settings:back"), TextStyle.SETTINGS_LABEL);
+    const cancelText = globalScene.addTextObject(0, 0, i18next.t("settings:back"), TextStyle.SETTINGS_LABEL);
     cancelText.setOrigin(0, 0.15);
     cancelText.setPositionRelative(iconCancel, -cancelText.width / 6 - 2, 0);
 
@@ -114,13 +113,13 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
         settingName += ` (${i18next.t("settings:requireReload")})`;
       }
 
-      this.settingLabels[s] = addTextObject(8, 28 + s * 16, settingName, TextStyle.SETTINGS_LABEL);
+      this.settingLabels[s] = globalScene.addTextObject(8, 28 + s * 16, settingName, TextStyle.SETTINGS_LABEL);
       this.settingLabels[s].setOrigin(0, 0);
 
       this.optionsContainer.add(this.settingLabels[s]);
       this.optionValueLabels.push(
         setting.options.map((option, o) => {
-          const valueLabel = addTextObject(
+          const valueLabel = globalScene.addTextObject(
             0,
             0,
             option.label,
@@ -165,11 +164,11 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
     this.messageBoxContainer.setName("settings-message-box");
     this.messageBoxContainer.setVisible(false);
 
-    const settingsMessageBox = addWindow(0, -1, globalScene.scaledCanvas.width - 2, 48);
+    const settingsMessageBox = globalScene.addWindow(0, -1, globalScene.scaledCanvas.width - 2, 48);
     settingsMessageBox.setOrigin(0, 1);
     this.messageBoxContainer.add(settingsMessageBox);
 
-    const messageText = addTextObject(8, -40, "", TextStyle.WINDOW, { maxLines: 2 });
+    const messageText = globalScene.addTextObject(8, -40, "", TextStyle.WINDOW, { maxLines: 2 });
     messageText.setWordWrapWidth(globalScene.game.canvas.width - 60);
     messageText.setName("settings-message");
     messageText.setOrigin(0, 0);

--- a/src/ui/settings/gamepad-binding-ui-handler.ts
+++ b/src/ui/settings/gamepad-binding-ui-handler.ts
@@ -2,7 +2,7 @@ import AbstractBindingUiHandler from "./abstract-binding-ui-handler";
 import type { Mode } from "../ui";
 import { Device } from "#enums/devices";
 import { getIconWithSettingName, getKeyWithKeycode } from "#app/configs/inputs/configHandler";
-import { addTextObject, TextStyle } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import { globalScene } from "#app/global-scene";
 
 export default class GamepadBindingUiHandler extends AbstractBindingUiHandler {
@@ -19,7 +19,7 @@ export default class GamepadBindingUiHandler extends AbstractBindingUiHandler {
     this.newButtonIcon.setOrigin(0.5);
     this.newButtonIcon.setVisible(false);
 
-    this.swapText = addTextObject(0, 0, "will swap with", TextStyle.WINDOW);
+    this.swapText = globalScene.addTextObject(0, 0, "will swap with", TextStyle.WINDOW);
     this.swapText.setOrigin(0.5);
     this.swapText.setPositionRelative(
       this.optionSelectBg,
@@ -33,7 +33,7 @@ export default class GamepadBindingUiHandler extends AbstractBindingUiHandler {
     this.targetButtonIcon.setOrigin(0.5);
     this.targetButtonIcon.setVisible(false);
 
-    this.actionLabel = addTextObject(0, 0, "Confirm swap", TextStyle.SETTINGS_LABEL);
+    this.actionLabel = globalScene.addTextObject(0, 0, "Confirm swap", TextStyle.SETTINGS_LABEL);
     this.actionLabel.setOrigin(0, 0.5);
     this.actionLabel.setPositionRelative(this.actionBg, this.actionBg.width - 75, this.actionBg.height / 2);
     this.actionsContainer.add(this.actionLabel);

--- a/src/ui/settings/keyboard-binding-ui-handler.ts
+++ b/src/ui/settings/keyboard-binding-ui-handler.ts
@@ -2,7 +2,7 @@ import AbstractBindingUiHandler from "./abstract-binding-ui-handler";
 import type { Mode } from "../ui";
 import { getKeyWithKeycode } from "#app/configs/inputs/configHandler";
 import { Device } from "#enums/devices";
-import { addTextObject, TextStyle } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import { globalScene } from "#app/global-scene";
 
 export default class KeyboardBindingUiHandler extends AbstractBindingUiHandler {
@@ -21,7 +21,7 @@ export default class KeyboardBindingUiHandler extends AbstractBindingUiHandler {
     this.newButtonIcon.setOrigin(0.5);
     this.newButtonIcon.setVisible(false);
 
-    this.actionLabel = addTextObject(0, 0, "Assign button", TextStyle.SETTINGS_LABEL);
+    this.actionLabel = globalScene.addTextObject(0, 0, "Assign button", TextStyle.SETTINGS_LABEL);
     this.actionLabel.setOrigin(0, 0.5);
     this.actionLabel.setPositionRelative(this.actionBg, this.actionBg.width - 80, this.actionBg.height / 2);
     this.actionsContainer.add(this.actionLabel);

--- a/src/ui/settings/navigationMenu.ts
+++ b/src/ui/settings/navigationMenu.ts
@@ -1,8 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { Mode } from "#app/ui/ui";
 import type { InputsIcons } from "#app/ui/settings/abstract-control-settings-ui-handler";
-import { addTextObject, setTextStyle, TextStyle } from "#app/ui/text";
-import { addWindow } from "#app/ui/ui-theme";
+import { setTextStyle, TextStyle } from "#app/ui/text";
 import { Button } from "#enums/buttons";
 import i18next from "i18next";
 
@@ -116,7 +115,7 @@ export default class NavigationMenu extends Phaser.GameObjects.Container {
    */
   setup() {
     const navigationManager = NavigationManager.getInstance();
-    const headerBg = addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
+    const headerBg = globalScene.addWindow(0, 0, globalScene.game.canvas.width / 6 - 2, 24);
     headerBg.setOrigin(0, 0);
     this.add(headerBg);
     this.width = headerBg.width;
@@ -137,7 +136,7 @@ export default class NavigationMenu extends Phaser.GameObjects.Container {
     let relative: Phaser.GameObjects.Sprite | Phaser.GameObjects.Text = iconPreviousTab;
     let relativeWidth: number = iconPreviousTab.width * 6;
     for (const label of navigationManager.labels) {
-      const labelText = addTextObject(0, 0, label, TextStyle.SETTINGS_LABEL);
+      const labelText = globalScene.addTextObject(0, 0, label, TextStyle.SETTINGS_LABEL);
       labelText.setOrigin(0, 0);
       labelText.setPositionRelative(relative, 6 + relativeWidth / 6, 0);
       this.add(labelText);

--- a/src/ui/settings/settings-gamepad-ui-handler.ts
+++ b/src/ui/settings/settings-gamepad-ui-handler.ts
@@ -1,4 +1,4 @@
-import { addTextObject, TextStyle } from "../text";
+import { TextStyle } from "../text";
 import type { Mode } from "../ui";
 import {
   setSettingGamepad,
@@ -53,7 +53,7 @@ export default class SettingsGamepadUiHandler extends AbstractControlSettingsUiH
     this.layout["noGamepads"] = new Map();
     const optionsContainer = globalScene.add.container(0, 0);
     optionsContainer.setVisible(false); // Initially hide the container as no gamepads are connected.
-    const label = addTextObject(8, 28, i18next.t("settings:gamepadPleasePlug"), TextStyle.SETTINGS_LABEL);
+    const label = globalScene.addTextObject(8, 28, i18next.t("settings:gamepadPleasePlug"), TextStyle.SETTINGS_LABEL);
     label.setOrigin(0, 0);
     optionsContainer.add(label);
     this.settingsContainer.add(optionsContainer);

--- a/src/ui/settings/settings-keyboard-ui-handler.ts
+++ b/src/ui/settings/settings-keyboard-ui-handler.ts
@@ -10,7 +10,7 @@ import {
 import { reverseValueToKeySetting, truncateString } from "#app/utils";
 import AbstractControlSettingsUiHandler from "#app/ui/settings/abstract-control-settings-ui-handler";
 import type { InterfaceConfig } from "#app/inputs-controller";
-import { addTextObject, TextStyle } from "#app/ui/text";
+import { TextStyle } from "#app/ui/text";
 import { deleteBind } from "#app/configs/inputs/configHandler";
 import { Device } from "#enums/devices";
 import { NavigationManager } from "#app/ui/settings/navigationMenu";
@@ -58,7 +58,7 @@ export default class SettingsKeyboardUiHandler extends AbstractControlSettingsUi
     this.layout["noKeyboard"] = new Map();
     const optionsContainer = globalScene.add.container(0, 0);
     optionsContainer.setVisible(false); // Initially hide the container as no gamepads are connected.
-    const label = addTextObject(8, 28, i18next.t("settings:keyboardPleasePress"), TextStyle.SETTINGS_LABEL);
+    const label = globalScene.addTextObject(8, 28, i18next.t("settings:keyboardPleasePress"), TextStyle.SETTINGS_LABEL);
     label.setOrigin(0, 0);
     optionsContainer.add(label);
     this.settingsContainer.add(optionsContainer);
@@ -68,7 +68,7 @@ export default class SettingsKeyboardUiHandler extends AbstractControlSettingsUi
     iconDelete.setPositionRelative(this.actionsBg, this.navigationContainer.width - 260, 4);
     this.navigationIcons["BUTTON_DELETE"] = iconDelete;
 
-    const deleteText = addTextObject(0, 0, i18next.t("settings:delete"), TextStyle.SETTINGS_LABEL);
+    const deleteText = globalScene.addTextObject(0, 0, i18next.t("settings:delete"), TextStyle.SETTINGS_LABEL);
     deleteText.setOrigin(0, 0.15);
     deleteText.setPositionRelative(iconDelete, -deleteText.width / 6 - 2, 0);
 

--- a/src/ui/starter-container.ts
+++ b/src/ui/starter-container.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import type PokemonSpecies from "../data/pokemon-species";
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 
 export class StarterContainer extends Phaser.GameObjects.Container {
   public species: PokemonSpecies;
@@ -57,7 +57,7 @@ export class StarterContainer extends Phaser.GameObjects.Container {
     this.add(this.shinyIcons);
 
     // value label
-    const label = addTextObject(1, 2, "0", TextStyle.WINDOW, { fontSize: "32px" });
+    const label = globalScene.addTextObject(1, 2, "0", TextStyle.WINDOW, { fontSize: "32px" });
     label.setShadowOffset(2, 2);
     label.setOrigin(0, 0);
     label.setVisible(false);

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -34,9 +34,8 @@ import type { OptionSelectItem } from "#app/ui/abstact-option-select-ui-handler"
 import MessageUiHandler from "#app/ui/message-ui-handler";
 import PokemonIconAnimHandler, { PokemonIconAnimMode } from "#app/ui/pokemon-icon-anim-handler";
 import { StatsContainer } from "#app/ui/stats-container";
-import { TextStyle, addBBCodeTextObject, addTextObject } from "#app/ui/text";
+import { TextStyle, addBBCodeTextObject } from "#app/ui/text";
 import { Mode } from "#app/ui/ui";
-import { addWindow } from "#app/ui/ui-theme";
 import { Egg } from "#app/data/egg";
 import Overrides from "#app/overrides";
 import { SettingKeyboard } from "#app/system/settings/settings-keyboard";
@@ -390,7 +389,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.shinyOverlay.setVisible(false);
     this.starterSelectContainer.add(this.shinyOverlay);
 
-    const starterContainerWindow = addWindow(speciesContainerX, filterBarHeight + 1, 175, 161);
+    const starterContainerWindow = globalScene.addWindow(speciesContainerX, filterBarHeight + 1, 175, 161);
     const starterContainerBg = globalScene.add.image(
       speciesContainerX + 1,
       filterBarHeight + 2,
@@ -399,9 +398,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     starterContainerBg.setOrigin(0, 0);
     this.starterSelectContainer.add(starterContainerBg);
 
-    this.starterSelectContainer.add(addWindow(teamWindowX, teamWindowY, teamWindowWidth, teamWindowHeight));
+    this.starterSelectContainer.add(globalScene.addWindow(teamWindowX, teamWindowY, teamWindowWidth, teamWindowHeight));
     this.starterSelectContainer.add(
-      addWindow(teamWindowX, teamWindowY + teamWindowHeight - 5, teamWindowWidth, teamWindowWidth, true),
+      globalScene.addWindow(teamWindowX, teamWindowY + teamWindowHeight - 5, teamWindowWidth, teamWindowWidth, true),
     );
     this.starterSelectContainer.add(starterContainerWindow);
 
@@ -566,15 +565,15 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.iconAnimHandler = new PokemonIconAnimHandler();
     this.iconAnimHandler.setup();
 
-    this.pokemonNumberText = addTextObject(17, 1, "0000", TextStyle.SUMMARY);
+    this.pokemonNumberText = globalScene.addTextObject(17, 1, "0000", TextStyle.SUMMARY);
     this.pokemonNumberText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonNumberText);
 
-    this.pokemonNameText = addTextObject(6, 112, "", TextStyle.SUMMARY);
+    this.pokemonNameText = globalScene.addTextObject(6, 112, "", TextStyle.SUMMARY);
     this.pokemonNameText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonNameText);
 
-    this.pokemonGrowthRateLabelText = addTextObject(
+    this.pokemonGrowthRateLabelText = globalScene.addTextObject(
       8,
       106,
       i18next.t("starterSelectUiHandler:growthRate"),
@@ -585,15 +584,15 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonGrowthRateLabelText.setVisible(false);
     this.starterSelectContainer.add(this.pokemonGrowthRateLabelText);
 
-    this.pokemonGrowthRateText = addTextObject(34, 106, "", TextStyle.SUMMARY_PINK, { fontSize: "36px" });
+    this.pokemonGrowthRateText = globalScene.addTextObject(34, 106, "", TextStyle.SUMMARY_PINK, { fontSize: "36px" });
     this.pokemonGrowthRateText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonGrowthRateText);
 
-    this.pokemonGenderText = addTextObject(96, 112, "", TextStyle.SUMMARY_ALT);
+    this.pokemonGenderText = globalScene.addTextObject(96, 112, "", TextStyle.SUMMARY_ALT);
     this.pokemonGenderText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonGenderText);
 
-    this.pokemonUncaughtText = addTextObject(
+    this.pokemonUncaughtText = globalScene.addTextObject(
       6,
       127,
       i18next.t("starterSelectUiHandler:uncaught"),
@@ -610,7 +609,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     // The font size should be set per language
     const starterInfoTextSize = textSettings?.starterInfoTextSize || 56;
 
-    this.pokemonAbilityLabelText = addTextObject(
+    this.pokemonAbilityLabelText = globalScene.addTextObject(
       6,
       127 + starterInfoYOffset,
       i18next.t("starterSelectUiHandler:ability"),
@@ -622,15 +621,21 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     this.starterSelectContainer.add(this.pokemonAbilityLabelText);
 
-    this.pokemonAbilityText = addTextObject(starterInfoXPos, 127 + starterInfoYOffset, "", TextStyle.SUMMARY_ALT, {
-      fontSize: starterInfoTextSize,
-    });
+    this.pokemonAbilityText = globalScene.addTextObject(
+      starterInfoXPos,
+      127 + starterInfoYOffset,
+      "",
+      TextStyle.SUMMARY_ALT,
+      {
+        fontSize: starterInfoTextSize,
+      },
+    );
     this.pokemonAbilityText.setOrigin(0, 0);
     this.pokemonAbilityText.setInteractive(new Phaser.Geom.Rectangle(0, 0, 250, 55), Phaser.Geom.Rectangle.Contains);
 
     this.starterSelectContainer.add(this.pokemonAbilityText);
 
-    this.pokemonPassiveLabelText = addTextObject(
+    this.pokemonPassiveLabelText = globalScene.addTextObject(
       6,
       136 + starterInfoYOffset,
       i18next.t("starterSelectUiHandler:passive"),
@@ -641,9 +646,15 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonPassiveLabelText.setVisible(false);
     this.starterSelectContainer.add(this.pokemonPassiveLabelText);
 
-    this.pokemonPassiveText = addTextObject(starterInfoXPos, 136 + starterInfoYOffset, "", TextStyle.SUMMARY_ALT, {
-      fontSize: starterInfoTextSize,
-    });
+    this.pokemonPassiveText = globalScene.addTextObject(
+      starterInfoXPos,
+      136 + starterInfoYOffset,
+      "",
+      TextStyle.SUMMARY_ALT,
+      {
+        fontSize: starterInfoTextSize,
+      },
+    );
     this.pokemonPassiveText.setOrigin(0, 0);
     this.pokemonPassiveText.setInteractive(new Phaser.Geom.Rectangle(0, 0, 250, 55), Phaser.Geom.Rectangle.Contains);
     this.starterSelectContainer.add(this.pokemonPassiveText);
@@ -660,7 +671,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonPassiveLockedIcon.setVisible(false);
     this.starterSelectContainer.add(this.pokemonPassiveLockedIcon);
 
-    this.pokemonNatureLabelText = addTextObject(
+    this.pokemonNatureLabelText = globalScene.addTextObject(
       6,
       145 + starterInfoYOffset,
       i18next.t("starterSelectUiHandler:nature"),
@@ -685,11 +696,16 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonEggMoveBgs = [];
     this.pokemonEggMoveLabels = [];
 
-    this.valueLimitLabel = addTextObject(teamWindowX + 17, 150, "0/10", TextStyle.TOOLTIP_CONTENT);
+    this.valueLimitLabel = globalScene.addTextObject(teamWindowX + 17, 150, "0/10", TextStyle.TOOLTIP_CONTENT);
     this.valueLimitLabel.setOrigin(0.5, 0);
     this.starterSelectContainer.add(this.valueLimitLabel);
 
-    const startLabel = addTextObject(teamWindowX + 17, 162, i18next.t("common:start"), TextStyle.TOOLTIP_CONTENT);
+    const startLabel = globalScene.addTextObject(
+      teamWindowX + 17,
+      162,
+      i18next.t("common:start"),
+      TextStyle.TOOLTIP_CONTENT,
+    );
     startLabel.setOrigin(0.5, 0);
     this.starterSelectContainer.add(startLabel);
 
@@ -784,15 +800,27 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.type2Icon.setOrigin(0, 0);
     this.starterSelectContainer.add(this.type2Icon);
 
-    this.pokemonLuckLabelText = addTextObject(8, 89, i18next.t("common:luckIndicator"), TextStyle.WINDOW_ALT, {
-      fontSize: "56px",
-    });
+    this.pokemonLuckLabelText = globalScene.addTextObject(
+      8,
+      89,
+      i18next.t("common:luckIndicator"),
+      TextStyle.WINDOW_ALT,
+      {
+        fontSize: "56px",
+      },
+    );
     this.pokemonLuckLabelText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonLuckLabelText);
 
-    this.pokemonLuckText = addTextObject(8 + this.pokemonLuckLabelText.displayWidth + 2, 89, "0", TextStyle.WINDOW, {
-      fontSize: "56px",
-    });
+    this.pokemonLuckText = globalScene.addTextObject(
+      8 + this.pokemonLuckLabelText.displayWidth + 2,
+      89,
+      "0",
+      TextStyle.WINDOW,
+      {
+        fontSize: "56px",
+      },
+    );
     this.pokemonLuckText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonLuckText);
 
@@ -816,14 +844,14 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonCandyDarknessOverlay.setAlpha(0.5);
     this.pokemonCandyContainer.add(this.pokemonCandyDarknessOverlay);
 
-    this.pokemonCandyCountText = addTextObject(9.5, 0, "x0", TextStyle.WINDOW_ALT, { fontSize: "56px" });
+    this.pokemonCandyCountText = globalScene.addTextObject(9.5, 0, "x0", TextStyle.WINDOW_ALT, { fontSize: "56px" });
     this.pokemonCandyCountText.setOrigin(0, 0);
     this.pokemonCandyContainer.add(this.pokemonCandyCountText);
 
     this.pokemonCandyContainer.setInteractive(new Phaser.Geom.Rectangle(0, 0, 30, 20), Phaser.Geom.Rectangle.Contains);
     this.starterSelectContainer.add(this.pokemonCandyContainer);
 
-    this.pokemonFormText = addTextObject(6, 42, "Form", TextStyle.WINDOW_ALT, { fontSize: "42px" });
+    this.pokemonFormText = globalScene.addTextObject(6, 42, "Form", TextStyle.WINDOW_ALT, { fontSize: "42px" });
     this.pokemonFormText.setOrigin(0, 0);
     this.starterSelectContainer.add(this.pokemonFormText);
 
@@ -836,7 +864,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     pokemonCaughtIcon.setScale(0.75);
     this.pokemonCaughtHatchedContainer.add(pokemonCaughtIcon);
 
-    this.pokemonCaughtCountText = addTextObject(24, 4, "0", TextStyle.SUMMARY_ALT);
+    this.pokemonCaughtCountText = globalScene.addTextObject(24, 4, "0", TextStyle.SUMMARY_ALT);
     this.pokemonCaughtCountText.setOrigin(0, 0);
     this.pokemonCaughtHatchedContainer.add(this.pokemonCaughtCountText);
 
@@ -850,7 +878,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonShinyIcon.setScale(1);
     this.pokemonCaughtHatchedContainer.add(this.pokemonShinyIcon);
 
-    this.pokemonHatchedCountText = addTextObject(24, 19, "0", TextStyle.SUMMARY_ALT);
+    this.pokemonHatchedCountText = globalScene.addTextObject(24, 19, "0", TextStyle.SUMMARY_ALT);
     this.pokemonHatchedCountText.setOrigin(0, 0);
     this.pokemonCaughtHatchedContainer.add(this.pokemonHatchedCountText);
 
@@ -863,7 +891,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       const moveBg = globalScene.add.nineslice(0, 0, "type_bgs", "unknown", 92, 14, 2, 2, 2, 2);
       moveBg.setOrigin(1, 0);
 
-      const moveLabel = addTextObject(-moveBg.width / 2, 0, "-", TextStyle.PARTY);
+      const moveLabel = globalScene.addTextObject(-moveBg.width / 2, 0, "-", TextStyle.PARTY);
       moveLabel.setOrigin(0.5, 0);
 
       this.pokemonMoveBgs.push(moveBg);
@@ -876,7 +904,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.pokemonMovesContainer.add(moveContainer);
     }
 
-    this.pokemonAdditionalMoveCountLabel = addTextObject(
+    this.pokemonAdditionalMoveCountLabel = globalScene.addTextObject(
       -this.pokemonMoveBgs[0].width / 2,
       56,
       "(+0)",
@@ -891,7 +919,12 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonEggMovesContainer = globalScene.add.container(102, 85);
     this.pokemonEggMovesContainer.setScale(0.375);
 
-    const eggMovesLabel = addTextObject(-46, 0, i18next.t("starterSelectUiHandler:eggMoves"), TextStyle.WINDOW_ALT);
+    const eggMovesLabel = globalScene.addTextObject(
+      -46,
+      0,
+      i18next.t("starterSelectUiHandler:eggMoves"),
+      TextStyle.WINDOW_ALT,
+    );
     eggMovesLabel.setOrigin(0.5, 0);
 
     this.pokemonEggMovesContainer.add(eggMovesLabel);
@@ -902,7 +935,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       const eggMoveBg = globalScene.add.nineslice(0, 0, "type_bgs", "unknown", 92, 14, 2, 2, 2, 2);
       eggMoveBg.setOrigin(1, 0);
 
-      const eggMoveLabel = addTextObject(-eggMoveBg.width / 2, 0, "???", TextStyle.PARTY);
+      const eggMoveLabel = globalScene.addTextObject(-eggMoveBg.width / 2, 0, "???", TextStyle.PARTY);
       eggMoveLabel.setOrigin(0.5, 0);
 
       this.pokemonEggMoveBgs.push(eggMoveBg);
@@ -937,7 +970,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.shinyIconElement.setName("sprite-shiny-icon-element");
     this.shinyIconElement.setScale(0.675);
     this.shinyIconElement.setOrigin(0.0, 0.0);
-    this.shinyLabel = addTextObject(
+    this.shinyLabel = globalScene.addTextObject(
       this.instructionRowX + this.instructionRowTextOffset,
       this.instructionRowY,
       i18next.t("starterSelectUiHandler:cycleShiny"),
@@ -956,7 +989,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.formIconElement.setName("sprite-form-icon-element");
     this.formIconElement.setScale(0.675);
     this.formIconElement.setOrigin(0.0, 0.0);
-    this.formLabel = addTextObject(
+    this.formLabel = globalScene.addTextObject(
       this.instructionRowX + this.instructionRowTextOffset,
       this.instructionRowY,
       i18next.t("starterSelectUiHandler:cycleForm"),
@@ -975,7 +1008,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.genderIconElement.setName("sprite-gender-icon-element");
     this.genderIconElement.setScale(0.675);
     this.genderIconElement.setOrigin(0.0, 0.0);
-    this.genderLabel = addTextObject(
+    this.genderLabel = globalScene.addTextObject(
       this.instructionRowX + this.instructionRowTextOffset,
       this.instructionRowY,
       i18next.t("starterSelectUiHandler:cycleGender"),
@@ -994,7 +1027,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.abilityIconElement.setName("sprite-ability-icon-element");
     this.abilityIconElement.setScale(0.675);
     this.abilityIconElement.setOrigin(0.0, 0.0);
-    this.abilityLabel = addTextObject(
+    this.abilityLabel = globalScene.addTextObject(
       this.instructionRowX + this.instructionRowTextOffset,
       this.instructionRowY,
       i18next.t("starterSelectUiHandler:cycleAbility"),
@@ -1013,7 +1046,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.natureIconElement.setName("sprite-nature-icon-element");
     this.natureIconElement.setScale(0.675);
     this.natureIconElement.setOrigin(0.0, 0.0);
-    this.natureLabel = addTextObject(
+    this.natureLabel = globalScene.addTextObject(
       this.instructionRowX + this.instructionRowTextOffset,
       this.instructionRowY,
       i18next.t("starterSelectUiHandler:cycleNature"),
@@ -1032,7 +1065,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.goFilterIconElement.setName("sprite-goFilter-icon-element");
     this.goFilterIconElement.setScale(0.675);
     this.goFilterIconElement.setOrigin(0.0, 0.0);
-    this.goFilterLabel = addTextObject(
+    this.goFilterLabel = globalScene.addTextObject(
       this.filterInstructionRowX + this.instructionRowTextOffset,
       this.filterInstructionRowY,
       i18next.t("starterSelectUiHandler:goFilter"),
@@ -1051,11 +1084,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.starterSelectMessageBoxContainer.setVisible(false);
     this.starterSelectContainer.add(this.starterSelectMessageBoxContainer);
 
-    this.starterSelectMessageBox = addWindow(1, -1, 318, 28);
+    this.starterSelectMessageBox = globalScene.addWindow(1, -1, 318, 28);
     this.starterSelectMessageBox.setOrigin(0, 1);
     this.starterSelectMessageBoxContainer.add(this.starterSelectMessageBox);
 
-    this.message = addTextObject(8, 8, "", TextStyle.WINDOW, { maxLines: 2 });
+    this.message = globalScene.addTextObject(8, 8, "", TextStyle.WINDOW, { maxLines: 2 });
     this.message.setOrigin(0, 0);
     this.starterSelectMessageBoxContainer.add(this.message);
 

--- a/src/ui/stats-container.ts
+++ b/src/ui/stats-container.ts
@@ -1,5 +1,5 @@
 import type BBCodeText from "phaser3-rex-plugins/plugins/gameobjects/tagtext/bbcodetext/BBCodeText";
-import { TextStyle, addBBCodeTextObject, addTextObject, getTextColor } from "./text";
+import { TextStyle, addBBCodeTextObject, getTextColor } from "./text";
 import { PERMANENT_STATS, getStatKey } from "#app/enums/stat";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
@@ -80,7 +80,7 @@ export class StatsContainer extends Phaser.GameObjects.Container {
     this.ivStatValueTexts = [];
 
     for (const s of PERMANENT_STATS) {
-      const statLabel = addTextObject(
+      const statLabel = globalScene.addTextObject(
         ivChartBg.x + ivChartSize * ivChartStatCoordMultipliers[s][0] * 1.325 + (this.showDiff ? 0 : ivLabelOffset[s]),
         ivChartBg.y
           + ivChartSize * ivChartStatCoordMultipliers[s][1] * 1.325

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -16,7 +16,7 @@ import { getStarterValueFriendshipCap, speciesStarterCosts } from "#app/data/bal
 import { argbFromRgba } from "@material/material-color-utilities";
 import { getTypeRgb } from "#app/data/type";
 import { Type } from "#enums/type";
-import { TextStyle, addBBCodeTextObject, addTextObject, getBBCodeFrag } from "#app/ui/text";
+import { TextStyle, addBBCodeTextObject, getBBCodeFrag } from "#app/ui/text";
 import type { Move } from "#app/data/move";
 import { MoveCategory } from "#app/enums/move-category";
 import { getPokeballAtlasKey } from "#app/data/pokeball";
@@ -141,7 +141,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.tabSprite.setOrigin(1, 1);
     this.summaryContainer.add(this.tabSprite);
 
-    const summaryLabel = addTextObject(4, -165, i18next.t("pokemonSummary:pokemonInfo"), TextStyle.SUMMARY);
+    const summaryLabel = globalScene.addTextObject(4, -165, i18next.t("pokemonSummary:pokemonInfo"), TextStyle.SUMMARY);
     summaryLabel.setOrigin(0, 1);
     this.summaryContainer.add(summaryLabel);
 
@@ -150,7 +150,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.shinyOverlay.setVisible(false);
     this.summaryContainer.add(this.shinyOverlay);
 
-    this.numberText = addTextObject(17, -149, "0000", TextStyle.SUMMARY);
+    this.numberText = globalScene.addTextObject(17, -149, "0000", TextStyle.SUMMARY);
     this.numberText.setOrigin(0, 1);
     this.summaryContainer.add(this.numberText);
 
@@ -162,7 +162,7 @@ export default class SummaryUiHandler extends UiHandler {
     );
     this.summaryContainer.add(this.pokemonSprite);
 
-    this.nameText = addTextObject(6, -54, "", TextStyle.SUMMARY);
+    this.nameText = globalScene.addTextObject(6, -54, "", TextStyle.SUMMARY);
     this.nameText.setOrigin(0, 0);
     this.summaryContainer.add(this.nameText);
 
@@ -205,7 +205,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.candyShadow.setInteractive(new Phaser.Geom.Rectangle(0, 0, 30, 16), Phaser.Geom.Rectangle.Contains);
     this.summaryContainer.add(this.candyShadow);
 
-    this.candyCountText = addTextObject(20, -146, "x0", TextStyle.WINDOW_ALT, { fontSize: "76px" });
+    this.candyCountText = globalScene.addTextObject(20, -146, "x0", TextStyle.WINDOW_ALT, { fontSize: "76px" });
     this.candyCountText.setOrigin(0, 0);
     this.summaryContainer.add(this.candyCountText);
 
@@ -224,7 +224,7 @@ export default class SummaryUiHandler extends UiHandler {
     this.friendshipShadow.setInteractive(new Phaser.Geom.Rectangle(0, 0, 50, 16), Phaser.Geom.Rectangle.Contains);
     this.summaryContainer.add(this.friendshipShadow);
 
-    this.friendshipText = addTextObject(20, -66, "x0", TextStyle.WINDOW_ALT, { fontSize: "76px" });
+    this.friendshipText = globalScene.addTextObject(20, -66, "x0", TextStyle.WINDOW_ALT, { fontSize: "76px" });
     this.friendshipText.setOrigin(0, 0);
     this.summaryContainer.add(this.friendshipText);
 
@@ -235,11 +235,11 @@ export default class SummaryUiHandler extends UiHandler {
     this.summaryContainer.add(this.championRibbon);
     this.championRibbon.setVisible(false);
 
-    this.levelText = addTextObject(36, -17, "", TextStyle.SUMMARY_ALT);
+    this.levelText = globalScene.addTextObject(36, -17, "", TextStyle.SUMMARY_ALT);
     this.levelText.setOrigin(0, 1);
     this.summaryContainer.add(this.levelText);
 
-    this.genderText = addTextObject(96, -17, "", TextStyle.SUMMARY);
+    this.genderText = globalScene.addTextObject(96, -17, "", TextStyle.SUMMARY);
     this.genderText.setOrigin(0, 1);
     this.summaryContainer.add(this.genderText);
 
@@ -250,7 +250,7 @@ export default class SummaryUiHandler extends UiHandler {
 
     this.statusContainer.add(statusBg);
 
-    const statusLabel = addTextObject(3, 0, i18next.t("pokemonSummary:status"), TextStyle.SUMMARY);
+    const statusLabel = globalScene.addTextObject(3, 0, i18next.t("pokemonSummary:status"), TextStyle.SUMMARY);
     statusLabel.setOrigin(0, 0);
 
     this.statusContainer.add(statusLabel);
@@ -270,17 +270,22 @@ export default class SummaryUiHandler extends UiHandler {
     moveEffectBg.setOrigin(0, 0);
     this.moveEffectContainer.add(moveEffectBg);
 
-    const moveEffectLabels = addTextObject(8, 12, i18next.t("pokemonSummary:powerAccuracyCategory"), TextStyle.SUMMARY);
+    const moveEffectLabels = globalScene.addTextObject(
+      8,
+      12,
+      i18next.t("pokemonSummary:powerAccuracyCategory"),
+      TextStyle.SUMMARY,
+    );
     moveEffectLabels.setLineSpacing(9);
     moveEffectLabels.setOrigin(0, 0);
 
     this.moveEffectContainer.add(moveEffectLabels);
 
-    this.movePowerText = addTextObject(99, 27, "0", TextStyle.WINDOW_ALT);
+    this.movePowerText = globalScene.addTextObject(99, 27, "0", TextStyle.WINDOW_ALT);
     this.movePowerText.setOrigin(1, 1);
     this.moveEffectContainer.add(this.movePowerText);
 
-    this.moveAccuracyText = addTextObject(99, 43, "0", TextStyle.WINDOW_ALT);
+    this.moveAccuracyText = globalScene.addTextObject(99, 43, "0", TextStyle.WINDOW_ALT);
     this.moveAccuracyText.setOrigin(1, 1);
     this.moveEffectContainer.add(this.moveAccuracyText);
 
@@ -795,11 +800,21 @@ export default class SummaryUiHandler extends UiHandler {
         trainerText.setOrigin(0, 0);
         profileContainer.add(trainerText);
 
-        const trainerIdText = addTextObject(174, 12, globalScene.gameData.trainerId.toString(), TextStyle.SUMMARY_ALT);
+        const trainerIdText = globalScene.addTextObject(
+          174,
+          12,
+          globalScene.gameData.trainerId.toString(),
+          TextStyle.SUMMARY_ALT,
+        );
         trainerIdText.setOrigin(0, 0);
         profileContainer.add(trainerIdText);
 
-        const typeLabel = addTextObject(7, 28, `${i18next.t("pokemonSummary:type")}/`, TextStyle.WINDOW_ALT);
+        const typeLabel = globalScene.addTextObject(
+          7,
+          28,
+          `${i18next.t("pokemonSummary:type")}/`,
+          TextStyle.WINDOW_ALT,
+        );
         typeLabel.setOrigin(0, 0);
         profileContainer.add(typeLabel);
 
@@ -827,11 +842,16 @@ export default class SummaryUiHandler extends UiHandler {
         }
 
         if (this.pokemon?.getLuck()) {
-          const luckLabelText = addTextObject(141, 28, i18next.t("common:luckIndicator"), TextStyle.SUMMARY_ALT);
+          const luckLabelText = globalScene.addTextObject(
+            141,
+            28,
+            i18next.t("common:luckIndicator"),
+            TextStyle.SUMMARY_ALT,
+          );
           luckLabelText.setOrigin(0, 0);
           profileContainer.add(luckLabelText);
 
-          const luckText = addTextObject(
+          const luckText = globalScene.addTextObject(
             141 + luckLabelText.displayWidth + 2,
             28,
             this.pokemon.getLuck().toString(),
@@ -878,13 +898,19 @@ export default class SummaryUiHandler extends UiHandler {
           abilityInfo.labelImage.setOrigin(0, 0);
           profileContainer.add(abilityInfo.labelImage);
 
-          abilityInfo.nameText = addTextObject(7, 66, abilityInfo.ability?.name!, TextStyle.SUMMARY_ALT); // TODO: is this bang correct?
+          abilityInfo.nameText = globalScene.addTextObject(7, 66, abilityInfo.ability?.name!, TextStyle.SUMMARY_ALT); // TODO: is this bang correct?
           abilityInfo.nameText.setOrigin(0, 1);
           profileContainer.add(abilityInfo.nameText);
 
-          abilityInfo.descriptionText = addTextObject(7, 69, abilityInfo.ability?.description!, TextStyle.WINDOW_ALT, {
-            wordWrap: { width: 1224 },
-          }); // TODO: is this bang correct?
+          abilityInfo.descriptionText = globalScene.addTextObject(
+            7,
+            69,
+            abilityInfo.ability?.description!,
+            TextStyle.WINDOW_ALT,
+            {
+              wordWrap: { width: 1224 },
+            },
+          ); // TODO: is this bang correct?
           abilityInfo.descriptionText.setOrigin(0, 0);
           profileContainer.add(abilityInfo.descriptionText);
 
@@ -950,7 +976,7 @@ export default class SummaryUiHandler extends UiHandler {
 
           const natureStatMultiplier = getNatureStatMultiplier(this.pokemon?.getNature()!, s); // TODO: is this bang correct?
 
-          const statLabel = addTextObject(
+          const statLabel = globalScene.addTextObject(
             27 + 115 * colIndex + (colIndex === 1 ? 5 : 0),
             56 + 16 * rowIndex,
             statName,
@@ -968,7 +994,12 @@ export default class SummaryUiHandler extends UiHandler {
               ? formatStat(this.pokemon?.getStat(stat)!) // TODO: is this bang correct?
               : `${formatStat(this.pokemon?.hp!, true)}/${formatStat(this.pokemon?.getMaxHp()!, true)}`; // TODO: are those bangs correct?
 
-          const statValue = addTextObject(120 + 88 * colIndex, 56 + 16 * rowIndex, statValueText, TextStyle.WINDOW_ALT);
+          const statValue = globalScene.addTextObject(
+            120 + 88 * colIndex,
+            56 + 16 * rowIndex,
+            statValueText,
+            TextStyle.WINDOW_ALT,
+          );
           statValue.setOrigin(1, 0);
           statsContainer.add(statValue);
         });
@@ -998,21 +1029,21 @@ export default class SummaryUiHandler extends UiHandler {
         const relLvExp = getLevelRelExp(pkmLvl + 1, pkmSpeciesGrowthRate);
         const expRatio = pkmLvl < globalScene.getMaxExpLevel() ? pkmLvlExp / relLvExp : 0;
 
-        const expLabel = addTextObject(6, 112, i18next.t("pokemonSummary:expPoints"), TextStyle.SUMMARY);
+        const expLabel = globalScene.addTextObject(6, 112, i18next.t("pokemonSummary:expPoints"), TextStyle.SUMMARY);
         expLabel.setOrigin(0, 0);
         statsContainer.add(expLabel);
 
-        const nextLvExpLabel = addTextObject(6, 128, i18next.t("pokemonSummary:nextLv"), TextStyle.SUMMARY);
+        const nextLvExpLabel = globalScene.addTextObject(6, 128, i18next.t("pokemonSummary:nextLv"), TextStyle.SUMMARY);
         nextLvExpLabel.setOrigin(0, 0);
         statsContainer.add(nextLvExpLabel);
 
-        const expText = addTextObject(208, 112, pkmExp.toString(), TextStyle.WINDOW_ALT);
+        const expText = globalScene.addTextObject(208, 112, pkmExp.toString(), TextStyle.WINDOW_ALT);
         expText.setOrigin(1, 0);
         statsContainer.add(expText);
 
         const nextLvExp =
           pkmLvl < globalScene.getMaxExpLevel() ? getLevelTotalExp(pkmLvl + 1, pkmSpeciesGrowthRate) - pkmExp : 0;
-        const nextLvExpText = addTextObject(208, 128, nextLvExp.toString(), TextStyle.WINDOW_ALT);
+        const nextLvExpText = globalScene.addTextObject(208, 128, nextLvExp.toString(), TextStyle.WINDOW_ALT);
         nextLvExpText.setOrigin(1, 0);
         statsContainer.add(nextLvExpText);
 
@@ -1042,7 +1073,7 @@ export default class SummaryUiHandler extends UiHandler {
         extraRowOverlay.setOrigin(0, 1);
         this.extraMoveRowContainer.add(extraRowOverlay);
 
-        const extraRowText = addTextObject(
+        const extraRowText = globalScene.addTextObject(
           35,
           0,
           this.summaryUiMode === SummaryUiMode.LEARN_MOVE && this.newMove
@@ -1068,7 +1099,7 @@ export default class SummaryUiHandler extends UiHandler {
           this.extraMoveRowContainer.add(ppOverlay);
 
           const pp = padInt(this.newMove?.pp!, 2, "  "); // TODO: is this bang correct?
-          const ppText = addTextObject(173, 1, `${pp}/${pp}`, TextStyle.WINDOW);
+          const ppText = globalScene.addTextObject(173, 1, `${pp}/${pp}`, TextStyle.WINDOW);
           ppText.setOrigin(0, 1);
           this.extraMoveRowContainer.add(ppText);
         }
@@ -1090,7 +1121,7 @@ export default class SummaryUiHandler extends UiHandler {
             moveRowContainer.add(typeIcon);
           }
 
-          const moveText = addTextObject(35, 0, move ? move.getName() : "-", TextStyle.SUMMARY);
+          const moveText = globalScene.addTextObject(35, 0, move ? move.getName() : "-", TextStyle.SUMMARY);
           moveText.setOrigin(0, 1);
           moveRowContainer.add(moveText);
 
@@ -1098,7 +1129,7 @@ export default class SummaryUiHandler extends UiHandler {
           ppOverlay.setOrigin(0, 1);
           moveRowContainer.add(ppOverlay);
 
-          const ppText = addTextObject(173, 1, "--/--", TextStyle.WINDOW);
+          const ppText = globalScene.addTextObject(173, 1, "--/--", TextStyle.WINDOW);
           ppText.setOrigin(0, 1);
 
           if (move) {
@@ -1110,7 +1141,9 @@ export default class SummaryUiHandler extends UiHandler {
           moveRowContainer.add(ppText);
         }
 
-        this.moveDescriptionText = addTextObject(2, 84, "", TextStyle.WINDOW_ALT, { wordWrap: { width: 1212 } });
+        this.moveDescriptionText = globalScene.addTextObject(2, 84, "", TextStyle.WINDOW_ALT, {
+          wordWrap: { width: 1212 },
+        });
         this.movesContainer.add(this.moveDescriptionText);
 
         const moveDescriptionTextMaskRect = globalScene.make.graphics({});

--- a/src/ui/title-ui-handler.ts
+++ b/src/ui/title-ui-handler.ts
@@ -1,7 +1,7 @@
 import OptionSelectUiHandler from "./settings/option-select-ui-handler";
 import { Mode } from "./ui";
 import { fixedInt, randItem } from "#app/utils";
-import { TextStyle, addTextObject, getTextStyleOptions } from "./text";
+import { TextStyle, getTextStyleOptions } from "./text";
 import { getSplashMessages } from "../data/splash-messages";
 import i18next from "i18next";
 import { TimedEventDisplay } from "#app/timed-event-manager";
@@ -46,7 +46,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       this.titleContainer.add(this.eventDisplay);
     }
 
-    this.playerCountLabel = addTextObject(
+    this.playerCountLabel = globalScene.addTextObject(
       globalScene.game.canvas.width / 6 - 2,
       globalScene.game.canvas.height / 6 - 13 - 576 * getTextStyleOptions(TextStyle.WINDOW, globalScene.uiTheme).scale,
       `? ${i18next.t("menu:playersOnline")}`,
@@ -56,9 +56,15 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
     this.playerCountLabel.setOrigin(1, 0);
     this.titleContainer.add(this.playerCountLabel);
 
-    this.splashMessageText = addTextObject(logo.x + 64, logo.y + logo.displayHeight - 8, "", TextStyle.MONEY, {
-      fontSize: "54px",
-    });
+    this.splashMessageText = globalScene.addTextObject(
+      logo.x + 64,
+      logo.y + logo.displayHeight - 8,
+      "",
+      TextStyle.MONEY,
+      {
+        fontSize: "54px",
+      },
+    );
     this.splashMessageText.setOrigin(0.5, 0.5);
     this.splashMessageText.setAngle(-20);
     this.titleContainer.add(this.splashMessageText);
@@ -73,7 +79,7 @@ export default class TitleUiHandler extends OptionSelectUiHandler {
       yoyo: true,
     });
 
-    this.appVersionText = addTextObject(logo.x - 60, logo.y + logo.displayHeight + 4, "", TextStyle.MONEY, {
+    this.appVersionText = globalScene.addTextObject(logo.x - 60, logo.y + logo.displayHeight + 4, "", TextStyle.MONEY, {
       fontSize: "54px",
     });
     this.appVersionText.setOrigin(0.5, 0.5);

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -14,7 +14,7 @@ import TargetSelectUiHandler from "./target-select-ui-handler";
 import SettingsUiHandler from "./settings/settings-ui-handler";
 import SettingsGamepadUiHandler from "./settings/settings-gamepad-ui-handler";
 import GameChallengesUiHandler from "./challenges-select-ui-handler";
-import { TextStyle, addTextObject } from "./text";
+import { TextStyle } from "./text";
 import AchvBar from "./achv-bar";
 import MenuUiHandler from "./menu-ui-handler";
 import AchvsUiHandler from "./achvs-ui-handler";
@@ -22,7 +22,6 @@ import OptionSelectUiHandler from "./settings/option-select-ui-handler";
 import EggHatchSceneHandler from "./egg-hatch-scene-handler";
 import EggListUiHandler from "./egg-list-ui-handler";
 import EggGachaUiHandler from "./egg-gacha-ui-handler";
-import { addWindow } from "./ui-theme";
 import LoginFormUiHandler from "./login-form-ui-handler";
 import RegistrationFormUiHandler from "./registration-form-ui-handler";
 import LoadingModalUiHandler from "./loading-modal-ui-handler";
@@ -242,15 +241,15 @@ export default class UI extends Phaser.GameObjects.Container {
     this.tooltipContainer.setName("tooltip");
     this.tooltipContainer.setVisible(false);
 
-    this.tooltipBg = addWindow(0, 0, 128, 31);
+    this.tooltipBg = globalScene.addWindow(0, 0, 128, 31);
     this.tooltipBg.setName("window-tooltip-bg");
     this.tooltipBg.setOrigin(0, 0);
 
-    this.tooltipTitle = addTextObject(64, 4, "", TextStyle.TOOLTIP_TITLE);
+    this.tooltipTitle = globalScene.addTextObject(64, 4, "", TextStyle.TOOLTIP_TITLE);
     this.tooltipTitle.setName("text-tooltip-title");
     this.tooltipTitle.setOrigin(0.5, 0);
 
-    this.tooltipContent = addTextObject(6, 16, "", TextStyle.TOOLTIP_CONTENT);
+    this.tooltipContent = globalScene.addTextObject(6, 16, "", TextStyle.TOOLTIP_CONTENT);
     this.tooltipContent.setName("text-tooltip-content");
     this.tooltipContent.setWordWrapWidth(850);
 

--- a/src/ui/unavailable-modal-ui-handler.ts
+++ b/src/ui/unavailable-modal-ui-handler.ts
@@ -1,6 +1,6 @@
 import type { ModalConfig } from "./modal-ui-handler";
 import { ModalUiHandler } from "./modal-ui-handler";
-import { addTextObject, TextStyle } from "./text";
+import { TextStyle } from "./text";
 import type { Mode } from "./ui";
 import { updateUserInfo } from "#app/account";
 import { removeCookie } from "#app/utils";
@@ -46,7 +46,7 @@ export default class UnavailableModalUiHandler extends ModalUiHandler {
   override setup(): void {
     super.setup();
 
-    const label = addTextObject(
+    const label = globalScene.addTextObject(
       this.getWidth() / 2,
       this.getHeight() / 2,
       i18next.t("menu:errorServerDown"),


### PR DESCRIPTION
## What are the changes the user will see?

None.

## Why am I making these changes?

This will make breaking globalScene up much easier. 

## What are the changes from a developer perspective?

addWindow and addTextObject, as they are now, are coded with the default assumption that they are adding a Phaser object to global scene. We could extend them by having the current scene be a parameter; however, I feel like that leads to more confusion. By making them class functions of SceneBase, any scene can use these methods + it logically makes sense that this.addWindow() / this.addTextObject() is adding a Phaser object to this (the specific scene).

I personally do not want this to be a permanent change and ideally, these functions would go into a scene that governs UI specifically. But, this should make the process of breaking down globalScene much easier. This is pretty much adding a little bit of spaghetti to clean up a larger chunk of spaghetti however.

## How to test the changes?
Game should function as normal. 

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?
