### PR TITLE
[Bug] Fix `arena.addTag()` args orderings

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1498,7 +1498,7 @@ export function getArenaTag(
  */
 export function loadArenaTag(source: ArenaTag | any): ArenaTag {
   const tag =
-    getArenaTag(source.tagType, source.turnCount, source.sourceMove, source.sourceId, source.side) ?? new NoneTag();
+    getArenaTag(source.tagType, source.sourceId, source.turnCount, source.sourceMove, source.side) ?? new NoneTag();
   tag.loadTag(source);
   return tag;
 }

--- a/src/data/move-attrs/swap-arena-tags-attr.ts
+++ b/src/data/move-attrs/swap-arena-tags-attr.ts
@@ -55,9 +55,9 @@ export class SwapArenaTagsAttr extends MoveEffectAttr {
         globalScene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.PLAYER, true);
         globalScene.arena.addTag(
           swapTagsType.tagType,
+          swapTagsType.sourceId!,
           swapTagsType.turnCount,
           swapTagsType.sourceMove,
-          swapTagsType.sourceId!,
           ArenaTagSide.ENEMY,
           true,
         ); // TODO: is the bang correct?
@@ -68,9 +68,9 @@ export class SwapArenaTagsAttr extends MoveEffectAttr {
         globalScene.arena.removeTagOnSide(swapTagsType.tagType, ArenaTagSide.ENEMY, true);
         globalScene.arena.addTag(
           swapTagsType.tagType,
+          swapTagsType.sourceId!,
           swapTagsType.turnCount,
           swapTagsType.sourceMove,
-          swapTagsType.sourceId!,
           ArenaTagSide.PLAYER,
           true,
         ); // TODO: is the bang correct?

--- a/test/moves/brick_break.test.ts
+++ b/test/moves/brick_break.test.ts
@@ -46,7 +46,7 @@ describe("Moves - Brick Break", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     [ArenaTagSide.PLAYER, ArenaTagSide.ENEMY].forEach((side) =>
-      game.scene.arena.addTag(tagType, 2, Moves.NONE, 0, side),
+      game.scene.arena.addTag(tagType, 0, 2, Moves.NONE, side),
     );
 
     game.move.select(Moves.BRICK_BREAK);
@@ -59,7 +59,7 @@ describe("Moves - Brick Break", () => {
   it("Reflect should not reduce Brick Break's damage when removed", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
-    game.scene.arena.addTag(ArenaTagType.REFLECT, 2, Moves.NONE, 0, ArenaTagSide.ENEMY);
+    game.scene.arena.addTag(ArenaTagType.REFLECT, 0, 2, Moves.NONE, ArenaTagSide.ENEMY);
 
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -78,7 +78,7 @@ describe("Moves - Brick Break", () => {
 
     await game.classicMode.startBattle([Species.FEEBAS]);
 
-    game.scene.arena.addTag(ArenaTagType.REFLECT, 2, Moves.NONE, 0, ArenaTagSide.ENEMY);
+    game.scene.arena.addTag(ArenaTagType.REFLECT, 0, 2, Moves.NONE, ArenaTagSide.ENEMY);
 
     game.move.select(Moves.BRICK_BREAK);
 

--- a/test/moves/court_change.test.ts
+++ b/test/moves/court_change.test.ts
@@ -39,17 +39,17 @@ describe("Moves - Court Change", () => {
     game.move.select(Moves.SAFEGUARD);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)?.tagType).toBe(
-      ArenaTagType.SAFEGUARD,
-    );
+    const tag1 = game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
+    expect(tag1?.tagType).toBe(ArenaTagType.SAFEGUARD);
+    expect(tag1?.turnCount).toBe(4);
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
 
     game.move.select(Moves.COURT_CHANGE);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)?.tagType).toBe(
-      ArenaTagType.SAFEGUARD,
-    );
+    const tag2 = game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
+    expect(tag2?.tagType).toBe(ArenaTagType.SAFEGUARD);
+    expect(tag2?.turnCount).toBe(3);
     expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
   });
 

--- a/test/moves/defog.test.ts
+++ b/test/moves/defog.test.ts
@@ -54,7 +54,7 @@ describe("Moves - Defog", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     [ArenaTagSide.PLAYER, ArenaTagSide.ENEMY].forEach((side) =>
-      game.scene.arena.addTag(tagType, 2, Moves.NONE, 0, side, true),
+      game.scene.arena.addTag(tagType, 0, 2, Moves.NONE, side, true),
     );
 
     game.move.select(Moves.DEFOG);
@@ -76,7 +76,7 @@ describe("Moves - Defog", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     [ArenaTagSide.PLAYER, ArenaTagSide.ENEMY].forEach((side) =>
-      game.scene.arena.addTag(tagType, 2, Moves.NONE, 0, side, true),
+      game.scene.arena.addTag(tagType, 0, 2, Moves.NONE, side, true),
     );
 
     game.move.select(Moves.DEFOG);

--- a/test/moves/rapid_spin.test.ts
+++ b/test/moves/rapid_spin.test.ts
@@ -71,7 +71,7 @@ describe("Moves - Rapid Spin", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     [ArenaTagSide.PLAYER, ArenaTagSide.ENEMY].forEach((side) =>
-      game.scene.arena.addTag(tagType, 1, Moves.NONE, 0, side),
+      game.scene.arena.addTag(tagType, 0, 1, Moves.NONE, side),
     );
 
     game.move.select(Moves.RAPID_SPIN);


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

Court Change will assign correct data to the swapped arena tags.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

Small fixes for #120.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

1. All usages of `getArenaTag()` and `arena.addTag()` should now use arguments in the correct order (tag type, source ID, turn count, move ID, side).
2. Updated the Court Change test to also check the arena tag's turn count.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details>
<summary> Before the changes: Court Change assigns incorrect data to the swapped arena tags </summary>

https://github.com/user-attachments/assets/3b87fbd4-1d66-4ae8-81ad-9f9635fea98c

</details>
<details>
<summary> After the changes: Court Change assigns correct data to the swapped arena tags </summary>

https://github.com/user-attachments/assets/27195d91-281f-4abb-80b5-68a7aee8e1cc

</details>

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

`npm run test court_change`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?