### PR TITLE
[Dev] Revert back workflows to use ubuntu-latest

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     # if: github.repository == 'despair-games/poketernity'
     if: false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     #if: github.repository == 'despair-games/poketernity'
     if: false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   run-linters: # Define a job named "run-linters"
     name: Run linters # Human-readable name for the job
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out Git repository # Step to check out the repository

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -15,7 +15,7 @@ jobs:
   pages:
     name: Github Pages
     if: github.repository == 'despair-games/poketernity'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       api-dir: ./
 

--- a/.github/workflows/test-shard-template.yml
+++ b/.github/workflows/test-shard-template.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     name: Shard ${{ inputs.shard }} of ${{ inputs.totalShards }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Reverts the workflow changes from PR #217 since it didn't fix the issue we were having (which seems to have resolved itself since 🤷 )

`runs-on: ubuntu-22.04` -> `runs-on: ubuntu-latest`
