### PR TITLE
[P2] Fire+Grass pledge should not damage magic guard

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1318,6 +1318,12 @@ class FireGrassPledgeTag extends ArenaTag {
     field
       .filter((pokemon) => !pokemon.isOfType(Type.FIRE) && !pokemon.switchOutStatus)
       .forEach((pokemon) => {
+        const cancelled = new BooleanHolder(false);
+        applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
+        if (cancelled.value) {
+          return;
+        }
+
         // "{pokemonNameWithAffix} was hurt by the sea of fire!"
         globalScene.queueMessage(
           i18next.t("arenaTag:fireGrassPledgeLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),

--- a/test/moves/pledge_moves.test.ts
+++ b/test/moves/pledge_moves.test.ts
@@ -138,6 +138,29 @@ describe("Moves - Pledge Moves", () => {
     enemyPokemon.forEach((p, i) => expect(enemyStartingHp[i] - p.hp).toBe(toDmgValue(p.getMaxHp() / 8)));
   });
 
+  it("Sea of fire should not damage magic guard", async () => {
+    game.override.enemyAbility(Abilities.MAGIC_GUARD);
+    await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
+
+    const enemyPokemon = game.scene.getEnemyField();
+
+    game.move.select(Moves.FIRE_PLEDGE, 0, BattlerIndex.ENEMY_2);
+    game.move.select(Moves.GRASS_PLEDGE, 1, BattlerIndex.ENEMY);
+
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+    // advance to the end of PLAYER_2's move this turn
+    for (let i = 0; i < 2; i++) {
+      await game.phaseInterceptor.to("MoveEndPhase");
+    }
+
+    expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
+    expect(game.scene.arena.getTagOnSide(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+
+    const enemyStartingHp = enemyPokemon.map((p) => p.hp);
+    await game.toNextTurn();
+    enemyPokemon.forEach((p, i) => expect(enemyStartingHp[i] - p.hp).toBe(0));
+  });
+
   it("Fire Pledge - should combine with Water Pledge to form a 150-power Water-type attack that creates a 'rainbow'", async () => {
     game.override.moveset([Moves.FIRE_PLEDGE, Moves.WATER_PLEDGE, Moves.FIERY_DANCE, Moves.SPLASH]);
 


### PR DESCRIPTION
## What are the changes the user will see?

The sea of fire from fire+grass pledge will no longer damage magic guard

## Why am I making these changes?

Bug discovered by PigeonBar in #294

## What are the changes from a developer perspective?

* Added a check for magic guard
```ts
const cancelled = new BooleanHolder(false);
    applyAbAttrs(BlockNonDirectDamageAbAttr, pokemon, false, cancelled);
    if (cancelled.value) {
      return;
    }
```
* Updated test

## Screenshots/Videos

n/a

## How to test the changes?

`npm run test pledge_moves`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
