### PR TITLE
[Dev] Fix waive roll fee override

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -68,10 +68,9 @@ class DefaultOverrides {
   readonly NEVER_CRIT_OVERRIDE: boolean = false;
   /** default 1000 */
   readonly STARTING_MONEY_OVERRIDE: number = 0;
-  /** Sets all shop item prices to 0 */
+  /** Sets all shop item prices and reroll cost to 0 */
   readonly WAIVE_SHOP_FEES_OVERRIDE: boolean = false;
-  /** Sets reroll price to 0 */
-  readonly WAIVE_ROLL_FEE_OVERRIDE: boolean = false;
+  /** Sets all candy upgrades cost to 0 in starter selection */
   readonly FREE_CANDY_UPGRADE_OVERRIDE: boolean = false;
   readonly POKEBALL_OVERRIDE: { active: boolean; pokeballs: PokeballCounts } = {
     active: false,

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -204,7 +204,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
       globalScene.tryRemovePhase((phase) => phase instanceof SelectModifierPhase);
     } else if (this.learnMoveType === LearnMoveType.MEMORY) {
       if (this.cost !== -1) {
-        if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+        if (!Overrides.WAIVE_SHOP_FEES_OVERRIDE) {
           globalScene.money -= this.cost;
           globalScene.updateMoneyText();
           globalScene.animateMoneyChanged(false);

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -28,7 +28,7 @@ import type ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import { SHOP_OPTIONS_ROW_LIMIT } from "#app/ui/modifier-select-ui-handler";
 import PartyUiHandler, { PartyOption, PartyUiMode } from "#app/ui/party-ui-handler";
 import { Mode } from "#app/ui/ui";
-import { isNullOrUndefined, NumberHolder } from "#app/utils";
+import { NumberHolder } from "#app/utils";
 import i18next from "i18next";
 import { BattlePhase } from "./abstract-battle-phase";
 
@@ -140,7 +140,7 @@ export class SelectModifierPhase extends BattlePhase {
                 ui.clearText();
                 ui.setMode(Mode.MESSAGE).then(() => super.end());
 
-                if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+                if (!Overrides.WAIVE_SHOP_FEES_OVERRIDE) {
                   globalScene.money -= rerollCost;
                   globalScene.updateMoneyText();
                   globalScene.animateMoneyChanged(false);
@@ -244,7 +244,7 @@ export class SelectModifierPhase extends BattlePhase {
           break;
       }
 
-      if (cost && money < cost && !Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+      if (cost && money < cost && !Overrides.WAIVE_SHOP_FEES_OVERRIDE) {
         ui.playError();
         return false;
       }
@@ -260,7 +260,7 @@ export class SelectModifierPhase extends BattlePhase {
 
         if (cost && !(modifier.type instanceof RememberMoveModifierType)) {
           if (result) {
-            if (!Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+            if (!Overrides.WAIVE_SHOP_FEES_OVERRIDE) {
               globalScene.money -= cost;
               globalScene.updateMoneyText();
               globalScene.animateMoneyChanged(false);
@@ -383,27 +383,22 @@ export class SelectModifierPhase extends BattlePhase {
   }
 
   public getRerollCost(lockRarities: boolean): number {
+    const multiplier = this.customModifierSettings?.rerollMultiplier ?? 1;
+    if (multiplier < 0) {
+      // Override reroll cost to -1 to signify there is nothing to reroll
+      return -1;
+    }
+
     let baseValue = 0;
-    if (Overrides.WAIVE_ROLL_FEE_OVERRIDE) {
+    if (Overrides.WAIVE_SHOP_FEES_OVERRIDE) {
       return baseValue;
     } else if (lockRarities) {
-      const tierValues = [50, 125, 300, 750, 2000];
+      const tierValues = [50, 125, 300, 750, 2000]; // TODO: this should be part of balance files
       for (const opt of this.typeOptions) {
         baseValue += tierValues[opt.type.tier ?? 0];
       }
     } else {
-      baseValue = 250;
-    }
-
-    let multiplier = 1;
-    if (!isNullOrUndefined(this.customModifierSettings?.rerollMultiplier)) {
-      if (this.customModifierSettings.rerollMultiplier < 0) {
-        // Completely overrides reroll cost to -1 and early exits
-        return -1;
-      }
-
-      // Otherwise, continue with custom multiplier
-      multiplier = this.customModifierSettings.rerollMultiplier;
+      baseValue = 250; // TODO: this should be part of balance files
     }
 
     const baseMultiplier = Math.min(

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -52,6 +52,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
   private cursorObj: Phaser.GameObjects.Image | null;
 
   constructor() {
+    // TODO: why does it use Mode.CONFIRM and not Mode.MODIFIER_SELECT?
     super(Mode.CONFIRM);
 
     this.options = [];
@@ -932,7 +933,7 @@ class ModifierOption extends Phaser.GameObjects.Container {
   }
 
   updateCostText(): void {
-    const cost = Overrides.WAIVE_ROLL_FEE_OVERRIDE ? 0 : this.modifierTypeOption.cost;
+    const cost = Overrides.WAIVE_SHOP_FEES_OVERRIDE ? 0 : this.modifierTypeOption.cost;
     const textStyle = cost <= globalScene.money ? TextStyle.MONEY : TextStyle.PARTY_RED;
 
     const formattedMoney = formatMoney(globalScene.moneyFormat, cost);


### PR DESCRIPTION

## What are the changes the ~~user~~ devs will see?

When using the waive roll fee override and reaching a reward screen with only the continue option:
- The "Continue" button will show properly
- It will no longer be possible to reroll, to match the override-less behavior

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

Those issue could lead people to think that things are not working as they should

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

- Merge `WAIVE_SHOP_FEES_OVERRIDE` and `WAIVE_ROLL_FEE_OVERRIDE` into one. WAIVE_SHOP_FEES_OVERRIDE was actually never used and WAIVE_ROLL_FEE_OVERRIDE handled both reroll and item costs. I chose to keep WAIVE_SHOP_FEES_OVERRIDE as the name, as it encompasses both item prices and roll prices
- The ui handler expects a rerollCost of -1 to signify that there's no item in the shop and no reroll should be possible. But the `getRerollCost` function was checking for the override first and always returning 0 if it was active. The code now checks first for the negative reroll cost, so that it takes priority over the overrides and the shop behaves as expected even with the override
- also added a couple todos for issues i noticed while doing the fix

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos
Before: invisible continue button, possibility to reroll
![shop-fee-before](https://github.com/user-attachments/assets/f7679905-0df0-4640-b1d9-7f5d0fe43d53)
After: visible continue button, no possibility to reroll
![shop-fee-after](https://github.com/user-attachments/assets/a3e8290e-bc7a-4c5b-9967-34706d482a17)

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
Check the shop for a normal wave and no reward wave both with and without the override active
```
  STARTING_WAVE_OVERRIDE: 11,
  MYSTERY_ENCOUNTER_RATE_OVERRIDE: 256,
  MYSTERY_ENCOUNTER_OVERRIDE: MysteryEncounterType.THE_POKEMON_SALESMAN,
  WAIVE_SHOP_FEES_OVERRIDE: true
```
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
- [X] Are all unit tests still passing? (`npm run test`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

~~Are there any localization additions or changes? If so:~~
