### PR TITLE
[Bug] Fix args for usages of `applyAbAttrs`

### DIFF
--- a/src/data/ab-attrs/terrain-event-type-change-ab-attr.ts
+++ b/src/data/ab-attrs/terrain-event-type-change-ab-attr.ts
@@ -12,12 +12,17 @@ import { PostSummonAbAttr } from "./post-summon-ab-attr";
  * @extends PostSummonAbAttr
  */
 export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
-  override apply(pokemon: Pokemon, _simulated: boolean): boolean {
+  override apply(pokemon: Pokemon, _simulated: boolean, onSummon: boolean = true): boolean {
     if (pokemon.isTerastallized()) {
       return false;
     }
 
     const currentTerrain = globalScene.arena.getTerrainType();
+
+    // If there is no terrain, only apply ability if the terrain changed to become empty (i.e., `onSummon` is false)
+    if (onSummon && currentTerrain === TerrainType.NONE) {
+      return false;
+    }
 
     const typeChange: Type[] = this.determineTypeChange(pokemon, currentTerrain);
     if (typeChange.length !== 0) {

--- a/src/data/ability.ts
+++ b/src/data/ability.ts
@@ -219,13 +219,13 @@ export class ForceSwitchOutHelper {
    * @param opponent The opponent Pokémon.
    * @returns `true` if the switch-out condition is met
    */
-  public getSwitchOutCondition(pokemon: Pokemon, opponent: Pokemon): boolean {
+  public getSwitchOutCondition(pokemon: Pokemon, _opponent: Pokemon): boolean {
     const switchOutTarget = pokemon;
     const player = switchOutTarget instanceof PlayerPokemon;
 
     if (player) {
       const blockedByAbility = new BooleanHolder(false);
-      applyAbAttrs(ForceSwitchOutImmunityAbAttr, opponent, false, blockedByAbility);
+      applyAbAttrs(ForceSwitchOutImmunityAbAttr, pokemon, false, blockedByAbility);
       return !blockedByAbility.value;
     }
 
@@ -314,10 +314,13 @@ export function applyAbAttrs<TAttr extends AbAttr>(
             queueShowAbility(pokemon, passive);
           }
         }
-
+      }
+      if (result) {
         const message = attr.getTriggerMessage(pokemon, ability.name, ...args);
         if (message) {
-          globalScene.queueMessage(message);
+          if (!simulated) {
+            globalScene.queueMessage(message);
+          }
           messages.push(message);
         }
       }

--- a/src/data/move-attrs/status-effect-attr.ts
+++ b/src/data/move-attrs/status-effect-attr.ts
@@ -59,7 +59,7 @@ export class StatusEffectAttr extends MoveEffectAttr {
         (!pokemon.status || (pokemon.status.effect === this.effect && moveChance < 0))
         && pokemon.trySetStatus(this.effect, true, user, this.turnsRemaining)
       ) {
-        applyAbAttrs(ConfusionOnStatusEffectAbAttr, user, false, target, move, null, this.effect);
+        applyAbAttrs(ConfusionOnStatusEffectAbAttr, user, false, target, move, this.effect);
         return true;
       }
     }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -391,7 +391,7 @@ export class Arena {
           (t) => "terrainTypes" in t && !(t.terrainTypes as TerrainType[]).find((t) => t === terrain),
         );
         applyAbAttrs(PostTerrainChangeAbAttr, pokemon, false, terrain);
-        applyAbAttrs(TerrainEventTypeChangeAbAttr, pokemon, false);
+        applyAbAttrs(TerrainEventTypeChangeAbAttr, pokemon, false, false);
       });
 
     return true;

--- a/test/abilities/poison_puppeteer.test.ts
+++ b/test/abilities/poison_puppeteer.test.ts
@@ -1,0 +1,85 @@
+import { TUTORIAL_BATTLE_WAVE } from "#app/data/special-waves";
+import { Abilities } from "#enums/abilities";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { StatusEffect } from "#enums/status-effect";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Poison Puppeteer", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.POISON_PUPPETEER)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyLevel(100)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should confuse the target if the user poisons the target directly", async () => {
+    await game.classicMode.startBattle([Species.MAREANIE]);
+
+    game.move.use(Moves.MORTAL_SPIN);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    expect(enemyPokemon.status?.effect).toBe(StatusEffect.POISON);
+    expect(enemyPokemon.getTag(BattlerTagType.CONFUSED)).toBeDefined();
+  });
+
+  it("should confuse the target if the user badly poisons the target directly", async () => {
+    await game.classicMode.startBattle([Species.MAREANIE]);
+
+    game.move.use(Moves.TOXIC);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    expect(enemyPokemon.status?.effect).toBe(StatusEffect.TOXIC);
+    expect(enemyPokemon.getTag(BattlerTagType.CONFUSED)).toBeDefined();
+  });
+
+  it("should not confuse the target if the user poisons the target via Toxic Spikes", async () => {
+    game.override.startingWave(TUTORIAL_BATTLE_WAVE);
+    await game.classicMode.startBattle([Species.MAREANIE]);
+
+    game.move.use(Moves.TOXIC_SPIKES);
+    await game.toNextTurn();
+
+    game.move.use(Moves.SPLASH);
+    await game.forceEnemyToSwitch();
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    expect(enemyPokemon.status?.effect).toBe(StatusEffect.POISON);
+    expect(enemyPokemon.getTag(BattlerTagType.CONFUSED)).toBeUndefined();
+  });
+
+  it("should not confuse the target if the user paralyzes the target", async () => {
+    await game.classicMode.startBattle([Species.MAREANIE]);
+
+    game.move.use(Moves.NUZZLE);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    expect(enemyPokemon.status?.effect).toBe(StatusEffect.PARALYSIS);
+    expect(enemyPokemon.getTag(BattlerTagType.CONFUSED)).toBeUndefined();
+  });
+});

--- a/test/abilities/suction_cups.test.ts
+++ b/test/abilities/suction_cups.test.ts
@@ -1,0 +1,59 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Suction Cups", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.SUCTION_CUPS)
+      .enemyLevel(100);
+  });
+
+  it("should prevent the user from being forced to switch out", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    game.move.use(Moves.WHIRLWIND);
+    await game.move.forceEnemyMove(Moves.SPLASH);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    expect(enemyPokemon.switchOutStatus).toBe(false);
+  });
+
+  it("should not prevent other Pokemon on the field from being forced to switch out via Wimp Out", async () => {
+    game.override.ability(Abilities.WIMP_OUT);
+    await game.classicMode.startBattle([Species.FEEBAS, Species.MILOTIC]);
+
+    const [feebas, milotic] = game.scene.getPlayerParty();
+
+    game.move.use(Moves.SPLASH);
+    await game.move.forceEnemyMove(Moves.FALSE_SWIPE);
+    game.doSelectPartyPokemon(1);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(feebas.isOnField()).toBe(false);
+    expect(feebas.isAllowedInBattle()).toBe(true);
+    expect(milotic.isOnField()).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->
1. Poison Puppeteer works again.
2. Suction Cups no longer prevents the opponent from switching out via Wimp Out.
3. Mimicry no longer activates if its user switches in when there is no terrain.
4. Trapping abilities display their trapping messages properly.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
Small fixes for #221.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
1. Removed a `null` that was left behind in Poison Puppeteer's application.
2. `ForceSwitchOutHelper` now checks if the Pokemon switching out, rather than its opponent, has Suction Cups.
3. #221 consolidated Mimicry's two functions `apply()` and `applyPostSummon()`, which introduced some regression when the Mimicry user is being summoned onto the field. To fix this, `apply()` has a 3rd param `onSummon` to restore the old behaviour of `applyPostSummon()`.
4. The `applyAbAttrs` function now also gathers ability messages when the ability is being simulated, which matches its behaviour from before #221.
5. Added some basic tests for Poison Puppeteer and Suction Cups.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details>
<summary> Before the changes: Poison Puppeteer does nothing </summary>

https://github.com/user-attachments/assets/9f7d8371-9704-4318-97c6-9c0404906bea

</details>
<details>
<summary> After the changes: Poison Puppeteer activates properly </summary>

https://github.com/user-attachments/assets/54e98c0f-09b1-4056-834c-6bbae8f72a0b

</details>
<details>
<summary> Before the changes: Wimp Out gets blocked by opponent's Suction Cups </summary>

https://github.com/user-attachments/assets/b0349b70-6300-42f8-99e1-ec23690face1

</details>
<details>
<summary> After the changes: Wimp Out no longer gets blocked by opponent's Suction Cups </summary>

https://github.com/user-attachments/assets/8a81c1a5-0d78-4979-beb0-7cc1f9b5f988

</details>
<details>
<summary> Before the changes: Mimicry activates when its user gets summoned with no terrain </summary>

https://github.com/user-attachments/assets/0a0f97ed-f517-4796-bf98-15a8e0f7de80

</details>
<details>
<summary> After the changes: Mimicry no longer activates when its user gets summoned with no terrain </summary>

https://github.com/user-attachments/assets/d9edfc1a-cda4-481f-9f8a-7309054c1dc3

</details>
<details>
<summary> Before the changes: Arena Trap displays a generic trapped message </summary>

https://github.com/user-attachments/assets/da65f16b-28d8-4d44-aa8d-d5ec8c925284

</details>
<details>
<summary> After the changes: Arena Trap displays the proper Arena Trap message </summary>

https://github.com/user-attachments/assets/4151628a-3339-4291-8c70-548e37391c27

</details>

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

`npm run test [poison_puppeteer | suction_cups]`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?