### PR TITLE
[Ability][Checkup] Changed file name/ability attribute of Early Bird + trySetStatus considers turnsRemaining even if asPhase is set to 'false'

### DIFF
--- a/src/data/ab-attrs/reduce-sleep-duration-ab-attr.ts
+++ b/src/data/ab-attrs/reduce-sleep-duration-ab-attr.ts
@@ -1,20 +1,21 @@
 import type { Pokemon } from "#app/field/pokemon";
 import type { NumberHolder } from "#app/utils";
-import type { StatusEffect } from "#enums/status-effect";
+import { StatusEffect } from "#enums/status-effect";
 import { AbAttr } from "./ab-attr";
 
 /**
- * Used by Early Bird, makes the pokemon wake up faster
+ * /**
+ * This attribute reduces the duration of sleep by half and is used by the ability Early Bird.
+ * Early Bird halves the sleep duration. When the Pokémon is put to sleep, the number of turns it will remain asleep is preset, between 1 and 5 (the range depends on the generation).
+ * This number of turns is halved for a Pokémon with Early Bird, rounded down if it is odd. So if only 1 turn is preset, it is rounded down to 0, causing the Pokémon to wake up the next time it moves.
  * @param statusEffect - The {@linkcode StatusEffect} to check for
  * @see {@linkcode apply}
  */
-export class ReduceStatusEffectDurationAbAttr extends AbAttr {
-  private readonly statusEffect: StatusEffect;
+export class ReduceSleepDurationAbAttr extends AbAttr {
+  private readonly statusEffect: StatusEffect = StatusEffect.SLEEP;
 
-  constructor(statusEffect: StatusEffect) {
+  constructor() {
     super(true);
-
-    this.statusEffect = statusEffect;
   }
 
   /**

--- a/src/data/ab-attrs/reduce-sleep-duration-ab-attr.ts
+++ b/src/data/ab-attrs/reduce-sleep-duration-ab-attr.ts
@@ -6,7 +6,7 @@ import { AbAttr } from "./ab-attr";
 /**
  * /**
  * This attribute reduces the duration of sleep by half and is used by the ability Early Bird.
- * Early Bird halves the sleep duration. When the Pokémon is put to sleep, the number of turns it will remain asleep is preset, between 1 and 5 (the range depends on the generation).
+ * Early Bird halves the sleep duration. When the Pokémon is put to sleep, the number of turns it will remain asleep is preset, between 1 and 3.
  * This number of turns is halved for a Pokémon with Early Bird, rounded down if it is odd. So if only 1 turn is preset, it is rounded down to 0, causing the Pokémon to wake up the next time it moves.
  * @param statusEffect - The {@linkcode StatusEffect} to check for
  * @see {@linkcode apply}

--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -36,7 +36,7 @@ import { ReduceBerryUseThresholdAbAttr } from "./ab-attrs/reduce-berry-use-thres
 import { ForceSwitchOutImmunityAbAttr } from "./ab-attrs/force-switch-out-immunity-ab-attr";
 import { IncreasePpAbAttr } from "./ab-attrs/increase-pp-ab-attr";
 import { FlinchStatStageChangeAbAttr } from "./ab-attrs/flinch-stat-stage-change-ab-attr";
-import { ReduceStatusEffectDurationAbAttr } from "./ab-attrs/reduce-status-effect-duration-ab-attr";
+import { ReduceSleepDurationAbAttr } from "./ab-attrs/reduce-sleep-duration-ab-attr";
 import { BlockRedirectAbAttr } from "./ab-attrs/block-redirect-ab-attr";
 import { RedirectTypeMoveAbAttr } from "./ab-attrs/redirect-type-move-ab-attr";
 import { PostFaintClearWeatherAbAttr } from "./ab-attrs/post-faint-clear-weather-ab-attr";
@@ -466,7 +466,7 @@ export function initAbilities() {
       .attr(ReceivedTypeDamageMultiplierAbAttr, Type.FIRE, 0.5)
       .attr(ReceivedTypeDamageMultiplierAbAttr, Type.ICE, 0.5)
       .ignorable(),
-    new Ability(Abilities.EARLY_BIRD, 3).attr(ReduceStatusEffectDurationAbAttr, StatusEffect.SLEEP),
+    new Ability(Abilities.EARLY_BIRD, 3).attr(ReduceSleepDurationAbAttr),
     new Ability(Abilities.FLAME_BODY, 3)
       .attr(PostDefendContactApplyStatusEffectAbAttr, 30, StatusEffect.BURN)
       .bypassFaint(),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4146,7 +4146,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     let sleepTurnsRemaining: NumberHolder;
 
     if (effect === StatusEffect.SLEEP) {
-      sleepTurnsRemaining = new NumberHolder(this.randSeedIntRange(2, 4));
+      sleepTurnsRemaining = new NumberHolder(turnsRemaining !== 0 ? turnsRemaining : this.randSeedIntRange(2, 4));
 
       this.setFrameRate(4);
 

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -4,7 +4,7 @@ import { IncreasePpAbAttr } from "#app/data/ab-attrs/increase-pp-ab-attr";
 import { PokemonTypeChangeAbAttr } from "#app/data/ab-attrs/pokemon-type-change-ab-attr";
 import { PostMoveUsedAbAttr } from "#app/data/ab-attrs/post-move-used-ab-attr";
 import { RedirectMoveAbAttr } from "#app/data/ab-attrs/redirect-move-ab-attr";
-import { ReduceStatusEffectDurationAbAttr } from "#app/data/ab-attrs/reduce-status-effect-duration-ab-attr";
+import { ReduceSleepDurationAbAttr } from "#app/data/ab-attrs/reduce-sleep-duration-ab-attr";
 import { applyAbAttrs, applyPostMoveUsedAbAttrs, applyPreAttackAbAttrs } from "#app/data/ability";
 import { allMoves } from "#app/data/all-moves";
 import type { DelayedAttackTag } from "#app/data/arena-tag";
@@ -234,13 +234,7 @@ export class MovePhase extends BattlePhase {
         case StatusEffect.SLEEP:
           applyMoveAttrs(BypassSleepAttr, this.pokemon, null, this.move.getMove());
           const turnsRemaining = new NumberHolder(this.pokemon.status.sleepTurnsRemaining ?? 0);
-          applyAbAttrs(
-            ReduceStatusEffectDurationAbAttr,
-            this.pokemon,
-            false,
-            this.pokemon.status.effect,
-            turnsRemaining,
-          );
+          applyAbAttrs(ReduceSleepDurationAbAttr, this.pokemon, false, this.pokemon.status.effect, turnsRemaining);
           if (Overrides.STATUS_ACTIVATION_OVERRIDE === true) {
             turnsRemaining.value = Math.max(turnsRemaining.value, 1);
           } else if (Overrides.STATUS_ACTIVATION_OVERRIDE === false) {

--- a/test/abilities/early_bird.test.ts
+++ b/test/abilities/early_bird.test.ts
@@ -1,4 +1,3 @@
-import { Status } from "#app/data/status-effect";
 import { MoveResult } from "#app/field/pokemon";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
@@ -63,26 +62,20 @@ describe("Abilities - Early Bird", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     const player = game.scene.getPlayerPokemon()!;
-    player.status = new Status(StatusEffect.SLEEP, 0, 4);
+    player.trySetStatus(StatusEffect.SLEEP, false, null, 3);
 
     game.move.select(Moves.SPLASH);
     await game.toNextTurn();
 
     expect(player.status?.effect).toBe(StatusEffect.SLEEP);
-    expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.FAIL);
-
-    game.move.select(Moves.SPLASH);
-    await game.toNextTurn();
-
-    expect(player.status?.effect).toBeUndefined();
-    expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.SUCCESS);
+    expect(player.status?.sleepTurnsRemaining).toBe(1);
   });
 
   it("reduces 1-turn sleep to 0 turns", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     const player = game.scene.getPlayerPokemon()!;
-    player.status = new Status(StatusEffect.SLEEP, 0, 2);
+    player.trySetStatus(StatusEffect.SLEEP, false, null, 1);
 
     game.move.select(Moves.SPLASH);
     await game.toNextTurn();


### PR DESCRIPTION
## What are the changes the user will see?

None.

## Why am I making these changes?

Part of ability checkups. 

## What are the changes from a developer perspective?

When setting a Pokemon to sleep, if asPhase was set to `false`, trySetStatus would ignore turnsRemaining and use a randomly generated number between 2 to 4. The game now checks if turnsRemaining has been set to a number not 0 before using the randomly generated number. 

## How to test the changes?
`npm run test early_bird`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
