### PR TITLE
[Move] Add `getHealRatio` helper function to `HealAttr`

### DIFF
--- a/src/data/move-attrs/boost-heal-attr.ts
+++ b/src/data/move-attrs/boost-heal-attr.ts
@@ -30,18 +30,11 @@ export class BoostHealAttr extends HealAttr {
     this.condition = condition;
   }
 
-  /**
-   * @param user {@linkcode Pokemon} using the move
-   * @param target {@linkcode Pokemon} target of the move
-   * @param move {@linkcode Move} with this attribute
-   * @param _args N/A
-   * @returns true if the move was successful
-   */
-  override apply(user: Pokemon, target: Pokemon, move: Move, _args: any[]): boolean {
-    const healRatio: number = (this.condition ? this.condition(user, target, move) : false)
-      ? this.boostedHealRatio
-      : this.normalHealRatio;
-    this.addHealPhase(target, healRatio);
-    return true;
+  protected override getHealRatio(user: Pokemon, target: Pokemon, move: Move): number {
+    if (this.condition && this.condition(user, target, move)) {
+      return this.boostedHealRatio;
+    } else {
+      return this.normalHealRatio;
+    }
   }
 }

--- a/src/data/move-attrs/heal-attr.ts
+++ b/src/data/move-attrs/heal-attr.ts
@@ -25,9 +25,17 @@ export class HealAttr extends MoveEffectAttr {
     this.showAnim = !!showAnim;
   }
 
-  override apply(user: Pokemon, target: Pokemon, _move: Move, _args: any[]): boolean {
-    this.addHealPhase(this.selfTarget ? user : target, this.healRatio);
+  override apply(user: Pokemon, target: Pokemon, move: Move, _args: any[]): boolean {
+    this.addHealPhase(this.selfTarget ? user : target, this.getHealRatio(user, target, move));
     return true;
+  }
+
+  /**
+   * Helper function to obtain this attribute's heal ratio
+   * @returns a heal ratio in the interval [0, 1]
+   */
+  protected getHealRatio(_user: Pokemon, _target: Pokemon, _move: Move): number {
+    return this.healRatio;
   }
 
   /**
@@ -46,8 +54,9 @@ export class HealAttr extends MoveEffectAttr {
     );
   }
 
-  override getTargetBenefitScore(user: Pokemon, target: Pokemon, _move: Move): number {
-    const score = (1 - (this.selfTarget ? user : target).getHpRatio()) * 20 - this.healRatio * 10;
+  override getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
+    const score =
+      (1 - (this.selfTarget ? user : target).getHpRatio()) * 20 - this.getHealRatio(user, target, move) * 10;
     return Math.round(score / (1 - this.healRatio / 2));
   }
 }

--- a/src/data/move-attrs/swallow-heal-attr.ts
+++ b/src/data/move-attrs/swallow-heal-attr.ts
@@ -9,28 +9,18 @@ import { HealAttr } from "#app/data/move-attrs/heal-attr";
  * @extends HealAttr
  */
 export class SwallowHealAttr extends HealAttr {
-  override apply(user: Pokemon, _target: Pokemon, _move: Move, _args: any[]): boolean {
+  protected override getHealRatio(user: Pokemon, _target: Pokemon, _move: Move): number {
     const stockpilingTag = user.getTag(StockpilingTag);
 
-    if (stockpilingTag && stockpilingTag.stockpiledCount > 0) {
-      const stockpiled = stockpilingTag.stockpiledCount;
-      let healRatio: number;
-
-      if (stockpiled === 1) {
-        healRatio = 0.25;
-      } else if (stockpiled === 2) {
-        healRatio = 0.5;
-      } else {
-        // stockpiled >= 3
-        healRatio = 1.0;
-      }
-
-      if (healRatio) {
-        this.addHealPhase(user, healRatio);
-        return true;
-      }
+    switch (stockpilingTag?.stockpiledCount) {
+      case 1:
+        return 0.25;
+      case 2:
+        return 0.5;
+      case 3:
+        return 1.0;
+      default:
+        return 0;
     }
-
-    return false;
   }
 }

--- a/src/data/move-attrs/weather-heal-attr.ts
+++ b/src/data/move-attrs/weather-heal-attr.ts
@@ -9,14 +9,12 @@ export abstract class WeatherHealAttr extends HealAttr {
     super(0.5);
   }
 
-  override apply(user: Pokemon, _target: Pokemon, _move: Move, _args: any[]): boolean {
-    let healRatio = 0.5;
+  protected override getHealRatio(_user: Pokemon, _target: Pokemon, _move: Move): number {
     if (!globalScene.arena.weather?.isEffectSuppressed()) {
       const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
-      healRatio = this.getWeatherHealRatio(weatherType);
+      return this.getWeatherHealRatio(weatherType);
     }
-    this.addHealPhase(user, healRatio);
-    return true;
+    return 0.5;
   }
 
   abstract getWeatherHealRatio(weatherType: WeatherType): number;

--- a/test/moves/floral_healing.test.ts
+++ b/test/moves/floral_healing.test.ts
@@ -1,0 +1,63 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Floral Healing", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.FLORAL_HEALING])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should heal the target by half of their maximum HP", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+    vi.spyOn(enemy, "getMaxHp").mockReturnValue(100);
+    enemy.hp = 1;
+
+    game.move.select(Moves.FLORAL_HEALING);
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(enemy.hp).toBe(51);
+  });
+
+  it("should heal the target by 2/3 of their maximum HP under Grassy Terrain", async () => {
+    game.override.enemyAbility(Abilities.GRASSY_SURGE);
+
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const enemy = game.scene.getEnemyPokemon()!;
+    vi.spyOn(enemy, "getMaxHp").mockReturnValue(100);
+    enemy.hp = 1;
+
+    game.move.select(Moves.FLORAL_HEALING);
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(enemy.hp).toBe(67);
+  });
+});

--- a/test/moves/synthesis.test.ts
+++ b/test/moves/synthesis.test.ts
@@ -1,0 +1,56 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { WeatherType } from "#enums/weather-type";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Synthesis", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.SYNTHESIS])
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it.each([
+    { weather: WeatherType.NONE, weatherName: "clear", expRatio: 50 },
+    { weather: WeatherType.SUNNY, weatherName: "sunny", expRatio: 66 },
+    { weather: WeatherType.RAIN, weatherName: "rainy", expRatio: 25 },
+  ])("should restore $expRatio percent of the user's HP in $weatherName weather", async ({ weather, expRatio }) => {
+    game.override.weather(weather);
+
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const player = game.scene.getPlayerPokemon()!;
+    vi.spyOn(player, "getMaxHp").mockReturnValue(100);
+    player.hp = 1;
+
+    game.move.select(Moves.SYNTHESIS);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(player.hp).toBe(expRatio + 1);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

`HealAttr` has a lot of subclasses that determine their heal ratios (i.e. the portion of the Pokemon's max HP healed) in different ways. This PR streamlines that logic across subclasses and allows the AI to evaluate healing moves more easily in the future.

## What are the changes from a developer perspective?

Added a helper `getHealRatio` function to `HealAttr`, which returns the attribute's `healRatio` field by default. Most subclasses of `HealAttr` now override this function instead of overriding `apply` with redundant code.

## Screenshots/Videos

## How to test the changes?

`npm run test swallow`
`npm run test synthesis`
`npm run test floral_healing`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?
