### PR TITLE
[P3] Fix protection bypass moves activating conditional protection messages

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -26,6 +26,7 @@ import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { ProtectStatAbAttr } from "./ab-attrs/protect-stat-ab-attr";
+import { MoveFlags } from "#enums/move-flags";
 
 export enum ArenaTagSide {
   BOTH,
@@ -339,12 +340,15 @@ export class ConditionalProtectTag extends ArenaTag {
     arena: Arena,
     simulated: boolean,
     isProtected: BooleanHolder,
-    _attacker: Pokemon,
+    attacker: Pokemon,
     defender: Pokemon,
     moveId: Moves,
-    ignoresProtectBypass: BooleanHolder,
   ): boolean {
-    if ((this.side === ArenaTagSide.PLAYER) === defender.isPlayer() && this.protectConditionFunc(arena, moveId)) {
+    if (
+      (this.side === ArenaTagSide.PLAYER) === defender.isPlayer()
+      && this.protectConditionFunc(arena, moveId)
+      && (this.ignoresBypass || !allMoves[moveId].checkFlag(MoveFlags.IGNORE_PROTECT, attacker, defender))
+    ) {
       if (!isProtected.value) {
         isProtected.value = true;
         if (!simulated) {
@@ -357,8 +361,6 @@ export class ConditionalProtectTag extends ArenaTag {
           );
         }
       }
-
-      ignoresProtectBypass.value = ignoresProtectBypass.value || this.ignoresBypass;
       return true;
     }
     return false;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1537,7 +1537,11 @@ export class ProtectedTag extends BattlerTag {
     );
   }
 
-  override apply(pokemon: Pokemon, simulated: boolean, ..._args: unknown[]): boolean {
+  override apply(pokemon: Pokemon, simulated: boolean, attacker: Pokemon, move: Move): boolean {
+    if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
+      return false;
+    }
+
     if (!simulated) {
       new CommonBattleAnim(CommonAnim.PROTECT, pokemon).play();
       globalScene.queueMessage(
@@ -1552,7 +1556,7 @@ export class ProtectedTag extends BattlerTag {
 export class DamageProtectedTag extends ProtectedTag {
   override apply(pokemon: Pokemon, simulated: boolean, attacker: Pokemon, move: Move): boolean {
     if (attacker.getMoveCategory(pokemon, move) !== MoveCategory.STATUS) {
-      return super.apply(pokemon, simulated);
+      return super.apply(pokemon, simulated, attacker, move);
     }
     return false;
   }

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1538,7 +1538,7 @@ export class ProtectedTag extends BattlerTag {
   }
 
   override apply(pokemon: Pokemon, simulated: boolean, attacker: Pokemon, move: Move): boolean {
-    if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
+    if (move.checkFlag(MoveFlags.IGNORE_PROTECT, attacker, pokemon)) {
       return false;
     }
 

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -684,8 +684,6 @@ export class MoveEffectPhase extends PokemonPhase {
     const targetSide = target.getArenaTagSide();
     /** Has the invoked move been cancelled by conditional protection (e.g Quick Guard)? */
     const hasConditionalProtectApplied = new BooleanHolder(false);
-    /** Does the applied conditional protection bypass Protect-ignoring effects? */
-    const bypassIgnoreProtect = new BooleanHolder(false);
     /** If the move is not targeting a Pokemon on the user's side, try to apply conditional protection effects */
     if (!this.move.getMove().isAllyTarget()) {
       globalScene.arena.applyTagsForSide(
@@ -696,15 +694,14 @@ export class MoveEffectPhase extends PokemonPhase {
         user,
         target,
         move.id,
-        bypassIgnoreProtect,
       );
     }
 
     /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */
     const isProtected =
-      (bypassIgnoreProtect.value || !this.move.getMove().checkFlag(MoveFlags.IGNORE_PROTECT, user, target))
-      && (hasConditionalProtectApplied.value
-        || target.findTags((t) => t instanceof ProtectedTag)[0]?.apply(target, simulated, user, move));
+      hasConditionalProtectApplied.value
+      || (!this.move.getMove().checkFlag(MoveFlags.IGNORE_PROTECT, user, target)
+        && target.findTags((t) => t instanceof ProtectedTag)[0]?.apply(target, simulated, user, move));
 
     if (isProtected) {
       return [HitCheckResult.PROTECTED, 0];

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -700,8 +700,7 @@ export class MoveEffectPhase extends PokemonPhase {
     /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */
     const isProtected =
       hasConditionalProtectApplied.value
-      || (!this.move.getMove().checkFlag(MoveFlags.IGNORE_PROTECT, user, target)
-        && target.findTags((t) => t instanceof ProtectedTag)[0]?.apply(target, simulated, user, move));
+      || target.findTags((t) => t instanceof ProtectedTag)[0]?.apply(target, simulated, user, move);
 
     if (isProtected) {
       return [HitCheckResult.PROTECTED, 0];


### PR DESCRIPTION
## What are the changes the user will see?

Conditional protection moves (e.g. Quick Guard) will no longer show their protection animations before moves that bypass protection hit their target.

## Why am I making these changes?

fixes #179 . This is a bug from #37 that was only discovered after Feint was refactored in #170 

## What are the changes from a developer perspective?

The `IGNORE_PROTECT` move flag is now checked within relevant tags (`ProtectedTag` and `ConditionalProtectTag`) instead of in `MoveEffectPhase#hitCheck` after already applying conditional protection tags

## Screenshots/Videos

https://github.com/user-attachments/assets/8114f6bf-7381-476e-91e6-7f99459dcb42

## How to test the changes?

Use the overrides below and start a run

```ts
const overrides = {
  MOVESET_OVERRIDE: Moves.FEINT,
  OPP_MOVESET_OVERRIDE: Moves.QUICK_GUARD
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

Using Feint against an enemy should bypass Quick Guard without activating the move's protection animation.

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [n/a] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?
