### PR TITLE
[Refactor] Add `AbstractConstructor` util + Convert parent move/ability attributes to `abstract`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -16,8 +16,8 @@ import {
   isNullOrUndefined,
   BooleanHolder,
   NumberHolder,
-  type Constructor,
   randItem,
+  type AbstractConstructor,
 } from "#app/utils";
 import type { Modifier, ModifierPredicate, TurnHeldItemTransferModifier } from "./modifier/modifier";
 import {
@@ -2438,7 +2438,7 @@ export default class BattleScene extends SceneBase {
    * @param targetPhase {@linkcode Phase} the type of phase to search for in phaseQueue
    * @returns boolean if a targetPhase was found and added
    */
-  prependToPhase(phase: Phase, targetPhase: Constructor<Phase>): boolean {
+  prependToPhase(phase: Phase, targetPhase: AbstractConstructor<Phase>): boolean {
     const targetIndex = this.phaseQueue.findIndex((ph) => ph instanceof targetPhase);
 
     if (targetIndex !== -1) {
@@ -2456,7 +2456,7 @@ export default class BattleScene extends SceneBase {
    * @param targetPhase {@linkcode Phase} the type of phase to search for in {@linkcode phaseQueue}
    * @returns `true` if a `targetPhase` was found to append to
    */
-  appendToPhase(phase: Phase, targetPhase: Constructor<Phase>): boolean {
+  appendToPhase(phase: Phase, targetPhase: AbstractConstructor<Phase>): boolean {
     const targetIndex = this.phaseQueue.findIndex((ph) => ph instanceof targetPhase);
 
     if (targetIndex !== -1 && this.phaseQueue.length > targetIndex) {
@@ -2910,7 +2910,7 @@ export default class BattleScene extends SceneBase {
    * @param player Whether to search the player (`true`) or the enemy (`false`); Defaults to `true`
    * @returns the list of all modifiers that matched `modifierType`.
    */
-  getModifiers<T extends PersistentModifier>(modifierType: Constructor<T>, player: boolean = true): T[] {
+  getModifiers<T extends PersistentModifier>(modifierType: AbstractConstructor<T>, player: boolean = true): T[] {
     return (player ? this.modifiers : this.enemyModifiers).filter((m): m is T => m instanceof modifierType);
   }
 
@@ -2942,7 +2942,7 @@ export default class BattleScene extends SceneBase {
    * @returns the list of all modifiers that matched `modifierType` and were applied.
    */
   applyShuffledModifiers<T extends PersistentModifier>(
-    modifierType: Constructor<T>,
+    modifierType: AbstractConstructor<T>,
     player: boolean = true,
     ...args: Parameters<T["apply"]>
   ): T[] {
@@ -2974,7 +2974,7 @@ export default class BattleScene extends SceneBase {
    * @returns the list of all modifiers that matched `modifierType` and were applied.
    */
   applyModifiers<T extends PersistentModifier>(
-    modifierType: Constructor<T>,
+    modifierType: AbstractConstructor<T>,
     player: boolean = true,
     ...args: Parameters<T["apply"]>
   ): T[] {
@@ -3009,7 +3009,7 @@ export default class BattleScene extends SceneBase {
    * @returns the first modifier that matches `modifierType` and was applied; return `null` if none matched
    */
   applyModifier<T extends PersistentModifier>(
-    modifierType: Constructor<T>,
+    modifierType: AbstractConstructor<T>,
     player: boolean = true,
     ...args: Parameters<T["apply"]>
   ): T | null {
@@ -3028,7 +3028,7 @@ export default class BattleScene extends SceneBase {
 
   triggerPokemonFormChange(
     pokemon: Pokemon,
-    formChangeTriggerType: Constructor<SpeciesFormChangeTrigger>,
+    formChangeTriggerType: AbstractConstructor<SpeciesFormChangeTrigger>,
     delayed: boolean = false,
     modal: boolean = false,
   ): boolean {
@@ -3092,7 +3092,7 @@ export default class BattleScene extends SceneBase {
     return true;
   }
 
-  validateAchvs(achvType: Constructor<Achv>, ...args: unknown[]): void {
+  validateAchvs(achvType: AbstractConstructor<Achv>, ...args: unknown[]): void {
     const filteredAchvs = Object.values(achvs).filter((a) => a instanceof achvType);
     for (const achv of filteredAchvs) {
       this.validateAchv(achv, args);

--- a/src/data/ab-attrs/field-move-power-boost-ab-attr.ts
+++ b/src/data/ab-attrs/field-move-power-boost-ab-attr.ts
@@ -8,7 +8,7 @@ import { PreAttackAbAttr } from "./pre-attack-ab-attr";
  * Boosts the power of a Pokémon's move under certain conditions.
  * @extends AbAttr
  */
-export class FieldMovePowerBoostAbAttr extends PreAttackAbAttr {
+export abstract class FieldMovePowerBoostAbAttr extends PreAttackAbAttr {
   private readonly condition: PokemonAttackCondition;
   private readonly powerMultiplier: number;
 

--- a/src/data/ab-attrs/post-attack-ab-attr.ts
+++ b/src/data/ab-attrs/post-attack-ab-attr.ts
@@ -3,7 +3,7 @@ import { MoveCategory } from "#enums/move-category";
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PostAttackAbAttr extends AbAttr {
+export abstract class PostAttackAbAttr extends AbAttr {
   /** Whether it only applies to attack moves. */
   private readonly attackMovesOnly: boolean;
 
@@ -40,13 +40,11 @@ export class PostAttackAbAttr extends AbAttr {
    * @param args Additional arguments for subclasses
    * @returns `true` if effects apply successfully
    */
-  protected applyPostAttack(
+  protected abstract applyPostAttack(
     _pokemon: Pokemon,
     _simulated: boolean,
     _defender: Pokemon,
     _move: Move,
     ..._args: unknown[]
-  ): boolean {
-    return false;
-  }
+  ): boolean;
 }

--- a/src/data/ab-attrs/post-battle-ab-attr.ts
+++ b/src/data/ab-attrs/post-battle-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PostBattleAbAttr extends AbAttr {
+export abstract class PostBattleAbAttr extends AbAttr {
   /**
    * Applies an effect at the end of a battle.
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-battle-init-ab-attr.ts
+++ b/src/data/ab-attrs/post-battle-init-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PostBattleInitAbAttr extends AbAttr {
+export abstract class PostBattleInitAbAttr extends AbAttr {
   /**
    * Applies an effect at the start of battle
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-biome-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-biome-change-ab-attr.ts
@@ -1,3 +1,3 @@
 import { AbAttr } from "./ab-attr";
 
-export class PostBiomeChangeAbAttr extends AbAttr {}
+export abstract class PostBiomeChangeAbAttr extends AbAttr {}

--- a/src/data/ab-attrs/post-damage-ab-attr.ts
+++ b/src/data/ab-attrs/post-damage-ab-attr.ts
@@ -5,7 +5,7 @@ import { AbAttr } from "./ab-attr";
  * Triggers after the Pokemon takes any damage
  * @extends AbAttr
  */
-export class PostDamageAbAttr extends AbAttr {
+export abstract class PostDamageAbAttr extends AbAttr {
   /**
    * Applies an effect after the Pokemon takes damage
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-defend-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Move } from "#app/data/move";
 import { type Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PostDefendAbAttr extends AbAttr {
+export abstract class PostDefendAbAttr extends AbAttr {
   /**
    * Applies an effect after being affected by another Pokemon's move.
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-faint-ab-attr.ts
+++ b/src/data/ab-attrs/post-faint-ab-attr.ts
@@ -3,7 +3,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { HitResult } from "#enums/hit-result";
 import { AbAttr } from "./ab-attr";
 
-export class PostFaintAbAttr extends AbAttr {
+export abstract class PostFaintAbAttr extends AbAttr {
   /**
    * Applies an effect after the source Pokemon faints
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-item-lost-ab-attr.ts
+++ b/src/data/ab-attrs/post-item-lost-ab-attr.ts
@@ -5,7 +5,7 @@ import { AbAttr } from "./ab-attr";
  * Triggers after the Pokemon loses or consumes an item
  * @extends AbAttr
  */
-export class PostItemLostAbAttr extends AbAttr {
+export abstract class PostItemLostAbAttr extends AbAttr {
   /**
    * Applies an effect when the source Pokemon loses or consumes an item
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-knock-out-ab-attr.ts
+++ b/src/data/ab-attrs/post-knock-out-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PostKnockOutAbAttr extends AbAttr {
+export abstract class PostKnockOutAbAttr extends AbAttr {
   /**
    * Applies an effect after a Pokemon other than the source faints
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-move-used-ab-attr.ts
+++ b/src/data/ab-attrs/post-move-used-ab-attr.ts
@@ -7,7 +7,7 @@ import { AbAttr } from "./ab-attr";
  * Triggers just after a move is used either by the opponent or the player
  * @extends AbAttr
  */
-export class PostMoveUsedAbAttr extends AbAttr {
+export abstract class PostMoveUsedAbAttr extends AbAttr {
   /**
    * Applies an effect after a move is used by any other Pokemon
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-stat-stage-change-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { BattleStat } from "#enums/stat";
 import { AbAttr } from "./ab-attr";
 
-export class PostStatStageChangeAbAttr extends AbAttr {
+export abstract class PostStatStageChangeAbAttr extends AbAttr {
   /**
    * Applies an effect after the source's stat stage(s) change
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-summon-ab-attr.ts
+++ b/src/data/ab-attrs/post-summon-ab-attr.ts
@@ -5,7 +5,7 @@ import { AbAttr } from "./ab-attr";
  * Base class for defining all {@linkcode Ability} Attributes post summon
  * @see {@linkcode applyPostSummon()}
  */
-export class PostSummonAbAttr extends AbAttr {
+export abstract class PostSummonAbAttr extends AbAttr {
   /**
    * Applies ability post summon (after switching in)
    * @param pokemon {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-terrain-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-terrain-change-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { TerrainType } from "#enums/terrain-type";
 import { AbAttr } from "./ab-attr";
 
-export class PostTerrainChangeAbAttr extends AbAttr {
+export abstract class PostTerrainChangeAbAttr extends AbAttr {
   /**
    * Applies an effect after the terrain on the field changes
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-turn-ab-attr.ts
+++ b/src/data/ab-attrs/post-turn-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PostTurnAbAttr extends AbAttr {
+export abstract class PostTurnAbAttr extends AbAttr {
   /**
    * Applies an effect at the end of a turn.
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-victory-ab-attr.ts
+++ b/src/data/ab-attrs/post-victory-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PostVictoryAbAttr extends AbAttr {
+export abstract class PostVictoryAbAttr extends AbAttr {
   /**
    * Applies an effect after the source KOs another Pokemon
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-weather-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-change-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { WeatherType } from "#enums/weather-type";
 import { AbAttr } from "./ab-attr";
 
-export class PostWeatherChangeAbAttr extends AbAttr {
+export abstract class PostWeatherChangeAbAttr extends AbAttr {
   /**
    * Applies an effect after the weather on the field changes
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/post-weather-lapse-ab-attr.ts
+++ b/src/data/ab-attrs/post-weather-lapse-ab-attr.ts
@@ -5,7 +5,7 @@ import { globalScene } from "#app/global-scene";
 import type { WeatherType } from "#enums/weather-type";
 import { AbAttr } from "./ab-attr";
 
-export class PostWeatherLapseAbAttr extends AbAttr {
+export abstract class PostWeatherLapseAbAttr extends AbAttr {
   protected readonly weatherTypes: WeatherType[];
 
   constructor(...weatherTypes: WeatherType[]) {

--- a/src/data/ab-attrs/pre-apply-battler-tag-ab-attr.ts
+++ b/src/data/ab-attrs/pre-apply-battler-tag-ab-attr.ts
@@ -3,7 +3,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
-export class PreApplyBattlerTagAbAttr extends AbAttr {
+export abstract class PreApplyBattlerTagAbAttr extends AbAttr {
   /**
    * Applies an effect before a battler tag is applied to the source
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/pre-attack-ab-attr.ts
+++ b/src/data/ab-attrs/pre-attack-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PreAttackAbAttr extends AbAttr {
+export abstract class PreAttackAbAttr extends AbAttr {
   /**
    * Applies an effect before the source moves
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/pre-defend-ab-attr.ts
+++ b/src/data/ab-attrs/pre-defend-ab-attr.ts
@@ -2,7 +2,7 @@ import type { Move } from "#app/data/move";
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PreDefendAbAttr extends AbAttr {
+export abstract class PreDefendAbAttr extends AbAttr {
   /**
    * Applies an effect before the source Pokemon is hit by an attack.
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/pre-set-status-ab-attr.ts
+++ b/src/data/ab-attrs/pre-set-status-ab-attr.ts
@@ -3,7 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import type { StatusEffect } from "#enums/status-effect";
 import { AbAttr } from "./ab-attr";
 
-export class PreSetStatusAbAttr extends AbAttr {
+export abstract class PreSetStatusAbAttr extends AbAttr {
   /**
    * Applies an effect before the source is afflicted with a status condition.
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/pre-stat-stage-change-ab-attr.ts
+++ b/src/data/ab-attrs/pre-stat-stage-change-ab-attr.ts
@@ -3,7 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import type { BattleStat } from "#enums/stat";
 import { AbAttr } from "./ab-attr";
 
-export class PreStatStageChangeAbAttr extends AbAttr {
+export abstract class PreStatStageChangeAbAttr extends AbAttr {
   /**
    * Applies an effect before the source's stat stage(s) would change
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/pre-switch-out-ab-attr.ts
+++ b/src/data/ab-attrs/pre-switch-out-ab-attr.ts
@@ -1,7 +1,7 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { AbAttr } from "./ab-attr";
 
-export class PreSwitchOutAbAttr extends AbAttr {
+export abstract class PreSwitchOutAbAttr extends AbAttr {
   constructor(showAbility: boolean = true) {
     super(showAbility, true);
   }

--- a/src/data/ab-attrs/pre-weather-damage-ab-attr.ts
+++ b/src/data/ab-attrs/pre-weather-damage-ab-attr.ts
@@ -3,7 +3,7 @@ import type { BooleanHolder } from "#app/utils";
 import type { Weather } from "../weather";
 import { PreWeatherEffectAbAttr } from "./pre-weather-effect-ab-attr";
 
-export class PreWeatherDamageAbAttr extends PreWeatherEffectAbAttr {
+export abstract class PreWeatherDamageAbAttr extends PreWeatherEffectAbAttr {
   constructor(showAbility: boolean = false) {
     super(showAbility, true);
   }

--- a/src/data/ab-attrs/pre-weather-effect-ab-attr.ts
+++ b/src/data/ab-attrs/pre-weather-effect-ab-attr.ts
@@ -3,7 +3,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { BooleanHolder } from "#app/utils";
 import { AbAttr } from "./ab-attr";
 
-export class PreWeatherEffectAbAttr extends AbAttr {
+export abstract class PreWeatherEffectAbAttr extends AbAttr {
   /**
    * Applies an effect before weather effects would trigger
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ab-attrs/variable-move-power-ab-attr.ts
+++ b/src/data/ab-attrs/variable-move-power-ab-attr.ts
@@ -3,7 +3,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { NumberHolder } from "#app/utils";
 import { PreAttackAbAttr } from "./pre-attack-ab-attr";
 
-export class VariableMovePowerAbAttr extends PreAttackAbAttr {
+export abstract class VariableMovePowerAbAttr extends PreAttackAbAttr {
   /**
    * Modifies a move's power when used by the source Pokemon
    * @param pokemon The {@linkcode Pokemon} with this ability

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -10,7 +10,7 @@ import { MoveEndPhase } from "#app/phases/move-end-phase";
 import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { SwitchPhase } from "#app/phases/switch-phase";
 import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
-import type { Constructor } from "#app/utils";
+import type { AbstractConstructor, Constructor } from "#app/utils";
 import { BooleanHolder } from "#app/utils";
 import { Abilities } from "#enums/abilities";
 import i18next from "i18next";
@@ -59,7 +59,7 @@ export class Ability implements Localizable {
    * @param attrType any attribute that extends {@linkcode AbAttr}
    * @returns Array of attributes that match `attrType`, Empty Array if none match.
    */
-  getAttrs<T extends AbAttr>(attrType: Constructor<T>): T[] {
+  getAttrs<T extends AbAttr>(attrType: AbstractConstructor<T>): T[] {
     return this.attrs.filter((a): a is T => a instanceof attrType);
   }
 
@@ -68,7 +68,7 @@ export class Ability implements Localizable {
    * @param attrType any attribute that extends {@linkcode AbAttr}
    * @returns true if the ability has attribute `attrType`
    */
-  hasAttr<T extends AbAttr>(attrType: Constructor<T>): boolean {
+  hasAttr<T extends AbAttr>(attrType: AbstractConstructor<T>): boolean {
     return this.attrs.some((attr) => attr instanceof attrType);
   }
 
@@ -280,7 +280,7 @@ export class ForceSwitchOutHelper {
  * @see {@linkcode AbAttr}
  */
 export function applyAbAttrs<TAttr extends AbAttr>(
-  attrType: Constructor<TAttr>,
+  attrType: AbstractConstructor<TAttr>,
   ...params: Parameters<TAttr["apply"]>
 ): string[] {
   const messages: string[] = [];

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -164,7 +164,7 @@ export class MistTag extends ArenaTag {
  * Reduces the damage of specific move categories in the arena.
  * @extends ArenaTag
  */
-export class WeakenMoveScreenTag extends ArenaTag {
+export abstract class WeakenMoveScreenTag extends ArenaTag {
   protected weakenedCategories: MoveCategory[];
 
   /**
@@ -289,7 +289,7 @@ type ProtectConditionFunc = (arena: Arena, moveId: Moves) => boolean;
  * Class to implement conditional team protection
  * applies protection based on the attributes of incoming moves
  */
-export class ConditionalProtectTag extends ArenaTag {
+export abstract class ConditionalProtectTag extends ArenaTag {
   /** The condition function to determine which moves are negated */
   protected protectConditionFunc: ProtectConditionFunc;
   /** Does this apply to all moves, including those that ignore other forms of protection? */
@@ -567,7 +567,7 @@ class WishTag extends ArenaTag {
 /**
  * Abstract class to implement weakened moves of a specific type.
  */
-export class WeakenMoveTypeTag extends ArenaTag {
+export abstract class WeakenMoveTypeTag extends ArenaTag {
   private weakenedType: Type;
 
   /**
@@ -674,7 +674,7 @@ export class IonDelugeTag extends ArenaTag {
 /**
  * Abstract class to implement arena traps.
  */
-export class ArenaTrapTag extends ArenaTag {
+export abstract class ArenaTrapTag extends ArenaTag {
   public layers: number;
   public maxLayers: number;
 

--- a/src/data/move-attrs/modified-damage-attr.ts
+++ b/src/data/move-attrs/modified-damage-attr.ts
@@ -8,7 +8,7 @@ import { MoveAttr } from "#app/data/move-attrs/move-attr";
  * @extends MoveAttr
  * @see {@linkcode getModifiedDamage}
  */
-export class ModifiedDamageAttr extends MoveAttr {
+export abstract class ModifiedDamageAttr extends MoveAttr {
   /**
    * Modifies damage after damage is otherwise fully calculated.
    * Typically used to enforce a damage threshold on a move.
@@ -32,7 +32,5 @@ export class ModifiedDamageAttr extends MoveAttr {
    * @param damage the calculated damage before applying this modifier
    * @returns the modified damage
    */
-  getModifiedDamage(_user: Pokemon, _target: Pokemon, _move: Move, damage: number): number {
-    return damage;
-  }
+  abstract getModifiedDamage(_user: Pokemon, _target: Pokemon, _move: Move, damage: number): number;
 }

--- a/src/data/move-attrs/move-effect-attr.ts
+++ b/src/data/move-attrs/move-effect-attr.ts
@@ -32,7 +32,7 @@ export interface MoveEffectAttrOptions {
  * @extends MoveAttr
  * @see {@linkcode apply}
  */
-export class MoveEffectAttr extends MoveAttr {
+export abstract class MoveEffectAttr extends MoveAttr {
   /**
    * A container for this attribute's optional parameters
    * @see {@linkcode MoveEffectAttrOptions} for supported params.

--- a/src/data/move-attrs/move-header-attr.ts
+++ b/src/data/move-attrs/move-header-attr.ts
@@ -8,7 +8,7 @@ import { MoveAttr } from "#app/data/move-attrs/move-attr";
  * @see {@linkcode MoveHeaderPhase}
  * @extends MoveAttr
  */
-export class MoveHeaderAttr extends MoveAttr {
+export abstract class MoveHeaderAttr extends MoveAttr {
   constructor() {
     super(true);
   }

--- a/src/data/move-attrs/override-move-effect-attr.ts
+++ b/src/data/move-attrs/override-move-effect-attr.ts
@@ -8,7 +8,7 @@ import type { BooleanHolder } from "#app/utils";
  * move effect chain in {@linkcode MoveEffectPhase}.
  * @extends MoveAttr
  */
-export class OverrideMoveEffectAttr extends MoveAttr {
+export abstract class OverrideMoveEffectAttr extends MoveAttr {
   /**
    * Applies effects that may cancel the subsequent effect
    * chain in {@linkcode MoveEffectPhase}

--- a/src/data/move-attrs/variable-accuracy-attr.ts
+++ b/src/data/move-attrs/variable-accuracy-attr.ts
@@ -7,7 +7,7 @@ import type { NumberHolder } from "#app/utils";
  * Attribute to modify move accuracy based on game state.
  * @extends MoveAttr
  */
-export class VariableAccuracyAttr extends MoveAttr {
+export abstract class VariableAccuracyAttr extends MoveAttr {
   /**
    * Modifies the given move's accuracy based on game state
    * @param _user the {@linkcode Pokemon} using the move

--- a/src/data/move-attrs/variable-atk-attr.ts
+++ b/src/data/move-attrs/variable-atk-attr.ts
@@ -7,7 +7,7 @@ import type { NumberHolder } from "#app/utils";
  * Attribute to change the offensive stat used for a move's damage calculations.
  * @extends MoveAttr
  */
-export class VariableAtkAttr extends MoveAttr {
+export abstract class VariableAtkAttr extends MoveAttr {
   constructor() {
     super();
   }

--- a/src/data/move-attrs/variable-def-attr.ts
+++ b/src/data/move-attrs/variable-def-attr.ts
@@ -8,7 +8,6 @@ import type { NumberHolder } from "#app/utils";
  * @extends MoveAttr
  */
 export abstract class VariableDefAttr extends MoveAttr {
-
   /**
    * Changes the defensive stat used in the current attack's damage calculation
    * @param _user the {@linkcode Pokemon} using the move

--- a/src/data/move-attrs/variable-def-attr.ts
+++ b/src/data/move-attrs/variable-def-attr.ts
@@ -7,7 +7,7 @@ import type { NumberHolder } from "#app/utils";
  * Attribute to change the defensive stat to be used in a move's damage calculations.
  * @extends MoveAttr
  */
-export class VariableDefAttr extends MoveAttr {
+export abstract class VariableDefAttr extends MoveAttr {
   constructor() {
     super();
   }

--- a/src/data/move-attrs/variable-def-attr.ts
+++ b/src/data/move-attrs/variable-def-attr.ts
@@ -8,9 +8,6 @@ import type { NumberHolder } from "#app/utils";
  * @extends MoveAttr
  */
 export abstract class VariableDefAttr extends MoveAttr {
-  constructor() {
-    super();
-  }
 
   /**
    * Changes the defensive stat used in the current attack's damage calculation

--- a/src/data/move-attrs/variable-move-category-attr.ts
+++ b/src/data/move-attrs/variable-move-category-attr.ts
@@ -7,7 +7,7 @@ import type { NumberHolder } from "#app/utils";
  * Attribute to modify a move's category (Physical, Special, or Status) based on game state.
  * @extends MoveAttr
  */
-export class VariableMoveCategoryAttr extends MoveAttr {
+export abstract class VariableMoveCategoryAttr extends MoveAttr {
   /**
    * Modifies the given move's category based on game state
    * @param _user the {@linkcode Pokemon} using the move

--- a/src/data/move-attrs/variable-move-type-attr.ts
+++ b/src/data/move-attrs/variable-move-type-attr.ts
@@ -7,7 +7,7 @@ import type { NumberHolder } from "#app/utils";
  * Attribute to modify a move's type based on game state.
  * @extends MoveAttr
  */
-export class VariableMoveTypeAttr extends MoveAttr {
+export abstract class VariableMoveTypeAttr extends MoveAttr {
   /**
    * Modifies the given move's type based on game state
    * @param _user the {@linkcode Pokemon} using the move

--- a/src/data/move-attrs/variable-move-type-chart-attr.ts
+++ b/src/data/move-attrs/variable-move-type-chart-attr.ts
@@ -8,7 +8,7 @@ import type { Type } from "#enums/type";
  * Attribute for moves which have a custom type chart interaction.
  * @extends MoveAttr
  */
-export class VariableMoveTypeChartAttr extends MoveAttr {
+export abstract class VariableMoveTypeChartAttr extends MoveAttr {
   /**
    * Modifies the given move's type effectiveness multiplier
    * @param _user {@linkcode Pokemon} using the move

--- a/src/data/move-attrs/variable-move-type-multiplier-attr.ts
+++ b/src/data/move-attrs/variable-move-type-multiplier-attr.ts
@@ -7,7 +7,7 @@ import type { NumberHolder } from "#app/utils";
  * Attribute to modify a move's type effectiveness in certain game states.
  * @extends MoveAttr
  */
-export class VariableMoveTypeMultiplierAttr extends MoveAttr {
+export abstract class VariableMoveTypeMultiplierAttr extends MoveAttr {
   /**
    * Modifies the given move's type effectiveness multiplier based on game state
    * @param _user the {@linkcode Pokemon} using the move

--- a/src/data/move-attrs/variable-power-attr.ts
+++ b/src/data/move-attrs/variable-power-attr.ts
@@ -7,7 +7,7 @@ import type { NumberHolder } from "#app/utils";
  * Attribute to modify a move's power based on game state.
  * @extends MoveAttr
  */
-export class VariablePowerAttr extends MoveAttr {
+export abstract class VariablePowerAttr extends MoveAttr {
   /**
    * Modifies the given move's power based on game state
    * @param _user the {@linkcode Pokemon} using the move

--- a/src/data/move-attrs/variable-target-attr.ts
+++ b/src/data/move-attrs/variable-target-attr.ts
@@ -7,7 +7,7 @@ import { MoveAttr } from "#app/data/move-attrs/move-attr";
  * Attribute to change a move's legal target set based on game state.
  * @extends MoveAttr
  */
-export abstract class VariableTargetAttr extends MoveAttr {
+export class VariableTargetAttr extends MoveAttr {
   private targetChangeFunc: (user: Pokemon, target: Pokemon, move: Move) => number;
 
   constructor(targetChange: (user: Pokemon, target: Pokemon, move: Move) => number) {

--- a/src/data/move-attrs/variable-target-attr.ts
+++ b/src/data/move-attrs/variable-target-attr.ts
@@ -7,7 +7,7 @@ import { MoveAttr } from "#app/data/move-attrs/move-attr";
  * Attribute to change a move's legal target set based on game state.
  * @extends MoveAttr
  */
-export class VariableTargetAttr extends MoveAttr {
+export abstract class VariableTargetAttr extends MoveAttr {
   private targetChangeFunc: (user: Pokemon, target: Pokemon, move: Move) => number;
 
   constructor(targetChange: (user: Pokemon, target: Pokemon, move: Move) => number) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -8,7 +8,7 @@ import {
   PokemonMultiHitModifier,
   AttackTypeBoosterModifier,
 } from "#app/modifier/modifier";
-import type { Constructor, nil } from "#app/utils";
+import type { AbstractConstructor, Constructor, nil } from "#app/utils";
 import { BooleanHolder, NumberHolder } from "#app/utils";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -129,7 +129,7 @@ export abstract class Move implements Localizable {
    * @param attrType any attribute that extends {@linkcode MoveAttr}
    * @returns Array of attributes that match `attrType`, Empty Array if none match.
    */
-  getAttrs<T extends MoveAttr>(attrType: Constructor<T>): T[] {
+  getAttrs<T extends MoveAttr>(attrType: AbstractConstructor<T>): T[] {
     return this.attrs.filter((a): a is T => a instanceof attrType);
   }
 
@@ -138,7 +138,7 @@ export abstract class Move implements Localizable {
    * @param attrType any attribute that extends {@linkcode MoveAttr}
    * @returns true if the move has attribute `attrType`
    */
-  hasAttr<T extends MoveAttr>(attrType: Constructor<T>): boolean {
+  hasAttr<T extends MoveAttr>(attrType: AbstractConstructor<T>): boolean {
     return this.attrs.some((attr) => attr instanceof attrType);
   }
 
@@ -827,7 +827,7 @@ export abstract class Move implements Localizable {
     const isMultiTarget = multiple && targets.length > 1;
 
     // ...cannot enhance multi-hit or sacrificial moves
-    const exceptAttrs: Constructor<MoveAttr>[] = [MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit];
+    const exceptAttrs: AbstractConstructor<MoveAttr>[] = [MultiHitAttr, SacrificialAttr, SacrificialAttrOnHit];
 
     // ...and cannot enhance these specific moves.
     const exceptMoves: Moves[] = [Moves.FLING, Moves.UPROAR, Moves.ROLLOUT, Moves.ICE_BALL, Moves.ENDEAVOR];
@@ -986,7 +986,7 @@ function ChargeMove<TBase extends SubMove>(Base: TBase) {
      * @returns Array of attributes that match `attrType`, or an empty array if
      * no matches are found.
      */
-    getChargeAttrs<T extends MoveAttr>(attrType: Constructor<T>): T[] {
+    getChargeAttrs<T extends MoveAttr>(attrType: AbstractConstructor<T>): T[] {
       return this.chargeAttrs.filter((attr): attr is T => attr instanceof attrType);
     }
 
@@ -995,7 +995,7 @@ function ChargeMove<TBase extends SubMove>(Base: TBase) {
      * @param attrType any attribute that extends {@linkcode MoveAttr}
      * @returns `true` if a matching attribute is found; `false` otherwise
      */
-    hasChargeAttr<T extends MoveAttr>(attrType: Constructor<T>): boolean {
+    hasChargeAttr<T extends MoveAttr>(attrType: AbstractConstructor<T>): boolean {
       return this.chargeAttrs.some((attr) => attr instanceof attrType);
     }
 
@@ -1055,7 +1055,7 @@ function applyMoveChargeAttrsInternal<TAttr extends MoveAttr>(
 }
 
 export function applyMoveAttrs<TAttr extends MoveAttr>(
-  attrType: Constructor<TAttr>,
+  attrType: AbstractConstructor<TAttr>,
   ...params: Parameters<TAttr["apply"]>
 ): void {
   applyMoveAttrsInternal((attr: MoveAttr) => attr instanceof attrType, ...params);
@@ -1069,7 +1069,7 @@ export function applyFilteredMoveAttrs<TAttr extends MoveAttr>(
 }
 
 export function applyMoveChargeAttrs<TAttr extends MoveAttr>(
-  attrType: Constructor<TAttr>,
+  attrType: AbstractConstructor<TAttr>,
   ...params: Parameters<TAttr["apply"]>
 ): void {
   applyMoveChargeAttrsInternal((attr: MoveAttr) => attr instanceof attrType, ...params);

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -4,7 +4,7 @@ import { StatusEffect } from "#enums/status-effect";
 import { allMoves } from "#app/data/all-moves";
 import { MoveCategory } from "#enums/move-category";
 import { Type } from "#enums/type";
-import type { Constructor, nil } from "#app/utils";
+import type { AbstractConstructor, nil } from "#app/utils";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
@@ -75,7 +75,7 @@ export class SpeciesFormChange {
     return true;
   }
 
-  findTrigger(triggerType: Constructor<SpeciesFormChangeTrigger>): SpeciesFormChangeTrigger | nil {
+  findTrigger(triggerType: AbstractConstructor<SpeciesFormChangeTrigger>): SpeciesFormChangeTrigger | nil {
     if (!this.trigger.hasTriggerType(triggerType)) {
       return null;
     }
@@ -105,7 +105,7 @@ export abstract class SpeciesFormChangeTrigger {
     return true;
   }
 
-  hasTriggerType(triggerType: Constructor<SpeciesFormChangeTrigger>): boolean {
+  hasTriggerType(triggerType: AbstractConstructor<SpeciesFormChangeTrigger>): boolean {
     return this instanceof triggerType;
   }
 }
@@ -133,7 +133,7 @@ export class SpeciesFormChangeCompoundTrigger {
     return true;
   }
 
-  hasTriggerType(triggerType: Constructor<SpeciesFormChangeTrigger>): boolean {
+  hasTriggerType(triggerType: AbstractConstructor<SpeciesFormChangeTrigger>): boolean {
     return !!this.triggers.find((t) => t.hasTriggerType(triggerType));
   }
 }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import type { BiomeTierTrainerPools, PokemonPools } from "#app/data/balance/biomes";
 import { biomePokemonPools, biomeTrainerPools } from "#app/data/balance/biomes";
 import { BiomePoolTier } from "#enums/biome-pool-tier";
-import { type Constructor, randSeedInt } from "#app/utils";
+import { type AbstractConstructor, randSeedInt } from "#app/utils";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { getPokemonSpecies } from "#app/data/pokemon-species";
 import { getWeatherClearMessage, getWeatherStartMessage, Weather } from "#app/data/weather";
@@ -588,7 +588,7 @@ export class Arena {
    * @param args array of parameters that the called upon tags may need
    */
   applyTagsForSide(
-    tagType: ArenaTagType | Constructor<ArenaTag>,
+    tagType: ArenaTagType | AbstractConstructor<ArenaTag>,
     side: ArenaTagSide,
     simulated: boolean,
     ...args: unknown[]
@@ -610,7 +610,7 @@ export class Arena {
    * @param simulated if `true`, this applies arena tags without changing game state
    * @param args array of parameters that the called upon tags may need
    */
-  applyTags(tagType: ArenaTagType | Constructor<ArenaTag>, simulated: boolean, ...args: unknown[]): void {
+  applyTags(tagType: ArenaTagType | AbstractConstructor<ArenaTag>, simulated: boolean, ...args: unknown[]): void {
     this.applyTagsForSide(tagType, ArenaTagSide.BOTH, simulated, ...args);
   }
 
@@ -666,7 +666,7 @@ export class Arena {
    * @param tagType The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
-  getTag(tagType: ArenaTagType | Constructor<ArenaTag>): ArenaTag | undefined {
+  getTag(tagType: ArenaTagType | AbstractConstructor<ArenaTag>): ArenaTag | undefined {
     return this.getTagOnSide(tagType, ArenaTagSide.BOTH);
   }
 
@@ -682,7 +682,7 @@ export class Arena {
    * @param side The {@linkcode ArenaTagSide} to look at
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
-  getTagOnSide(tagType: ArenaTagType | Constructor<ArenaTag>, side: ArenaTagSide): ArenaTag | undefined {
+  getTagOnSide(tagType: ArenaTagType | AbstractConstructor<ArenaTag>, side: ArenaTagSide): ArenaTag | undefined {
     return typeof tagType === "number"
       ? this.tags.find(
           (t) =>

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -49,7 +49,6 @@ import {
 } from "#app/data/balance/starters";
 import { starterPassiveAbilities } from "#app/data/balance/passives";
 import {
-  type Constructor,
   isNullOrUndefined,
   randSeedInt,
   type nil,
@@ -62,6 +61,7 @@ import {
   rgbToHsv,
   deltaRgb,
   isBetween,
+  type AbstractConstructor,
 } from "#app/utils";
 import type { TypeDamageMultiplier } from "#app/data/type";
 import { getTypeDamageMultiplier, getTypeRgb } from "#app/data/type";
@@ -1720,7 +1720,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns Whether an ability with that attribute is present and active
    */
   public hasAbilityWithAttr(
-    attrType: Constructor<AbAttr>,
+    attrType: AbstractConstructor<AbAttr>,
     canApply: boolean = true,
     ignoreOverride?: boolean,
   ): boolean {
@@ -3535,9 +3535,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   getTag(tagType: BattlerTagType): BattlerTag | nil;
 
   /** @overload */
-  getTag<T extends BattlerTag>(tagType: Constructor<T>): T | nil;
+  getTag<T extends BattlerTag>(tagType: AbstractConstructor<T>): T | nil;
 
-  getTag(tagType: BattlerTagType | Constructor<BattlerTag>): BattlerTag | nil {
+  getTag(tagType: BattlerTagType | AbstractConstructor<BattlerTag>): BattlerTag | nil {
     if (!this.summonData) {
       return null;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1596,7 +1596,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns An array of all the ability attributes on this ability.
    */
   public getAbilityAttrs<T extends AbAttr = AbAttr>(
-    attrType: { new (...args: any[]): T },
+    attrType: AbstractConstructor<T>,
     canApply: boolean = true,
     ignoreOverride: boolean = false,
   ): T[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -343,8 +343,17 @@ export async function localPing() {
   }
 }
 
-/** Alias for the constructor of a class */
+/**
+ * Alias for the constructor of a class.
+ * Can be used to build an object of templated type.
+ * Use {@linkcode AbstractConstructor} instead if comparing types
+ */
 export type Constructor<T> = new (...args: unknown[]) => T;
+/**
+ * Alias for an abstract constructor of a class.
+ * Should be used when comparing types, e.g. with `instanceof`.
+ */
+export type AbstractConstructor<T> = abstract new (...args: unknown[]) => T;
 
 export class BooleanHolder {
   public value: boolean;


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

Trying to make implementations less error-prone.

## What are the changes from a developer perspective?

- `utils`: Added a new util `AbstractConstructor`, which is basically an abstract version of `Constructor`. Using this instead of `Constructor` for type checks (i.e. `instanceof`) allows for comparing against abstract types.
- Some parent classes for arena tags, move attributes, and ability attributes are now `abstract`.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

`npm run test`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?
