### PR TITLE
[Refactor] Future-proof `allMoves` to accommodate non-sequential `Moves` enum values

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1213,7 +1213,7 @@ export default class BattleScene extends SceneBase {
     if (reloadI18n) {
       const localizable: Localizable[] = [
         ...allSpecies,
-        ...allMoves,
+        ...Object.values(allMoves),
         ...allAbilities,
         ...getEnumValues(ModifierPoolType)
           .map((mpt) => getModifierPoolForType(mpt))

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -245,10 +245,11 @@ import { ArenaTagRelativeSide } from "#enums/arena-tag-relative-side";
 import { NoDamageAgainstFlyingAttr } from "./move-attrs/no-damage-against-flying-attr";
 import { SkyDropAttr } from "./move-attrs/sky-drop-attr";
 
-export const allMoves: Move[] = [];
+// Initialized as being empty; it will be filled during `initMoves()`
+export const allMoves: { [moveId in Moves]: Move } = {} as any;
 
 export function initMoves() {
-  allMoves.push(
+  const rawAllMoves = [
     new SelfStatusMove(Moves.NONE, Type.NORMAL, MoveCategory.STATUS, -1, -1, 0, 1),
     new AttackMove(Moves.POUND, Type.NORMAL, MoveCategory.PHYSICAL, 40, 100, 35, -1, 0, 1),
     new AttackMove(Moves.KARATE_CHOP, Type.FIGHTING, MoveCategory.PHYSICAL, 50, 100, 25, -1, 0, 1).attr(HighCritAttr),
@@ -3699,10 +3700,13 @@ export function initMoves() {
       StatusEffectAttr,
       StatusEffect.TOXIC,
     ),
-  );
-  allMoves.map((m) => {
-    if (m.getAttrs(StatStageChangeAttr).some((a) => a.selfTarget && a.stages < 0)) {
-      selfStatLowerMoves.push(m.id);
+  ];
+
+  for (const move of rawAllMoves) {
+    // Make sure `allMoves` assigns correct ID to every move, and check if the move is a self-stat-lowering move
+    allMoves[move.id] = move;
+    if (move.getAttrs(StatStageChangeAttr).some((a) => a.selfTarget && a.stages < 0)) {
+      selfStatLowerMoves.push(move.id);
     }
-  });
+  }
 }

--- a/src/data/balance/egg-moves.ts
+++ b/src/data/balance/egg-moves.ts
@@ -592,7 +592,7 @@ function parseEggMoves(content: string): void {
 
   lines.forEach((line, _l) => {
     const cols = line.split(",").slice(0, 5);
-    const moveNames = allMoves.map((m) => m.name.replace(/ \([A-Z]\)$/, "").toLowerCase());
+    const moveNames = Object.values(allMoves).map((m) => m.name.replace(/ \([A-Z]\)$/, "").toLowerCase());
     const enumSpeciesName = cols[0].toUpperCase().replace(/[ -]/g, "_");
     const species = speciesValues[speciesNames.findIndex((s) => s === enumSpeciesName)];
 

--- a/test/testUtils/testFileInitialization.ts
+++ b/test/testUtils/testFileInitialization.ts
@@ -79,7 +79,7 @@ export function initTestFile() {
   HTMLCanvasElement.prototype.getContext = () => mockContext;
 
   // Initialize all of these things if and only if they have not been initialized yet
-  if (allMoves.length === 0) {
+  if (Object.values(allMoves).length === 0) {
     initMoves();
     initVouchers();
     initAchievements();


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

None, hopefully.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

These changes should help to accommodate assigning non-sequential `Moves` enum values (e.g., negative values, or large positive values) for moves which are outside the [main list of moves](https://bulbapedia.bulbagarden.net/wiki/List_of_moves#List_of_moves) (e.g., G-Max Moves). This feature came up while discussing ~~#283~~ #294.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

`allMoves` is now an object whose keys are the move ID's (following the `Moves` enum) and whose values are the actual moves. This allows the `allMoves[Moves.SOMETHING]` pattern to keep working correctly.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Mess around with the `Moves` enum. Moves should still work correctly in-game, and the tests (expect for `all_moves.test.ts`) should still pass.

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
