### PR TITLE
[Bug] Fix being able to import data/session/run-history

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const MAX_INT_ATTR_VALUE = 0x80000000;
 export const SAVES_ZIP_PREFIX = `${APP_ABBREVIATION}_`;
 
 /** File extension for save files. */
-export const SAVE_FILE_EXTENSION = `.txt`;
+export const SAVE_FILE_EXTENSION = `txt`;
 
 /** Prefix for local storage keys. */
 export const LS_PREFIX = APP_ABBREVIATION;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const MAX_INT_ATTR_VALUE = 0x80000000;
 export const SAVES_ZIP_PREFIX = `${APP_ABBREVIATION}_`;
 
 /** File extension for save files. */
-export const SAVE_FILE_EXTENSION = `${APP_ABBREVIATION}.txt`;
+export const SAVE_FILE_EXTENSION = `.txt`;
 
 /** Prefix for local storage keys. */
 export const LS_PREFIX = APP_ABBREVIATION;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import { bypassLogin, SETTINGS_LS_KEY, TUTORIALS_LS_KEY } from "#app/constants";
+import { APP_ABBREVIATION, bypassLogin, SETTINGS_LS_KEY, TUTORIALS_LS_KEY } from "#app/constants";
 import { globalScene } from "#app/global-scene";
 import type { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
 import type { Pokemon } from "#app/field/pokemon";
@@ -1268,7 +1268,7 @@ export class GameData {
         const blob = new Blob([encryptedData.toString()], { type: "text/json" });
         const link = document.createElement("a");
         link.href = window.URL.createObjectURL(blob);
-        link.download = `${dataKey}.${SAVE_FILE_EXTENSION}`;
+        link.download = `${dataKey}.${APP_ABBREVIATION}.${SAVE_FILE_EXTENSION}`;
         link.click();
         link.remove();
       };

--- a/src/ui/login-form-ui-handler.ts
+++ b/src/ui/login-form-ui-handler.ts
@@ -10,7 +10,7 @@ import type { OptionSelectItem } from "#app/ui/abstact-option-select-ui-handler"
 import { api } from "#app/plugins/api/api";
 import { globalScene } from "#app/global-scene";
 import JSZip from "jszip";
-import { SAVE_FILE_EXTENSION, SAVES_ZIP_PREFIX } from "#app/constants";
+import { APP_ABBREVIATION, SAVE_FILE_EXTENSION, SAVES_ZIP_PREFIX } from "#app/constants";
 
 interface BuildInteractableImageOpts {
   scale?: number;
@@ -257,10 +257,13 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
       if (dataKeys.length > 0 || sessionKeys.length > 0) {
         const zip = new JSZip();
         for (let i = 0; i < dataKeys.length; i++) {
-          zip.file(dataKeys[i] + `.${SAVE_FILE_EXTENSION}`, localStorage.getItem(dataKeys[i])!);
+          zip.file(dataKeys[i] + `.${APP_ABBREVIATION}.${SAVE_FILE_EXTENSION}`, localStorage.getItem(dataKeys[i])!);
         }
         for (let i = 0; i < sessionKeys.length; i++) {
-          zip.file(sessionKeys[i] + `.${SAVE_FILE_EXTENSION}`, localStorage.getItem(sessionKeys[i])!);
+          zip.file(
+            sessionKeys[i] + `.${APP_ABBREVIATION}.${SAVE_FILE_EXTENSION}`,
+            localStorage.getItem(sessionKeys[i])!,
+          );
         }
         zip.generateAsync({ type: "blob" }).then((content) => {
           const url = URL.createObjectURL(content);

--- a/test/testUtils/testUtils.ts
+++ b/test/testUtils/testUtils.ts
@@ -2,9 +2,9 @@ import i18next, { type ParseKeys } from "i18next";
 import fs from "fs";
 import path from "path";
 import { vi } from "vitest";
-import { SAVE_FILE_EXTENSION } from "#app/constants";
+import { APP_ABBREVIATION, SAVE_FILE_EXTENSION } from "#app/constants";
 
-export const EVERYTHING_SAVE_FILE_PATH = `test/testUtils/saves/everything.${SAVE_FILE_EXTENSION}`;
+export const EVERYTHING_SAVE_FILE_PATH = `test/testUtils/saves/everything.${APP_ABBREVIATION}.${SAVE_FILE_EXTENSION}`;
 
 /**
  * Sets up the i18next mock.


### PR DESCRIPTION
## What are the changes the user will see?

- Data can be imported again
- Sessions can be imported again
- Run-histories can be imported again

## Why am I making these changes?

The functionality was broken with #285.
The `SAVE_FILE_EXTENSION` was `.pkty.txt` but that's not a format the browser can understand thus not being able to give the user the proper suggested file-format 

## What are the changes from a developer perspective?

- Remove `APP_ABBREVIATION` from `SAVE_FILE_EXTENSION` and instead replace the calls with `${APP_ABBREVIATION}.${SAVE_FILE_EXTENSION}`

## Screenshots/Videos

https://github.com/user-attachments/assets/7aeb917b-889b-4d12-9084-e005f81be45d


## How to test the changes?

Start the game and test all the imports

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
