### PR TITLE
[Move] Add attr for changing stats of all opps

### DIFF
--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -244,6 +244,7 @@ import { crashDamageFunc, frenzyMissFunc } from "./move-utils";
 import { ArenaTagRelativeSide } from "#enums/arena-tag-relative-side";
 import { NoDamageAgainstFlyingAttr } from "./move-attrs/no-damage-against-flying-attr";
 import { SkyDropAttr } from "./move-attrs/sky-drop-attr";
+import { StatStageChangeAllOppsAttr } from "./move-attrs/stat-stage-change-all-opps";
 
 // Initialized as being empty; it will be filled during `initMoves()`
 export const allMoves: { [moveId in Moves]: Move } = {} as any;
@@ -3333,9 +3334,11 @@ export function initMoves() {
     new AttackMove(Moves.G_MAX_SNOOZE, Type.DARK, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),
-    new AttackMove(Moves.G_MAX_TARTNESS, Type.GRASS, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
-      .target(MoveTarget.ALL_NEAR_ENEMIES)
-      .unimplemented(),
+    new AttackMove(Moves.G_MAX_TARTNESS, Type.GRASS, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8).attr(
+      StatStageChangeAllOppsAttr,
+      [Stat.EVA],
+      1,
+    ),
     new AttackMove(Moves.G_MAX_SWEETNESS, Type.GRASS, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),
@@ -3348,9 +3351,11 @@ export function initMoves() {
     new AttackMove(Moves.G_MAX_MELTDOWN, Type.STEEL, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),
-    new AttackMove(Moves.G_MAX_FOAM_BURST, Type.WATER, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
-      .target(MoveTarget.ALL_NEAR_ENEMIES)
-      .unimplemented(),
+    new AttackMove(Moves.G_MAX_FOAM_BURST, Type.WATER, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8).attr(
+      StatStageChangeAllOppsAttr,
+      [Stat.SPD],
+      2,
+    ),
     new AttackMove(Moves.G_MAX_CENTIFERNO, Type.FIRE, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .unimplemented(),

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -244,7 +244,7 @@ import { crashDamageFunc, frenzyMissFunc } from "./move-utils";
 import { ArenaTagRelativeSide } from "#enums/arena-tag-relative-side";
 import { NoDamageAgainstFlyingAttr } from "./move-attrs/no-damage-against-flying-attr";
 import { SkyDropAttr } from "./move-attrs/sky-drop-attr";
-import { StatStageChangeAllOppsAttr } from "./move-attrs/stat-stage-change-all-opps";
+import { StatStageChangeAllOppsAttr } from "./move-attrs/stat-stage-change-all-opps-attr";
 
 // Initialized as being empty; it will be filled during `initMoves()`
 export const allMoves: { [moveId in Moves]: Move } = {} as any;
@@ -3337,7 +3337,7 @@ export function initMoves() {
     new AttackMove(Moves.G_MAX_TARTNESS, Type.GRASS, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8).attr(
       StatStageChangeAllOppsAttr,
       [Stat.EVA],
-      1,
+      -1,
     ),
     new AttackMove(Moves.G_MAX_SWEETNESS, Type.GRASS, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)
@@ -3354,7 +3354,7 @@ export function initMoves() {
     new AttackMove(Moves.G_MAX_FOAM_BURST, Type.WATER, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8).attr(
       StatStageChangeAllOppsAttr,
       [Stat.SPD],
-      2,
+      -2,
     ),
     new AttackMove(Moves.G_MAX_CENTIFERNO, Type.FIRE, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.ALL_NEAR_ENEMIES)

--- a/src/data/move-attrs/stat-stage-change-all-opps-attr.ts
+++ b/src/data/move-attrs/stat-stage-change-all-opps-attr.ts
@@ -1,9 +1,7 @@
-import { MoveCategory } from "#enums/move-category";
-import { type BattleStat, Stat } from "#enums/stat";
-import { PlayerPokemon, type Pokemon } from "#app/field/pokemon";
+import { type BattleStat } from "#enums/stat";
+import { type Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
-import { AttackMove } from "../move";
 import type { Move } from "#app/data/move";
 import { type MoveEffectAttrOptions, MoveEffectAttr } from "#app/data/move-attrs/move-effect-attr";
 import type { MoveConditionFunc } from "../move-conditions";
@@ -41,14 +39,10 @@ interface StatStageChangeAllOppsAttrOptions extends MoveEffectAttrOptions {
 export class StatStageChangeAllOppsAttr extends MoveEffectAttr {
   public stats: BattleStat[];
   public stages: number;
-  /**
-   * Container for optional parameters to this attribute.
-   * @see {@linkcode StatStageChangeAttrOptions} for available optional params
-   */
-  protected override options?: StatStageChangeAllOppsAttrOptions;
+  public override options?: StatStageChangeAllOppsAttrOptions;
 
-  constructor(stats: BattleStat[], stages: number, selfTarget?: boolean, options?: StatStageChangeAllOppsAttrOptions) {
-    super(selfTarget, options);
+  constructor(stats: BattleStat[], stages: number, options?: StatStageChangeAllOppsAttrOptions) {
+    super(true, options);
     this.stats = stats;
     this.stages = stages;
     this.options = options;
@@ -78,12 +72,12 @@ export class StatStageChangeAllOppsAttr extends MoveEffectAttr {
     const moveChance = this.getMoveChance(user, target, move, false, true);
     if (moveChance < 0 || moveChance === 100 || user.randSeedInt(100) < moveChance) {
       let allOpps: Pokemon[];
-      if (target instanceof PlayerPokemon) {
+      if (target.isPlayer()) {
         allOpps = globalScene.getPlayerField();
       } else {
         allOpps = globalScene.getEnemyField();
       }
-      allOpps = allOpps.filter((p) => p.isActive);
+      allOpps = allOpps.filter((p) => p.isActive(true));
       allOpps.forEach((opp) =>
         globalScene.unshiftPhase(
           new StatStageChangePhase(opp.getBattlerIndex(), false, this.stats, this.stages, {
@@ -97,7 +91,7 @@ export class StatStageChangeAllOppsAttr extends MoveEffectAttr {
     return false;
   }
 
-  override getTargetBenefitScore(user: Pokemon, target: Pokemon, _move: Move): number {
+  override getTargetBenefitScore(_user: Pokemon, target: Pokemon, _move: Move): number {
     let ret = 0;
     for (const stat of this.stats) {
       let levels = this.stages;
@@ -107,23 +101,7 @@ export class StatStageChangeAllOppsAttr extends MoveEffectAttr {
       } else {
         levels = Math.max(statStage + levels, -6) - statStage;
       }
-      let noEffect = false;
-      switch (stat) {
-        case Stat.ATK:
-          break;
-        case Stat.DEF:
-          noEffect = !user.getMoveset().find((m) => m instanceof AttackMove && m.category === MoveCategory.PHYSICAL);
-          break;
-        case Stat.SPATK:
-          break;
-        case Stat.SPDEF:
-          noEffect = !user.getMoveset().find((m) => m instanceof AttackMove && m.category === MoveCategory.SPECIAL);
-          break;
-      }
-      if (noEffect) {
-        continue;
-      }
-      ret += levels * 4 + (levels > 0 ? -2 : 2);
+      ret += levels * 4 + 2;
     }
     return ret;
   }

--- a/src/data/move-attrs/stat-stage-change-all-opps-attr.ts
+++ b/src/data/move-attrs/stat-stage-change-all-opps-attr.ts
@@ -20,14 +20,14 @@ interface StatStageChangeAllOppsAttrOptions extends MoveEffectAttrOptions {
 
 /**
  * Attribute used for G-Max moves that change the stats of all opponents
- *
+ * ```
  * +-------------+----------+--------+
  * | G-Max Move  |   Stat   | Change |
  * +-------------+----------+--------+
  * | Foam Burst  | Speed    |     -2 |
  * | Tartness    | Evasion  |     -1 |
  * +-------------+----------+--------+
- *
+ * ```
  * @param stats {@linkcode BattleStat} Array of stat(s) to change
  * @param stages How many stages to change the stat(s) by, [-6, 6]
  * @param selfTarget `true` if the move is self-targetting

--- a/src/data/move-attrs/stat-stage-change-all-opps.ts
+++ b/src/data/move-attrs/stat-stage-change-all-opps.ts
@@ -1,0 +1,130 @@
+import { MoveCategory } from "#enums/move-category";
+import { type BattleStat, Stat } from "#enums/stat";
+import { PlayerPokemon, type Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
+import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
+import { AttackMove } from "../move";
+import type { Move } from "#app/data/move";
+import { type MoveEffectAttrOptions, MoveEffectAttr } from "#app/data/move-attrs/move-effect-attr";
+import type { MoveConditionFunc } from "../move-conditions";
+
+/**
+ * Set of optional parameters that may be applied to stat stage changing effects
+ * @extends MoveEffectAttrOptions
+ * @see {@linkcode StatStageChangeAttr}
+ */
+interface StatStageChangeAllOppsAttrOptions extends MoveEffectAttrOptions {
+  /** If defined, needs to be met in order for the stat change to apply */
+  condition?: MoveConditionFunc;
+  /** `true` to display a message */
+  showMessage?: boolean;
+}
+
+/**
+ * Attribute used for G-Max moves that change the stats of all opponents
+ *
+ * +-------------+----------+--------+
+ * | G-Max Move  |   Stat   | Change |
+ * +-------------+----------+--------+
+ * | Foam Burst  | Speed    |     -2 |
+ * | Tartness    | Evasion  |     -1 |
+ * +-------------+----------+--------+
+ *
+ * @param stats {@linkcode BattleStat} Array of stat(s) to change
+ * @param stages How many stages to change the stat(s) by, [-6, 6]
+ * @param selfTarget `true` if the move is self-targetting
+ * @param options {@linkcode StatStageChangeAttrOptions} Container for any optional parameters for this attribute.
+ *
+ * @extends MoveEffectAttr
+ */
+
+export class StatStageChangeAllOppsAttr extends MoveEffectAttr {
+  public stats: BattleStat[];
+  public stages: number;
+  /**
+   * Container for optional parameters to this attribute.
+   * @see {@linkcode StatStageChangeAttrOptions} for available optional params
+   */
+  protected override options?: StatStageChangeAllOppsAttrOptions;
+
+  constructor(stats: BattleStat[], stages: number, selfTarget?: boolean, options?: StatStageChangeAllOppsAttrOptions) {
+    super(selfTarget, options);
+    this.stats = stats;
+    this.stages = stages;
+    this.options = options;
+  }
+
+  /**
+   * The condition required for the stat stage change to apply.
+   * Defaults to `null` (i.e. no condition required).
+   */
+  private get condition() {
+    return this.options?.condition ?? null;
+  }
+
+  /**
+   * `true` to display a message for the stat change.
+   * @default true
+   */
+  private get showMessage() {
+    return this.options?.showMessage ?? true;
+  }
+
+  override apply(user: Pokemon, target: Pokemon, move: Move): boolean {
+    if (this.condition && !this.condition(user, target, move)) {
+      return false;
+    }
+
+    const moveChance = this.getMoveChance(user, target, move, false, true);
+    if (moveChance < 0 || moveChance === 100 || user.randSeedInt(100) < moveChance) {
+      let allOpps: Pokemon[];
+      if (target instanceof PlayerPokemon) {
+        allOpps = globalScene.getPlayerField();
+      } else {
+        allOpps = globalScene.getEnemyField();
+      }
+      allOpps = allOpps.filter((p) => p.isActive);
+      allOpps.forEach((opp) =>
+        globalScene.unshiftPhase(
+          new StatStageChangePhase(opp.getBattlerIndex(), false, this.stats, this.stages, {
+            showMessage: this.showMessage,
+          }),
+        ),
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  override getTargetBenefitScore(user: Pokemon, target: Pokemon, _move: Move): number {
+    let ret = 0;
+    for (const stat of this.stats) {
+      let levels = this.stages;
+      const statStage = target.getStatStage(stat);
+      if (levels > 0) {
+        levels = Math.min(statStage + levels, 6) - statStage;
+      } else {
+        levels = Math.max(statStage + levels, -6) - statStage;
+      }
+      let noEffect = false;
+      switch (stat) {
+        case Stat.ATK:
+          break;
+        case Stat.DEF:
+          noEffect = !user.getMoveset().find((m) => m instanceof AttackMove && m.category === MoveCategory.PHYSICAL);
+          break;
+        case Stat.SPATK:
+          break;
+        case Stat.SPDEF:
+          noEffect = !user.getMoveset().find((m) => m instanceof AttackMove && m.category === MoveCategory.SPECIAL);
+          break;
+      }
+      if (noEffect) {
+        continue;
+      }
+      ret += levels * 4 + (levels > 0 ? -2 : 2);
+    }
+    return ret;
+  }
+}

--- a/test/moves/gmax_opp_stat_stage_change.test.ts
+++ b/test/moves/gmax_opp_stat_stage_change.test.ts
@@ -1,0 +1,92 @@
+import { BattlerIndex } from "#enums/battler-index";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, it, expect } from "vitest";
+import type { EffectiveStat } from "#enums/stat";
+import { Stat } from "#enums/stat";
+
+describe("Moves - G-Max debuff both opponents", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("double")
+      .startingLevel(100)
+      .moveset([Moves.G_MAX_FOAM_BURST, Moves.G_MAX_TARTNESS, Moves.SPLASH])
+      .enemySpecies(Species.HAPPINY)
+      .enemyLevel(1)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it.each([
+    { gmaxMove: Moves.G_MAX_FOAM_BURST, statDropped: Stat.SPD, statChangeAmt: -2 },
+    { gmaxMove: Moves.G_MAX_TARTNESS, statDropped: Stat.EVA, statChangeAmt: -1 },
+  ])("G-Max moves should debuff both opponents", async ({ gmaxMove, statDropped, statChangeAmt }) => {
+    await game.classicMode.startBattle([Species.SUNKERN, Species.SUNKERN]);
+
+    game.move.select(gmaxMove, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.SPLASH, 1);
+
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2]);
+    await game.phaseInterceptor.to("MoveEndPhase", false);
+
+    const enemyParty = game.scene.getEnemyParty();
+    await game.toNextTurn();
+
+    enemyParty.forEach((pokemon) => {
+      if (pokemon.isActive()) {
+        expect(pokemon.getStatStage(statDropped as EffectiveStat)).toBe(statChangeAmt);
+      }
+    });
+  });
+
+  it("G-Max debuff moves should still drop stats through substitute", async () => {
+    game.override.enemyAbility(Abilities.PRANKSTER).enemyMoveset([Moves.SUBSTITUTE]);
+    await game.classicMode.startBattle([Species.SUNKERN, Species.SUNKERN]);
+
+    game.move.select(Moves.G_MAX_FOAM_BURST, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.SPLASH, 1);
+
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2]);
+    await game.phaseInterceptor.to("MoveEndPhase", false);
+
+    const enemyParty = game.scene.getEnemyParty();
+    await game.toNextTurn();
+    enemyParty.forEach((pokemon) => {
+      expect(pokemon.getStatStage(Stat.SPD)).toBe(-2);
+    });
+  });
+
+  it("G-Max debuff moves should not drop stats through clear body", async () => {
+    game.override.enemyAbility(Abilities.CLEAR_BODY).enemyMoveset([Moves.SUBSTITUTE]);
+    await game.classicMode.startBattle([Species.SUNKERN, Species.SUNKERN]);
+
+    game.move.select(Moves.G_MAX_FOAM_BURST, 0, BattlerIndex.ENEMY);
+    game.move.select(Moves.SPLASH, 1);
+
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2]);
+    await game.phaseInterceptor.to("MoveEndPhase", false);
+
+    const enemyParty = game.scene.getEnemyParty();
+    await game.toNextTurn();
+    enemyParty.forEach((pokemon) => {
+      expect(pokemon.getStatStage(Stat.SPD)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

None

## Why am I making these changes?

We did not have an attr for a move that does damage to one target but changes stats for all opponents

## What are the changes from a developer perspective?

* Created `stat-stage-change-all-opps.ts`

## Screenshots/Videos

n/a

## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: [Moves.G_MAX_TARTNESS, Moves.G_MAX_FOAM_BURST]
}
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
