### PR TITLE
[Bug] Fix certain DoT anims showing on wrong side

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -848,7 +848,7 @@ export default class BattleScene extends SceneBase {
    * This function is allowed to return non-active (e.g., fainted) Pokemon.
    * @param battlerIndex The battler index to search for.
    */
-  public getFieldPokemonByBattlerIndex(battlerIndex: BattlerIndex): Pokemon | undefined {
+  public getFieldPokemonByBattlerIndex(battlerIndex?: BattlerIndex): Pokemon | undefined {
     return this.getField().find((p) => p.getBattlerIndex() === battlerIndex);
   }
 

--- a/src/phases/common-anim-phase.ts
+++ b/src/phases/common-anim-phase.ts
@@ -2,6 +2,7 @@ import type { BattlerIndex } from "#enums/battler-index";
 import type { CommonAnim } from "#app/data/battle-anims";
 import { CommonBattleAnim } from "#app/data/battle-anims";
 import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
+import { globalScene } from "#app/global-scene";
 
 /**
  * Plays a {@linkcode CommonBattleAnim}
@@ -23,8 +24,9 @@ export class CommonAnimPhase extends PokemonPhase {
   }
 
   public override start(): void {
-    const target = this.targetIndex !== undefined ? this.getOpposingField()[this.targetIndex] : this.getPokemon();
-    new CommonBattleAnim(this.anim, this.getPokemon(), target).play(false, () => {
+    const user = this.getPokemon();
+    const target = globalScene.getFieldPokemonByBattlerIndex(this.targetIndex) ?? user;
+    new CommonBattleAnim(this.anim, user, target).play(false, () => {
       this.end();
     });
   }


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

If the player's Pokemon gets damaged by certain DoT effects (e.g., Salt Cure), the animation now plays on the player's Pokemon instead of the enemy Pokemon.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->
Bug discovered while testing #294.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

In CommonAnimPhase, `targetIndex` is a `BattlerIndex` instead of a `FieldIndex`. So, I have changed it to properly search for the target Pokemon by its battler index.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details>
<summary> Before the changes: Salt Cure's DoT anim plays on the enemy even when damaging the player </summary>

https://github.com/user-attachments/assets/3d152927-5d86-4da5-ba5c-59d8e5ed8c50

</details>
<details>
<summary> After the changes: Salt Cure's DoT anim plays on the player Pokemon when damaging the player </summary>

https://github.com/user-attachments/assets/6cdf6d6e-a896-4363-910f-6af3b98da601

</details>

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->
Let the opponent use moves such as Salt Cure, Curse, Attract, etc.

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?