### PR TITLE
[Bug] Prevent pokemon with 0 HP from being statused

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3977,6 +3977,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     ignoreField: boolean = false,
   ): boolean {
     if (effect !== StatusEffect.FAINT) {
+      if (this.isFainted()) {
+        return false;
+      }
       if (overrideStatus ? this.status?.effect === effect : this.status) {
         return false;
       }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3977,9 +3977,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     ignoreField: boolean = false,
   ): boolean {
     if (effect !== StatusEffect.FAINT) {
-      if (this.isFainted()) {
-        return false;
-      }
       if (overrideStatus ? this.status?.effect === effect : this.status) {
         return false;
       }
@@ -4072,6 +4069,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     sourceText: string | null = null,
   ): boolean {
     if (!this.canSetStatus(effect, asPhase, false, sourcePokemon)) {
+      return false;
+    }
+    if (this.isFainted() && effect !== StatusEffect.FAINT) {
       return false;
     }
 

--- a/test/data/status_effect.test.ts
+++ b/test/data/status_effect.test.ts
@@ -428,7 +428,8 @@ describe("Status Effects", () => {
       const player = game.field.getPlayerPokemon();
       player.hp = 0;
 
-      expect(player.canSetStatus(StatusEffect.BURN)).toBe(false);
+      expect(player.trySetStatus(StatusEffect.BURN)).toBe(false);
+      expect(player.status?.effect).not.toBe(StatusEffect.BURN);
     });
   });
 });

--- a/test/data/status_effect.test.ts
+++ b/test/data/status_effect.test.ts
@@ -394,4 +394,43 @@ describe("Status Effects", () => {
       expect(player.getLastXMoves(1)[0].result).toBe(MoveResult.SUCCESS);
     });
   });
+
+  describe("Behavior", () => {
+    let phaserGame: Phaser.Game;
+    let game: GameManager;
+
+    beforeAll(() => {
+      phaserGame = new Phaser.Game({
+        type: Phaser.HEADLESS,
+      });
+    });
+
+    afterEach(() => {
+      game.phaseInterceptor.restoreOg();
+    });
+
+    beforeEach(() => {
+      game = new GameManager(phaserGame);
+      game.override
+        .moveset([Moves.SPLASH])
+        .ability(Abilities.BALL_FETCH)
+        .battleType("single")
+        .disableCrits()
+        .enemySpecies(Species.MAGIKARP)
+        .enemyAbility(Abilities.BALL_FETCH)
+        .enemyMoveset(Moves.NUZZLE)
+        .enemyLevel(2000);
+    });
+
+    it("should not inflict a 0 HP mon with a status", async () => {
+      await game.classicMode.startBattle([Species.FEEBAS, Species.MILOTIC]);
+
+      const player = game.field.getPlayerPokemon();
+
+      game.move.select(Moves.SPLASH);
+      await game.phaseInterceptor.to("FaintPhase", false);
+
+      expect(player.status?.effect).not.toBe(StatusEffect.PARALYSIS);
+    });
+  });
 });

--- a/test/data/status_effect.test.ts
+++ b/test/data/status_effect.test.ts
@@ -426,11 +426,9 @@ describe("Status Effects", () => {
       await game.classicMode.startBattle([Species.FEEBAS, Species.MILOTIC]);
 
       const player = game.field.getPlayerPokemon();
+      player.hp = 0;
 
-      game.move.select(Moves.SPLASH);
-      await game.phaseInterceptor.to("FaintPhase", false);
-
-      expect(player.status?.effect).not.toBe(StatusEffect.PARALYSIS);
+      expect(player.canSetStatus(StatusEffect.BURN)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
A Pokémon will no longer be able to be statused if it has 0 HP (aka: is fainted).

## Why am I making these changes?
Fixes PR3585 

## What are the changes from a developer perspective?
`Pokemon.canSetStatus()` now returns `false` if the Pokémon has 0 HP.

## How to test the changes?
`npm run test status_effect`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?