### PR TITLE
[Bug] Fix generic trapped text not displaying

### DIFF
--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -1,10 +1,10 @@
 import type { TurnCommand } from "#app/battle";
 import { BattleType } from "#enums/battle-type";
-import { type ArenaTag } from "#app/data/arena-tag";
+import { type FairyLockTag } from "#app/data/arena-tag";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { speciesStarterCosts } from "#app/data/balance/starters";
 import type { EncoreTag } from "#app/data/battler-tags";
-import { TrappedTag, type BattlerTag } from "#app/data/battler-tags";
+import { TrappedTag } from "#app/data/battler-tags";
 import { getMoveTargets, type MoveTargetSet } from "#app/data/move";
 import type { PlayerPokemon } from "#app/field/pokemon";
 import { FieldPosition } from "#enums/field-position";
@@ -310,6 +310,22 @@ export class CommandPhase extends FieldPhase {
         const isSwitch = command === Command.POKEMON;
         const batonPass = isSwitch && (args[0] as boolean);
         const trappedAbMessages: string[] = [];
+
+        const showNoEscapeText = (text: string): void => {
+          ui.showText(
+            text,
+            null,
+            () => {
+              ui.showText("", 0);
+              if (!isSwitch) {
+                ui.setMode(Mode.COMMAND, this.fieldIndex);
+              }
+            },
+            null,
+            true,
+          );
+        };
+
         if (batonPass || !playerPokemon.isTrapped(trappedAbMessages)) {
           currentBattle.turnCommands[this.fieldIndex] = isSwitch
             ? { command: Command.POKEMON, cursor: cursor, args: args }
@@ -322,57 +338,31 @@ export class CommandPhase extends FieldPhase {
           if (!isSwitch) {
             ui.setMode(Mode.MESSAGE);
           }
-          ui.showText(
-            trappedAbMessages[0],
-            null,
-            () => {
-              ui.showText("", 0);
-              if (!isSwitch) {
-                ui.setMode(Mode.COMMAND, this.fieldIndex);
-              }
-            },
-            null,
-            true,
-          );
+          showNoEscapeText(trappedAbMessages[0]);
         } else {
           const trapTag = playerPokemon.getTag(TrappedTag);
           const fairyLockTag = arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
 
-          if (!trapTag && !fairyLockTag) {
-            i18next.t(`battle:noEscape${isSwitch ? "Switch" : "Flee"}`);
-            break;
-          }
           if (!isSwitch) {
             ui.setMode(Mode.COMMAND, this.fieldIndex);
             ui.setMode(Mode.MESSAGE);
           }
-          const showNoEscapeText = (tag: BattlerTag | ArenaTag): void => {
-            ui.showText(
-              i18next.t("battle:noEscapePokemon", {
-                pokemonName:
-                  tag.sourceId && globalScene.getPokemonById(tag.sourceId)
-                    ? getPokemonNameWithAffix(globalScene.getPokemonById(tag.sourceId))
-                    : "",
-                moveName: tag.getMoveName(),
-                escapeVerb: isSwitch ? i18next.t("battle:escapeVerbSwitch") : i18next.t("battle:escapeVerbFlee"),
-              }),
-              null,
-              () => {
-                ui.showText("", 0);
-                if (!isSwitch) {
-                  ui.setMode(Mode.COMMAND, this.fieldIndex);
-                }
-              },
-              null,
-              true,
-            );
+
+          const getNoEscapeText = (tag?: TrappedTag | FairyLockTag) => {
+            if (!tag) {
+              return i18next.t(`battle:noEscape${isSwitch ? "Switch" : "Flee"}`);
+            }
+            return i18next.t("battle:noEscapePokemon", {
+              pokemonName:
+                tag.sourceId && globalScene.getPokemonById(tag.sourceId)
+                  ? getPokemonNameWithAffix(globalScene.getPokemonById(tag.sourceId))
+                  : "",
+              moveName: tag.getMoveName(),
+              escapeVerb: isSwitch ? i18next.t("battle:escapeVerbSwitch") : i18next.t("battle:escapeVerbFlee"),
+            });
           };
 
-          if (trapTag) {
-            showNoEscapeText(trapTag);
-          } else if (fairyLockTag) {
-            showNoEscapeText(fairyLockTag);
-          }
+          showNoEscapeText(getNoEscapeText(trapTag ?? fairyLockTag));
         }
         break;
     }


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

If a Pokemon is trapped for a reason that is not a trapping ability or a trapping tag (e.g., Dondozo being commanded), the game will properly display the trapped message.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

(Bug discovered while working on #263.)

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

The `showNoEscapeText()` function is slightly rewritten to allow any text argument, and it is now also applied to the generic trapped message.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details>
<summary> Before the changes: The generic trapped message does not display </summary>

https://github.com/user-attachments/assets/0e150eb1-b024-4860-b473-95be1f94bb7d

</details>
<details>
<summary> After the changes: The generic trapped message displays properly </summary>

https://github.com/user-attachments/assets/c5320a82-a71d-45c1-b214-19b625c7cd58

</details>
<details>
<summary> After the changes: The trapped message for Fairy Lock still displays properly </summary>

https://github.com/user-attachments/assets/577643c7-b35b-42d0-ad0c-f50560608728

</details>
<details>
<summary> After the changes: The trapped message for Arena Trap still displays properly </summary>

https://github.com/user-attachments/assets/c50f3fdc-19f3-4abf-a811-5cd57a4d6b6c

</details>

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Try to switch out or flee while a Pokemon is trapped.

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?