### PR TITLE
[Move][P2] Fix Secret Power interaction with multi-hit enhancers

### DIFF
--- a/src/data/move-attrs/secret-power-attr.ts
+++ b/src/data/move-attrs/secret-power-attr.ts
@@ -20,7 +20,7 @@ import { applyAbAttrs, applyPreDefendAbAttrs } from "../ability";
  */
 export class SecretPowerAttr extends MoveEffectAttr {
   constructor() {
-    super(false);
+    super(false, { firstHitOnly: true });
   }
 
   /**

--- a/src/data/move-attrs/secret-power-attr.ts
+++ b/src/data/move-attrs/secret-power-attr.ts
@@ -20,7 +20,7 @@ import { applyAbAttrs, applyPreDefendAbAttrs } from "../ability";
  */
 export class SecretPowerAttr extends MoveEffectAttr {
   constructor() {
-    super(false, { firstHitOnly: true });
+    super(false, { lastHitOnly: true });
   }
 
   /**

--- a/test/abilities/parental_bond.test.ts
+++ b/test/abilities/parental_bond.test.ts
@@ -445,10 +445,9 @@ describe("Abilities - Parental Bond", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase");
     await game.phaseInterceptor.to("MoveEffectPhase", false);
-    // The enemy's Sp Atk should drop before the second hit
-    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-1);
+    // The enemy's Sp Atk should not drop before the second hit
+    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
     await game.phaseInterceptor.to("MoveEndPhase", false);
-    // should still be at -1 after the second hit
     expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-1);
     expect(playerPokemon.turnData.hitCount).toBe(2);
   });

--- a/test/abilities/parental_bond.test.ts
+++ b/test/abilities/parental_bond.test.ts
@@ -429,7 +429,7 @@ describe("Abilities - Parental Bond", () => {
     expect(enemyPokemon.damageAndUpdate).toHaveBeenCalledTimes(2);
   });
 
-  it("should only apply the effects of Secret Power on the first hit", async () => {
+  it("should only apply the effects of Secret Power on the final hit", async () => {
     game.override.moveset(Moves.SECRET_POWER).enemyMoveset(Moves.MISTY_TERRAIN); // Secret Power lowers Sp Atk in Misty Terrain
 
     vi.spyOn(allMoves[Moves.SECRET_POWER], "chance", "get").mockReturnValue(-1);


### PR DESCRIPTION
## What are the changes the user will see?

Secret Power now only applies its effect on its last hit when enhanced by Parental Bond or Multi-Lens.

## Why am I making these changes?

From [Bulba's page on Parental Bond](https://bulbapedia.bulbagarden.net/wiki/Parental_Bond_(Ability)):
> Any attack which has a secondary effect (except [Secret Power](https://bulbapedia.bulbagarden.net/wiki/Secret_Power_(move))) has the same secondary effect on both strikes (such as [Power-Up Punch](https://bulbapedia.bulbagarden.net/wiki/Power-Up_Punch_(move))); if a secondary effect has a certain chance of occurring, each strike has an independent chance of activating that effect.
> ...
> Unlike other secondary effects, [Secret Power](https://bulbapedia.bulbagarden.net/wiki/Secret_Power_(move))'s secondary effect can only occur after the final strike.

## What are the changes from a developer perspective?

- `SecretPowerAttr` now uses the `lastHitOnly` option.
- 1 new test in `abilities/parental_bond.test.ts` covering the ability's interaction with Secret Power

## Screenshots/Videos

Parental Bond tests passing:

![image](https://github.com/user-attachments/assets/b62ac2ae-33e2-4858-a933-93a245387ca9)

## How to test the changes?

`npm run test parental_bond`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?
