### PR TITLE
[Refactor] Make `args` type-inferrable for Ability attributes

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1308,7 +1308,7 @@ export default class BattleScene extends SceneBase {
   getDoubleBattleChance(newWaveIndex: number, playerField: PlayerPokemon[]) {
     const doubleChance = new NumberHolder(newWaveIndex % 10 === 0 ? 32 : 8);
     this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
-    playerField.forEach((p) => applyAbAttrs(DoubleBattleChanceAbAttr, p, null, false, doubleChance));
+    playerField.forEach((p) => applyAbAttrs(DoubleBattleChanceAbAttr, p, false, doubleChance));
     return Math.max(doubleChance.value, 1);
   }
 
@@ -2712,7 +2712,7 @@ export default class BattleScene extends SceneBase {
     const cancelled = new BooleanHolder(false);
 
     if (source && source.isPlayer() !== target.isPlayer()) {
-      applyAbAttrs(BlockItemTheftAbAttr, source, cancelled);
+      applyAbAttrs(BlockItemTheftAbAttr, source);
     }
 
     if (cancelled.value) {

--- a/src/data/ab-attrs/ab-attr.ts
+++ b/src/data/ab-attrs/ab-attr.ts
@@ -1,6 +1,5 @@
 import type { AbAttrCondition } from "#app/@types/AbAttrCondition";
 import { type Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder } from "#app/utils";
 
 export abstract class AbAttr {
   public showAbility: boolean;
@@ -10,13 +9,17 @@ export abstract class AbAttr {
     this.showAbility = showAbility;
   }
 
-  apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder | null,
-    _args: any[],
-  ): boolean {
+  /**
+   * Applies the effects of this attribute
+   * @param _pokemon The {@linkcode Pokemon} with the ability
+   * @param _passive `true` if the source ability is a Pokemon's passive
+   * @param _simulated `true` if attribute effects should be resolved without changing game state
+   * @param _args Any additional parameters or data to modify
+   * @returns `true` if this attribute applies successfully. If {@linkcode showAbility} is enabled,
+   * and this apply call is not simulated, returning `true` activates the ability's flyout
+   * and {@linkcode getTriggerMessage | trigger message} (if applicable)
+   */
+  apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 

--- a/src/data/ab-attrs/add-second-strike-ab-attr.ts
+++ b/src/data/ab-attrs/add-second-strike-ab-attr.ts
@@ -33,11 +33,9 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
     _simulated: boolean,
     _defender: Pokemon,
     move: Move,
-    args: any[],
+    hitCount: NumberHolder,
+    multiplier: NumberHolder,
   ): boolean {
-    const hitCount = args[0] as NumberHolder;
-    const multiplier = args[1] as NumberHolder;
-
     if (move.canBeMultiStrikeEnhanced(pokemon)) {
       this.showAbility = !!hitCount?.value;
       if (hitCount?.value) {

--- a/src/data/ab-attrs/allied-field-damage-reduction-ab-attr.ts
+++ b/src/data/ab-attrs/allied-field-damage-reduction-ab-attr.ts
@@ -1,6 +1,6 @@
 import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
-import { type BooleanHolder, type NumberHolder } from "#app/utils";
+import type { BooleanHolder, NumberHolder } from "#app/utils";
 import { PreDefendAbAttr } from "./pre-defend-ab-attr";
 
 /**
@@ -28,9 +28,8 @@ export class AlliedFieldDamageReductionAbAttr extends PreDefendAbAttr {
     _attacker: Pokemon,
     _move: Move,
     _cancelled: BooleanHolder,
-    args: any[],
+    multiplier: NumberHolder,
   ): boolean {
-    const multiplier = args[0] as NumberHolder;
     multiplier.value *= this.damageMultiplier;
     return true;
   }

--- a/src/data/ab-attrs/arena-trap-ab-attr.ts
+++ b/src/data/ab-attrs/arena-trap-ab-attr.ts
@@ -30,7 +30,6 @@ export class ArenaTrapAbAttr extends CheckTrappedAbAttr {
     _simulated: boolean,
     trapped: BooleanHolder,
     otherPokemon: Pokemon,
-    _args: any[],
   ): boolean {
     if (this.arenaTrapCondition(pokemon, otherPokemon)) {
       if (

--- a/src/data/ab-attrs/attack-type-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/attack-type-immunity-ab-attr.ts
@@ -3,7 +3,7 @@ import { type Move } from "#app/data/move";
 import { NeutralDamageAgainstFlyingTypeMultiplierAttr } from "../move-attrs/neutral-damage-against-flying-type-multiplier-attr";
 import { MoveCategory } from "../../enums/move-category";
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder } from "#app/utils";
+import type { BooleanHolder, NumberHolder } from "#app/utils";
 import type { Type } from "#enums/type";
 import { TypeImmunityAbAttr } from "./type-immunity-ab-attr";
 
@@ -26,14 +26,14 @@ export class AttackTypeImmunityAbAttr extends TypeImmunityAbAttr {
     attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    args: any[],
+    typeMultiplier: NumberHolder,
   ): boolean {
     // this is a hacky way to fix the Levitate/Thousand Arrows interaction, but it works for now...
     if (
       attacker.getMoveCategory(pokemon, move) !== MoveCategory.STATUS
       && !move.hasAttr(NeutralDamageAgainstFlyingTypeMultiplierAttr)
     ) {
-      return super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
+      return super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, typeMultiplier);
     }
     return false;
   }

--- a/src/data/ab-attrs/block-crit-ab-attr.ts
+++ b/src/data/ab-attrs/block-crit-ab-attr.ts
@@ -10,16 +10,7 @@ import { AbAttr } from "./ab-attr";
  * @extends AbAttr
  */
 export class BlockCritAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const isCritical = args[0] as BooleanHolder;
-
-    // Only if isCritical is `true`, then the game checks if any crit-blocking abilities would nullify the result.
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, isCritical: BooleanHolder): boolean {
     if (isCritical.value) {
       isCritical.value = false;
       return true;

--- a/src/data/ab-attrs/block-item-theft-ab-attr.ts
+++ b/src/data/ab-attrs/block-item-theft-ab-attr.ts
@@ -5,13 +5,7 @@ import i18next from "i18next";
 import { AbAttr } from "./ab-attr";
 
 export class BlockItemTheftAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
 
     return true;

--- a/src/data/ab-attrs/block-non-direct-damage-ab-attr.ts
+++ b/src/data/ab-attrs/block-non-direct-damage-ab-attr.ts
@@ -3,13 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class BlockNonDirectDamageAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
     return true;
   }

--- a/src/data/ab-attrs/block-one-hit-ko-ab-attr.ts
+++ b/src/data/ab-attrs/block-one-hit-ko-ab-attr.ts
@@ -3,13 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class BlockOneHitKOAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
     return true;
   }

--- a/src/data/ab-attrs/block-recoil-damage-ab-attr.ts
+++ b/src/data/ab-attrs/block-recoil-damage-ab-attr.ts
@@ -5,15 +5,8 @@ import i18next from "i18next";
 import { AbAttr } from "./ab-attr";
 
 export class BlockRecoilDamageAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
-
     return true;
   }
 

--- a/src/data/ab-attrs/block-status-damage-ab-attr.ts
+++ b/src/data/ab-attrs/block-status-damage-ab-attr.ts
@@ -24,13 +24,7 @@ export class BlockStatusDamageAbAttr extends AbAttr {
    * @param N/A
    * @returns Returns `true` if status damage is blocked
    */
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     if (pokemon.status && this.effects.includes(pokemon.status.effect)) {
       cancelled.value = true;
       return true;

--- a/src/data/ab-attrs/block-weather-damage-attr.ts
+++ b/src/data/ab-attrs/block-weather-damage-attr.ts
@@ -32,7 +32,6 @@ export class BlockWeatherDamageAttr extends PreWeatherDamageAbAttr {
     _simulated: boolean,
     weather: Weather,
     cancelled: BooleanHolder,
-    _args: any[],
   ): boolean {
     if (!this.weatherTypes.length || this.weatherTypes.indexOf(weather?.weatherType) > -1) {
       cancelled.value = true;

--- a/src/data/ab-attrs/bonus-crit-ab-attr.ts
+++ b/src/data/ab-attrs/bonus-crit-ab-attr.ts
@@ -3,14 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class BonusCritAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const bonusCrit: BooleanHolder = args[0];
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, bonusCrit: BooleanHolder): boolean {
     bonusCrit.value = true;
     return true;
   }

--- a/src/data/ab-attrs/bypass-burn-damage-reduction-ab-attr.ts
+++ b/src/data/ab-attrs/bypass-burn-damage-reduction-ab-attr.ts
@@ -7,15 +7,8 @@ export class BypassBurnDamageReductionAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
-
     return true;
   }
 }

--- a/src/data/ab-attrs/bypass-speed-chance-ab-attr.ts
+++ b/src/data/ab-attrs/bypass-speed-chance-ab-attr.ts
@@ -28,21 +28,13 @@ export class BypassSpeedChanceAbAttr extends AbAttr {
    * bypass move order in their priority bracket when pokemon choose damaging move
    * @param pokemon {@linkcode Pokemon} applying this ability
    * @param _passive N/A
-   * @param _cancelled N/A
    * @param args [0] {@linkcode BooleanHolder} set to true when the ability activated
    * @returns whether the ability was activated
    */
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
+  override apply(pokemon: Pokemon, _passive: boolean, simulated: boolean, bypassSpeed: BooleanHolder): boolean {
     if (simulated) {
       return false;
     }
-    const bypassSpeed = args[0] as BooleanHolder;
 
     if (!bypassSpeed.value && pokemon.randSeedInt(100) < this.chance) {
       const turnCommand = globalScene.currentBattle.turnCommands[pokemon.getBattlerIndex()];

--- a/src/data/ab-attrs/change-move-priority-ab-attr.ts
+++ b/src/data/ab-attrs/change-move-priority-ab-attr.ts
@@ -1,6 +1,6 @@
 import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 /**
@@ -27,11 +27,9 @@ export class ChangeMovePriorityAbAttr extends AbAttr {
     pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
+    move: Move,
+    priority: NumberHolder,
   ): boolean {
-    const move: Move = args[0];
-    const priority: NumberHolder = args[1];
     if (!this.moveFunc(pokemon, move)) {
       return false;
     }

--- a/src/data/ab-attrs/check-trapped-ab-attr.ts
+++ b/src/data/ab-attrs/check-trapped-ab-attr.ts
@@ -24,7 +24,7 @@ export class CheckTrappedAbAttr extends AbAttr {
     _simulated: boolean,
     _trapped: BooleanHolder,
     _otherPokemon: Pokemon,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/commander-ab-attr.ts
+++ b/src/data/ab-attrs/commander-ab-attr.ts
@@ -15,7 +15,7 @@ import { AbAttr } from "./ab-attr";
  * causing attacks that target the source to always miss.
  */
 export class CommanderAbAttr extends AbAttr {
-  override apply(pokemon: Pokemon, _passive: boolean, simulated: boolean, _cancelled: null, _args: any[]): boolean {
+  override apply(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     // TODO: Should this work with X + Dondozo fusions?
     if (globalScene.currentBattle?.double && pokemon.getAlly()?.species.speciesId === Species.DONDOZO) {
       // If the ally Dondozo is fainted or was previously "commanded" by

--- a/src/data/ab-attrs/conditional-crit-ab-attr.ts
+++ b/src/data/ab-attrs/conditional-crit-ab-attr.ts
@@ -20,21 +20,18 @@ export class ConditionalCritAbAttr extends AbAttr {
 
   /**
    * @param pokemon {@linkcode Pokemon} user.
-   * @param args -
-   * - [0] {@linkcode BooleanHolder} Set to `true` if it should be a critical hit.
-   * - [1] {@linkcode Pokemon} Target.
-   * - [2] {@linkcode Move} used by ability user.
+   * @param isCritical {@linkcode BooleanHolder} Set to `true` if it should be a critical hit.
+   * @param target {@linkcode Pokemon} Target.
+   * @param move {@linkcode Move} used by ability user.
    */
   override apply(
     pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
+    isCritical: BooleanHolder,
+    target: Pokemon,
+    move: Move,
   ): boolean {
-    const isCritical: BooleanHolder = args[0];
-    const target: Pokemon = args[1];
-    const move: Move = args[2];
     if (!this.condition(pokemon, target, move)) {
       return false;
     }

--- a/src/data/ab-attrs/confusion-on-status-effect-ab-attr.ts
+++ b/src/data/ab-attrs/confusion-on-status-effect-ab-attr.ts
@@ -38,9 +38,8 @@ export class ConfusionOnStatusEffectAbAttr extends PostAttackAbAttr {
     defender: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    args: any[],
+    effect: StatusEffect,
   ): boolean {
-    const effect: StatusEffect = args[0];
     if (this.effects.includes(effect) && !defender.isFainted()) {
       if (simulated) {
         return defender.canAddTag(BattlerTagType.CONFUSED);

--- a/src/data/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
+++ b/src/data/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
@@ -7,13 +7,7 @@ import { PostKnockOutAbAttr } from "./post-knock-out-ab-attr";
 import { UncopiableAbilityAbAttr } from "./uncopiable-ability-ab-attr";
 
 export class CopyFaintedAllyAbilityAbAttr extends PostKnockOutAbAttr {
-  override applyPostKnockOut(
-    pokemon: Pokemon,
-    _passive: boolean,
-    simulated: boolean,
-    knockedOut: Pokemon,
-    _args: any[],
-  ): boolean {
+  override applyPostKnockOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, knockedOut: Pokemon): boolean {
     if (pokemon.isPlayer() === knockedOut.isPlayer() && !knockedOut.getAbility().hasAttr(UncopiableAbilityAbAttr)) {
       if (!simulated) {
         pokemon.summonData.ability = knockedOut.getAbility().id;

--- a/src/data/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
+++ b/src/data/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
@@ -7,14 +7,22 @@ import { PostKnockOutAbAttr } from "./post-knock-out-ab-attr";
 import { UncopiableAbilityAbAttr } from "./uncopiable-ability-ab-attr";
 
 export class CopyFaintedAllyAbilityAbAttr extends PostKnockOutAbAttr {
-  override applyPostKnockOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, knockedOut: Pokemon): boolean {
-    if (pokemon.isPlayer() === knockedOut.isPlayer() && !knockedOut.getAbility().hasAttr(UncopiableAbilityAbAttr)) {
+  override applyPostKnockOut(
+    pokemon: Pokemon,
+    _passive: boolean,
+    simulated: boolean,
+    knockedOutPokemon: Pokemon,
+  ): boolean {
+    if (
+      pokemon.isPlayer() === knockedOutPokemon.isPlayer()
+      && !knockedOutPokemon.getAbility().hasAttr(UncopiableAbilityAbAttr)
+    ) {
       if (!simulated) {
-        pokemon.summonData.ability = knockedOut.getAbility().id;
+        pokemon.summonData.ability = knockedOutPokemon.getAbility().id;
         globalScene.queueMessage(
           i18next.t("abilityTriggers:copyFaintedAllyAbility", {
-            pokemonNameWithAffix: getPokemonNameWithAffix(knockedOut),
-            abilityName: allAbilities[knockedOut.getAbility().id].name,
+            pokemonNameWithAffix: getPokemonNameWithAffix(knockedOutPokemon),
+            abilityName: allAbilities[knockedOutPokemon.getAbility().id].name,
           }),
         );
       }

--- a/src/data/ab-attrs/damage-boost-ab-attr.ts
+++ b/src/data/ab-attrs/damage-boost-ab-attr.ts
@@ -35,10 +35,9 @@ export class DamageBoostAbAttr extends PreAttackAbAttr {
     _simulated: boolean,
     defender: Pokemon,
     move: Move,
-    args: any[],
+    multiplier: NumberHolder,
   ): boolean {
     if (this.condition(pokemon, defender, move)) {
-      const multiplier = args[0] as NumberHolder;
       multiplier.value *= this.damageMultiplier;
       return true;
     }

--- a/src/data/ab-attrs/double-battle-chance-ab-attr.ts
+++ b/src/data/ab-attrs/double-battle-chance-ab-attr.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 /**
@@ -14,17 +14,10 @@ export class DoubleBattleChanceAbAttr extends AbAttr {
 
   /**
    * Increases the chance of a double battle occurring
-   * @param args [0] {@linkcode NumberHolder} for double battle chance
+   * @param doubleBattleChance {@linkcode NumberHolder} for double battle chance
    * @returns true if the ability was applied
    */
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const doubleBattleChance = args[0] as NumberHolder;
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, doubleBattleChance: NumberHolder): boolean {
     // This is divided because the chance is generated as a number from 0 to doubleBattleChance.value using Utils.randSeedInt
     // A double battle will initiate if the generated number is 0
     doubleBattleChance.value = doubleBattleChance.value / 4;

--- a/src/data/ab-attrs/double-berry-effect-ab-attr.ts
+++ b/src/data/ab-attrs/double-berry-effect-ab-attr.ts
@@ -1,18 +1,10 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class DoubleBerryEffectAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const berryEffect: NumberHolder = args[0];
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, berryEffect: NumberHolder): boolean {
     berryEffect.value *= 2;
-
     return true;
   }
 }

--- a/src/data/ab-attrs/download-ab-attr.ts
+++ b/src/data/ab-attrs/download-ab-attr.ts
@@ -20,7 +20,7 @@ export class DownloadAbAttr extends PostSummonAbAttr {
    * @param pokemon The {@linkcode Pokemon} with this ability
    * @returns Returns `true` if ability is used successful, `false` if not.
    */
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     this.enemyDef = 0;
     this.enemySpDef = 0;
 

--- a/src/data/ab-attrs/effect-spore-ab-attr.ts
+++ b/src/data/ab-attrs/effect-spore-ab-attr.ts
@@ -28,7 +28,6 @@ export class EffectSporeAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (attacker.hasAbility(Abilities.OVERCOAT) || attacker.isOfType(Type.GRASS)) {
       return false;

--- a/src/data/ab-attrs/fetch-ball-ab-attr.ts
+++ b/src/data/ab-attrs/fetch-ball-ab-attr.ts
@@ -17,7 +17,7 @@ export class FetchBallAbAttr extends PostTurnAbAttr {
    * @param _args N/A
    * @returns true if player has used a pokeball and this pokemon is owned by the player
    */
-  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (simulated) {
       return false;
     }

--- a/src/data/ab-attrs/field-move-power-boost-ab-attr.ts
+++ b/src/data/ab-attrs/field-move-power-boost-ab-attr.ts
@@ -2,13 +2,13 @@ import type { PokemonAttackCondition } from "#app/@types/PokemonAttackCondition"
 import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
 import type { NumberHolder } from "#app/utils";
-import { AbAttr } from "./ab-attr";
+import { PreAttackAbAttr } from "./pre-attack-ab-attr";
 
 /**
  * Boosts the power of a Pokémon's move under certain conditions.
  * @extends AbAttr
  */
-export class FieldMovePowerBoostAbAttr extends AbAttr {
+export class FieldMovePowerBoostAbAttr extends PreAttackAbAttr {
   private readonly condition: PokemonAttackCondition;
   private readonly powerMultiplier: number;
 
@@ -22,16 +22,15 @@ export class FieldMovePowerBoostAbAttr extends AbAttr {
     this.powerMultiplier = powerMultiplier;
   }
 
-  applyPreAttack(
+  override applyPreAttack(
     pokemon: Pokemon | null,
     _passive: boolean | null,
     _simulated: boolean,
     defender: Pokemon | null,
     move: Move,
-    args: any[],
+    movePower: NumberHolder,
   ): boolean {
     if (this.condition(pokemon, defender, move)) {
-      const movePower: NumberHolder = args[0];
       movePower.value *= this.powerMultiplier;
 
       return true;

--- a/src/data/ab-attrs/field-prevent-explosion-like-ab-attr.ts
+++ b/src/data/ab-attrs/field-prevent-explosion-like-ab-attr.ts
@@ -24,10 +24,11 @@ export class FieldPreventExplosionLikeAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     cancelled: BooleanHolder,
-    args: any[],
+    moveUser: string,
+    moveName: string,
   ): boolean {
-    this.moveUser = args[0];
-    this.moveName = args[1];
+    this.moveUser = moveUser;
+    this.moveName = moveName;
     cancelled.value = true;
     return true;
   }

--- a/src/data/ab-attrs/field-priority-move-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/field-priority-move-immunity-ab-attr.ts
@@ -12,7 +12,6 @@ export class FieldPriorityMoveImmunityAbAttr extends PreDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    _args: any[],
   ): boolean {
     if (move.moveTarget === MoveTarget.USER || move.moveTarget === MoveTarget.NEAR_ALLY) {
       return false;

--- a/src/data/ab-attrs/flinch-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/flinch-stat-stage-change-ab-attr.ts
@@ -1,7 +1,6 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
-import type { BooleanHolder } from "#app/utils";
 import type { BattleStat } from "#enums/stat";
 import { FlinchEffectAbAttr } from "./flinch-effect-ab-attr";
 
@@ -16,13 +15,7 @@ export class FlinchStatStageChangeAbAttr extends FlinchEffectAbAttr {
     this.stages = stages;
   }
 
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    simulated: boolean,
-    _cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!simulated) {
       globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, this.stats, this.stages));
     }

--- a/src/data/ab-attrs/force-switch-out-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/force-switch-out-immunity-ab-attr.ts
@@ -3,13 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class ForceSwitchOutImmunityAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
     return true;
   }

--- a/src/data/ab-attrs/forewarn-ab-attr.ts
+++ b/src/data/ab-attrs/forewarn-ab-attr.ts
@@ -8,7 +8,7 @@ import i18next from "i18next";
 import { PostSummonAbAttr } from "./post-summon-ab-attr";
 
 export class ForewarnAbAttr extends PostSummonAbAttr {
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     let maxPowerSeen = 0;
     let maxMove = "";
     let movePower = 0;

--- a/src/data/ab-attrs/form-block-damage-ab-attr.ts
+++ b/src/data/ab-attrs/form-block-damage-ab-attr.ts
@@ -51,11 +51,10 @@ export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
     attacker: Pokemon,
     move: Move,
     _cancelled: BooleanHolder,
-    args: any[],
+    multiplier: NumberHolder,
   ): boolean {
     if (this.condition(pokemon, attacker, move) && !move.hitsSubstitute(attacker, pokemon)) {
       if (!simulated) {
-        const multiplier: NumberHolder = args[0];
         multiplier.value *= this.multiplier;
         pokemon.removeTag(this.tagType);
         if (this.recoilDamageFunc) {

--- a/src/data/ab-attrs/frisk-ab-attr.ts
+++ b/src/data/ab-attrs/frisk-ab-attr.ts
@@ -6,7 +6,7 @@ import i18next from "i18next";
 import { PostSummonAbAttr } from "./post-summon-ab-attr";
 
 export class FriskAbAttr extends PostSummonAbAttr {
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!simulated) {
       for (const opponent of pokemon.getOpponents()) {
         globalScene.queueMessage(

--- a/src/data/ab-attrs/full-hp-resist-type-ab-attr.ts
+++ b/src/data/ab-attrs/full-hp-resist-type-ab-attr.ts
@@ -2,7 +2,7 @@ import { type Move } from "#app/data/move";
 import { FixedDamageAttr } from "../move-attrs/fixed-damage-attr";
 import type { Pokemon } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { type BooleanHolder, NumberHolder } from "#app/utils";
+import type { BooleanHolder, NumberHolder } from "#app/utils";
 import i18next from "i18next";
 import { PreDefendAbAttr } from "./pre-defend-ab-attr";
 
@@ -30,13 +30,8 @@ export class FullHpResistTypeAbAttr extends PreDefendAbAttr {
     _attacker: Pokemon,
     move: Move | null,
     _cancelled: BooleanHolder | null,
-    args: any[],
+    typeMultiplier: NumberHolder,
   ): boolean {
-    const typeMultiplier = args[0];
-    if (!(typeMultiplier && typeMultiplier instanceof NumberHolder)) {
-      return false;
-    }
-
     if (move && move.hasAttr(FixedDamageAttr)) {
       return false;
     }

--- a/src/data/ab-attrs/gorilla-tactics-ab-attr.ts
+++ b/src/data/ab-attrs/gorilla-tactics-ab-attr.ts
@@ -31,7 +31,6 @@ export class GorillaTacticsAbAttr extends PostAttackAbAttr {
     _defender: Pokemon,
     _move: Move,
     _hitResult: HitResult | null,
-    _args: any[],
   ): boolean {
     if (simulated) {
       return simulated;

--- a/src/data/ab-attrs/heal-from-berry-use-ab-attr.ts
+++ b/src/data/ab-attrs/heal-from-berry-use-ab-attr.ts
@@ -22,7 +22,7 @@ export class HealFromBerryUseAbAttr extends AbAttr {
     this.healPercent = Phaser.Math.Clamp(healPercent, 0, 1);
   }
 
-  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean, ..._args: any[]): boolean {
+  override apply(pokemon: Pokemon, passive: boolean, simulated: boolean): boolean {
     const { name: abilityName } = passive ? pokemon.getPassiveAbility() : pokemon.getAbility();
     if (!simulated) {
       globalScene.unshiftPhase(

--- a/src/data/ab-attrs/ignore-move-effect-ab-attr.ts
+++ b/src/data/ab-attrs/ignore-move-effect-ab-attr.ts
@@ -19,9 +19,8 @@ export class IgnoreMoveEffectsAbAttr extends PreDefendAbAttr {
     _attacker: Pokemon,
     _move: Move,
     _cancelled: BooleanHolder,
-    args: any[],
+    effectChance: NumberHolder,
   ): boolean {
-    const effectChance: NumberHolder = args[0];
     if (effectChance.value <= 0) {
       return false;
     }

--- a/src/data/ab-attrs/ignore-opponent-stat-stages-ab-attr.ts
+++ b/src/data/ab-attrs/ignore-opponent-stat-stages-ab-attr.ts
@@ -21,13 +21,18 @@ export class IgnoreOpponentStatStagesAbAttr extends AbAttr {
    * @param _pokemon n/a
    * @param _passive n/a
    * @param _simulated n/a
-   * @param _cancelled n/a
-   * @param args A BooleanHolder that represents whether or not to ignore a stat's stat changes
+   * @param stat The {@linkcode EffectiveStat} to be ignored by this ability
+   * @param ignoreStatStage A {@linkcode BooleanHolder} that represents whether or not to ignore a stat's stat changes
    * @returns true if the stat is ignored, false otherwise
    */
-  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: BooleanHolder, args: any[]) {
-    const stat: EffectiveStat = args[0];
-    const ignoreStatStage: BooleanHolder = args[1];
+  override apply(
+    _pokemon: Pokemon,
+    _passive: boolean,
+    _simulated: boolean,
+    _cancelled: BooleanHolder,
+    stat: EffectiveStat,
+    ignoreStatStage: BooleanHolder,
+  ) {
     if (this.stats.includes(stat)) {
       ignoreStatStage.value = true;
       return true;

--- a/src/data/ab-attrs/ignore-type-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/ignore-type-immunity-ab-attr.ts
@@ -18,10 +18,9 @@ export class IgnoreTypeImmunityAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     cancelled: BooleanHolder,
-    args: any[],
+    moveType: Type,
+    defType: Type,
   ): boolean {
-    const moveType: Type = args[0];
-    const defType: Type = args[1];
     if (this.defenderType === defType && this.allowedMoveTypes.includes(moveType)) {
       cancelled.value = true;
       return true;

--- a/src/data/ab-attrs/ignore-type-status-effect-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/ignore-type-status-effect-immunity-ab-attr.ts
@@ -25,10 +25,9 @@ export class IgnoreTypeStatusEffectImmunityAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     cancelled: BooleanHolder,
-    args: any[],
+    effect: StatusEffect,
+    defType: Type,
   ): boolean {
-    const effect: StatusEffect = args[0];
-    const defType: Type = args[1];
     if (this.statusEffect.includes(effect) && this.defenderType.includes(defType)) {
       cancelled.value = true;
       return true;

--- a/src/data/ab-attrs/infiltrator-ab-attr.ts
+++ b/src/data/ab-attrs/infiltrator-ab-attr.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
-import { BooleanHolder } from "#app/utils";
+import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 /**
@@ -12,16 +12,11 @@ export class InfiltratorAbAttr extends AbAttr {
    * @param _pokemon n/a
    * @param _passive n/a
    * @param _simulated n/a
-   * @param _cancelled n/a
-   * @param args `[0]` a {@linkcode BooleanHolder | BooleanHolder} containing the flag
+   * @param bypassed a {@linkcode BooleanHolder} containing the flag
    * @returns `true` if the bypass flag was successfully set; `false` otherwise.
    */
-  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _cancelled: null, args: any[]): boolean {
-    const bypassed = args[0];
-    if (args[0] instanceof BooleanHolder) {
-      bypassed.value = true;
-      return true;
-    }
-    return false;
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, bypassed: BooleanHolder): boolean {
+    bypassed.value = true;
+    return true;
   }
 }

--- a/src/data/ab-attrs/intimidate-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/intimidate-immunity-ab-attr.ts
@@ -9,13 +9,7 @@ export class IntimidateImmunityAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
     return true;
   }

--- a/src/data/ab-attrs/low-hp-move-type-attack-multiplier-ab-attr.ts
+++ b/src/data/ab-attrs/low-hp-move-type-attack-multiplier-ab-attr.ts
@@ -39,13 +39,12 @@ export class LowHpMoveTypeAttackMultiplierAbAttr extends StatMultiplierAbAttr {
     simulated: boolean,
     stat: BattleStat,
     statValue: NumberHolder,
-    args: any[],
+    move: Move,
+    target: Pokemon,
   ): boolean {
-    const move: Move | null = args[0];
-    const target: Pokemon | null = args[1];
     const category =
       !isNullOrUndefined(move) && !isNullOrUndefined(target) ? pokemon.getMoveCategory(target, move) : move?.category;
     this.stat = category === MoveCategory.SPECIAL ? Stat.SPATK : Stat.ATK;
-    return super.applyStatStage(pokemon, passive, simulated, stat, statValue, args);
+    return super.applyStatStage(pokemon, passive, simulated, stat, statValue, move, target);
   }
 }

--- a/src/data/ab-attrs/max-multi-hit-ab-attr.ts
+++ b/src/data/ab-attrs/max-multi-hit-ab-attr.ts
@@ -8,9 +8,8 @@ export class MaxMultiHitAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     _cancelled: BooleanHolder,
-    args: any[],
+    hitValue: NumberHolder,
   ): boolean {
-    const hitValue: NumberHolder = args[0];
     hitValue.value = 0;
 
     return true;

--- a/src/data/ab-attrs/max-multi-hit-ab-attr.ts
+++ b/src/data/ab-attrs/max-multi-hit-ab-attr.ts
@@ -1,15 +1,9 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class MaxMultiHitAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    hitValue: NumberHolder,
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, hitValue: NumberHolder): boolean {
     hitValue.value = 0;
 
     return true;

--- a/src/data/ab-attrs/money-ab-attr.ts
+++ b/src/data/ab-attrs/money-ab-attr.ts
@@ -15,8 +15,7 @@ export class MoneyAbAttr extends PostBattleAbAttr {
    * @param args - `[0]`: boolean for if the battle ended in a victory
    * @returns `true` if successful
    */
-  override applyPostBattle(_pokemon: Pokemon, _passive: boolean, simulated: boolean, args: any[]): boolean {
-    const isVictory: boolean = args[0];
+  override applyPostBattle(_pokemon: Pokemon, _passive: boolean, simulated: boolean, isVictory: boolean): boolean {
     if (!simulated && isVictory) {
       globalScene.currentBattle.moneyScattered += globalScene.getWaveMoneyAmount(0.2);
       return true;

--- a/src/data/ab-attrs/moody-ab-attr.ts
+++ b/src/data/ab-attrs/moody-ab-attr.ts
@@ -18,10 +18,9 @@ export class MoodyAbAttr extends PostTurnAbAttr {
    * @param pokemon {@linkcode Pokemon} that has this ability
    * @param _passive N/A
    * @param simulated `true` if applying in a simulated call.
-   * @param _args N/A
    * @returns `true`
    */
-  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const canRaise = EFFECTIVE_STATS.filter((s) => pokemon.getStatStage(s) < 6);
     let canLower = EFFECTIVE_STATS.filter((s) => pokemon.getStatStage(s) > -6);
 

--- a/src/data/ab-attrs/move-ability-bypass-ab-attr.ts
+++ b/src/data/ab-attrs/move-ability-bypass-ab-attr.ts
@@ -17,9 +17,8 @@ export class MoveAbilityBypassAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     cancelled: BooleanHolder,
-    args: any[],
+    move: Move,
   ): boolean {
-    const move: Move = args[0];
     if (this.moveIgnoreFunc(pokemon, move)) {
       cancelled.value = true;
       return true;

--- a/src/data/ab-attrs/move-effect-chance-multiplier-ab-attr.ts
+++ b/src/data/ab-attrs/move-effect-chance-multiplier-ab-attr.ts
@@ -1,6 +1,6 @@
 import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { Moves } from "#enums/moves";
 import { AbAttr } from "./ab-attr";
 
@@ -25,15 +25,10 @@ export class MoveEffectChanceMultiplierAbAttr extends AbAttr {
     _pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
+    moveChance: NumberHolder,
+    move: Move,
+    showAbility: boolean,
   ): boolean {
-    const moveChance: NumberHolder = args[0];
-    const move: Move = args[1];
-    // const target: Pokemon = args[2];
-    // const selfEffect: boolean = args[3];
-    const showAbility: boolean = args[4];
-
     this.showAbility = showAbility;
 
     const exceptMoves = [Moves.ORDER_UP, Moves.ELECTRO_SHOT];

--- a/src/data/ab-attrs/move-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/move-immunity-ab-attr.ts
@@ -22,7 +22,6 @@ export class MoveImmunityAbAttr extends PreDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    _args: any[],
   ): boolean {
     if (this.immuneCondition(pokemon, attacker, move)) {
       cancelled.value = true;

--- a/src/data/ab-attrs/move-immunity-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/move-immunity-stat-stage-change-ab-attr.ts
@@ -24,9 +24,8 @@ export class MoveImmunityStatStageChangeAbAttr extends MoveImmunityAbAttr {
     attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    args: any[],
   ): boolean {
-    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
+    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled);
     if (ret && !simulated) {
       globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [this.stat], this.stages));
     }

--- a/src/data/ab-attrs/move-power-boost-ab-attr.ts
+++ b/src/data/ab-attrs/move-power-boost-ab-attr.ts
@@ -20,15 +20,12 @@ export class MovePowerBoostAbAttr extends VariableMovePowerAbAttr {
     _simulated: boolean,
     defender: Pokemon,
     move: Move,
-    args: any[],
+    power: NumberHolder,
   ): boolean {
     if (this.condition(pokemon, defender, move)) {
-      const power: NumberHolder = args[0];
       power.value *= this.powerMultiplier;
-
       return true;
     }
-
     return false;
   }
 }

--- a/src/data/ab-attrs/move-type-change-ab-attr.ts
+++ b/src/data/ab-attrs/move-type-change-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { PokemonAttackCondition } from "#app/@types/PokemonAttackCondition";
 import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
-import type { nil, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import type { Type } from "#enums/type";
 import { PreAttackAbAttr } from "./pre-attack-ab-attr";
 
@@ -21,11 +21,10 @@ export class MoveTypeChangeAbAttr extends PreAttackAbAttr {
     _simulated: boolean,
     defender: Pokemon,
     move: Move,
-    args: any[],
+    moveType: NumberHolder,
+    power: NumberHolder,
   ): boolean {
     if (this.condition && this.condition(pokemon, defender, move)) {
-      const moveType: NumberHolder | nil = args[0];
-      const power: NumberHolder | nil = args[1];
       if (moveType) {
         moveType.value = this.newType;
       }

--- a/src/data/ab-attrs/mult-crit-ab-attr.ts
+++ b/src/data/ab-attrs/mult-crit-ab-attr.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class MultCritAbAttr extends AbAttr {
@@ -11,16 +11,9 @@ export class MultCritAbAttr extends AbAttr {
     this.multAmount = multAmount;
   }
 
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const critMult = args[0] as NumberHolder;
-    if (critMult.value > 1) {
-      critMult.value *= this.multAmount;
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, critMultiplier: NumberHolder): boolean {
+    if (critMultiplier.value > 1) {
+      critMultiplier.value *= this.multAmount;
       return true;
     }
 

--- a/src/data/ab-attrs/non-super-effective-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/non-super-effective-immunity-ab-attr.ts
@@ -23,10 +23,8 @@ export class NonSuperEffectiveImmunityAbAttr extends TypeImmunityAbAttr {
     _attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    args: any[],
+    typeMultiplier: NumberHolder,
   ): boolean {
-    const typeMultiplier: NumberHolder = args[0];
-
     if (move instanceof AttackMove && typeMultiplier.value < 2) {
       cancelled.value = true; // Suppresses "No Effect" message
       typeMultiplier.value = 0;

--- a/src/data/ab-attrs/pokemon-type-change-ab-attr.ts
+++ b/src/data/ab-attrs/pokemon-type-change-ab-attr.ts
@@ -23,7 +23,6 @@ export class PokemonTypeChangeAbAttr extends PreAttackAbAttr {
     simulated: boolean,
     _defender: Pokemon,
     move: Move,
-    _args: any[],
   ): boolean {
     if (
       !pokemon.isTerastallized()

--- a/src/data/ab-attrs/post-attack-ab-attr.ts
+++ b/src/data/ab-attrs/post-attack-ab-attr.ts
@@ -30,12 +30,12 @@ export class PostAttackAbAttr extends AbAttr {
     defender: Pokemon,
     move: Move,
     hitResult: HitResult | null,
-    args: any[],
+    ...args: unknown[]
   ): boolean {
     // When attackRequired is true, we require the move to be an attack move and to deal damage before checking secondary requirements.
     // If attackRequired is false, we always defer to the secondary requirements.
     if (this.attackCondition(pokemon, defender, move)) {
-      return this.applyPostAttackAfterMoveTypeCheck(pokemon, passive, simulated, defender, move, hitResult, args);
+      return this.applyPostAttackAfterMoveTypeCheck(pokemon, passive, simulated, defender, move, hitResult, ...args);
     } else {
       return false;
     }
@@ -51,7 +51,7 @@ export class PostAttackAbAttr extends AbAttr {
     _defender: Pokemon,
     _move: Move,
     _hitResult: HitResult | null,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-attack-apply-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/post-attack-apply-battler-tag-ab-attr.ts
@@ -35,7 +35,6 @@ export class PostAttackApplyBattlerTagAbAttr extends PostAttackAbAttr {
     target: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     /**
      * The battler tag is only applied to the target if

--- a/src/data/ab-attrs/post-attack-apply-status-effect-ab-attr.ts
+++ b/src/data/ab-attrs/post-attack-apply-status-effect-ab-attr.ts
@@ -26,7 +26,6 @@ export class PostAttackApplyStatusEffectAbAttr extends PostAttackAbAttr {
     target: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     /**
      * The status is only applied to the target if

--- a/src/data/ab-attrs/post-attack-steal-held-item-ab-attr.ts
+++ b/src/data/ab-attrs/post-attack-steal-held-item-ab-attr.ts
@@ -24,7 +24,6 @@ export class PostAttackStealHeldItemAbAttr extends PostAttackAbAttr {
     defender: Pokemon,
     move: Move,
     hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (
       !simulated

--- a/src/data/ab-attrs/post-battle-ab-attr.ts
+++ b/src/data/ab-attrs/post-battle-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
 export class PostBattleAbAttr extends AbAttr {
-  applyPostBattle(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _args: any[]): boolean {
+  applyPostBattle(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 }

--- a/src/data/ab-attrs/post-battle-init-ab-attr.ts
+++ b/src/data/ab-attrs/post-battle-init-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
 export class PostBattleInitAbAttr extends AbAttr {
-  applyPostBattleInit(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _args: any[]): boolean {
+  applyPostBattleInit(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 }

--- a/src/data/ab-attrs/post-battle-init-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-battle-init-form-change-ab-attr.ts
@@ -12,7 +12,7 @@ export class PostBattleInitFormChangeAbAttr extends PostBattleInitAbAttr {
     this.formFunc = formFunc;
   }
 
-  override applyPostBattleInit(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostBattleInit(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const formIndex = this.formFunc(pokemon);
     if (formIndex !== pokemon.formIndex && !simulated) {
       return globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger, false);

--- a/src/data/ab-attrs/post-battle-init-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-battle-init-stat-stage-change-ab-attr.ts
@@ -17,7 +17,7 @@ export class PostBattleInitStatStageChangeAbAttr extends PostBattleInitAbAttr {
     this.selfTarget = selfTarget;
   }
 
-  override applyPostBattleInit(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostBattleInit(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const statStageChangePhases: StatStageChangePhase[] = [];
 
     if (!simulated) {

--- a/src/data/ab-attrs/post-battle-loot-ab-attr.ts
+++ b/src/data/ab-attrs/post-battle-loot-ab-attr.ts
@@ -10,9 +10,8 @@ export class PostBattleLootAbAttr extends PostBattleAbAttr {
    * @param args - `[0]`: boolean for if the battle ended in a victory
    * @returns `true` if successful
    */
-  override applyPostBattle(pokemon: Pokemon, _passive: boolean, simulated: boolean, args: any[]): boolean {
+  override applyPostBattle(pokemon: Pokemon, _passive: boolean, simulated: boolean, isVictory: boolean): boolean {
     const postBattleLoot = globalScene.currentBattle.postBattleLoot;
-    const isVictory: boolean = args[0];
 
     if (!simulated && postBattleLoot.length > 0 && isVictory) {
       const randItem = randSeedItem(postBattleLoot);

--- a/src/data/ab-attrs/post-biome-change-terrain-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-biome-change-terrain-change-ab-attr.ts
@@ -1,6 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
-import type { BooleanHolder } from "#app/utils";
 import type { TerrainType } from "#enums/terrain-type";
 import { PostBiomeChangeAbAttr } from "./post-biome-change-ab-attr";
 
@@ -13,13 +12,7 @@ export class PostBiomeChangeTerrainChangeAbAttr extends PostBiomeChangeAbAttr {
     this.terrainType = terrainType;
   }
 
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    simulated: boolean,
-    _cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (simulated) {
       return globalScene.arena.terrain?.terrainType !== this.terrainType;
     } else {

--- a/src/data/ab-attrs/post-biome-change-weather-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-biome-change-weather-change-ab-attr.ts
@@ -1,6 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
-import type { BooleanHolder } from "#app/utils";
 import type { WeatherType } from "#enums/weather-type";
 import { PostBiomeChangeAbAttr } from "./post-biome-change-ab-attr";
 
@@ -13,13 +12,7 @@ export class PostBiomeChangeWeatherChangeAbAttr extends PostBiomeChangeAbAttr {
     this.weatherType = weatherType;
   }
 
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    simulated: boolean,
-    _cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!globalScene.arena.weather?.isImmutable()) {
       if (simulated) {
         return globalScene.arena.weather?.weatherType !== this.weatherType;

--- a/src/data/ab-attrs/post-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-damage-ab-attr.ts
@@ -11,8 +11,8 @@ export class PostDamageAbAttr extends AbAttr {
     _damage: number,
     _passive: boolean,
     _simulated: boolean,
-    _args: any[],
     _source?: Pokemon,
+    ..._args: any[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-damage-ab-attr.ts
@@ -12,7 +12,7 @@ export class PostDamageAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     _source?: Pokemon,
-    ..._args: any[]
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-dancing-move-ab-attr.ts
+++ b/src/data/ab-attrs/post-dancing-move-ab-attr.ts
@@ -31,7 +31,6 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
     source: Pokemon,
     targets: BattlerIndex[],
     simulated: boolean,
-    _args: any[],
   ): boolean {
     // List of tags that prevent the Dancer from replicating the move
     const forbiddenTags = [

--- a/src/data/ab-attrs/post-defend-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-ab-attr.ts
@@ -10,7 +10,7 @@ export class PostDefendAbAttr extends AbAttr {
     _attacker: Pokemon,
     _move: Move,
     _hitResult: HitResult | null,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-defend-ability-give-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-ability-give-ab-attr.ts
@@ -23,7 +23,6 @@ export class PostDefendAbilityGiveAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (
       move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)

--- a/src/data/ab-attrs/post-defend-ability-swap-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-ability-swap-ab-attr.ts
@@ -15,7 +15,6 @@ export class PostDefendAbilitySwapAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (
       move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)

--- a/src/data/ab-attrs/post-defend-apply-arena-trap-tag-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-apply-arena-trap-tag-ab-attr.ts
@@ -25,7 +25,6 @@ export class PostDefendApplyArenaTrapTagAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (this.condition(pokemon, attacker, move)) {
       const tag = globalScene.arena.getTag(this.tagType) as ArenaTrapTag;

--- a/src/data/ab-attrs/post-defend-apply-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-apply-battler-tag-ab-attr.ts
@@ -25,7 +25,6 @@ export class PostDefendApplyBattlerTagAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (this.condition(pokemon, attacker, move)) {
       if (!pokemon.getTag(this.tagType) && !simulated) {

--- a/src/data/ab-attrs/post-defend-contact-apply-status-effect-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-contact-apply-status-effect-ab-attr.ts
@@ -42,7 +42,6 @@ export class PostDefendContactApplyStatusEffectAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (
       move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)

--- a/src/data/ab-attrs/post-defend-contact-apply-tag-chance-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-contact-apply-tag-chance-ab-attr.ts
@@ -25,7 +25,6 @@ export class PostDefendContactApplyTagChanceAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && pokemon.randSeedInt(100) < this.chance) {
       if (simulated) {

--- a/src/data/ab-attrs/post-defend-contact-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-contact-damage-ab-attr.ts
@@ -24,7 +24,6 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (
       !simulated

--- a/src/data/ab-attrs/post-defend-crit-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-crit-stat-stage-change-ab-attr.ts
@@ -30,7 +30,6 @@ export class PostDefendCritStatStageChangeAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     _move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     const attacksReceivedEntry = pokemon.turnData.attacksReceived[0];
     if (

--- a/src/data/ab-attrs/post-defend-hp-gated-stat-tage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-hp-gated-stat-tage-change-ab-attr.ts
@@ -37,7 +37,6 @@ export class PostDefendHpGatedStatStageChangeAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     const hpGateFlat: number = Math.ceil(pokemon.getMaxHp() * this.hpGate);
     // TODO: Normalize `attacksReceived[]` checks

--- a/src/data/ab-attrs/post-defend-move-disable-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-move-disable-ab-attr.ts
@@ -21,7 +21,6 @@ export class PostDefendMoveDisableAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (attacker.getTag(BattlerTagType.DISABLED) === null) {
       if (

--- a/src/data/ab-attrs/post-defend-perish-song-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-perish-song-ab-attr.ts
@@ -29,7 +29,6 @@ export class PostDefendPerishSongAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
       if (pokemon.getTag(BattlerTagType.PERISH_SONG) && attacker.getTag(BattlerTagType.PERISH_SONG)) {

--- a/src/data/ab-attrs/post-defend-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-stat-stage-change-ab-attr.ts
@@ -50,7 +50,6 @@ export class PostDefendStatStageChangeAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (this.condition(pokemon, attacker, move)) {
       if (simulated) {

--- a/src/data/ab-attrs/post-defend-steal-held-item-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-steal-held-item-ab-attr.ts
@@ -24,7 +24,6 @@ export class PostDefendStealHeldItemAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (!simulated && hitResult < HitResult.NO_EFFECT && (!this.condition || this.condition(pokemon, attacker, move))) {
       const heldItems = this.getTargetHeldItems(attacker).filter((i) => i.isTransferable);

--- a/src/data/ab-attrs/post-defend-terrain-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-terrain-change-ab-attr.ts
@@ -21,7 +21,6 @@ export class PostDefendTerrainChangeAbAttr extends PostDefendAbAttr {
     _attacker: Pokemon,
     _move: Move,
     hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (hitResult < HitResult.NO_EFFECT) {
       if (simulated) {

--- a/src/data/ab-attrs/post-defend-type-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-type-change-ab-attr.ts
@@ -14,7 +14,6 @@ export class PostDefendTypeChangeAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (hitResult < HitResult.NO_EFFECT) {
       if (simulated) {

--- a/src/data/ab-attrs/post-defend-weather-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-weather-change-ab-attr.ts
@@ -24,7 +24,6 @@ export class PostDefendWeatherChangeAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (this.condition && !this.condition(pokemon, attacker, move)) {
       return false;

--- a/src/data/ab-attrs/post-faint-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-ab-attr.ts
@@ -11,7 +11,7 @@ export class PostFaintAbAttr extends AbAttr {
     _attacker?: Pokemon,
     _move?: Move,
     _hitResult?: HitResult,
-    ..._args: any[]
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-faint-clear-weather-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-clear-weather-ab-attr.ts
@@ -27,7 +27,6 @@ export class PostFaintClearWeatherAbAttr extends PostFaintAbAttr {
     _attacker?: Pokemon,
     _move?: Move,
     _hitResult?: HitResult,
-    ..._args: any[]
   ): boolean {
     const weatherType = globalScene.arena.weather?.weatherType;
     let turnOffWeather = false;

--- a/src/data/ab-attrs/post-faint-contact-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-contact-damage-ab-attr.ts
@@ -31,8 +31,8 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
     if (move && attacker && move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
       //If the mon didn't die to indirect damage
       const cancelled = new BooleanHolder(false);
-      globalScene.getField(true).map((p) => applyAbAttrs(FieldPreventExplosionLikeAbAttr, p, cancelled, simulated));
-      applyAbAttrs(BlockNonDirectDamageAbAttr, attacker, cancelled, simulated);
+      globalScene.getField(true).map((p) => applyAbAttrs(FieldPreventExplosionLikeAbAttr, p, simulated, cancelled));
+      applyAbAttrs(BlockNonDirectDamageAbAttr, attacker, simulated, cancelled);
       if (cancelled.value) {
         return false;
       }

--- a/src/data/ab-attrs/post-faint-contact-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-contact-damage-ab-attr.ts
@@ -27,7 +27,6 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
     attacker?: Pokemon,
     move?: Move,
     _hitResult?: HitResult,
-    ..._args: any[]
   ): boolean {
     if (move && attacker && move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
       //If the mon didn't die to indirect damage

--- a/src/data/ab-attrs/post-faint-hp-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-hp-damage-ab-attr.ts
@@ -17,7 +17,6 @@ export class PostFaintHPDamageAbAttr extends PostFaintAbAttr {
     attacker?: Pokemon,
     move?: Move,
     _hitResult?: HitResult,
-    ..._args: any[]
   ): boolean {
     if (!move || !attacker || !attacker.isOnField()) {
       return false;

--- a/src/data/ab-attrs/post-faint-unsuppressed-weather-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-unsuppressed-weather-form-change-ab-attr.ts
@@ -19,7 +19,6 @@ export class PostFaintUnsuppressedWeatherFormChangeAbAttr extends PostFaintAbAtt
    * @param _attacker n/a
    * @param _move n/a
    * @param _hitResult n/a
-   * @param _args n/a
    * @returns whether the form change was triggered
    */
   override applyPostFaint(
@@ -29,7 +28,6 @@ export class PostFaintUnsuppressedWeatherFormChangeAbAttr extends PostFaintAbAtt
     _attacker: Pokemon,
     _move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     const pokemonToTransform = getPokemonWithWeatherBasedForms();
 

--- a/src/data/ab-attrs/post-intimidate-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-intimidate-stat-stage-change-ab-attr.ts
@@ -17,13 +17,7 @@ export class PostIntimidateStatStageChangeAbAttr extends AbAttr {
     this.overwrites = overwrites;
   }
 
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(pokemon: Pokemon, _passive: boolean, simulated: boolean, cancelled: BooleanHolder): boolean {
     if (!simulated) {
       globalScene.pushPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), false, this.stats, this.stages));
     }

--- a/src/data/ab-attrs/post-item-lost-ab-attr.ts
+++ b/src/data/ab-attrs/post-item-lost-ab-attr.ts
@@ -6,7 +6,7 @@ import { AbAttr } from "./ab-attr";
  * @extends AbAttr
  */
 export class PostItemLostAbAttr extends AbAttr {
-  applyPostItemLost(_pokemon: Pokemon, _simulated: boolean, _args: any[]): boolean {
+  applyPostItemLost(_pokemon: Pokemon, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 }

--- a/src/data/ab-attrs/post-item-lost-apply-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/post-item-lost-apply-battler-tag-ab-attr.ts
@@ -17,7 +17,7 @@ export class PostItemLostApplyBattlerTagAbAttr extends PostItemLostAbAttr {
    * @param pokemon {@linkcode Pokemon} with this ability
    * @returns `true` if BattlerTag was applied
    */
-  override applyPostItemLost(pokemon: Pokemon, simulated: boolean, _args: any[]): boolean {
+  override applyPostItemLost(pokemon: Pokemon, simulated: boolean): boolean {
     if (!pokemon.getTag(this.tagType)) {
       if (!simulated) {
         pokemon.addTag(this.tagType);

--- a/src/data/ab-attrs/post-knock-out-ab-attr.ts
+++ b/src/data/ab-attrs/post-knock-out-ab-attr.ts
@@ -6,7 +6,7 @@ export class PostKnockOutAbAttr extends AbAttr {
     _pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
-    _knockedOut: Pokemon,
+    _knockedOutPokemon: Pokemon,
     ..._args: unknown[]
   ): boolean {
     return false;

--- a/src/data/ab-attrs/post-knock-out-ab-attr.ts
+++ b/src/data/ab-attrs/post-knock-out-ab-attr.ts
@@ -7,7 +7,7 @@ export class PostKnockOutAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     _knockedOut: Pokemon,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-knock-out-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-knock-out-stat-stage-change-ab-attr.ts
@@ -15,13 +15,7 @@ export class PostKnockOutStatStageChangeAbAttr extends PostKnockOutAbAttr {
     this.stages = stages;
   }
 
-  override applyPostKnockOut(
-    pokemon: Pokemon,
-    _passive: boolean,
-    simulated: boolean,
-    _knockedOut: Pokemon,
-    _args: any[],
-  ): boolean {
+  override applyPostKnockOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, _knockedOut: Pokemon): boolean {
     const stat = typeof this.stat === "function" ? this.stat(pokemon) : this.stat;
     if (!simulated) {
       globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [stat], this.stages));

--- a/src/data/ab-attrs/post-knock-out-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-knock-out-stat-stage-change-ab-attr.ts
@@ -15,7 +15,12 @@ export class PostKnockOutStatStageChangeAbAttr extends PostKnockOutAbAttr {
     this.stages = stages;
   }
 
-  override applyPostKnockOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, _knockedOut: Pokemon): boolean {
+  override applyPostKnockOut(
+    pokemon: Pokemon,
+    _passive: boolean,
+    simulated: boolean,
+    _knockedOutPokemon: Pokemon,
+  ): boolean {
     const stat = typeof this.stat === "function" ? this.stat(pokemon) : this.stat;
     if (!simulated) {
       globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [stat], this.stages));

--- a/src/data/ab-attrs/post-move-used-ab-attr.ts
+++ b/src/data/ab-attrs/post-move-used-ab-attr.ts
@@ -14,7 +14,7 @@ export class PostMoveUsedAbAttr extends AbAttr {
     _source: Pokemon,
     _targets: BattlerIndex[],
     _simulated: boolean,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-set-status-ab-attr.ts
+++ b/src/data/ab-attrs/post-set-status-ab-attr.ts
@@ -22,7 +22,7 @@ export class PostSetStatusAbAttr extends AbAttr {
     _passive: boolean,
     _effect: StatusEffect,
     _simulated: boolean,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-stat-stage-change-ab-attr.ts
@@ -9,7 +9,7 @@ export class PostStatStageChangeAbAttr extends AbAttr {
     _statsChanged: BattleStat[],
     _stagesChanged: number,
     _selfTarget: boolean,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-stat-stage-change-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-stat-stage-change-stat-stage-change-ab-attr.ts
@@ -24,7 +24,6 @@ export class PostStatStageChangeStatStageChangeAbAttr extends PostStatStageChang
     statStagesChanged: BattleStat[],
     stagesChanged: number,
     selfTarget: boolean,
-    _args: any[],
   ): boolean {
     if (this.condition(pokemon, statStagesChanged, stagesChanged) && !selfTarget) {
       if (!simulated) {

--- a/src/data/ab-attrs/post-summon-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-ab-attr.ts
@@ -13,7 +13,7 @@ export class PostSummonAbAttr extends AbAttr {
    * @param _args Set of unique arguments needed by this attribute
    * @returns true if application of the ability succeeds
    */
-  applyPostSummon(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _args: any[]): boolean {
+  applyPostSummon(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 }

--- a/src/data/ab-attrs/post-summon-add-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-add-battler-tag-ab-attr.ts
@@ -13,7 +13,7 @@ export class PostSummonAddBattlerTagAbAttr extends PostSummonAbAttr {
     this.turnCount = turnCount;
   }
 
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (simulated) {
       return pokemon.canAddTag(this.tagType);
     } else {

--- a/src/data/ab-attrs/post-summon-ally-heal-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-ally-heal-ab-attr.ts
@@ -17,7 +17,7 @@ export class PostSummonAllyHealAbAttr extends PostSummonAbAttr {
     this.showAnim = showAnim;
   }
 
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const target = pokemon.getAlly();
     if (target?.isActive(true)) {
       if (!simulated) {

--- a/src/data/ab-attrs/post-summon-clear-ally-stat-stages-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-clear-ally-stat-stages-ab-attr.ts
@@ -15,7 +15,7 @@ import { PostSummonAbAttr } from "./post-summon-ab-attr";
  * @see {@linkcode applyPostSummon}
  */
 export class PostSummonClearAllyStatStagesAbAttr extends PostSummonAbAttr {
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const target = pokemon.getAlly();
     if (target?.isActive(true)) {
       if (!simulated) {

--- a/src/data/ab-attrs/post-summon-copy-ability-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-copy-ability-ab-attr.ts
@@ -17,7 +17,7 @@ export class PostSummonCopyAbilityAbAttr extends PostSummonAbAttr {
   private target: Pokemon;
   private targetAbilityName: string;
 
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const targets = pokemon.getOpponents();
     if (!targets.length) {
       return false;

--- a/src/data/ab-attrs/post-summon-copy-ally-stats-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-copy-ally-stats-ab-attr.ts
@@ -10,7 +10,7 @@ import { PostSummonAbAttr } from "./post-summon-ab-attr";
  * @extends PostSummonAbAttr
  */
 export class PostSummonCopyAllyStatsAbAttr extends PostSummonAbAttr {
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!globalScene.currentBattle.double) {
       return false;
     }

--- a/src/data/ab-attrs/post-summon-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-form-change-ab-attr.ts
@@ -12,7 +12,7 @@ export class PostSummonFormChangeAbAttr extends PostSummonAbAttr {
     this.formFunc = formFunc;
   }
 
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const formIndex = this.formFunc(pokemon);
     if (formIndex !== pokemon.formIndex) {
       return simulated || globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeManualTrigger, false);

--- a/src/data/ab-attrs/post-summon-form-change-by-weather-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-form-change-by-weather-ab-attr.ts
@@ -26,10 +26,9 @@ export class PostSummonFormChangeByWeatherAbAttr extends PostSummonAbAttr {
    * if it is the specific Pokemon and ability
    * @param pokemon the {@linkcode Pokemon} with this ability
    * @param passive n/a
-   * @param _args n/a
    * @returns whether the form change was triggered
    */
-  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean): boolean {
     const isCastformWithForecast =
       pokemon.species.speciesId === Species.CASTFORM && this.ability === Abilities.FORECAST;
     const isCherrimWithFlowerGift =

--- a/src/data/ab-attrs/post-summon-message-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-message-ab-attr.ts
@@ -11,7 +11,7 @@ export class PostSummonMessageAbAttr extends PostSummonAbAttr {
     this.messageFunc = messageFunc;
   }
 
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!simulated) {
       globalScene.queueMessage(this.messageFunc(pokemon));
     }

--- a/src/data/ab-attrs/post-summon-remove-arena-tag-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-remove-arena-tag-ab-attr.ts
@@ -17,7 +17,7 @@ export class PostSummonRemoveArenaTagAbAttr extends PostSummonAbAttr {
     this.arenaTags = arenaTags;
   }
 
-  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!simulated) {
       for (const arenaTag of this.arenaTags) {
         globalScene.arena.removeTag(arenaTag);

--- a/src/data/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
@@ -40,8 +40,8 @@ export class PostSummonStatStageChangeAbAttr extends PostSummonAbAttr {
     for (const opponent of pokemon.getOpponents()) {
       const cancelled = new BooleanHolder(false);
       if (this.intimidate) {
-        applyAbAttrs(IntimidateImmunityAbAttr, opponent, cancelled, simulated);
-        applyAbAttrs(PostIntimidateStatStageChangeAbAttr, opponent, cancelled, simulated);
+        applyAbAttrs(IntimidateImmunityAbAttr, opponent, simulated, cancelled);
+        applyAbAttrs(PostIntimidateStatStageChangeAbAttr, opponent, simulated, cancelled);
 
         if (opponent.getTag(BattlerTagType.SUBSTITUTE)) {
           cancelled.value = true;

--- a/src/data/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
@@ -25,7 +25,7 @@ export class PostSummonStatStageChangeAbAttr extends PostSummonAbAttr {
     this.intimidate = intimidate;
   }
 
-  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean): boolean {
     if (simulated) {
       return true;
     }

--- a/src/data/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
@@ -33,12 +33,11 @@ export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageC
    *
    * @param pokemon The {@linkcode Pokemon} being summoned
    * @param passive Whether the effect is passive
-   * @param args Additional arguments
    * @returns Returns `true` if the stat change was applied, otherwise `false`
    */
-  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean): boolean {
     if (globalScene.arena.getTagOnSide(this.tagType, pokemon.getArenaTagSide())) {
-      return super.applyPostSummon(pokemon, passive, simulated, args);
+      return super.applyPostSummon(pokemon, passive, simulated);
     }
     return false;
   }

--- a/src/data/ab-attrs/post-summon-terrain-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-terrain-change-ab-attr.ts
@@ -12,7 +12,7 @@ export class PostSummonTerrainChangeAbAttr extends PostSummonAbAttr {
     this.terrainType = terrainType;
   }
 
-  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (simulated) {
       return globalScene.arena.terrain?.terrainType !== this.terrainType;
     } else {

--- a/src/data/ab-attrs/post-summon-transform-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-transform-ab-attr.ts
@@ -11,7 +11,7 @@ import { PostSummonAbAttr } from "./post-summon-ab-attr";
  * @extends PostSummonAbAttr
  */
 export class PostSummonTransformAbAttr extends PostSummonAbAttr {
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const targets = pokemon.getOpponents();
     if (simulated || !targets.length) {
       return simulated;

--- a/src/data/ab-attrs/post-summon-unnamed-message-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-unnamed-message-ab-attr.ts
@@ -16,7 +16,7 @@ export class PostSummonUnnamedMessageAbAttr extends PostSummonAbAttr {
     this.message = message;
   }
 
-  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!simulated) {
       globalScene.queueMessage(this.message);
     }

--- a/src/data/ab-attrs/post-summon-user-field-remove-status-effect-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-user-field-remove-status-effect-ab-attr.ts
@@ -26,10 +26,9 @@ export class PostSummonUserFieldRemoveStatusEffectAbAttr extends PostSummonAbAtt
    *
    * @param pokemon - The Pokémon that triggered the ability.
    * @param _passive - n/a
-   * @param _args - n/a
    * @returns A boolean or a promise that resolves to a boolean indicating the result of the ability application.
    */
-  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const allowedPokemon = pokemon.getField().filter((p) => p.isAllowedInBattle());
 
     if (allowedPokemon.length < 1) {

--- a/src/data/ab-attrs/post-summon-weather-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-weather-change-ab-attr.ts
@@ -17,7 +17,7 @@ export class PostSummonWeatherChangeAbAttr extends PostSummonAbAttr {
     this.weatherType = weatherType;
   }
 
-  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (simulated) {
       return globalScene.arena.weather?.weatherType !== this.weatherType;
     } else {

--- a/src/data/ab-attrs/post-summon-weather-suppressed-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-weather-suppressed-form-change-ab-attr.ts
@@ -16,7 +16,7 @@ export class PostSummonWeatherSuppressedFormChangeAbAttr extends PostSummonAbAtt
    * @param _args n/a
    * @returns whether a Pokemon was reverted to its normal form
    */
-  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]) {
+  override applyPostSummon(_pokemon: Pokemon, _passive: boolean, simulated: boolean) {
     const pokemonToTransform = getPokemonWithWeatherBasedForms();
 
     if (pokemonToTransform.length < 1) {

--- a/src/data/ab-attrs/post-terrain-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-terrain-change-ab-attr.ts
@@ -8,7 +8,7 @@ export class PostTerrainChangeAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     _terrain: TerrainType,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-terrain-change-add-battler-tag-attr.ts
+++ b/src/data/ab-attrs/post-terrain-change-add-battler-tag-attr.ts
@@ -21,7 +21,6 @@ export class PostTerrainChangeAddBattlerTagAttr extends PostTerrainChangeAbAttr 
     _passive: boolean,
     simulated: boolean,
     terrain: TerrainType,
-    _args: any[],
   ): boolean {
     if (!this.terrainTypes.find((t) => t === terrain)) {
       return false;

--- a/src/data/ab-attrs/post-turn-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
 export class PostTurnAbAttr extends AbAttr {
-  applyPostTurn(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _args: any[]): boolean {
+  applyPostTurn(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 }

--- a/src/data/ab-attrs/post-turn-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-form-change-ab-attr.ts
@@ -12,7 +12,7 @@ export class PostTurnFormChangeAbAttr extends PostTurnAbAttr {
     this.formFunc = formFunc;
   }
 
-  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const formIndex = this.formFunc(pokemon);
     if (formIndex !== pokemon.formIndex) {
       if (!simulated) {

--- a/src/data/ab-attrs/post-turn-heal-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-heal-ab-attr.ts
@@ -7,7 +7,7 @@ import i18next from "i18next";
 import { PostTurnAbAttr } from "./post-turn-ab-attr";
 
 export class PostTurnHealAbAttr extends PostTurnAbAttr {
-  override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean): boolean {
     if (!pokemon.isFullHp()) {
       if (!simulated) {
         const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;

--- a/src/data/ab-attrs/post-turn-hurt-if-sleeping-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-hurt-if-sleeping-ab-attr.ts
@@ -22,7 +22,7 @@ export class PostTurnHurtIfSleepingAbAttr extends PostTurnAbAttr {
    * @param _args N/A
    * @returns `true` if any opponents are sleeping
    */
-  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     let hadEffect = false;
     for (const opp of pokemon.getOpponents()) {
       if (

--- a/src/data/ab-attrs/post-turn-loot-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-loot-ab-attr.ts
@@ -23,7 +23,7 @@ export class PostTurnLootAbAttr extends PostTurnAbAttr {
     super();
   }
 
-  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const pass = Phaser.Math.RND.realInRange(0, 1);
     if (Phaser.Math.Clamp(this.procChance(pokemon), 0, 1) < pass) {
       return false;

--- a/src/data/ab-attrs/post-turn-reset-status-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-reset-status-ab-attr.ts
@@ -18,7 +18,7 @@ export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
     this.allyTarget = allyTarget;
   }
 
-  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (this.allyTarget) {
       this.target = pokemon.getAlly();
     } else {

--- a/src/data/ab-attrs/post-turn-status-heal-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-status-heal-ab-attr.ts
@@ -27,7 +27,7 @@ export class PostTurnStatusHealAbAttr extends PostTurnAbAttr {
    * @param _args N/A
    * @returns Returns `true` if healed from status, `false` if not
    */
-  override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, passive: boolean, simulated: boolean): boolean {
     if (pokemon.status && this.effects.includes(pokemon.status.effect)) {
       if (!pokemon.isFullHp()) {
         if (!simulated) {

--- a/src/data/ab-attrs/post-victory-ab-attr.ts
+++ b/src/data/ab-attrs/post-victory-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
 export class PostVictoryAbAttr extends AbAttr {
-  applyPostVictory(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _args: any[]): boolean {
+  applyPostVictory(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 }

--- a/src/data/ab-attrs/post-victory-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-victory-form-change-ab-attr.ts
@@ -12,7 +12,7 @@ export class PostVictoryFormChangeAbAttr extends PostVictoryAbAttr {
     this.formFunc = formFunc;
   }
 
-  override applyPostVictory(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostVictory(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const formIndex = this.formFunc(pokemon);
     if (formIndex !== pokemon.formIndex) {
       if (!simulated) {

--- a/src/data/ab-attrs/post-victory-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-victory-stat-stage-change-ab-attr.ts
@@ -15,7 +15,7 @@ export class PostVictoryStatStageChangeAbAttr extends PostVictoryAbAttr {
     this.stages = stages;
   }
 
-  override applyPostVictory(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostVictory(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const stat = typeof this.stat === "function" ? this.stat(pokemon) : this.stat;
     if (!simulated) {
       globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [stat], this.stages));

--- a/src/data/ab-attrs/post-weather-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-change-ab-attr.ts
@@ -8,7 +8,7 @@ export class PostWeatherChangeAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     _weather: WeatherType,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-weather-change-add-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-change-add-battler-tag-ab-attr.ts
@@ -21,7 +21,6 @@ export class PostWeatherChangeAddBattlerTagAttr extends PostWeatherChangeAbAttr 
     _passive: boolean,
     simulated: boolean,
     weather: WeatherType,
-    _args: any[],
   ): boolean {
     if (!this.weatherTypes.find((w) => weather === w)) {
       return false;

--- a/src/data/ab-attrs/post-weather-change-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-change-form-change-ab-attr.ts
@@ -35,7 +35,6 @@ export class PostWeatherChangeFormChangeAbAttr extends PostWeatherChangeAbAttr {
     _passive: boolean,
     simulated: boolean,
     _weather: WeatherType,
-    _args: any[],
   ): boolean {
     const isCastformWithForecast =
       pokemon.species.speciesId === Species.CASTFORM && this.ability === Abilities.FORECAST;

--- a/src/data/ab-attrs/post-weather-lapse-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-lapse-ab-attr.ts
@@ -19,7 +19,7 @@ export class PostWeatherLapseAbAttr extends AbAttr {
     _passive: boolean,
     _simulated: boolean,
     _weather: Weather | null,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/post-weather-lapse-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-lapse-damage-ab-attr.ts
@@ -18,13 +18,7 @@ export class PostWeatherLapseDamageAbAttr extends PostWeatherLapseAbAttr {
     this.damageFactor = damageFactor;
   }
 
-  override applyPostWeatherLapse(
-    pokemon: Pokemon,
-    passive: boolean,
-    simulated: boolean,
-    _weather: Weather,
-    _args: any[],
-  ): boolean {
+  override applyPostWeatherLapse(pokemon: Pokemon, passive: boolean, simulated: boolean, _weather: Weather): boolean {
     if (pokemon.hasAbilityWithAttr(BlockNonDirectDamageAbAttr)) {
       return false;
     }

--- a/src/data/ab-attrs/post-weather-lapse-heal-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-lapse-heal-ab-attr.ts
@@ -17,13 +17,7 @@ export class PostWeatherLapseHealAbAttr extends PostWeatherLapseAbAttr {
     this.healFactor = healFactor;
   }
 
-  override applyPostWeatherLapse(
-    pokemon: Pokemon,
-    passive: boolean,
-    simulated: boolean,
-    _weather: Weather,
-    _args: any[],
-  ): boolean {
+  override applyPostWeatherLapse(pokemon: Pokemon, passive: boolean, simulated: boolean, _weather: Weather): boolean {
     if (!pokemon.isFullHp()) {
       const abilityName = (!passive ? pokemon.getAbility() : pokemon.getPassiveAbility()).name;
       if (!simulated) {

--- a/src/data/ab-attrs/pre-apply-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/pre-apply-battler-tag-ab-attr.ts
@@ -10,7 +10,7 @@ export class PreApplyBattlerTagAbAttr extends AbAttr {
     _simulated: boolean,
     _tag: BattlerTag,
     _cancelled: BooleanHolder,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/pre-apply-battler-tag-immunnity-ab-attr.ts
+++ b/src/data/ab-attrs/pre-apply-battler-tag-immunnity-ab-attr.ts
@@ -26,7 +26,6 @@ export class PreApplyBattlerTagImmunityAbAttr extends PreApplyBattlerTagAbAttr {
     simulated: boolean,
     tag: BattlerTag,
     cancelled: BooleanHolder,
-    _args: any[],
   ): boolean {
     if (this.immuneTagTypes.includes(tag.tagType)) {
       cancelled.value = true;

--- a/src/data/ab-attrs/pre-attack-ab-attr.ts
+++ b/src/data/ab-attrs/pre-attack-ab-attr.ts
@@ -9,7 +9,7 @@ export class PreAttackAbAttr extends AbAttr {
     _simulated: boolean,
     _defender: Pokemon | null,
     _move: Move,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/pre-defend-ab-attr.ts
+++ b/src/data/ab-attrs/pre-defend-ab-attr.ts
@@ -11,7 +11,7 @@ export class PreDefendAbAttr extends AbAttr {
     _attacker: Pokemon,
     _move: Move | null,
     _cancelled: BooleanHolder | null,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/pre-defend-full-hp-endure-ab-attr.ts
+++ b/src/data/ab-attrs/pre-defend-full-hp-endure-ab-attr.ts
@@ -12,9 +12,8 @@ export class PreDefendFullHpEndureAbAttr extends PreDefendAbAttr {
     _attacker: Pokemon,
     _move: Move,
     _cancelled: BooleanHolder,
-    args: any[],
+    damage: NumberHolder,
   ): boolean {
-    const damage: NumberHolder = args[0];
     if (
       pokemon.isFullHp()
       && pokemon.getMaxHp() > 1 // Checks if pokemon has Wonder Guard (which forces 1hp)

--- a/src/data/ab-attrs/pre-set-status-ab-attr.ts
+++ b/src/data/ab-attrs/pre-set-status-ab-attr.ts
@@ -10,7 +10,7 @@ export class PreSetStatusAbAttr extends AbAttr {
     _simulated: boolean,
     _effect: StatusEffect | undefined,
     _cancelled: BooleanHolder,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/pre-set-status-effect-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/pre-set-status-effect-immunity-ab-attr.ts
@@ -27,7 +27,6 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
    * @param _passive - n/a
    * @param effect - The status effect being applied.
    * @param cancelled - A holder for a boolean value indicating if the status application was cancelled.
-   * @param _args - n/a
    * @returns A boolean indicating the result of the status application.
    */
   override applyPreSetStatus(
@@ -36,7 +35,6 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
     _simulated: boolean,
     effect: StatusEffect,
     cancelled: BooleanHolder,
-    _args: any[],
   ): boolean {
     if (this.immuneEffects.length < 1 || this.immuneEffects.includes(effect)) {
       cancelled.value = true;

--- a/src/data/ab-attrs/pre-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/pre-stat-stage-change-ab-attr.ts
@@ -10,7 +10,7 @@ export class PreStatStageChangeAbAttr extends AbAttr {
     _simulated: boolean,
     _stat: BattleStat,
     _cancelled: BooleanHolder,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/pre-switch-out-ab-attr.ts
+++ b/src/data/ab-attrs/pre-switch-out-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
 export class PreSwitchOutAbAttr extends AbAttr {
-  applyPreSwitchOut(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, _args: any[]): boolean {
+  applyPreSwitchOut(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
     return false;
   }
 }

--- a/src/data/ab-attrs/pre-switch-out-clear-weather-ab-attr.ts
+++ b/src/data/ab-attrs/pre-switch-out-clear-weather-ab-attr.ts
@@ -15,7 +15,7 @@ export class PreSwitchOutClearWeatherAbAttr extends PreSwitchOutAbAttr {
    * @param _args N/A
    * @returns Returns `true` if the weather clears, otherwise `false`.
    */
-  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const weatherType = globalScene.arena.weather?.weatherType;
     let turnOffWeather = false;
     let weatherAbility: Abilities | null = null;

--- a/src/data/ab-attrs/pre-switch-out-form-change-ab-attr.ts
+++ b/src/data/ab-attrs/pre-switch-out-form-change-ab-attr.ts
@@ -24,7 +24,7 @@ export class PreSwitchOutFormChangeAbAttr extends PreSwitchOutAbAttr {
    * @param _args N/A
    * @returns true if the form change was successful
    */
-  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     const formIndex = this.formFunc(pokemon);
     if (formIndex !== pokemon.formIndex) {
       if (!simulated) {

--- a/src/data/ab-attrs/pre-switch-out-heal-ab-attr.ts
+++ b/src/data/ab-attrs/pre-switch-out-heal-ab-attr.ts
@@ -3,7 +3,7 @@ import { toDmgValue } from "#app/utils";
 import { PreSwitchOutAbAttr } from "./pre-switch-out-ab-attr";
 
 export class PreSwitchOutHealAbAttr extends PreSwitchOutAbAttr {
-  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!pokemon.isFullHp()) {
       if (!simulated) {
         const healAmount = toDmgValue(pokemon.getMaxHp() * 0.33);

--- a/src/data/ab-attrs/pre-switch-out-reset-status-ab-attr.ts
+++ b/src/data/ab-attrs/pre-switch-out-reset-status-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import { PreSwitchOutAbAttr } from "./pre-switch-out-ab-attr";
 
 export class PreSwitchOutResetStatusAbAttr extends PreSwitchOutAbAttr {
-  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPreSwitchOut(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (pokemon.status) {
       if (!simulated) {
         pokemon.resetStatus();

--- a/src/data/ab-attrs/pre-weather-effect-ab-attr.ts
+++ b/src/data/ab-attrs/pre-weather-effect-ab-attr.ts
@@ -10,7 +10,7 @@ export class PreWeatherEffectAbAttr extends AbAttr {
     _simulated: boolean,
     _weather: Weather | null,
     _cancelled: BooleanHolder,
-    _args: any[],
+    ..._args: unknown[]
   ): boolean {
     return false;
   }

--- a/src/data/ab-attrs/prevent-berry-use-ab-attr.ts
+++ b/src/data/ab-attrs/prevent-berry-use-ab-attr.ts
@@ -3,13 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class PreventBerryUseAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, cancelled: BooleanHolder): boolean {
     cancelled.value = true;
 
     return true;

--- a/src/data/ab-attrs/prevent-bypass-speed-chance-ab-attr.ts
+++ b/src/data/ab-attrs/prevent-bypass-speed-chance-ab-attr.ts
@@ -21,19 +21,16 @@ export class PreventBypassSpeedChanceAbAttr extends AbAttr {
   }
 
   /**
-   * @param bypassSpeed - `args[0]`: determines if a Pokemon is able to bypass speed at the moment
-   * @param canCheckHeldItems - `args[1]`: determines if a Pokemon has access to Quick Claw's effects or not
+   * @param bypassSpeed determines if a Pokemon is able to bypass speed at the moment
+   * @param canCheckHeldItems determines if a Pokemon has access to Quick Claw's effects or not
    */
   override apply(
     pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
+    bypassSpeed: BooleanHolder,
+    canCheckHeldItems: BooleanHolder,
   ): boolean {
-    const bypassSpeed = args[0] as BooleanHolder;
-    const canCheckHeldItems = args[1] as BooleanHolder;
-
     const turnCommand = globalScene.currentBattle.turnCommands[pokemon.getBattlerIndex()];
     const isCommandFight = turnCommand?.command === Command.FIGHT;
     const move = turnCommand?.move?.move ? allMoves[turnCommand.move.move] : null;

--- a/src/data/ab-attrs/protect-stat-ab-attr.ts
+++ b/src/data/ab-attrs/protect-stat-ab-attr.ts
@@ -26,7 +26,6 @@ export class ProtectStatAbAttr extends PreStatStageChangeAbAttr {
    * @param simulated
    * @param stat the {@linkcode BattleStat} being affected
    * @param cancelled The {@linkcode BooleanHolder} that will be set to true if the stat is protected
-   * @param _args
    * @returns true if the stat is protected, false otherwise
    */
   override applyPreStatStageChange(
@@ -35,7 +34,6 @@ export class ProtectStatAbAttr extends PreStatStageChangeAbAttr {
     _simulated: boolean,
     stat: BattleStat,
     cancelled: BooleanHolder,
-    _args: any[],
   ): boolean {
     if (isNullOrUndefined(this.protectedStat) || stat === this.protectedStat) {
       cancelled.value = true;

--- a/src/data/ab-attrs/received-move-damage-multiplier-ab-attr.ts
+++ b/src/data/ab-attrs/received-move-damage-multiplier-ab-attr.ts
@@ -27,9 +27,8 @@ export class ReceivedMoveDamageMultiplierAbAttr extends PreDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _cancelled: BooleanHolder,
-    args: any[],
+    multiplier: NumberHolder,
   ): boolean {
-    const multiplier: NumberHolder = args[0];
     if (this.condition(pokemon, attacker, move)) {
       multiplier.value *= this.damageMultiplier;
 

--- a/src/data/ab-attrs/redirect-move-ab-attr.ts
+++ b/src/data/ab-attrs/redirect-move-ab-attr.ts
@@ -1,21 +1,13 @@
 import { allMoves } from "#app/data/all-moves";
 import { MoveTarget } from "../../enums/move-target";
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import type { Moves } from "#enums/moves";
 import { AbAttr } from "./ab-attr";
 
 export class RedirectMoveAbAttr extends AbAttr {
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const move: Moves = args[0];
+  override apply(pokemon: Pokemon, _passive: boolean, _simulated: boolean, move: Moves, target: NumberHolder): boolean {
     if (this.canRedirect(move)) {
-      const target = args[1] as NumberHolder;
       const newTarget = pokemon.getBattlerIndex();
       if (target.value !== newTarget) {
         target.value = newTarget;

--- a/src/data/ab-attrs/reduce-berry-use-threshold-ab-attr.ts
+++ b/src/data/ab-attrs/reduce-berry-use-threshold-ab-attr.ts
@@ -1,17 +1,10 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class ReduceBerryUseThresholdAbAttr extends AbAttr {
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
+  override apply(pokemon: Pokemon, _passive: boolean, _simulated: boolean, threshold: NumberHolder): boolean {
     const hpRatio = pokemon.getHpRatio();
-    const threshold: NumberHolder = args[0];
 
     if (threshold.value < hpRatio) {
       threshold.value *= 2;

--- a/src/data/ab-attrs/reduce-burn-damage-ab-attr.ts
+++ b/src/data/ab-attrs/reduce-burn-damage-ab-attr.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
-import { type BooleanHolder, type NumberHolder, toDmgValue } from "#app/utils";
+import { type NumberHolder, toDmgValue } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 /**
@@ -19,14 +19,7 @@ export class ReduceBurnDamageAbAttr extends AbAttr {
    * @param args `[0]` {@linkcode NumberHolder} The damage value being modified
    * @returns `true`
    */
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const damage: NumberHolder = args[0];
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, damage: NumberHolder): boolean {
     damage.value = toDmgValue(damage.value * this.multiplier);
 
     return true;

--- a/src/data/ab-attrs/reduce-burn-damage-ab-attr.ts
+++ b/src/data/ab-attrs/reduce-burn-damage-ab-attr.ts
@@ -15,8 +15,7 @@ export class ReduceBurnDamageAbAttr extends AbAttr {
    * Applies the damage reduction
    * @param _pokemon N/A
    * @param _passive N/A
-   * @param _cancelled N/A
-   * @param args `[0]` {@linkcode NumberHolder} The damage value being modified
+   * @param damage {@linkcode NumberHolder} The damage value being modified
    * @returns `true`
    */
   override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, damage: NumberHolder): boolean {

--- a/src/data/ab-attrs/reduce-status-effect-duration-ab-attr.ts
+++ b/src/data/ab-attrs/reduce-status-effect-duration-ab-attr.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
-import { type BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import type { StatusEffect } from "#enums/status-effect";
 import { AbAttr } from "./ab-attr";
 
@@ -28,14 +28,9 @@ export class ReduceStatusEffectDurationAbAttr extends AbAttr {
     _pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
+    statusEffect: StatusEffect,
+    turnsRemaining: NumberHolder,
   ): boolean {
-    const statusEffect: StatusEffect = args[0];
-    const turnsRemaining = args[1];
-    if (!(turnsRemaining instanceof NumberHolder)) {
-      return false;
-    }
     if (statusEffect === this.statusEffect) {
       turnsRemaining.value -= 1;
       return true;

--- a/src/data/ab-attrs/reverse-drain-ab-attr.ts
+++ b/src/data/ab-attrs/reverse-drain-ab-attr.ts
@@ -32,7 +32,6 @@ export class ReverseDrainAbAttr extends PostDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _hitResult: HitResult,
-    _args: any[],
   ): boolean {
     if (move.hasAttr(HitHealAttr)) {
       if (!simulated) {

--- a/src/data/ab-attrs/run-success-ab-attr.ts
+++ b/src/data/ab-attrs/run-success-ab-attr.ts
@@ -1,18 +1,10 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class RunSuccessAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const escapeChance: NumberHolder = args[0];
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, escapeChance: NumberHolder): boolean {
     escapeChance.value = 256;
-
     return true;
   }
 }

--- a/src/data/ab-attrs/speed-boost-ab-attr.ts
+++ b/src/data/ab-attrs/speed-boost-ab-attr.ts
@@ -5,7 +5,7 @@ import { Stat } from "#enums/stat";
 import { PostTurnAbAttr } from "./post-turn-ab-attr";
 
 export class SpeedBoostAbAttr extends PostTurnAbAttr {
-  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostTurn(pokemon: Pokemon, _passive: boolean, simulated: boolean): boolean {
     if (!simulated) {
       if (!pokemon.turnData.switchedInThisTurn && !pokemon.turnData.failedRunAway) {
         globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [Stat.SPD], 1));

--- a/src/data/ab-attrs/stab-boost-ab-attr.ts
+++ b/src/data/ab-attrs/stab-boost-ab-attr.ts
@@ -1,16 +1,9 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class StabBoostAbAttr extends AbAttr {
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const stabMultiplier: NumberHolder = args[0];
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, stabMultiplier: NumberHolder): boolean {
     if (stabMultiplier.value > 1) {
       stabMultiplier.value += 0.5;
       return true;

--- a/src/data/ab-attrs/stat-multiplier-ab-attr.ts
+++ b/src/data/ab-attrs/stat-multiplier-ab-attr.ts
@@ -3,7 +3,7 @@ import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
 import type { NumberHolder } from "#app/utils";
 import type { BattleStat } from "#enums/stat";
-import { AbAttr } from "./ab-attr";
+import { StatStageAbAttr } from "./stat-stage-ab-attr";
 
 /**
  * Ability attribute that multiplies a Pokemon's stat by a factor
@@ -36,28 +36,26 @@ import { AbAttr } from "./ab-attr";
 +-----------------------+-------+--------+----------------------------------+
 ```
  */
-export class StatMultiplierAbAttr extends AbAttr {
-  public stat: BattleStat;
+export class StatMultiplierAbAttr extends StatStageAbAttr {
   private readonly multiplier: number;
   private readonly condition?: PokemonAttackCondition;
 
   constructor(stat: BattleStat, multiplier: number, condition?: PokemonAttackCondition) {
-    super(false);
+    super(stat);
 
-    this.stat = stat;
     this.multiplier = multiplier;
     this.condition = condition;
   }
 
-  applyStatStage(
+  override applyStatStage(
     pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
     stat: BattleStat,
     statValue: NumberHolder,
-    args: any[],
+    move: Move,
+    _target?: Pokemon,
   ): boolean {
-    const move = args[0] as Move;
     if (stat === this.stat && (!this.condition || this.condition(pokemon, null, move))) {
       statValue.value *= this.multiplier;
       return true;

--- a/src/data/ab-attrs/stat-stage-ab-attr.ts
+++ b/src/data/ab-attrs/stat-stage-ab-attr.ts
@@ -1,0 +1,24 @@
+import type { Pokemon } from "#app/field/pokemon";
+import type { NumberHolder } from "#app/utils";
+import type { BattleStat } from "#enums/stat";
+import { AbAttr } from "./ab-attr";
+
+export class StatStageAbAttr extends AbAttr {
+  public stat: BattleStat;
+
+  constructor(stat: BattleStat) {
+    super(false);
+    this.stat = stat;
+  }
+
+  applyStatStage(
+    _pokemon: Pokemon,
+    _passive: boolean,
+    _simulated: boolean,
+    _stat: BattleStat,
+    _statValue: NumberHolder,
+    ..._args: unknown[]
+  ): boolean {
+    return false;
+  }
+}

--- a/src/data/ab-attrs/stat-stage-change-copy-ab-attr.ts
+++ b/src/data/ab-attrs/stat-stage-change-copy-ab-attr.ts
@@ -1,7 +1,6 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
-import type { BooleanHolder } from "#app/utils";
 import type { BattleStat } from "#enums/stat";
 import { AbAttr } from "./ab-attr";
 
@@ -10,11 +9,9 @@ export class StatStageChangeCopyAbAttr extends AbAttr {
     pokemon: Pokemon,
     _passive: boolean,
     simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
+    stats: BattleStat[],
+    stages: number,
   ): boolean {
-    const stats: BattleStat[] = args[0];
-    const stages: number = args[1];
     if (!simulated) {
       globalScene.unshiftPhase(
         new StatStageChangePhase(pokemon.getBattlerIndex(), true, stats, stages, { canBeCopied: false }),

--- a/src/data/ab-attrs/stat-stage-change-multiplier-ab-attr.ts
+++ b/src/data/ab-attrs/stat-stage-change-multiplier-ab-attr.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class StatStageChangeMultiplierAbAttr extends AbAttr {
@@ -11,14 +11,7 @@ export class StatStageChangeMultiplierAbAttr extends AbAttr {
     this.multiplier = multiplier;
   }
 
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const stages: NumberHolder = args[0];
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, stages: NumberHolder): boolean {
     stages.value *= this.multiplier;
 
     return true;

--- a/src/data/ab-attrs/suppress-field-abilities-ab-attr.ts
+++ b/src/data/ab-attrs/suppress-field-abilities-ab-attr.ts
@@ -13,12 +13,11 @@ export class SuppressFieldAbilitiesAbAttr extends AbAttr {
     _pokemon: Pokemon,
     _passive: boolean,
     _simulated: boolean,
-    cancelled: BooleanHolder,
-    args: any[],
+    suppressed: BooleanHolder,
+    ability: Ability,
   ): boolean {
-    const ability = args[0] as Ability;
     if (!ability.hasAttr(UnsuppressableAbilityAbAttr) && !ability.hasAttr(SuppressFieldAbilitiesAbAttr)) {
-      cancelled.value = true;
+      suppressed.value = true;
       return true;
     }
     return false;

--- a/src/data/ab-attrs/suppress-weather-effect-ab-attr.ts
+++ b/src/data/ab-attrs/suppress-weather-effect-ab-attr.ts
@@ -18,7 +18,6 @@ export class SuppressWeatherEffectAbAttr extends PreWeatherEffectAbAttr {
     _simulated: boolean,
     weather: Weather,
     cancelled: BooleanHolder,
-    _args: any[],
   ): boolean {
     if (this.affectsImmutable || weather.isImmutable()) {
       cancelled.value = true;

--- a/src/data/ab-attrs/sync-encounter-nature-ab-attr.ts
+++ b/src/data/ab-attrs/sync-encounter-nature-ab-attr.ts
@@ -1,5 +1,4 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 export class SyncEncounterNatureAbAttr extends AbAttr {
@@ -7,14 +6,7 @@ export class SyncEncounterNatureAbAttr extends AbAttr {
     super(false);
   }
 
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const opponent: Pokemon = args[0];
+  override apply(pokemon: Pokemon, _passive: boolean, _simulated: boolean, opponent: Pokemon): boolean {
     opponent.setNature(pokemon.getNature());
 
     return true;

--- a/src/data/ab-attrs/synchronize-status-ab-attr.ts
+++ b/src/data/ab-attrs/synchronize-status-ab-attr.ts
@@ -25,7 +25,6 @@ export class SynchronizeStatusAbAttr extends PostSetStatusAbAttr {
     _passive: boolean,
     effect: StatusEffect,
     simulated: boolean,
-    _args: any[],
   ): boolean {
     /** Synchronizable statuses */
     const syncStatuses = new Set<StatusEffect>([

--- a/src/data/ab-attrs/terrain-event-type-change-ab-attr.ts
+++ b/src/data/ab-attrs/terrain-event-type-change-ab-attr.ts
@@ -62,7 +62,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
    * Checks if the Pokemon should change types if summoned into an active terrain
    * @returns `true` if there is an active terrain requiring a type change | `false` if not
    */
-  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, _args: any[]): boolean {
+  override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean): boolean {
     if (globalScene.arena.getTerrainType() !== TerrainType.NONE) {
       // TODO: `apply()` probably shouldn't be used this way
       return this.apply(pokemon, passive, simulated);

--- a/src/data/ab-attrs/terrain-event-type-change-ab-attr.ts
+++ b/src/data/ab-attrs/terrain-event-type-change-ab-attr.ts
@@ -1,7 +1,6 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { BooleanHolder } from "#app/utils";
 import { TerrainType } from "#enums/terrain-type";
 import { Type } from "#enums/type";
 import i18next from "i18next";
@@ -13,13 +12,7 @@ import { PostSummonAbAttr } from "./post-summon-ab-attr";
  * @extends PostSummonAbAttr
  */
 export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
-  override apply(
-    pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    _args: any[],
-  ): boolean {
+  override apply(pokemon: Pokemon, _passive: boolean, _simulated: boolean): boolean {
     if (pokemon.isTerastallized()) {
       return false;
     }
@@ -72,7 +65,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
   override applyPostSummon(pokemon: Pokemon, passive: boolean, simulated: boolean, _args: any[]): boolean {
     if (globalScene.arena.getTerrainType() !== TerrainType.NONE) {
       // TODO: `apply()` probably shouldn't be used this way
-      return this.apply(pokemon, passive, simulated, new BooleanHolder(false), []);
+      return this.apply(pokemon, passive, simulated);
     }
     return false;
   }

--- a/src/data/ab-attrs/type-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/type-immunity-ab-attr.ts
@@ -30,7 +30,7 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
    * @param attacker - The attacking {@linkcode Pokemon}
    * @param move The used {@linkcode Move}
    * @param _cancelled N/A
-   * @param args `[0]`: {@linkcode NumberHolder} gets set to `0` if the pokemon is immune
+   * @param typeMultiplier {@linkcode NumberHolder} gets set to `0` if the pokemon is immune
    */
   override applyPreDefend(
     pokemon: Pokemon,
@@ -39,9 +39,8 @@ export class TypeImmunityAbAttr extends PreDefendAbAttr {
     attacker: Pokemon,
     move: Move,
     _cancelled: BooleanHolder,
-    args: any[],
+    typeMultiplier: NumberHolder,
   ): boolean {
-    const typeMultiplier: NumberHolder = args[0];
     // Field moves should ignore immunity
     if ([MoveTarget.BOTH_SIDES, MoveTarget.ENEMY_SIDE, MoveTarget.USER_SIDE].includes(move.moveTarget)) {
       return false;

--- a/src/data/ab-attrs/type-immunity-add-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/type-immunity-add-battler-tag-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { AbAttrCondition } from "#app/@types/AbAttrCondition";
 import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder } from "#app/utils";
+import type { BooleanHolder, NumberHolder } from "#app/utils";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { Type } from "#enums/type";
 import { TypeImmunityAbAttr } from "./type-immunity-ab-attr";
@@ -24,9 +24,9 @@ export class TypeImmunityAddBattlerTagAbAttr extends TypeImmunityAbAttr {
     attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    args: any[],
+    typeMultiplier: NumberHolder,
   ): boolean {
-    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
+    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, typeMultiplier);
 
     if (ret) {
       cancelled.value = true; // Suppresses "No Effect" message

--- a/src/data/ab-attrs/type-immunity-heal-ab-attr.ts
+++ b/src/data/ab-attrs/type-immunity-heal-ab-attr.ts
@@ -3,7 +3,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { PokemonHealPhase } from "#app/phases/pokemon-heal-phase";
-import { type BooleanHolder, toDmgValue } from "#app/utils";
+import { type BooleanHolder, type NumberHolder, toDmgValue } from "#app/utils";
 import type { Type } from "#enums/type";
 import i18next from "i18next";
 import { TypeImmunityAbAttr } from "./type-immunity-ab-attr";
@@ -20,9 +20,9 @@ export class TypeImmunityHealAbAttr extends TypeImmunityAbAttr {
     attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    args: any[],
+    typeMultiplier: NumberHolder,
   ): boolean {
-    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
+    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, typeMultiplier);
 
     if (ret) {
       if (!pokemon.isFullHp() && !simulated) {

--- a/src/data/ab-attrs/type-immunity-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/type-immunity-stat-stage-change-ab-attr.ts
@@ -3,7 +3,7 @@ import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
-import type { BooleanHolder } from "#app/utils";
+import type { BooleanHolder, NumberHolder } from "#app/utils";
 import type { BattleStat } from "#enums/stat";
 import type { Type } from "#enums/type";
 import { TypeImmunityAbAttr } from "./type-immunity-ab-attr";
@@ -26,9 +26,9 @@ export class TypeImmunityStatStageChangeAbAttr extends TypeImmunityAbAttr {
     attacker: Pokemon,
     move: Move,
     cancelled: BooleanHolder,
-    args: any[],
+    typeMultiplier: NumberHolder,
   ): boolean {
-    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args);
+    const ret = super.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, typeMultiplier);
 
     if (ret) {
       cancelled.value = true; // Suppresses "No Effect" message

--- a/src/data/ab-attrs/variable-move-power-ab-attr.ts
+++ b/src/data/ab-attrs/variable-move-power-ab-attr.ts
@@ -1,5 +1,6 @@
 import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
+import type { NumberHolder } from "#app/utils";
 import { PreAttackAbAttr } from "./pre-attack-ab-attr";
 
 export class VariableMovePowerAbAttr extends PreAttackAbAttr {
@@ -9,9 +10,8 @@ export class VariableMovePowerAbAttr extends PreAttackAbAttr {
     _simulated: boolean,
     _defender: Pokemon,
     _move: Move,
-    _args: any[],
+    _power: NumberHolder,
   ): boolean {
-    //const power = args[0] as Utils.NumberHolder;
     return false;
   }
 }

--- a/src/data/ab-attrs/variable-move-power-boost-ab-attr.ts
+++ b/src/data/ab-attrs/variable-move-power-boost-ab-attr.ts
@@ -27,10 +27,9 @@ export class VariableMovePowerBoostAbAttr extends VariableMovePowerAbAttr {
     _simulated: boolean,
     defender: Pokemon,
     move: Move,
-    args: any[],
+    power: NumberHolder,
   ): boolean {
     const multiplier = this.multFunc(pokemon, defender, move);
-    const power: NumberHolder = args[0];
     if (multiplier !== 1) {
       power.value *= multiplier;
       return true;

--- a/src/data/ab-attrs/weather-based-speed-doubler-ab-attr.ts
+++ b/src/data/ab-attrs/weather-based-speed-doubler-ab-attr.ts
@@ -5,6 +5,7 @@ import { Stat } from "#enums/stat";
 import type { Pokemon } from "#app/field/pokemon";
 import type { NumberHolder } from "#app/utils";
 import { getWeatherCondition } from "#app/data/all-abilities";
+import type { Move } from "../move";
 
 /**
  * Ability attribute that doubles speed if specific weather(s) are active
@@ -34,10 +35,10 @@ export class WeatherBasedSpeedDoublerAbAttr extends StatMultiplierAbAttr {
     simulated: boolean,
     stat: BattleStat,
     statValue: NumberHolder,
-    args: any[],
+    move: Move,
   ): boolean {
     if (getWeatherCondition(...this.weather)(pokemon)) {
-      return super.applyStatStage(pokemon, passive, simulated, stat, statValue, args);
+      return super.applyStatStage(pokemon, passive, simulated, stat, statValue, move);
     }
     return false;
   }

--- a/src/data/ab-attrs/weight-multiplier-ab-attr.ts
+++ b/src/data/ab-attrs/weight-multiplier-ab-attr.ts
@@ -1,5 +1,5 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder, NumberHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
 /**
@@ -16,14 +16,7 @@ export class WeightMultiplierAbAttr extends AbAttr {
     this.multiplier = multiplier;
   }
 
-  override apply(
-    _pokemon: Pokemon,
-    _passive: boolean,
-    _simulated: boolean,
-    _cancelled: BooleanHolder,
-    args: any[],
-  ): boolean {
-    const weight: NumberHolder = args[0];
+  override apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, weight: NumberHolder): boolean {
     weight.value *= this.multiplier;
 
     return true;

--- a/src/data/ab-attrs/wonder-skin-ab-attr.ts
+++ b/src/data/ab-attrs/wonder-skin-ab-attr.ts
@@ -18,9 +18,8 @@ export class WonderSkinAbAttr extends PreDefendAbAttr {
     _attacker: Pokemon,
     move: Move,
     _cancelled: BooleanHolder,
-    args: any[],
+    moveAccuracy: NumberHolder,
   ): boolean {
-    const moveAccuracy = args[0] as NumberHolder;
     if (move.category === MoveCategory.STATUS && moveAccuracy.value >= 50) {
       moveAccuracy.value = 50;
       return true;

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -682,14 +682,14 @@ export function applyPostAttackAbAttrs(
 export function applyPostKnockOutAbAttrs(
   attrType: Constructor<PostKnockOutAbAttr>,
   pokemon: Pokemon,
-  knockedOut: Pokemon,
+  knockedOutPokemon: Pokemon,
   simulated: boolean = false,
   ...args: any[]
 ): void {
   applyAbAttrsInternal<PostKnockOutAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostKnockOut(pokemon, passive, simulated, knockedOut, ...args),
+    (attr, passive) => attr.applyPostKnockOut(pokemon, passive, simulated, knockedOutPokemon, ...args),
     args,
     false,
     simulated,

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -477,7 +477,7 @@ export function applyAbAttrs(
   attrType: Constructor<AbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<AbAttr>(
     attrType,
@@ -493,7 +493,7 @@ export function applyPostBattleInitAbAttrs(
   attrType: Constructor<PostBattleInitAbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostBattleInitAbAttr>(
     attrType,
@@ -512,7 +512,7 @@ export function applyPreDefendAbAttrs(
   move: Move | null,
   cancelled: BooleanHolder | null,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PreDefendAbAttr>(
     attrType,
@@ -531,7 +531,7 @@ export function applyPostDefendAbAttrs(
   move: Move,
   hitResult: HitResult | null,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostDefendAbAttr>(
     attrType,
@@ -550,7 +550,7 @@ export function applyPostMoveUsedAbAttrs(
   source: Pokemon,
   targets: BattlerIndex[],
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostMoveUsedAbAttr>(
     attrType,
@@ -568,7 +568,7 @@ export function applyStatMultiplierAbAttrs(
   stat: BattleStat,
   statValue: NumberHolder,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<StatStageAbAttr>(
     attrType,
@@ -584,7 +584,7 @@ export function applyPostSetStatusAbAttrs(
   effect: StatusEffect,
   sourcePokemon?: Pokemon | null,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostSetStatusAbAttr>(
     attrType,
@@ -648,7 +648,7 @@ export function applyPreAttackAbAttrs(
   defender: Pokemon | null,
   move: Move,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PreAttackAbAttr>(
     attrType,
@@ -667,7 +667,7 @@ export function applyPostAttackAbAttrs(
   move: Move,
   hitResult: HitResult | null,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostAttackAbAttr>(
     attrType,
@@ -684,7 +684,7 @@ export function applyPostKnockOutAbAttrs(
   pokemon: Pokemon,
   knockedOutPokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostKnockOutAbAttr>(
     attrType,
@@ -700,7 +700,7 @@ export function applyPostVictoryAbAttrs(
   attrType: Constructor<PostVictoryAbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostVictoryAbAttr>(
     attrType,
@@ -716,7 +716,7 @@ export function applyPostSummonAbAttrs(
   attrType: Constructor<PostSummonAbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostSummonAbAttr>(
     attrType,
@@ -732,7 +732,7 @@ export function applyPreSwitchOutAbAttrs(
   attrType: Constructor<PreSwitchOutAbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PreSwitchOutAbAttr>(
     attrType,
@@ -750,7 +750,7 @@ export function applyPreStatStageChangeAbAttrs(
   stat: BattleStat,
   cancelled: BooleanHolder,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PreStatStageChangeAbAttr>(
     attrType,
@@ -769,7 +769,7 @@ export function applyPostStatStageChangeAbAttrs(
   stages: number,
   selfTarget: boolean,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostStatStageChangeAbAttr>(
     attrType,
@@ -787,7 +787,7 @@ export function applyPreSetStatusAbAttrs(
   effect: StatusEffect | undefined,
   cancelled: BooleanHolder,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PreSetStatusAbAttr>(
     attrType,
@@ -805,7 +805,7 @@ export function applyPreApplyBattlerTagAbAttrs(
   tag: BattlerTag,
   cancelled: BooleanHolder,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PreApplyBattlerTagAbAttr>(
     attrType,
@@ -823,7 +823,7 @@ export function applyPreWeatherEffectAbAttrs(
   weather: Weather | null,
   cancelled: BooleanHolder,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PreWeatherDamageAbAttr>(
     attrType,
@@ -839,7 +839,7 @@ export function applyPostTurnAbAttrs(
   attrType: Constructor<PostTurnAbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostTurnAbAttr>(
     attrType,
@@ -856,7 +856,7 @@ export function applyPostWeatherChangeAbAttrs(
   pokemon: Pokemon,
   weather: WeatherType,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostWeatherChangeAbAttr>(
     attrType,
@@ -873,7 +873,7 @@ export function applyPostWeatherLapseAbAttrs(
   pokemon: Pokemon,
   weather: Weather | null,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostWeatherLapseAbAttr>(
     attrType,
@@ -890,7 +890,7 @@ export function applyPostTerrainChangeAbAttrs(
   pokemon: Pokemon,
   terrain: TerrainType,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostTerrainChangeAbAttr>(
     attrType,
@@ -909,7 +909,7 @@ export function applyCheckTrappedAbAttrs(
   otherPokemon: Pokemon,
   messages: string[],
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<CheckTrappedAbAttr>(
     attrType,
@@ -926,7 +926,7 @@ export function applyPostBattleAbAttrs(
   attrType: Constructor<PostBattleAbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostBattleAbAttr>(
     attrType,
@@ -945,7 +945,7 @@ export function applyPostFaintAbAttrs(
   move?: Move,
   hitResult?: HitResult,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostFaintAbAttr>(
     attrType,
@@ -961,7 +961,7 @@ export function applyPostItemLostAbAttrs(
   attrType: Constructor<PostItemLostAbAttr>,
   pokemon: Pokemon,
   simulated: boolean = false,
-  ...args: any[]
+  ...args: unknown[]
 ): void {
   applyAbAttrsInternal<PostItemLostAbAttr>(
     attrType,

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -264,7 +264,7 @@ class ForceSwitchOutHelper {
 
     if (player) {
       const blockedByAbility = new BooleanHolder(false);
-      applyAbAttrs(ForceSwitchOutImmunityAbAttr, opponent, blockedByAbility);
+      applyAbAttrs(ForceSwitchOutImmunityAbAttr, opponent, false, blockedByAbility);
       return !blockedByAbility.value;
     }
 
@@ -301,7 +301,7 @@ class ForceSwitchOutHelper {
    */
   public getFailedText(target: Pokemon): string | null {
     const blockedByAbility = new BooleanHolder(false);
-    applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, blockedByAbility);
+    applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, false, blockedByAbility);
     return blockedByAbility.value
       ? i18next.t("moveTriggers:cannotBeSwitchedOut", { pokemonName: getPokemonNameWithAffix(target) })
       : null;
@@ -476,14 +476,13 @@ function applyAbAttrsInternal<TAttr extends AbAttr>(
 export function applyAbAttrs(
   attrType: Constructor<AbAttr>,
   pokemon: Pokemon,
-  cancelled: BooleanHolder | null,
   simulated: boolean = false,
   ...args: any[]
 ): void {
   applyAbAttrsInternal<AbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.apply(pokemon, passive, simulated, cancelled, ...args),
+    (attr, passive) => attr.apply(pokemon, passive, simulated, ...args),
     args,
     false,
     simulated,

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -36,7 +36,6 @@ import type { PostDefendAbAttr } from "./ab-attrs/post-defend-ab-attr";
 import type { PostStatStageChangeAbAttr } from "./ab-attrs/post-stat-stage-change-ab-attr";
 import type { AbAttrCondition } from "#app/@types/AbAttrCondition";
 import type { FieldMultiplyStatAbAttr } from "./ab-attrs/field-multiply-stat-ab-attr";
-import type { StatMultiplierAbAttr } from "./ab-attrs/stat-multiplier-ab-attr";
 import type { PostAttackAbAttr } from "./ab-attrs/post-attack-ab-attr";
 import type { PostSetStatusAbAttr } from "./ab-attrs/post-set-status-ab-attr";
 import type { PostVictoryAbAttr } from "./ab-attrs/post-victory-ab-attr";
@@ -58,6 +57,7 @@ import type { PostBattleAbAttr } from "./ab-attrs/post-battle-ab-attr";
 import type { PostFaintAbAttr } from "./ab-attrs/post-faint-ab-attr";
 import { ForceSwitchOutImmunityAbAttr } from "./ab-attrs/force-switch-out-immunity-ab-attr";
 import { queueShowAbility } from "./ability-utils";
+import type { StatStageAbAttr } from "./ab-attrs/stat-stage-ab-attr";
 
 export class Ability implements Localizable {
   public id: Abilities;
@@ -363,7 +363,6 @@ export class PostDamageForceSwitchAbAttr extends PostDamageAbAttr {
     damage: number,
     _passive: boolean,
     _simulated: boolean,
-    _args: any[],
     source?: Pokemon,
   ): boolean {
     const moveHistory = pokemon.getMoveHistory();
@@ -484,7 +483,7 @@ export function applyAbAttrs(
   applyAbAttrsInternal<AbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.apply(pokemon, passive, simulated, cancelled, args),
+    (attr, passive) => attr.apply(pokemon, passive, simulated, cancelled, ...args),
     args,
     false,
     simulated,
@@ -500,7 +499,7 @@ export function applyPostBattleInitAbAttrs(
   applyAbAttrsInternal<PostBattleInitAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostBattleInit(pokemon, passive, simulated, args),
+    (attr, passive) => attr.applyPostBattleInit(pokemon, passive, simulated, ...args),
     args,
     false,
     simulated,
@@ -519,7 +518,7 @@ export function applyPreDefendAbAttrs(
   applyAbAttrsInternal<PreDefendAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, args),
+    (attr, passive) => attr.applyPreDefend(pokemon, passive, simulated, attacker, move, cancelled, ...args),
     args,
     false,
     simulated,
@@ -538,7 +537,7 @@ export function applyPostDefendAbAttrs(
   applyAbAttrsInternal<PostDefendAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostDefend(pokemon, passive, simulated, attacker, move, hitResult, args),
+    (attr, passive) => attr.applyPostDefend(pokemon, passive, simulated, attacker, move, hitResult, ...args),
     args,
     false,
     simulated,
@@ -557,7 +556,7 @@ export function applyPostMoveUsedAbAttrs(
   applyAbAttrsInternal<PostMoveUsedAbAttr>(
     attrType,
     pokemon,
-    (attr, _passive) => attr.applyPostMoveUsed(pokemon, move, source, targets, simulated, args),
+    (attr, _passive) => attr.applyPostMoveUsed(pokemon, move, source, targets, simulated, ...args),
     args,
     false,
     simulated,
@@ -565,17 +564,17 @@ export function applyPostMoveUsedAbAttrs(
 }
 
 export function applyStatMultiplierAbAttrs(
-  attrType: Constructor<StatMultiplierAbAttr>,
+  attrType: Constructor<StatStageAbAttr>,
   pokemon: Pokemon,
   stat: BattleStat,
   statValue: NumberHolder,
   simulated: boolean = false,
   ...args: any[]
 ): void {
-  applyAbAttrsInternal<StatMultiplierAbAttr>(
+  applyAbAttrsInternal<StatStageAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyStatStage(pokemon, passive, simulated, stat, statValue, args),
+    (attr, passive) => attr.applyStatStage(pokemon, passive, simulated, stat, statValue, ...args),
     args,
   );
 }
@@ -591,7 +590,7 @@ export function applyPostSetStatusAbAttrs(
   applyAbAttrsInternal<PostSetStatusAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostSetStatus(pokemon, sourcePokemon, passive, effect, simulated, args),
+    (attr, passive) => attr.applyPostSetStatus(pokemon, sourcePokemon, passive, effect, simulated, ...args),
     args,
     false,
     simulated,
@@ -610,7 +609,7 @@ export function applyPostDamageAbAttrs(
   applyAbAttrsInternal<PostDamageAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostDamage(pokemon, damage, passive, simulated, args, source),
+    (attr, passive) => attr.applyPostDamage(pokemon, damage, passive, simulated, source, ...args),
     args,
   );
 }
@@ -655,7 +654,7 @@ export function applyPreAttackAbAttrs(
   applyAbAttrsInternal<PreAttackAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPreAttack(pokemon, passive, simulated, defender, move, args),
+    (attr, passive) => attr.applyPreAttack(pokemon, passive, simulated, defender, move, ...args),
     args,
     false,
     simulated,
@@ -674,7 +673,7 @@ export function applyPostAttackAbAttrs(
   applyAbAttrsInternal<PostAttackAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostAttack(pokemon, passive, simulated, defender, move, hitResult, args),
+    (attr, passive) => attr.applyPostAttack(pokemon, passive, simulated, defender, move, hitResult, ...args),
     args,
     false,
     simulated,
@@ -691,7 +690,7 @@ export function applyPostKnockOutAbAttrs(
   applyAbAttrsInternal<PostKnockOutAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostKnockOut(pokemon, passive, simulated, knockedOut, args),
+    (attr, passive) => attr.applyPostKnockOut(pokemon, passive, simulated, knockedOut, ...args),
     args,
     false,
     simulated,
@@ -707,7 +706,7 @@ export function applyPostVictoryAbAttrs(
   applyAbAttrsInternal<PostVictoryAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostVictory(pokemon, passive, simulated, args),
+    (attr, passive) => attr.applyPostVictory(pokemon, passive, simulated, ...args),
     args,
     false,
     simulated,
@@ -723,7 +722,7 @@ export function applyPostSummonAbAttrs(
   applyAbAttrsInternal<PostSummonAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostSummon(pokemon, passive, simulated, args),
+    (attr, passive) => attr.applyPostSummon(pokemon, passive, simulated, ...args),
     args,
     false,
     simulated,
@@ -739,7 +738,7 @@ export function applyPreSwitchOutAbAttrs(
   applyAbAttrsInternal<PreSwitchOutAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPreSwitchOut(pokemon, passive, simulated, args),
+    (attr, passive) => attr.applyPreSwitchOut(pokemon, passive, simulated, ...args),
     args,
     true,
     simulated,
@@ -757,7 +756,7 @@ export function applyPreStatStageChangeAbAttrs(
   applyAbAttrsInternal<PreStatStageChangeAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPreStatStageChange(pokemon, passive, simulated, stat, cancelled, args),
+    (attr, passive) => attr.applyPreStatStageChange(pokemon, passive, simulated, stat, cancelled, ...args),
     args,
     false,
     simulated,
@@ -776,7 +775,7 @@ export function applyPostStatStageChangeAbAttrs(
   applyAbAttrsInternal<PostStatStageChangeAbAttr>(
     attrType,
     pokemon,
-    (attr, _passive) => attr.applyPostStatStageChange(pokemon, simulated, stats, stages, selfTarget, args),
+    (attr, _passive) => attr.applyPostStatStageChange(pokemon, simulated, stats, stages, selfTarget, ...args),
     args,
     false,
     simulated,
@@ -794,7 +793,7 @@ export function applyPreSetStatusAbAttrs(
   applyAbAttrsInternal<PreSetStatusAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPreSetStatus(pokemon, passive, simulated, effect, cancelled, args),
+    (attr, passive) => attr.applyPreSetStatus(pokemon, passive, simulated, effect, cancelled, ...args),
     args,
     false,
     simulated,
@@ -812,7 +811,7 @@ export function applyPreApplyBattlerTagAbAttrs(
   applyAbAttrsInternal<PreApplyBattlerTagAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPreApplyBattlerTag(pokemon, passive, simulated, tag, cancelled, args),
+    (attr, passive) => attr.applyPreApplyBattlerTag(pokemon, passive, simulated, tag, cancelled, ...args),
     args,
     false,
     simulated,
@@ -830,7 +829,7 @@ export function applyPreWeatherEffectAbAttrs(
   applyAbAttrsInternal<PreWeatherDamageAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPreWeatherEffect(pokemon, passive, simulated, weather, cancelled, args),
+    (attr, passive) => attr.applyPreWeatherEffect(pokemon, passive, simulated, weather, cancelled, ...args),
     args,
     true,
     simulated,
@@ -846,7 +845,7 @@ export function applyPostTurnAbAttrs(
   applyAbAttrsInternal<PostTurnAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostTurn(pokemon, passive, simulated, args),
+    (attr, passive) => attr.applyPostTurn(pokemon, passive, simulated, ...args),
     args,
     false,
     simulated,
@@ -863,7 +862,7 @@ export function applyPostWeatherChangeAbAttrs(
   applyAbAttrsInternal<PostWeatherChangeAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostWeatherChange(pokemon, passive, simulated, weather, args),
+    (attr, passive) => attr.applyPostWeatherChange(pokemon, passive, simulated, weather, ...args),
     args,
     false,
     simulated,
@@ -880,7 +879,7 @@ export function applyPostWeatherLapseAbAttrs(
   applyAbAttrsInternal<PostWeatherLapseAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostWeatherLapse(pokemon, passive, simulated, weather, args),
+    (attr, passive) => attr.applyPostWeatherLapse(pokemon, passive, simulated, weather, ...args),
     args,
     false,
     simulated,
@@ -897,7 +896,7 @@ export function applyPostTerrainChangeAbAttrs(
   applyAbAttrsInternal<PostTerrainChangeAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostTerrainChange(pokemon, passive, simulated, terrain, args),
+    (attr, passive) => attr.applyPostTerrainChange(pokemon, passive, simulated, terrain, ...args),
     args,
     false,
     simulated,
@@ -916,7 +915,7 @@ export function applyCheckTrappedAbAttrs(
   applyAbAttrsInternal<CheckTrappedAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyCheckTrapped(pokemon, passive, simulated, trapped, otherPokemon, args),
+    (attr, passive) => attr.applyCheckTrapped(pokemon, passive, simulated, trapped, otherPokemon, ...args),
     args,
     false,
     simulated,
@@ -933,7 +932,7 @@ export function applyPostBattleAbAttrs(
   applyAbAttrsInternal<PostBattleAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostBattle(pokemon, passive, simulated, args),
+    (attr, passive) => attr.applyPostBattle(pokemon, passive, simulated, ...args),
     args,
     false,
     simulated,
@@ -952,7 +951,7 @@ export function applyPostFaintAbAttrs(
   applyAbAttrsInternal<PostFaintAbAttr>(
     attrType,
     pokemon,
-    (attr, passive) => attr.applyPostFaint(pokemon, passive, simulated, attacker, move, hitResult, args),
+    (attr, passive) => attr.applyPostFaint(pokemon, passive, simulated, attacker, move, hitResult, ...args),
     args,
     false,
     simulated,
@@ -968,7 +967,7 @@ export function applyPostItemLostAbAttrs(
   applyAbAttrsInternal<PostItemLostAbAttr>(
     attrType,
     pokemon,
-    (attr, _passive) => attr.applyPostItemLost(pokemon, simulated, args),
+    (attr, _passive) => attr.applyPostItemLost(pokemon, simulated, ...args),
     args,
   );
 }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -147,7 +147,7 @@ export class MistTag extends ArenaTag {
     if (attacker) {
       const bypassed = new BooleanHolder(false);
       // TODO: Allow this to be simulated
-      applyAbAttrs(InfiltratorAbAttr, attacker, null, false, bypassed);
+      applyAbAttrs(InfiltratorAbAttr, attacker, simulated, bypassed);
       if (bypassed.value) {
         return false;
       }
@@ -205,14 +205,14 @@ export class WeakenMoveScreenTag extends ArenaTag {
    */
   override apply(
     _arena: Arena,
-    _simulated: boolean,
+    simulated: boolean,
     attacker: Pokemon,
     moveCategory: MoveCategory,
     damageMultiplier: NumberHolder,
   ): boolean {
     if (this.weakenedCategories.includes(moveCategory)) {
       const bypassed = new BooleanHolder(false);
-      applyAbAttrs(InfiltratorAbAttr, attacker, null, false, bypassed);
+      applyAbAttrs(InfiltratorAbAttr, attacker, simulated, bypassed);
       if (bypassed.value) {
         return false;
       }
@@ -764,7 +764,7 @@ class SpikesTag extends ArenaTrapTag {
   override activateTrap(pokemon: Pokemon, simulated: boolean): boolean {
     if (pokemon.isGrounded()) {
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, simulated, cancelled);
 
       if (simulated) {
         return !cancelled.value;
@@ -951,7 +951,7 @@ class StealthRockTag extends ArenaTrapTag {
 
   override activateTrap(pokemon: Pokemon, simulated: boolean): boolean {
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+    applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, simulated, cancelled);
 
     if (cancelled.value) {
       return false;
@@ -1018,7 +1018,7 @@ class StickyWebTag extends ArenaTrapTag {
   override activateTrap(pokemon: Pokemon, simulated: boolean): boolean {
     if (pokemon.isGrounded()) {
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(ProtectStatAbAttr, pokemon, cancelled);
+      applyAbAttrs(ProtectStatAbAttr, pokemon, simulated, cancelled);
 
       if (simulated) {
         return !cancelled.value;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -627,7 +627,7 @@ export class FlinchedTag extends BattlerTag {
   override onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
 
-    applyAbAttrs(FlinchEffectAbAttr, pokemon, null);
+    applyAbAttrs(FlinchEffectAbAttr, pokemon);
   }
 
   /**
@@ -930,7 +930,7 @@ export class SeedTag extends BattlerTag {
       const source = pokemon.getOpponents().find((o) => o.getBattlerIndex() === this.sourceIndex);
       if (source) {
         const cancelled = new BooleanHolder(false);
-        applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+        applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
 
         if (!cancelled.value) {
           globalScene.unshiftPhase(
@@ -1004,7 +1004,7 @@ export class PowderTag extends BattlerTag {
           );
 
           const cancelDamage = new BooleanHolder(false);
-          applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelDamage);
+          applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelDamage);
           if (!cancelDamage.value) {
             pokemon.damageAndUpdate(Math.floor(pokemon.getMaxHp() / 4), HitResult.OTHER);
           }
@@ -1051,7 +1051,7 @@ export class NightmareTag extends BattlerTag {
       globalScene.unshiftPhase(new CommonAnimPhase(pokemon.getBattlerIndex(), undefined, CommonAnim.CURSE)); // TODO: Update animation type
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4));
@@ -1392,7 +1392,7 @@ export abstract class DamagingTrapTag extends TrappedTag {
       globalScene.unshiftPhase(new CommonAnimPhase(pokemon.getBattlerIndex(), undefined, this.commonAnim));
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8));
@@ -2150,7 +2150,7 @@ export class SaltCuredTag extends BattlerTag {
       );
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         const pokemonSteelOrWater = pokemon.isOfType(Type.STEEL) || pokemon.isOfType(Type.WATER);
@@ -2199,7 +2199,7 @@ export class CursedTag extends BattlerTag {
       );
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4));
@@ -2530,7 +2530,7 @@ export class GulpMissileTag extends BattlerTag {
       }
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, attacker, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, attacker, false, cancelled);
 
       if (!cancelled.value) {
         attacker.damageAndUpdate(Math.max(1, Math.floor(attacker.getMaxHp() / 4)), HitResult.OTHER);
@@ -2910,7 +2910,7 @@ export class MysteryEncounterPostSummonTag extends BattlerTag {
 
     if (lapseType === BattlerTagLapseType.CUSTOM) {
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(ProtectStatAbAttr, pokemon, cancelled);
+      applyAbAttrs(ProtectStatAbAttr, pokemon, false, cancelled);
       if (!cancelled.value) {
         if (pokemon.mysteryEncounterBattleEffects) {
           pokemon.mysteryEncounterBattleEffects(pokemon);

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -43,25 +43,25 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
         const threshold = new NumberHolder(0.25);
         // Offset BerryType such that LIECHI -> Stat.ATK = 1, GANLON -> Stat.DEF = 2, so on and so forth
         const stat: BattleStat = berryType - BerryType.ENIGMA;
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, false, threshold);
         return pokemon.getHpRatio() < threshold.value && pokemon.getStatStage(stat) < 6;
       };
     case BerryType.LANSAT:
       return (pokemon: Pokemon) => {
         const threshold = new NumberHolder(0.25);
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, false, threshold);
         return pokemon.getHpRatio() < 0.25 && !pokemon.getTag(BattlerTagType.CRIT_BOOST);
       };
     case BerryType.STARF:
       return (pokemon: Pokemon) => {
         const threshold = new NumberHolder(0.25);
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, false, threshold);
         return pokemon.getHpRatio() < 0.25;
       };
     case BerryType.LEPPA:
       return (pokemon: Pokemon) => {
         const threshold = new NumberHolder(0.25);
-        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, null, false, threshold);
+        applyAbAttrs(ReduceBerryUseThresholdAbAttr, pokemon, false, threshold);
         return !!pokemon.getMoveset().find((m) => !m.getPpRatio());
       };
   }
@@ -78,7 +78,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
           pokemon.battleData.berriesEaten.push(berryType);
         }
         const hpHealed = new NumberHolder(toDmgValue(pokemon.getMaxHp() / 4));
-        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, hpHealed);
+        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, false, hpHealed);
         globalScene.unshiftPhase(
           new PokemonHealPhase(pokemon.getBattlerIndex(), hpHealed.value, {
             message: i18next.t("battle:hpHealBerry", {
@@ -113,7 +113,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         // Offset BerryType such that LIECHI -> Stat.ATK = 1, GANLON -> Stat.DEF = 2, so on and so forth
         const stat: BattleStat = berryType - BerryType.ENIGMA;
         const statStages = new NumberHolder(1);
-        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, statStages);
+        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, false, statStages);
         globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [stat], statStages.value));
         applyPostItemLostAbAttrs(PostItemLostAbAttr, berryOwner ?? pokemon, false);
       };
@@ -132,7 +132,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         }
         const randStat = randSeedInt(Stat.SPD, Stat.ATK);
         const stages = new NumberHolder(2);
-        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, null, false, stages);
+        applyAbAttrs(DoubleBerryEffectAbAttr, pokemon, false, stages);
         globalScene.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), true, [randStat], stages.value));
         applyPostItemLostAbAttrs(PostItemLostAbAttr, berryOwner ?? pokemon, false);
       };

--- a/src/data/move-attrs/eat-berry-attr.ts
+++ b/src/data/move-attrs/eat-berry-attr.ts
@@ -57,6 +57,6 @@ export class EatBerryAttr extends MoveEffectAttr {
 
   eatBerry(consumer: Pokemon, berryOwner?: Pokemon) {
     getBerryEffectFunc(this.chosenBerry!.berryType)(consumer, berryOwner); // consumer eats the berry
-    applyAbAttrs(HealFromBerryUseAbAttr, consumer, new BooleanHolder(false));
+    applyAbAttrs(HealFromBerryUseAbAttr, consumer);
   }
 }

--- a/src/data/move-attrs/flame-burst-attr.ts
+++ b/src/data/move-attrs/flame-burst-attr.ts
@@ -25,7 +25,7 @@ export class FlameBurstAttr extends MoveEffectAttr {
     const cancelled = new BooleanHolder(false);
 
     if (targetAlly) {
-      applyAbAttrs(BlockNonDirectDamageAbAttr, targetAlly, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, targetAlly, false, cancelled);
     }
 
     if (cancelled.value || !targetAlly || targetAlly.switchOutStatus) {

--- a/src/data/move-attrs/flinch-attr.ts
+++ b/src/data/move-attrs/flinch-attr.ts
@@ -28,7 +28,7 @@ export class FlinchAttr extends AddBattlerTagAttr {
   ): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, false, moveChance, move, showAbility);
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, false, moveChance, move, showAbility);
 
     if (moveChance.value <= move.chance) {
       const userSide = user.getArenaTagSide();

--- a/src/data/move-attrs/flinch-attr.ts
+++ b/src/data/move-attrs/flinch-attr.ts
@@ -28,17 +28,7 @@ export class FlinchAttr extends AddBattlerTagAttr {
   ): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(
-      MoveEffectChanceMultiplierAbAttr,
-      user,
-      null,
-      false,
-      moveChance,
-      move,
-      target,
-      selfEffect,
-      showAbility,
-    );
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, false, moveChance, move, showAbility);
 
     if (moveChance.value <= move.chance) {
       const userSide = user.getArenaTagSide();

--- a/src/data/move-attrs/force-switch-out-attr.ts
+++ b/src/data/move-attrs/force-switch-out-attr.ts
@@ -193,7 +193,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 
   override getFailedText(_user: Pokemon, target: Pokemon, _move: Move, _cancelled: BooleanHolder): string | null {
     const blockedByAbility = new BooleanHolder(false);
-    applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, blockedByAbility);
+    applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, false, blockedByAbility);
     return blockedByAbility.value
       ? i18next.t("moveTriggers:cannotBeSwitchedOut", { pokemonName: getPokemonNameWithAffix(target) })
       : null;
@@ -221,7 +221,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
         }
 
         const blockedByAbility = new BooleanHolder(false);
-        applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, blockedByAbility);
+        applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, false, blockedByAbility);
         return !blockedByAbility.value;
       }
 

--- a/src/data/move-attrs/half-sacrificial-attr.ts
+++ b/src/data/move-attrs/half-sacrificial-attr.ts
@@ -27,7 +27,7 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
 
     const cancelled = new BooleanHolder(false);
     // Check to see if the Pokemon has an ability that blocks non-direct damage
-    applyAbAttrs(BlockNonDirectDamageAbAttr, user, cancelled);
+    applyAbAttrs(BlockNonDirectDamageAbAttr, user, false, cancelled);
     if (!cancelled.value) {
       user.damageAndUpdate(toDmgValue(user.getMaxHp() / 2), HitResult.OTHER, false, true, true);
       globalScene.queueMessage(

--- a/src/data/move-attrs/move-effect-attr.ts
+++ b/src/data/move-attrs/move-effect-attr.ts
@@ -132,17 +132,7 @@ export class MoveEffectAttr extends MoveAttr {
   getMoveChance(user: Pokemon, target: Pokemon, move: Move, selfEffect: boolean, showAbility?: boolean): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(
-      MoveEffectChanceMultiplierAbAttr,
-      user,
-      null,
-      false,
-      moveChance,
-      move,
-      target,
-      selfEffect,
-      showAbility,
-    );
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, false, moveChance, move, showAbility);
 
     const userSide = user.getArenaTagSide();
     globalScene.arena.applyTagsForSide(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);

--- a/src/data/move-attrs/move-effect-attr.ts
+++ b/src/data/move-attrs/move-effect-attr.ts
@@ -132,7 +132,7 @@ export class MoveEffectAttr extends MoveAttr {
   getMoveChance(user: Pokemon, target: Pokemon, move: Move, selfEffect: boolean, showAbility?: boolean): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, false, moveChance, move, showAbility);
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, false, moveChance, move, showAbility);
 
     const userSide = user.getArenaTagSide();
     globalScene.arena.applyTagsForSide(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);

--- a/src/data/move-attrs/multi-hit-attr.ts
+++ b/src/data/move-attrs/multi-hit-attr.ts
@@ -67,7 +67,7 @@ export class MultiHitAttr extends MoveAttr {
       case MultiHitType._2_TO_5: {
         const rand = user.randSeedInt(16);
         const hitValue = new NumberHolder(rand);
-        applyAbAttrs(MaxMultiHitAbAttr, user, null, false, hitValue);
+        applyAbAttrs(MaxMultiHitAbAttr, user, false, hitValue);
         if (hitValue.value >= 10) {
           return 2;
         } else if (hitValue.value >= 4) {

--- a/src/data/move-attrs/one-hit-ko-attr.ts
+++ b/src/data/move-attrs/one-hit-ko-attr.ts
@@ -33,7 +33,7 @@ export class OneHitKOAttr extends MoveAttr {
   override getCondition(): MoveConditionFunc {
     return (user, target, _move) => {
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockOneHitKOAbAttr, target, cancelled);
+      applyAbAttrs(BlockOneHitKOAbAttr, target, false, cancelled);
       return !cancelled.value && user.level >= target.level;
     };
   }

--- a/src/data/move-attrs/recoil-attr.ts
+++ b/src/data/move-attrs/recoil-attr.ts
@@ -33,8 +33,8 @@ export class RecoilAttr extends MoveEffectAttr {
 
     const cancelled = new BooleanHolder(false);
     if (!this.unblockable) {
-      applyAbAttrs(BlockRecoilDamageAttr, user, cancelled);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, user, cancelled);
+      applyAbAttrs(BlockRecoilDamageAttr, user, false, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, user, false, cancelled);
     }
 
     if (cancelled.value) {

--- a/src/data/move-attrs/remove-held-item-attr.ts
+++ b/src/data/move-attrs/remove-held-item-attr.ts
@@ -32,7 +32,7 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
     }
 
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(BlockItemTheftAbAttr, target, cancelled); // Check for abilities that block item theft
+    applyAbAttrs(BlockItemTheftAbAttr, target, false, cancelled); // Check for abilities that block item theft
 
     if (cancelled.value === true) {
       return false;

--- a/src/data/move-attrs/secret-power-attr.ts
+++ b/src/data/move-attrs/secret-power-attr.ts
@@ -166,7 +166,7 @@ export class SecretPowerAttr extends MoveEffectAttr {
   ): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, false, moveChance, move, showAbility);
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, false, moveChance, move, showAbility);
 
     if (!selfEffect) {
       applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr, target, user, null, null, false, moveChance);

--- a/src/data/move-attrs/secret-power-attr.ts
+++ b/src/data/move-attrs/secret-power-attr.ts
@@ -166,17 +166,7 @@ export class SecretPowerAttr extends MoveEffectAttr {
   ): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(
-      MoveEffectChanceMultiplierAbAttr,
-      user,
-      null,
-      false,
-      moveChance,
-      move,
-      target,
-      selfEffect,
-      showAbility,
-    );
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, user, null, false, moveChance, move, showAbility);
 
     if (!selfEffect) {
       applyPreDefendAbAttrs(IgnoreMoveEffectsAbAttr, target, user, null, null, false, moveChance);

--- a/src/data/move-attrs/steal-eat-berry-attr.ts
+++ b/src/data/move-attrs/steal-eat-berry-attr.ts
@@ -20,7 +20,7 @@ export class StealEatBerryAttr extends EatBerryAttr {
 
   override apply(user: Pokemon, target: Pokemon, _move: Move): boolean {
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(BlockItemTheftAbAttr, target, cancelled); // check for abilities that block item theft
+    applyAbAttrs(BlockItemTheftAbAttr, target, false, cancelled); // check for abilities that block item theft
     if (cancelled.value === true) {
       return false;
     }

--- a/src/data/move-attrs/steal-positive-stats-attr.ts
+++ b/src/data/move-attrs/steal-positive-stats-attr.ts
@@ -25,7 +25,7 @@ export class StealPositiveStatsAttr extends MoveEffectAttr {
     for (const s of BATTLE_STATS) {
       if (target.getStatStage(s) > 0) {
         const userStatChange = new NumberHolder(target.getStatStage(s));
-        applyAbAttrs(StatStageChangeMultiplierAbAttr, user, null, false, userStatChange);
+        applyAbAttrs(StatStageChangeMultiplierAbAttr, user, false, userStatChange);
         user.setStatStage(s, user.getStatStage(s) + userStatChange.value);
         target.setStatStage(s, 0);
       }

--- a/src/data/move-conditions.ts
+++ b/src/data/move-conditions.ts
@@ -108,7 +108,7 @@ export const failIfDampCondition: MoveConditionFunc = (user, _target, move) => {
   globalScene
     .getField(true)
     .map((p) =>
-      applyAbAttrs(FieldPreventExplosionLikeAbAttr, p, cancelled, undefined, getPokemonNameWithAffix(user), move.name),
+      applyAbAttrs(FieldPreventExplosionLikeAbAttr, p, undefined, cancelled, getPokemonNameWithAffix(user), move.name),
     );
   return !cancelled.value;
 };

--- a/src/data/move-utils.ts
+++ b/src/data/move-utils.ts
@@ -11,7 +11,7 @@ import type { UserMoveConditionFunc } from "./move-conditions";
 
 export const crashDamageFunc = (user: Pokemon, _move: Move) => {
   const cancelled = new BooleanHolder(false);
-  applyAbAttrs(BlockNonDirectDamageAbAttr, user, cancelled);
+  applyAbAttrs(BlockNonDirectDamageAbAttr, user, false, cancelled);
   if (cancelled.value) {
     return false;
   }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -311,7 +311,7 @@ export abstract class Move implements Localizable {
 
     const bypassed = new BooleanHolder(false);
     // TODO: Allow this to be simulated
-    applyAbAttrs(InfiltratorAbAttr, user, null, false, bypassed);
+    applyAbAttrs(InfiltratorAbAttr, user, false, bypassed);
 
     return !bypassed.value && !this.hasFlag(MoveFlags.SOUND_BASED) && !this.hasFlag(MoveFlags.IGNORE_SUBSTITUTE);
   }
@@ -589,7 +589,7 @@ export abstract class Move implements Localizable {
       case MoveFlags.IGNORE_ABILITIES:
         if (user.hasAbilityWithAttr(MoveAbilityBypassAbAttr)) {
           const abilityEffectsIgnored = new BooleanHolder(false);
-          applyAbAttrs(MoveAbilityBypassAbAttr, user, abilityEffectsIgnored, false, this);
+          applyAbAttrs(MoveAbilityBypassAbAttr, user, false, abilityEffectsIgnored, this);
           if (abilityEffectsIgnored.value) {
             return true;
           }
@@ -807,7 +807,7 @@ export abstract class Move implements Localizable {
     const priority = new NumberHolder(this.priority);
 
     applyMoveAttrs(IncrementMovePriorityAttr, user, null, this, priority);
-    applyAbAttrs(ChangeMovePriorityAbAttr, user, null, simulated, this, priority);
+    applyAbAttrs(ChangeMovePriorityAbAttr, user, simulated, this, priority);
 
     return priority.value;
   }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -774,7 +774,7 @@ export abstract class Move implements Localizable {
         .flat(),
     );
     for (const aura of fieldAuras) {
-      aura.applyPreAttack(source, null, simulated, target, this, [power]);
+      aura.applyPreAttack(source, null, simulated, target, this, power);
     }
 
     const alliedField: Pokemon[] = source.getField();

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -389,7 +389,7 @@ export class Arena {
           (t) => "terrainTypes" in t && !(t.terrainTypes as TerrainType[]).find((t) => t === terrain),
         );
         applyPostTerrainChangeAbAttrs(PostTerrainChangeAbAttr, pokemon, terrain);
-        applyAbAttrs(TerrainEventTypeChangeAbAttr, pokemon, null, false);
+        applyAbAttrs(TerrainEventTypeChangeAbAttr, pokemon, false);
       });
 
     return true;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1758,12 +1758,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
           if (p.getAbility().hasAttr(SuppressFieldAbilitiesAbAttr) && p.canApplyAbility()) {
             p.getAbility()
               .getAttrs(SuppressFieldAbilitiesAbAttr)
-              .map((a) => a.apply(this, false, false, suppressed, [ability]));
+              .map((a) => a.apply(this, false, false, suppressed, ability));
           }
           if (p.getPassiveAbility().hasAttr(SuppressFieldAbilitiesAbAttr) && p.canApplyAbility(true)) {
             p.getPassiveAbility()
               .getAttrs(SuppressFieldAbilitiesAbAttr)
-              .map((a) => a.apply(this, true, false, suppressed, [ability]));
+              .map((a) => a.apply(this, true, false, suppressed, ability));
           }
         });
       if (suppressed.value) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1164,7 +1164,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     globalScene.applyModifiers(TempCritBoosterModifier, source.isPlayer(), critStage);
 
     const bonusCrit = new BooleanHolder(false);
-    applyAbAttrs(BonusCritAbAttr, source, null, simulated, bonusCrit);
+    applyAbAttrs(BonusCritAbAttr, source, simulated, bonusCrit);
     if (bonusCrit.value) {
       critStage.value += 1;
     }
@@ -1831,7 +1831,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const weight = new NumberHolder(this.getSpeciesForm().weight - weightRemoved);
 
     // This will trigger the ability overlay so only call this function when necessary
-    applyAbAttrs(WeightMultiplierAbAttr, this, null, false, weight);
+    applyAbAttrs(WeightMultiplierAbAttr, this, false, weight);
     return Math.max(minWeight, weight.value);
   }
 
@@ -2055,7 +2055,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         if (source) {
           const ignoreImmunity = new BooleanHolder(false);
           if (source.isActive(true) && source.hasAbilityWithAttr(IgnoreTypeImmunityAbAttr)) {
-            applyAbAttrs(IgnoreTypeImmunityAbAttr, source, ignoreImmunity, simulated, moveType, defType);
+            applyAbAttrs(IgnoreTypeImmunityAbAttr, source, simulated, ignoreImmunity, moveType, defType);
           }
           if (ignoreImmunity.value) {
             if (multiplier.value === 0) {
@@ -2988,7 +2988,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         }
       }
       if (!ignoreOppAbility) {
-        applyAbAttrs(IgnoreOpponentStatStagesAbAttr, opponent, null, simulated, stat, ignoreStatStage);
+        applyAbAttrs(IgnoreOpponentStatStagesAbAttr, opponent, simulated, stat, ignoreStatStage);
       }
       if (move) {
         applyMoveAttrs(IgnoreOpponentStatStagesAttr, this, opponent, move, ignoreStatStage);
@@ -3025,8 +3025,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const ignoreAccStatStage = new BooleanHolder(false);
     const ignoreEvaStatStage = new BooleanHolder(false);
 
-    applyAbAttrs(IgnoreOpponentStatStagesAbAttr, target, null, false, Stat.ACC, ignoreAccStatStage);
-    applyAbAttrs(IgnoreOpponentStatStagesAbAttr, this, null, false, Stat.EVA, ignoreEvaStatStage);
+    applyAbAttrs(IgnoreOpponentStatStagesAbAttr, target, false, Stat.ACC, ignoreAccStatStage);
+    applyAbAttrs(IgnoreOpponentStatStagesAbAttr, this, false, Stat.EVA, ignoreEvaStatStage);
     applyMoveAttrs(IgnoreOpponentStatStagesAttr, this, target, sourceMove, ignoreEvaStatStage);
 
     globalScene.applyModifiers(TempStatStageBoosterModifier, this.isPlayer(), Stat.ACC, userAccStage);
@@ -3277,7 +3277,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     /** The damage multiplier when the given move critically hits */
     const criticalMultiplier = new NumberHolder(isCritical ? 1.5 : 1);
-    applyAbAttrs(MultCritAbAttr, source, null, simulated, criticalMultiplier);
+    applyAbAttrs(MultCritAbAttr, source, simulated, criticalMultiplier);
 
     /**
      * A multiplier for random damage spread in the range [0.85, 1]
@@ -3299,7 +3299,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     if (!ignoreSourceAbility) {
-      applyAbAttrs(StabBoostAbAttr, source, null, simulated, stabMultiplier);
+      applyAbAttrs(StabBoostAbAttr, source, simulated, stabMultiplier);
     }
 
     stabMultiplier.value = Math.min(stabMultiplier.value, 2.25);
@@ -3310,7 +3310,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       if (!move.hasAttr(BypassBurnDamageReductionAttr)) {
         const burnDamageReductionCancelled = new BooleanHolder(false);
         if (!ignoreSourceAbility) {
-          applyAbAttrs(BypassBurnDamageReductionAbAttr, source, burnDamageReductionCancelled, simulated);
+          applyAbAttrs(BypassBurnDamageReductionAbAttr, source, simulated, burnDamageReductionCancelled);
         }
         if (!burnDamageReductionCancelled.value) {
           burnMultiplier.value = 0.5;
@@ -3464,13 +3464,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       isCritical.value = true;
     }
     applyMoveAttrs(CritOnlyAttr, source, this, move, isCritical);
-    applyAbAttrs(ConditionalCritAbAttr, source, null, simulated, isCritical, this, move);
+    applyAbAttrs(ConditionalCritAbAttr, source, simulated, isCritical, this, move);
     if (!isCritical.value) {
       const critChance = [24, 8, 2, 1][Math.max(0, Math.min(this.getCritStage(source, move, false), 3))];
       isCritical.value = critChance === 1 || !globalScene.randBattleSeedInt(critChance);
     }
 
-    applyAbAttrs(BlockCritAbAttr, this, null, simulated, isCritical);
+    applyAbAttrs(BlockCritAbAttr, this, simulated, isCritical);
 
     return isCritical.value;
   }
@@ -4112,7 +4112,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
           // Check if the source Pokemon has an ability that cancels the Poison/Toxic immunity
           const cancelImmunity = new BooleanHolder(false);
           if (sourcePokemon) {
-            applyAbAttrs(IgnoreTypeStatusEffectImmunityAbAttr, sourcePokemon, cancelImmunity, false, effect, defType);
+            applyAbAttrs(IgnoreTypeStatusEffectImmunityAbAttr, sourcePokemon, false, cancelImmunity, effect, defType);
             if (cancelImmunity.value) {
               return false;
             }
@@ -4272,7 +4272,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (globalScene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, defendingSide)) {
       const bypassed = new BooleanHolder(false);
       if (attacker) {
-        applyAbAttrs(InfiltratorAbAttr, attacker, null, false, bypassed);
+        applyAbAttrs(InfiltratorAbAttr, attacker, false, bypassed);
       }
       return !bypassed.value;
     }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2088,7 +2088,7 @@ export class PokemonInstantReviveModifier extends PokemonHeldItemModifier {
 
     // Reapply Commander on the Pokemon's side of the field, if applicable
     const field = pokemon.getField();
-    field.forEach((p) => applyAbAttrs(CommanderAbAttr, p, null, false));
+    field.forEach((p) => applyAbAttrs(CommanderAbAttr, p, false));
     return true;
   }
 

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -34,7 +34,7 @@ export class AttemptRunPhase extends PokemonPhase {
 
     this.attemptRunAway(playerField, enemyField, escapeChance);
 
-    applyAbAttrs(RunSuccessAbAttr, playerPokemon, null, false, escapeChance);
+    applyAbAttrs(RunSuccessAbAttr, playerPokemon, false, escapeChance);
 
     if (playerPokemon.randSeedInt(100) < escapeChance.value && !this.forceFailEscape) {
       globalScene.playSound("se/flee");

--- a/src/phases/berry-phase.ts
+++ b/src/phases/berry-phase.ts
@@ -26,7 +26,7 @@ export class BerryPhase extends FieldPhase {
 
       if (hasUsableBerry) {
         const cancelled = new BooleanHolder(false);
-        pokemon.getOpponents().map((opp) => applyAbAttrs(PreventBerryUseAbAttr, opp, cancelled));
+        pokemon.getOpponents().map((opp) => applyAbAttrs(PreventBerryUseAbAttr, opp, false, cancelled));
 
         if (cancelled.value) {
           globalScene.queueMessage(
@@ -47,7 +47,7 @@ export class BerryPhase extends FieldPhase {
 
           globalScene.updateModifiers(pokemon.isPlayer());
 
-          applyAbAttrs(HealFromBerryUseAbAttr, pokemon, new BooleanHolder(false));
+          applyAbAttrs(HealFromBerryUseAbAttr, pokemon);
         }
       }
     });

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -154,7 +154,7 @@ export class EncounterPhase extends BattlePhase {
             .slice(0, !double ? 1 : 2)
             .reverse()
             .forEach((playerPokemon) => {
-              applyAbAttrs(SyncEncounterNatureAbAttr, playerPokemon, null, false, currentBattle.enemyParty[e]);
+              applyAbAttrs(SyncEncounterNatureAbAttr, playerPokemon, false, currentBattle.enemyParty[e]);
             });
         }
       }

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -226,7 +226,6 @@ export class MovePhase extends BattlePhase {
           applyAbAttrs(
             ReduceStatusEffectDurationAbAttr,
             this.pokemon,
-            null,
             false,
             this.pokemon.status.effect,
             turnsRemaining,
@@ -482,7 +481,7 @@ export class MovePhase extends BattlePhase {
       globalScene
         .getField(true)
         .filter((p) => p !== this.pokemon)
-        .forEach((p) => applyAbAttrs(RedirectMoveAbAttr, p, null, false, this.move.moveId, redirectTarget));
+        .forEach((p) => applyAbAttrs(RedirectMoveAbAttr, p, false, this.move.moveId, redirectTarget));
 
       /** `true` if an Ability is responsible for redirecting the move to another target; `false` otherwise */
       let redirectedByAbility = currentTarget !== redirectTarget.value;

--- a/src/phases/new-biome-encounter-phase.ts
+++ b/src/phases/new-biome-encounter-phase.ts
@@ -21,7 +21,7 @@ export class NewBiomeEncounterPhase extends NextEncounterPhase {
     }
 
     for (const pokemon of globalScene.getPlayerParty().filter((p) => p.isOnField())) {
-      applyAbAttrs(PostBiomeChangeAbAttr, pokemon, null);
+      applyAbAttrs(PostBiomeChangeAbAttr, pokemon);
     }
 
     const enemyField = globalScene.getEnemyField();

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -34,7 +34,7 @@ export class PostSummonPhase extends PokemonPhase {
 
     applyPostSummonAbAttrs(PostSummonAbAttr, pokemon);
     const field = pokemon.getField();
-    field.forEach((p) => applyAbAttrs(CommanderAbAttr, p, null, false));
+    field.forEach((p) => applyAbAttrs(CommanderAbAttr, p, false));
 
     this.end();
   }

--- a/src/phases/post-turn-status-effect-phase.ts
+++ b/src/phases/post-turn-status-effect-phase.ts
@@ -24,8 +24,8 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
       pokemon.status.incrementTurn();
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
-      applyAbAttrs(BlockStatusDamageAbAttr, pokemon, cancelled);
+      applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
+      applyAbAttrs(BlockStatusDamageAbAttr, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         globalScene.queueMessage(
@@ -42,7 +42,7 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
             break;
           case StatusEffect.BURN:
             damage.value = Math.max(pokemon.getMaxHp() >> 4, 1);
-            applyAbAttrs(ReduceBurnDamageAbAttr, pokemon, null, false, damage);
+            applyAbAttrs(ReduceBurnDamageAbAttr, pokemon, false, damage);
             break;
         }
 

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -76,7 +76,7 @@ export class StatStageChangePhase extends PokemonPhase {
     const stages = new NumberHolder(this.stages);
 
     if (!this.ignoreAbilities) {
-      applyAbAttrs(StatStageChangeMultiplierAbAttr, pokemon, null, false, stages);
+      applyAbAttrs(StatStageChangeMultiplierAbAttr, pokemon, false, stages);
     }
 
     let simulate = false;
@@ -148,7 +148,7 @@ export class StatStageChangePhase extends PokemonPhase {
 
       if (stages.value > 0 && this.canBeCopied) {
         for (const opponent of pokemon.getOpponents()) {
-          applyAbAttrs(StatStageChangeCopyAbAttr, opponent, null, false, this.stats, stages.value);
+          applyAbAttrs(StatStageChangeCopyAbAttr, opponent, false, this.stats, stages.value);
         }
       }
 

--- a/src/phases/turn-start-phase.ts
+++ b/src/phases/turn-start-phase.ts
@@ -79,8 +79,8 @@ export class TurnStartPhase extends FieldPhase {
       .map((p) => {
         const bypassSpeed = new BooleanHolder(false);
         const canCheckHeldItems = new BooleanHolder(true);
-        applyAbAttrs(BypassSpeedChanceAbAttr, p, null, false, bypassSpeed);
-        applyAbAttrs(PreventBypassSpeedChanceAbAttr, p, null, false, bypassSpeed, canCheckHeldItems);
+        applyAbAttrs(BypassSpeedChanceAbAttr, p, false, bypassSpeed);
+        applyAbAttrs(PreventBypassSpeedChanceAbAttr, p, false, bypassSpeed, canCheckHeldItems);
         if (canCheckHeldItems.value) {
           globalScene.applyModifiers(BypassSpeedChanceModifier, p.isPlayer(), p, bypassSpeed);
         }

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -48,7 +48,7 @@ export class WeatherEffectPhase extends CommonAnimPhase {
           const cancelled = new BooleanHolder(false);
 
           applyPreWeatherEffectAbAttrs(PreWeatherDamageAbAttr, pokemon, weather, cancelled);
-          applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, cancelled);
+          applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
 
           if (
             cancelled.value

--- a/test/abilities/effect_spore.test.ts
+++ b/test/abilities/effect_spore.test.ts
@@ -139,7 +139,6 @@ describe("Abilities - Effect Spore", () => {
         enemyPokemon,
         allMoves[Moves.TACKLE],
         HitResult.EFFECTIVE,
-        [],
       );
     }
 

--- a/test/abilities/fluffy.test.ts
+++ b/test/abilities/fluffy.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - Fluffy", () => {
     game.move.select(Moves.TACKLE);
     await game.phaseInterceptor.to("BerryPhase");
 
-    const damageMultiplier = (abilitySpy.mock.lastCall?.[6][0] as NumberHolder).value;
+    const damageMultiplier = (abilitySpy.mock.lastCall?.[6] as NumberHolder).value;
     expect(allMoves[Moves.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
     expect(damageMultiplier).toBe(0.5);
   });
@@ -56,7 +56,7 @@ describe("Abilities - Fluffy", () => {
     game.move.select(Moves.EMBER);
     await game.phaseInterceptor.to("BerryPhase");
 
-    const damageMultiplier = (abilitySpy.mock.lastCall?.[6][0] as NumberHolder).value;
+    const damageMultiplier = (abilitySpy.mock.lastCall?.[6] as NumberHolder).value;
     expect(damageMultiplier).toBe(2);
   });
 
@@ -69,7 +69,7 @@ describe("Abilities - Fluffy", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase");
 
-    const damageMultiplier = (abilitySpy.mock.lastCall?.[6][0] as NumberHolder).value;
+    const damageMultiplier = (abilitySpy.mock.lastCall?.[6] as NumberHolder).value;
     expect(allMoves[Moves.FIRE_FANG].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
     expect(damageMultiplier).toBe(1);
   });
@@ -83,7 +83,7 @@ describe("Abilities - Fluffy", () => {
     game.move.select(Moves.TACKLE);
     await game.phaseInterceptor.to("BerryPhase");
 
-    const damageMultiplier = (abilitySpy.mock.lastCall?.[6][0] as NumberHolder).value;
+    const damageMultiplier = (abilitySpy.mock.lastCall?.[6] as NumberHolder).value;
     expect(allMoves[Moves.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
     expect(damageMultiplier).toBe(1);
   });

--- a/test/abilities/infiltrator.test.ts
+++ b/test/abilities/infiltrator.test.ts
@@ -49,11 +49,11 @@ describe("Abilities - Infiltrator", () => {
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
 
-    const preScreenDmg = enemy.getAttackDamage(player, allMoves[move]).damage;
+    const preScreenDmg = enemy.getAttackDamage(player, allMoves[move], false, false, false, false).damage;
 
     game.scene.arena.addTag(tagType, 1, Moves.NONE, enemy.id, ArenaTagSide.ENEMY, true);
 
-    const postScreenDmg = enemy.getAttackDamage(player, allMoves[move]).damage;
+    const postScreenDmg = enemy.getAttackDamage(player, allMoves[move], false, false, false, false).damage;
 
     expect(postScreenDmg).toBe(preScreenDmg);
     expect(player.battleData.abilitiesApplied[0]).toBe(Abilities.INFILTRATOR);

--- a/test/abilities/shield_dust.test.ts
+++ b/test/abilities/shield_dust.test.ts
@@ -53,7 +53,7 @@ describe("Abilities - Shield Dust", () => {
     expect(move.id).toBe(Moves.AIR_SLASH);
 
     const chance = new NumberHolder(move.chance);
-    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, false);
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, false, chance, move, false);
     applyPreDefendAbAttrs(
       IgnoreMoveEffectsAbAttr,
       phase.getFirstTarget()!,

--- a/test/abilities/shield_dust.test.ts
+++ b/test/abilities/shield_dust.test.ts
@@ -53,16 +53,7 @@ describe("Abilities - Shield Dust", () => {
     expect(move.id).toBe(Moves.AIR_SLASH);
 
     const chance = new NumberHolder(move.chance);
-    applyAbAttrs(
-      MoveEffectChanceMultiplierAbAttr,
-      phase.getUserPokemon()!,
-      null,
-      false,
-      chance,
-      move,
-      phase.getFirstTarget(),
-      false,
-    );
+    applyAbAttrs(MoveEffectChanceMultiplierAbAttr, phase.getUserPokemon()!, null, false, chance, move, false);
     applyPreDefendAbAttrs(
       IgnoreMoveEffectsAbAttr,
       phase.getFirstTarget()!,


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

Cleaner code is nice. This was also done for move attributes in #149 

## What are the changes from a developer perspective?

`AbAttr#apply`'s signature has been changed from

```ts
apply(
  _pokemon: Pokemon,
  _passive: boolean,
  _simulated: boolean,
  _cancelled: BooleanHolder | null,
  _args: any[],
): boolean {
```

to

```ts
apply(_pokemon: Pokemon, _passive: boolean, _simulated: boolean, ..._args: unknown[]): boolean {
```

allowing for overrides of the function to have named parameters for any additional data instead of being forced to use the pattern

```ts
const arg = args[0] as X
// do stuff with arg
```

## How to test the changes?

`npm run test`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [n/a] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?
