### PR TITLE
[Test] Rename `game.pokemonHelper` to `game.field`

### DIFF
--- a/test/moves/toxic_spikes.test.ts
+++ b/test/moves/toxic_spikes.test.ts
@@ -136,7 +136,7 @@ describe("Moves - Toxic Spikes", () => {
   it("should apply even if the target is fainted", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
-    const enemyPokemon = game.pokemonHelper.getEnemyPokemon();
+    const enemyPokemon = game.field.getEnemyPokemon();
 
     game.move.use(Moves.TOXIC_SPIKES);
     await game.move.forceEnemyMove(Moves.MEMENTO);

--- a/test/moves/whirlwind.test.ts
+++ b/test/moves/whirlwind.test.ts
@@ -37,7 +37,7 @@ describe("Moves - Whirlwind", () => {
   ])("should not hit a flying target: $name (=$move)", async ({ move }) => {
     await game.classicMode.startBattle([Species.STARAPTOR]);
 
-    const staraptor = game.pokemonHelper.getPlayerPokemon();
+    const staraptor = game.field.getPlayerPokemon();
 
     game.move.use(move);
     await game.move.forceEnemyMove(Moves.WHIRLWIND);

--- a/test/moves/will_o_wisp.test.ts
+++ b/test/moves/will_o_wisp.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Will-O-Wisp", () => {
   it("should burn the opponent", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
-    const enemy = game.pokemonHelper.getEnemyPokemon();
+    const enemy = game.field.getEnemyPokemon();
 
     game.move.use(Moves.WILL_O_WISP);
     await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);

--- a/test/testUtils/gameManager.ts
+++ b/test/testUtils/gameManager.ts
@@ -46,7 +46,7 @@ import { DailyModeHelper } from "#test/testUtils/helpers/dailyModeHelper";
 import { ModifierHelper } from "#test/testUtils/helpers/modifiersHelper";
 import { MoveHelper } from "#test/testUtils/helpers/moveHelper";
 import { OverridesHelper } from "#test/testUtils/helpers/overridesHelper";
-import { PokemonHelper } from "#test/testUtils/helpers/pokemonHelper";
+import { FieldHelper } from "#test/testUtils/helpers/fieldHelper";
 import { ReloadHelper } from "#test/testUtils/helpers/reloadHelper";
 import { SettingsHelper } from "#test/testUtils/helpers/settingsHelper";
 import type { InputsHandler } from "#test/testUtils/inputsHandler";
@@ -75,7 +75,7 @@ export class GameManager {
   public readonly settings: SettingsHelper;
   public readonly reload: ReloadHelper;
   public readonly modifiers: ModifierHelper;
-  public readonly field: PokemonHelper;
+  public readonly field: FieldHelper;
 
   /**
    * Creates an instance of GameManager.
@@ -120,7 +120,7 @@ export class GameManager {
     this.settings = new SettingsHelper(this);
     this.reload = new ReloadHelper(this);
     this.modifiers = new ModifierHelper(this);
-    this.field = new PokemonHelper(this);
+    this.field = new FieldHelper(this);
 
     // Disables Mystery Encounters on all tests (can be overridden at test level)
     this.override.mysteryEncounterChance(0);

--- a/test/testUtils/gameManager.ts
+++ b/test/testUtils/gameManager.ts
@@ -75,7 +75,7 @@ export class GameManager {
   public readonly settings: SettingsHelper;
   public readonly reload: ReloadHelper;
   public readonly modifiers: ModifierHelper;
-  public readonly pokemonHelper: PokemonHelper;
+  public readonly field: PokemonHelper;
 
   /**
    * Creates an instance of GameManager.
@@ -120,7 +120,7 @@ export class GameManager {
     this.settings = new SettingsHelper(this);
     this.reload = new ReloadHelper(this);
     this.modifiers = new ModifierHelper(this);
-    this.pokemonHelper = new PokemonHelper(this);
+    this.field = new PokemonHelper(this);
 
     // Disables Mystery Encounters on all tests (can be overridden at test level)
     this.override.mysteryEncounterChance(0);

--- a/test/testUtils/helpers/fieldHelper.ts
+++ b/test/testUtils/helpers/fieldHelper.ts
@@ -6,7 +6,7 @@ import { expect } from "vitest";
 import { type globalScene } from "#app/global-scene";
 
 /** Helper to manage pokemon */
-export class PokemonHelper extends GameManagerHelper {
+export class FieldHelper extends GameManagerHelper {
   /**
    * Passthrough for {@linkcode globalScene.getPlayerPokemon} that adds an `undefined` check for
    * the Pokemon so that the return type for the function doesn't have `undefined`.


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Consensus on variable naming.

## What are the changes from a developer perspective?
`PokemonHelper` instance in `GameManager` renamed from `pokemonHelper` to `field`.
`PokemonHelper` class renamed to `FieldHelper`.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?