### PR TITLE
[Refactor] trainer-config.initForEvilTeamLeader

### DIFF
--- a/src/data/balance/trainer-configs/evil-boss-trainer-configs.ts
+++ b/src/data/balance/trainer-configs/evil-boss-trainer-configs.ts
@@ -8,13 +8,47 @@ import { PokeballType } from "#enums/pokeball";
 import { Species } from "#enums/species";
 import { TrainerType } from "#enums/trainer-type";
 
+const rocket_boss_title = "Rocket Boss";
+const rocket_music = "battle_rocket_boss";
+const GIOVANNI = "Giovanni";
+
+const magma_boss_title = "Magma Boss";
+const MAXIE = "Maxie";
+const aqua_boss_title = "Aqua Boss";
+const ARCHIE = "Archie";
+const aqua_magma_music = "battle_aqua_magma_boss";
+
+const galactic_boss_title = "Galactic Boss";
+const CYRUS = "Cyrus";
+const galactic_music = "battle_galactic_boss";
+
+const plasma_boss_title = "Plasma Boss";
+const GHETSIS = "Ghetsis";
+const plasma_music = "battle_plasma_boss";
+
+const flare_boss_title = "Flare Boss";
+const LYSANDRE = "Lysandre";
+const flare_music = "battle_flare_boss";
+
+const aether_boss_title = "Aether Boss";
+const LUSAMINE = "Lusamine";
+const aether_music = "battle_aether_boss";
+const skull_boss_title = "Skull Boss";
+const GUZMA = "Guzma";
+const skull_music = "battle_skull_boss";
+
+const macro_boss_title = "Macro Boss";
+const ROSE = "Rose";
+const macro_music = "battle_macro_boss";
+
+const star_boss_title = "Star Boss";
+const PENNY = "Cassiopeia";
+const star_music = "battle_star_boss";
+
 let t = TrainerType.ROCKET_BOSS_GIOVANNI_1;
 export const evilBossTrainerConfigs: TrainerConfigs = {
   [TrainerType.ROCKET_BOSS_GIOVANNI_1]: new TrainerConfig(t)
-    .setName("Giovanni")
-    .initForEvilTeamLeader("Rocket Boss", [])
-    .setMixedBattleBgm("battle_rocket_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(rocket_boss_title, GIOVANNI, false, rocket_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.PERSIAN, Species.ALOLA_PERSIAN], TrainerSlot.TRAINER, true, (p) => {
@@ -37,10 +71,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ROCKET_BOSS_GIOVANNI_2]: new TrainerConfig(++t)
-    .setName("Giovanni")
-    .initForEvilTeamLeader("Rocket Boss", [], true)
-    .setMixedBattleBgm("battle_rocket_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(rocket_boss_title, GIOVANNI, true, rocket_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.TYRANITAR, Species.IRON_THORNS], TrainerSlot.TRAINER, true, (p) => {
@@ -81,10 +112,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.MAXIE]: new TrainerConfig(++t)
-    .setName("Maxie")
-    .initForEvilTeamLeader("Magma Boss", [])
-    .setMixedBattleBgm("battle_aqua_magma_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(magma_boss_title, MAXIE, false, aqua_magma_music)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.MIGHTYENA]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.CROBAT, Species.GLISCOR]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.WEEZING, Species.GALAR_WEEZING]))
@@ -102,10 +130,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.MAXIE_2]: new TrainerConfig(++t)
-    .setName("Maxie")
-    .initForEvilTeamLeader("Magma Boss", [], true)
-    .setMixedBattleBgm("battle_aqua_magma_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(magma_boss_title, MAXIE, true, aqua_magma_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.SOLROCK, Species.TYPHLOSION], TrainerSlot.TRAINER, true, (p) => {
@@ -149,10 +174,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ARCHIE]: new TrainerConfig(++t)
-    .setName("Archie")
-    .initForEvilTeamLeader("Aqua Boss", [])
-    .setMixedBattleBgm("battle_aqua_magma_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(aqua_boss_title, ARCHIE, false, aqua_magma_music)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.LINOONE]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.CROBAT, Species.PELIPPER]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.MUK, Species.ALOLA_MUK]))
@@ -170,10 +192,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ARCHIE_2]: new TrainerConfig(++t)
-    .setName("Archie")
-    .initForEvilTeamLeader("Aqua Boss", [], true)
-    .setMixedBattleBgm("battle_aqua_magma_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(aqua_boss_title, ARCHIE, true, aqua_magma_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.EMPOLEON, Species.LUDICOLO], TrainerSlot.TRAINER, true, (p) => {
@@ -223,10 +242,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.CYRUS]: new TrainerConfig(++t)
-    .setName("Cyrus")
-    .initForEvilTeamLeader("Galactic Boss", [])
-    .setMixedBattleBgm("battle_galactic_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(galactic_boss_title, CYRUS, false, galactic_music)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.GYARADOS]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.HONCHKROW, Species.HISUI_BRAVIARY]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.CROBAT, Species.GLISCOR]))
@@ -250,10 +266,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.CYRUS_2]: new TrainerConfig(++t)
-    .setName("Cyrus")
-    .initForEvilTeamLeader("Galactic Boss", [], true)
-    .setMixedBattleBgm("battle_galactic_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(galactic_boss_title, CYRUS, true, galactic_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.AZELF, Species.UXIE, Species.MESPRIT], TrainerSlot.TRAINER, true, (p) => {
@@ -290,10 +303,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GHETSIS]: new TrainerConfig(++t)
-    .setName("Ghetsis")
-    .initForEvilTeamLeader("Plasma Boss", [])
-    .setMixedBattleBgm("battle_plasma_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(plasma_boss_title, GHETSIS, false, plasma_music)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.COFAGRIGUS, Species.RUNERIGUS]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.BOUFFALANT]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.SEISMITOAD, Species.CARRACOSTA]))
@@ -309,10 +319,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GHETSIS_2]: new TrainerConfig(++t)
-    .setName("Ghetsis")
-    .initForEvilTeamLeader("Plasma Boss", [], true)
-    .setMixedBattleBgm("battle_plasma_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(plasma_boss_title, GHETSIS, true, plasma_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.GENESECT], TrainerSlot.TRAINER, true, (p) => {
@@ -354,10 +361,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LYSANDRE]: new TrainerConfig(++t)
-    .setName("Lysandre")
-    .initForEvilTeamLeader("Flare Boss", [])
-    .setMixedBattleBgm("battle_flare_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(flare_boss_title, LYSANDRE, false, flare_music)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.MIENSHAO]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.HONCHKROW, Species.TALONFLAME]))
     .setPartyMemberFunc(
@@ -381,10 +385,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LYSANDRE_2]: new TrainerConfig(++t)
-    .setName("Lysandre")
-    .initForEvilTeamLeader("Flare Boss", [], true)
-    .setMixedBattleBgm("battle_flare_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(flare_boss_title, LYSANDRE, true, flare_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.SCREAM_TAIL, Species.FLUTTER_MANE], TrainerSlot.TRAINER, true, (p) => {
@@ -422,10 +423,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LUSAMINE]: new TrainerConfig(++t)
-    .setName("Lusamine")
-    .initForEvilTeamLeader("Aether Boss", [])
-    .setMixedBattleBgm("battle_aether_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(aether_boss_title, LUSAMINE, false, aether_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.CLEFABLE], TrainerSlot.TRAINER, true, (p) => {
@@ -446,10 +444,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LUSAMINE_2]: new TrainerConfig(++t)
-    .setName("Lusamine")
-    .initForEvilTeamLeader("Aether Boss", [], true)
-    .setMixedBattleBgm("battle_aether_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(aether_boss_title, LUSAMINE, true, aether_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.NIHILEGO], TrainerSlot.TRAINER, true, (p) => {
@@ -495,10 +490,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GUZMA]: new TrainerConfig(++t)
-    .setName("Guzma")
-    .initForEvilTeamLeader("Skull Boss", [])
-    .setMixedBattleBgm("battle_skull_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(skull_boss_title, GUZMA, false, skull_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.LOKIX, Species.YANMEGA], TrainerSlot.TRAINER, true, (p) => {
@@ -542,10 +534,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GUZMA_2]: new TrainerConfig(++t)
-    .setName("Guzma")
-    .initForEvilTeamLeader("Skull Boss", [], true)
-    .setMixedBattleBgm("battle_skull_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(skull_boss_title, GUZMA, true, skull_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.GOLISOPOD], TrainerSlot.TRAINER, true, (p) => {
@@ -599,10 +588,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ROSE]: new TrainerConfig(++t)
-    .setName("Rose")
-    .initForEvilTeamLeader("Macro Boss", [])
-    .setMixedBattleBgm("battle_macro_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(macro_boss_title, ROSE, false, macro_music)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.ARCHALUDON]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.FERROTHORN, Species.ESCAVALIER]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.SIRFETCHD, Species.MR_RIME]))
@@ -620,10 +606,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ROSE_2]: new TrainerConfig(++t)
-    .setName("Rose")
-    .initForEvilTeamLeader("Macro Boss", [], true)
-    .setMixedBattleBgm("battle_macro_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(macro_boss_title, ROSE, true, macro_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.ARCHALUDON], TrainerSlot.TRAINER, true, (p) => {
@@ -665,10 +648,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.PENNY]: new TrainerConfig(++t)
-    .setName("Cassiopeia")
-    .initForEvilTeamLeader("Star Boss", [])
-    .setMixedBattleBgm("battle_star_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(star_boss_title, PENNY, false, star_music)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.VAPOREON, Species.JOLTEON, Species.FLAREON]))
     .setPartyMemberFunc(
       1,
@@ -714,10 +694,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       ]; //TODO: is the bang correct?
     }),
   [TrainerType.PENNY_2]: new TrainerConfig(++t)
-    .setName("Cassiopeia")
-    .initForEvilTeamLeader("Star Boss", [], true)
-    .setMixedBattleBgm("battle_star_boss")
-    .setVictoryBgm("victory_team_plasma")
+    .initForEvilTeamLeader(star_boss_title, PENNY, true, star_music)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.SYLVEON], TrainerSlot.TRAINER, true, (p) => {

--- a/src/data/balance/trainer-configs/evil-boss-trainer-configs.ts
+++ b/src/data/balance/trainer-configs/evil-boss-trainer-configs.ts
@@ -8,47 +8,47 @@ import { PokeballType } from "#enums/pokeball";
 import { Species } from "#enums/species";
 import { TrainerType } from "#enums/trainer-type";
 
-const rocket_boss_title = "Rocket Boss";
-const rocket_music = "battle_rocket_boss";
+const ROCKET_BOSS_TITLE = "Rocket Boss";
+const ROCKET_MUSIC = "battle_rocket_boss";
 const GIOVANNI = "Giovanni";
 
-const magma_boss_title = "Magma Boss";
+const MAGMA_BOSS_TITLE = "Magma Boss";
 const MAXIE = "Maxie";
-const aqua_boss_title = "Aqua Boss";
+const AQUA_BOSS_TITLE = "Aqua Boss";
 const ARCHIE = "Archie";
-const aqua_magma_music = "battle_aqua_magma_boss";
+const AQUA_MAGMA_MUSIC = "battle_aqua_magma_boss";
 
-const galactic_boss_title = "Galactic Boss";
+const GALACTIC_BOSS_TITLE = "Galactic Boss";
 const CYRUS = "Cyrus";
-const galactic_music = "battle_galactic_boss";
+const GALACTIC_MUSIC = "battle_galactic_boss";
 
-const plasma_boss_title = "Plasma Boss";
+const PLASMA_BOSS_TITLE = "Plasma Boss";
 const GHETSIS = "Ghetsis";
-const plasma_music = "battle_plasma_boss";
+const PLASMA_MUSIC = "battle_plasma_boss";
 
-const flare_boss_title = "Flare Boss";
+const FLARE_BOSS_TITLE = "Flare Boss";
 const LYSANDRE = "Lysandre";
-const flare_music = "battle_flare_boss";
+const FLARE_MUSIC = "battle_flare_boss";
 
-const aether_boss_title = "Aether Boss";
+const AETHER_BOSS_TITLE = "Aether Boss";
 const LUSAMINE = "Lusamine";
-const aether_music = "battle_aether_boss";
-const skull_boss_title = "Skull Boss";
+const AETHER_MUSIC = "battle_aether_boss";
+const SKULL_BOSS_TITLE = "Skull Boss";
 const GUZMA = "Guzma";
-const skull_music = "battle_skull_boss";
+const SKULL_MUSIC = "battle_skull_boss";
 
-const macro_boss_title = "Macro Boss";
+const MACRO_BOSS_TITLE = "Macro Boss";
 const ROSE = "Rose";
-const macro_music = "battle_macro_boss";
+const MACRO_MUSIC = "battle_macro_boss";
 
-const star_boss_title = "Star Boss";
+const STAR_BOSS_TITLE = "Star Boss";
 const PENNY = "Cassiopeia";
-const star_music = "battle_star_boss";
+const STAR_MUSIC = "battle_star_boss";
 
 let t = TrainerType.ROCKET_BOSS_GIOVANNI_1;
 export const evilBossTrainerConfigs: TrainerConfigs = {
   [TrainerType.ROCKET_BOSS_GIOVANNI_1]: new TrainerConfig(t)
-    .initForEvilTeamLeader(rocket_boss_title, GIOVANNI, false, rocket_music)
+    .initForEvilTeamLeader(ROCKET_BOSS_TITLE, GIOVANNI, false, ROCKET_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.PERSIAN, Species.ALOLA_PERSIAN], TrainerSlot.TRAINER, true, (p) => {
@@ -71,7 +71,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ROCKET_BOSS_GIOVANNI_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(rocket_boss_title, GIOVANNI, true, rocket_music)
+    .initForEvilTeamLeader(ROCKET_BOSS_TITLE, GIOVANNI, true, ROCKET_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.TYRANITAR, Species.IRON_THORNS], TrainerSlot.TRAINER, true, (p) => {
@@ -112,7 +112,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.MAXIE]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(magma_boss_title, MAXIE, false, aqua_magma_music)
+    .initForEvilTeamLeader(MAGMA_BOSS_TITLE, MAXIE, false, AQUA_MAGMA_MUSIC)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.MIGHTYENA]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.CROBAT, Species.GLISCOR]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.WEEZING, Species.GALAR_WEEZING]))
@@ -130,7 +130,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.MAXIE_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(magma_boss_title, MAXIE, true, aqua_magma_music)
+    .initForEvilTeamLeader(MAGMA_BOSS_TITLE, MAXIE, true, AQUA_MAGMA_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.SOLROCK, Species.TYPHLOSION], TrainerSlot.TRAINER, true, (p) => {
@@ -174,7 +174,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ARCHIE]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(aqua_boss_title, ARCHIE, false, aqua_magma_music)
+    .initForEvilTeamLeader(AQUA_BOSS_TITLE, ARCHIE, false, AQUA_MAGMA_MUSIC)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.LINOONE]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.CROBAT, Species.PELIPPER]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.MUK, Species.ALOLA_MUK]))
@@ -192,7 +192,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ARCHIE_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(aqua_boss_title, ARCHIE, true, aqua_magma_music)
+    .initForEvilTeamLeader(AQUA_BOSS_TITLE, ARCHIE, true, AQUA_MAGMA_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.EMPOLEON, Species.LUDICOLO], TrainerSlot.TRAINER, true, (p) => {
@@ -242,7 +242,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.CYRUS]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(galactic_boss_title, CYRUS, false, galactic_music)
+    .initForEvilTeamLeader(GALACTIC_BOSS_TITLE, CYRUS, false, GALACTIC_MUSIC)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.GYARADOS]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.HONCHKROW, Species.HISUI_BRAVIARY]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.CROBAT, Species.GLISCOR]))
@@ -266,7 +266,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.CYRUS_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(galactic_boss_title, CYRUS, true, galactic_music)
+    .initForEvilTeamLeader(GALACTIC_BOSS_TITLE, CYRUS, true, GALACTIC_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.AZELF, Species.UXIE, Species.MESPRIT], TrainerSlot.TRAINER, true, (p) => {
@@ -303,7 +303,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GHETSIS]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(plasma_boss_title, GHETSIS, false, plasma_music)
+    .initForEvilTeamLeader(PLASMA_BOSS_TITLE, GHETSIS, false, PLASMA_MUSIC)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.COFAGRIGUS, Species.RUNERIGUS]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.BOUFFALANT]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.SEISMITOAD, Species.CARRACOSTA]))
@@ -319,7 +319,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GHETSIS_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(plasma_boss_title, GHETSIS, true, plasma_music)
+    .initForEvilTeamLeader(PLASMA_BOSS_TITLE, GHETSIS, true, PLASMA_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.GENESECT], TrainerSlot.TRAINER, true, (p) => {
@@ -361,7 +361,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LYSANDRE]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(flare_boss_title, LYSANDRE, false, flare_music)
+    .initForEvilTeamLeader(FLARE_BOSS_TITLE, LYSANDRE, false, FLARE_MUSIC)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.MIENSHAO]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.HONCHKROW, Species.TALONFLAME]))
     .setPartyMemberFunc(
@@ -385,7 +385,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LYSANDRE_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(flare_boss_title, LYSANDRE, true, flare_music)
+    .initForEvilTeamLeader(FLARE_BOSS_TITLE, LYSANDRE, true, FLARE_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.SCREAM_TAIL, Species.FLUTTER_MANE], TrainerSlot.TRAINER, true, (p) => {
@@ -423,7 +423,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LUSAMINE]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(aether_boss_title, LUSAMINE, false, aether_music)
+    .initForEvilTeamLeader(AETHER_BOSS_TITLE, LUSAMINE, false, AETHER_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.CLEFABLE], TrainerSlot.TRAINER, true, (p) => {
@@ -444,7 +444,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.LUSAMINE_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(aether_boss_title, LUSAMINE, true, aether_music)
+    .initForEvilTeamLeader(AETHER_BOSS_TITLE, LUSAMINE, true, AETHER_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.NIHILEGO], TrainerSlot.TRAINER, true, (p) => {
@@ -490,7 +490,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GUZMA]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(skull_boss_title, GUZMA, false, skull_music)
+    .initForEvilTeamLeader(SKULL_BOSS_TITLE, GUZMA, false, SKULL_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.LOKIX, Species.YANMEGA], TrainerSlot.TRAINER, true, (p) => {
@@ -534,7 +534,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.GUZMA_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(skull_boss_title, GUZMA, true, skull_music)
+    .initForEvilTeamLeader(SKULL_BOSS_TITLE, GUZMA, true, SKULL_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.GOLISOPOD], TrainerSlot.TRAINER, true, (p) => {
@@ -588,7 +588,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ROSE]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(macro_boss_title, ROSE, false, macro_music)
+    .initForEvilTeamLeader(MACRO_BOSS_TITLE, ROSE, false, MACRO_MUSIC)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.ARCHALUDON]))
     .setPartyMemberFunc(1, getRandomPartyMemberFunc([Species.FERROTHORN, Species.ESCAVALIER]))
     .setPartyMemberFunc(2, getRandomPartyMemberFunc([Species.SIRFETCHD, Species.MR_RIME]))
@@ -606,7 +606,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.ROSE_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(macro_boss_title, ROSE, true, macro_music)
+    .initForEvilTeamLeader(MACRO_BOSS_TITLE, ROSE, true, MACRO_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.ARCHALUDON], TrainerSlot.TRAINER, true, (p) => {
@@ -648,7 +648,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       }),
     ),
   [TrainerType.PENNY]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(star_boss_title, PENNY, false, star_music)
+    .initForEvilTeamLeader(STAR_BOSS_TITLE, PENNY, false, STAR_MUSIC)
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([Species.VAPOREON, Species.JOLTEON, Species.FLAREON]))
     .setPartyMemberFunc(
       1,
@@ -694,7 +694,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       ]; //TODO: is the bang correct?
     }),
   [TrainerType.PENNY_2]: new TrainerConfig(++t)
-    .initForEvilTeamLeader(star_boss_title, PENNY, true, star_music)
+    .initForEvilTeamLeader(STAR_BOSS_TITLE, PENNY, true, STAR_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([Species.SYLVEON], TrainerSlot.TRAINER, true, (p) => {

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1121,18 +1121,14 @@ export class TrainerConfig {
   }
 
   /**
-   * Initializes the trainer configuration for an evil team leader. Temporarily hardcoding evil leader teams though.
-   * @param signatureSpecies The signature species for the evil team leader.
-   * @param specialtyTypes The specialty types for the evil team Leader.
-   * @param boolean Whether or not this is the rematch fight
+   * Initializes the trainer configuration for an evil team leader.
+   * @param title the string representation of the evil team leader's title
+   * @param name the string representation of the evil team leader's name
+   * @param rematch Whether or not this is the rematch fight
+   * @param mixedBattleBgm the string representation of the mixed battle bgm
    * @returns The updated TrainerConfig instance.
    * **/
-  initForEvilTeamLeader(
-    title: string,
-    signatureSpecies: (Species | Species[])[],
-    rematch: boolean = false,
-    ...specialtyTypes: Type[]
-  ): TrainerConfig {
+  initForEvilTeamLeader(title: string, name: string, rematch: boolean = false, mixedBattleBgm: string): TrainerConfig {
     if (!getIsInitialized()) {
       initI18n();
     }
@@ -1141,17 +1137,7 @@ export class TrainerConfig {
     } else {
       this.setPartyTemplates(trainerPartyTemplates.RIVAL_5);
     }
-    signatureSpecies.forEach((speciesPool, s) => {
-      if (!Array.isArray(speciesPool)) {
-        speciesPool = [speciesPool];
-      }
-      this.setPartyMemberFunc(-(s + 1), getRandomPartyMemberFunc(speciesPool));
-    });
-    if (specialtyTypes.length) {
-      this.setSpeciesFilter((p) => specialtyTypes.find((t) => p.isOfType(t)) !== undefined);
-      this.setSpecialtyTypes(...specialtyTypes);
-    }
-    const nameForCall = this.name.toLowerCase().replace(/\s/g, "_");
+    const nameForCall = name.toLowerCase().replace(/\s/g, "_");
     this.name = i18next.t(`trainerNames:${nameForCall}`);
     this.setTitle(title);
     this.setMoneyMultiplier(2.5);
@@ -1159,6 +1145,7 @@ export class TrainerConfig {
     this.setStaticParty();
     this.setHasVoucher(true);
     this.setBattleBgm("battle_plasma_boss");
+    this.setMixedBattleBgm(mixedBattleBgm);
     this.setVictoryBgm("victory_team_plasma");
 
     return this;


### PR DESCRIPTION
## What are the changes the user will see?

None

## Why am I making these changes?

While refactoring #315 I also noticed there was a lot of duplicated code relating to the `trainer-config.initForEvilTeamLeader` function

## What are the changes from a developer perspective?

* Deleted unused and duplicated code
* Moved magic strings in `evil-boss-trainer-configs` into consts

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/4c3289f7-9e1f-490c-928e-ab0241a24ffd)
Music and localization still work

## How to test the changes?

```ts
const overrides = {
  STARTING_WAVE_OVERRIDE:165,
}
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
