### PR TITLE
[Ability][Checkup][Bug] Gale Wings Checkup

### DIFF
--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -944,7 +944,7 @@ export function initAbilities() {
       .attr(NoFusionAbilityAbAttr),
     new Ability(Abilities.GALE_WINGS, 6).attr(
       ChangeMovePriorityAbAttr,
-      (pokemon, move) => pokemon.isFullHp() && pokemon.getMoveType(move) === Type.FLYING,
+      (pokemon, move) => pokemon.isFullHp() && move.type === Type.FLYING,
       1,
     ),
     new Ability(Abilities.MEGA_LAUNCHER, 6).attr(

--- a/test/abilities/gale_wings.test.ts
+++ b/test/abilities/gale_wings.test.ts
@@ -79,4 +79,20 @@ describe("Abilities - Gale Wings", () => {
     expect(flyingMove.getPriority).toHaveLastReturnedWith(flyingMove.priority);
     expect(playerPokemon.getMoveType(flyingMove)).toBe(Type.FLYING);
   });
+
+  it("should not boost the priority of originally Normal-type moves transformed by Aerilate", async () => {
+    game.override.moveset(Moves.TACKLE).passiveAbility(Abilities.AERILATE);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+
+    const flyingMove = allMoves[Moves.TACKLE];
+    vi.spyOn(flyingMove, "getPriority");
+
+    game.move.select(Moves.TACKLE);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon.isFullHp()).toBe(true);
+    expect(flyingMove.getPriority).toHaveLastReturnedWith(flyingMove.priority);
+    expect(playerPokemon.getMoveType(flyingMove)).toBe(Type.FLYING);
+  });
 });

--- a/test/abilities/gale_wings.test.ts
+++ b/test/abilities/gale_wings.test.ts
@@ -1,0 +1,82 @@
+import { allMoves } from "#app/data/all-moves";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Type } from "#enums/type";
+
+describe("Abilities - Gale Wings", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.WING_ATTACK])
+      .ability(Abilities.GALE_WINGS)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should boost the priority of flying type moves by 1 at full HP", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon();
+
+    const flyingMove = allMoves[Moves.WING_ATTACK];
+    vi.spyOn(flyingMove, "getPriority");
+
+    game.move.select(Moves.WING_ATTACK);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon?.isFullHp()).toBe(true);
+    expect(flyingMove.getPriority).toHaveLastReturnedWith(flyingMove.priority + 1);
+  });
+
+  it("should not boost the priority of flying type moves if not at full HP", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    playerPokemon.hp = 1;
+
+    const flyingMove = allMoves[Moves.WING_ATTACK];
+    vi.spyOn(flyingMove, "getPriority");
+
+    game.move.select(Moves.WING_ATTACK);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon.isFullHp()).toBe(false);
+    expect(flyingMove.getPriority).toHaveLastReturnedWith(flyingMove.priority);
+  });
+
+  it("should not boost the priority of variable-type moves", async () => {
+    game.override.moveset(Moves.HIDDEN_POWER);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    //IVs for Flying-Type Hidden Power
+    playerPokemon.ivs = [31, 31, 31, 30, 30, 30];
+
+    const flyingMove = allMoves[Moves.HIDDEN_POWER];
+    vi.spyOn(flyingMove, "getPriority");
+
+    game.move.select(Moves.HIDDEN_POWER);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon.isFullHp()).toBe(true);
+    expect(flyingMove.getPriority).toHaveLastReturnedWith(flyingMove.priority);
+    expect(playerPokemon.getMoveType(flyingMove)).toBe(Type.FLYING);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

Variable-type moves that begin as Normal Type and become Flying-type will no longer be affected by Gale Wings. 

## Why am I making these changes?

Ability checkups...

## What are the changes from a developer perspective?

Gale Wings' conditional now checks if the move defaults as Flying-type.
Tests have been written for Gale Wings. 

## How to test the changes?

`npm run test gale_wings`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?