### PR TITLE
[Move] Add sharp steel

### DIFF
--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -3305,9 +3305,10 @@ export function initMoves() {
     new AttackMove(Moves.G_MAX_MALODOR, Type.POISON, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),
-    new AttackMove(Moves.G_MAX_STONESURGE, Type.WATER, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
-      .target(MoveTarget.ALL_NEAR_ENEMIES)
-      .unimplemented(),
+    new AttackMove(Moves.G_MAX_STONESURGE, Type.WATER, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8).attr(
+      AddArenaTrapTagHitAttr,
+      ArenaTagType.STEALTH_ROCK,
+    ),
     new AttackMove(Moves.G_MAX_WIND_RAGE, Type.FLYING, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -3342,9 +3342,10 @@ export function initMoves() {
     new AttackMove(Moves.G_MAX_SMITE, Type.FAIRY, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),
-    new AttackMove(Moves.G_MAX_STEELSURGE, Type.STEEL, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
-      .target(MoveTarget.ALL_NEAR_ENEMIES)
-      .unimplemented(),
+    new AttackMove(Moves.G_MAX_STEELSURGE, Type.STEEL, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8).attr(
+      AddArenaTrapTagHitAttr,
+      ArenaTagType.SHARP_STEEL,
+    ),
     new AttackMove(Moves.G_MAX_MELTDOWN, Type.STEEL, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -925,13 +925,28 @@ export class DelayedAttackTag extends ArenaTag {
 }
 
 /**
- * Arena Tag class for {@link https://bulbapedia.bulbagarden.net/wiki/Stealth_Rock_(move) Stealth Rock}.
- * Applies up to 1 layer of Stealth Rocks, dealing percentage-based damage to any Pokémon
- * who is summoned into the trap, based on the Rock type's type effectiveness.
+ * Class used for hazards that damage based on type. The two existing ones are
+ * Stealth rock (produced by stealth rock and stone axe) and
+ * Sharp steel (produced by G-Max steelsurge)
  */
-class StealthRockTag extends ArenaTrapTag {
-  constructor(sourceId: number, side: ArenaTagSide) {
-    super(ArenaTagType.STEALTH_ROCK, Moves.STEALTH_ROCK, sourceId, side, 1);
+class TypeHazardTag extends ArenaTrapTag {
+  public damagingType: Type;
+  public onAddKey: string;
+  public activateTrapKey: string;
+
+  constructor(
+    arenaTagType: ArenaTagType,
+    damagingType: Type,
+    sourceId: number,
+    side: ArenaTagSide,
+    sourceMove: Moves,
+    onAddKey: string,
+    activateTrapKey: string,
+  ) {
+    super(arenaTagType, sourceMove, sourceId, side, 1);
+    this.damagingType = damagingType;
+    this.onAddKey = onAddKey;
+    this.activateTrapKey = activateTrapKey;
   }
 
   override onAdd(arena: Arena, quiet: boolean = false): void {
@@ -939,39 +954,13 @@ class StealthRockTag extends ArenaTrapTag {
 
     const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
     if (!quiet && source) {
-      globalScene.queueMessage(
-        i18next.t("arenaTag:stealthRockOnAdd", { opponentDesc: source.getOpponentDescriptor() }),
-      );
+      globalScene.queueMessage(i18next.t(this.onAddKey, { opponentDesc: source.getOpponentDescriptor() }));
     }
   }
 
   getDamageHpRatio(pokemon: Pokemon): number {
-    const effectiveness = pokemon.getAttackTypeEffectiveness(Type.ROCK, undefined, true);
-
-    let damageHpRatio: number = 0;
-
-    switch (effectiveness) {
-      case 0:
-        damageHpRatio = 0;
-        break;
-      case 0.25:
-        damageHpRatio = 0.03125;
-        break;
-      case 0.5:
-        damageHpRatio = 0.0625;
-        break;
-      case 1:
-        damageHpRatio = 0.125;
-        break;
-      case 2:
-        damageHpRatio = 0.25;
-        break;
-      case 4:
-        damageHpRatio = 0.5;
-        break;
-    }
-
-    return damageHpRatio;
+    const effectiveness = pokemon.getAttackTypeEffectiveness(this.damagingType, undefined, true);
+    return effectiveness * 0.125;
   }
 
   override activateTrap(pokemon: Pokemon, simulated: boolean): boolean {
@@ -990,7 +979,7 @@ class StealthRockTag extends ArenaTrapTag {
       }
       const damage = toDmgValue(pokemon.getMaxHp() * damageHpRatio);
       globalScene.queueMessage(
-        i18next.t("arenaTag:stealthRockActivateTrap", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
+        i18next.t(this.activateTrapKey, { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       );
       pokemon.damageAndUpdate(damage, HitResult.OTHER);
       if (pokemon.turnData) {
@@ -1005,6 +994,34 @@ class StealthRockTag extends ArenaTrapTag {
   override getMatchupScoreMultiplier(pokemon: Pokemon): number {
     const damageHpRatio = this.getDamageHpRatio(pokemon);
     return Phaser.Math.Linear(super.getMatchupScoreMultiplier(pokemon), 1, 1 - Math.pow(damageHpRatio, damageHpRatio));
+  }
+}
+
+class StealthRockTag extends TypeHazardTag {
+  constructor(sourceId: number, side: ArenaTagSide) {
+    super(
+      ArenaTagType.STEALTH_ROCK,
+      Type.ROCK,
+      sourceId,
+      side,
+      Moves.STEALTH_ROCK,
+      "arenaTag:stealthRockOnAdd",
+      "arenaTag:stealthRockActivateTrap",
+    );
+  }
+}
+
+class SharpSteelTag extends TypeHazardTag {
+  constructor(sourceId: number, side: ArenaTagSide) {
+    super(
+      ArenaTagType.SHARP_STEEL,
+      Type.STEEL,
+      sourceId,
+      side,
+      Moves.G_MAX_STEELSURGE,
+      "arenaTag:sharpSteelOnAdd",
+      "arenaTag:sharpSteelActivateTrap",
+    );
   }
 }
 
@@ -1583,6 +1600,8 @@ export function getArenaTag(
         side,
         Type.ROCK,
       );
+    case ArenaTagType.SHARP_STEEL:
+      return new SharpSteelTag(sourceId, side);
     default:
       return null;
   }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -930,9 +930,9 @@ export class DelayedAttackTag extends ArenaTag {
  * Sharp steel (produced by G-Max steelsurge)
  */
 class TypeHazardTag extends ArenaTrapTag {
-  public damagingType: Type;
-  public onAddKey: string;
-  public activateTrapKey: string;
+  public readonly damagingType: Type;
+  public readonly onAddKey: string;
+  public readonly activateTrapKey: string;
 
   constructor(
     arenaTagType: ArenaTagType,

--- a/src/data/move-attrs/remove-arena-trap-attr.ts
+++ b/src/data/move-attrs/remove-arena-trap-attr.ts
@@ -10,7 +10,13 @@ import { RemoveArenaTagsAttr } from "./remove-arena-tags-attr";
 export class RemoveArenaTrapAttr extends RemoveArenaTagsAttr {
   constructor(targetBothSides: boolean = false) {
     super(
-      [ArenaTagType.SPIKES, ArenaTagType.TOXIC_SPIKES, ArenaTagType.STEALTH_ROCK, ArenaTagType.STICKY_WEB],
+      [
+        ArenaTagType.SPIKES,
+        ArenaTagType.TOXIC_SPIKES,
+        ArenaTagType.STEALTH_ROCK,
+        ArenaTagType.STICKY_WEB,
+        ArenaTagType.SHARP_STEEL,
+      ],
       targetBothSides ? ArenaTagRelativeSide.ALL : ArenaTagRelativeSide.USER,
     );
   }

--- a/src/data/move-attrs/swap-arena-tags-attr.ts
+++ b/src/data/move-attrs/swap-arena-tags-attr.ts
@@ -14,6 +14,7 @@ export const courtChangeArenaTags = [
   ArenaTagType.REFLECT,
   ArenaTagType.SPIKES,
   ArenaTagType.STEALTH_ROCK,
+  ArenaTagType.SHARP_STEEL,
   ArenaTagType.STICKY_WEB,
   ArenaTagType.TAILWIND,
   ArenaTagType.TOXIC_SPIKES,

--- a/src/enums/arena-tag-type.ts
+++ b/src/enums/arena-tag-type.ts
@@ -32,4 +32,5 @@ export enum ArenaTagType {
   G_MAX_WILDFIRE,
   G_MAX_CANNONADE,
   G_MAX_VOLCALITH,
+  SHARP_STEEL,
 }

--- a/test/arena/type_hazard.test.ts
+++ b/test/arena/type_hazard.test.ts
@@ -1,0 +1,111 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { toDmgValue } from "#app/utils";
+
+describe("Arena - Type Hazards", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .moveset([Moves.STEALTH_ROCK, Moves.G_MAX_STEELSURGE, Moves.ROAR, Moves.SPLASH])
+      .enemyMoveset(Moves.SPLASH)
+      .enemySpecies(Species.RAMPARDOS);
+  });
+
+  it("should not damage the team that set them", async () => {
+    await game.classicMode.startBattle([Species.ABRA, Species.ABRA]);
+
+    game.move.select(Moves.STEALTH_ROCK);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    const player = game.scene.getPlayerParty()[0];
+    expect(player.hp).toBe(player.getMaxHp());
+  }, 20000);
+
+  it("should damage opposing pokemon that are forced to switch in", async () => {
+    game.override.startingWave(5);
+    await game.classicMode.startBattle([Species.ABRA, Species.ABRA]);
+
+    game.move.select(Moves.STEALTH_ROCK);
+    await game.toNextTurn();
+
+    game.move.select(Moves.ROAR);
+    await game.toNextTurn();
+
+    const enemy = game.scene.getEnemyParty()[0];
+    const damage = enemy.getMaxHp() - enemy.hp;
+    expect(damage).toBe(toDmgValue(enemy.getMaxHp() / 8));
+  }, 20000);
+
+  it("should damage opposing pokemon that choose to switch in", async () => {
+    game.override.startingWave(5);
+    await game.classicMode.startBattle([Species.ABRA, Species.ABRA]);
+
+    game.move.select(Moves.STEALTH_ROCK);
+    await game.toNextTurn();
+
+    game.move.select(Moves.SPLASH);
+    game.forceEnemyToSwitch();
+    await game.toNextTurn();
+
+    const enemy = game.scene.getEnemyParty()[0];
+    const damage = enemy.getMaxHp() - enemy.hp;
+    expect(damage).toBe(toDmgValue(enemy.getMaxHp() / 8));
+  }, 20000);
+
+  it("should not damage opposing pokemon with magic guard", async () => {
+    game.override.startingWave(5);
+    game.override.enemyAbility(Abilities.MAGIC_GUARD);
+    await game.classicMode.startBattle([Species.ABRA, Species.ABRA]);
+
+    game.move.select(Moves.STEALTH_ROCK);
+    await game.toNextTurn();
+
+    game.move.select(Moves.SPLASH);
+    game.forceEnemyToSwitch();
+    await game.toNextTurn();
+
+    const enemy = game.scene.getEnemyParty()[0];
+    const damage = enemy.getMaxHp() - enemy.hp;
+    expect(damage).toBe(0);
+  }, 20000);
+
+  it("should respect type matchups", async () => {
+    game.override.startingWave(5);
+    await game.classicMode.startBattle([Species.ABRA, Species.ABRA]);
+
+    game.move.select(Moves.G_MAX_STEELSURGE);
+    await game.toNextTurn();
+
+    game.move.select(Moves.SPLASH);
+    game.forceEnemyToSwitch();
+    await game.toNextTurn();
+
+    const enemy = game.scene.getEnemyParty()[0];
+    const damage = enemy.getMaxHp() - enemy.hp;
+    expect(damage).toBe(toDmgValue(enemy.getMaxHp() / 4));
+  }, 20000);
+});


### PR DESCRIPTION
## What are the changes the user will see?

None

## Why am I making these changes?

See #283

## What are the changes from a developer perspective?

* Created a new `enums/arena-tag-type`
* Created a new `TypeHazardTag` in `arena-tag` and refactored `StealthRockTag`
* Created a test for `arena/type_hazard`

## Screenshots/Videos

n/a

## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: [Moves.STEALTH_ROCK, Moves.G_MAX_STEELSURGE, Moves.ROAR]
}
```

`npm run test type_hazard`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [x] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/Despair-Games/poketernity-locales/pull/19
- [ ] Has the translation team been contacted for proofreading/translation?
