### PR TITLE
[UI] Starter select candy upgrade code cleanup

### DIFF
--- a/src/@types/Settings.ts
+++ b/src/@types/Settings.ts
@@ -1,6 +1,4 @@
 import type { BattleStyle } from "#enums/battle-style";
-import type { CandyUpgradeDisplayMode } from "#enums/candy-upgrade-display";
-import type { CandyUpgradeNotificationMode } from "#enums/candy-upgrade-notification-mode";
 import type { DamageNumbersMode } from "#enums/damage-numbers-mode";
 import type { EaseType } from "#enums/ease-type";
 import type { EggSkipPreference } from "#enums/egg-skip-preference";
@@ -51,8 +49,6 @@ export interface DisplaySettings {
   damageNumbersMode: DamageNumbersMode;
   enableMoveAnimations: boolean;
   showStatsOnLevelUp: boolean;
-  candyUpgradeNotificationMode: CandyUpgradeNotificationMode;
-  candyUpgradeDisplayMode: CandyUpgradeDisplayMode;
   enableMoveInfo: boolean;
   showMovesetFlyout: boolean;
   showArenaFlyout: boolean;

--- a/src/enums/candy-upgrade-display.ts
+++ b/src/enums/candy-upgrade-display.ts
@@ -1,4 +1,0 @@
-export enum CandyUpgradeDisplayMode {
-  ICON,
-  ANIMATION,
-}

--- a/src/enums/candy-upgrade-notification-mode.ts
+++ b/src/enums/candy-upgrade-notification-mode.ts
@@ -1,5 +1,0 @@
-export enum CandyUpgradeNotificationMode {
-  OFF,
-  PASSIVES_ONLY,
-  ON,
-}

--- a/src/system/settings/default-settings.ts
+++ b/src/system/settings/default-settings.ts
@@ -6,8 +6,6 @@ import type {
   UserFacingSettings,
 } from "#app/@types/Settings";
 import { BattleStyle } from "#app/enums/battle-style";
-import { CandyUpgradeDisplayMode } from "#app/enums/candy-upgrade-display";
-import { CandyUpgradeNotificationMode } from "#app/enums/candy-upgrade-notification-mode";
 import { DamageNumbersMode } from "#app/enums/damage-numbers-mode";
 import { EaseType } from "#app/enums/ease-type";
 import { EggSkipPreference } from "#app/enums/egg-skip-preference";
@@ -43,8 +41,6 @@ export const defaultDisplaySettings: DisplaySettings = {
   damageNumbersMode: DamageNumbersMode.OFF,
   enableMoveAnimations: true,
   showStatsOnLevelUp: true,
-  candyUpgradeNotificationMode: CandyUpgradeNotificationMode.ON,
-  candyUpgradeDisplayMode: CandyUpgradeDisplayMode.ICON,
   enableMoveInfo: true,
   showMovesetFlyout: true,
   showArenaFlyout: true,

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -4,10 +4,11 @@ import { addWindow, WindowVariant } from "./ui-theme";
 import i18next from "i18next";
 
 export enum DropDownState {
-  ON = 0,
-  OFF = 1,
-  EXCLUDE = 2,
-  UNLOCKABLE = 3,
+  ON,
+  OFF,
+  EXCLUDE,
+  UNLOCKABLE,
+  PARTIAL,
 }
 
 export enum DropDownType {
@@ -51,6 +52,7 @@ export class DropDownOption extends Phaser.GameObjects.Container {
   private currentLabelIndex: number;
   private labels: DropDownLabel[];
   private onColor = 0x33bbff;
+  private partialColor = 0xffff00;
   private offColor = 0x272727;
   private excludeColor = 0xff5555;
   private unlockableColor = 0xffff00;
@@ -124,6 +126,9 @@ export class DropDownOption extends Phaser.GameObjects.Container {
         break;
       case DropDownState.UNLOCKABLE:
         this.toggle.setTint(this.unlockableColor);
+        break;
+      case DropDownState.PARTIAL:
+        this.toggle.setTint(this.partialColor);
         break;
     }
   }

--- a/src/ui/settings/settings-ui-items.ts
+++ b/src/ui/settings/settings-ui-items.ts
@@ -7,8 +7,6 @@ import type {
 } from "#app/@types/Settings";
 import { GAME_SPEEDS } from "#app/constants";
 import { BattleStyle } from "#app/enums/battle-style";
-import { CandyUpgradeDisplayMode } from "#app/enums/candy-upgrade-display";
-import { CandyUpgradeNotificationMode } from "#app/enums/candy-upgrade-notification-mode";
 import { DamageNumbersMode } from "#app/enums/damage-numbers-mode";
 import { EaseType } from "#app/enums/ease-type";
 import { EggSkipPreference } from "#app/enums/egg-skip-preference";
@@ -243,24 +241,6 @@ export const displaySettingUiItems: SettingsUiItem<DisplaySettingsKey>[] = [
     key: "showStatsOnLevelUp",
     label: t("settings:showStatsOnLevelUp"),
     options: useOnOffOptions(),
-  },
-  {
-    key: "candyUpgradeNotificationMode",
-    label: t("settings:candyUpgradeNotification"),
-    options: [
-      { value: CandyUpgradeNotificationMode.OFF, label: t("settings:off") },
-      { value: CandyUpgradeNotificationMode.PASSIVES_ONLY, label: t("settings:passivesOnly") },
-      { value: CandyUpgradeNotificationMode.ON, label: t("settings:on") },
-    ],
-  },
-  {
-    key: "candyUpgradeDisplayMode",
-    label: t("settings:candyUpgradeDisplay"),
-    options: [
-      { value: CandyUpgradeDisplayMode.ICON, label: t("settings:icon") },
-      { value: CandyUpgradeDisplayMode.ANIMATION, label: t("settings:animation") },
-    ],
-    requiresReload: true,
   },
   {
     key: "enableMoveInfo",

--- a/src/ui/starter-container.ts
+++ b/src/ui/starter-container.ts
@@ -11,8 +11,6 @@ export class StarterContainer extends Phaser.GameObjects.Container {
   public hiddenAbilityIcon: Phaser.GameObjects.Image;
   public favoriteIcon: Phaser.GameObjects.Image;
   public classicWinIcon: Phaser.GameObjects.Image;
-  public candyUpgradeIcon: Phaser.GameObjects.Image;
-  public candyUpgradeOverlayIcon: Phaser.GameObjects.Image;
   public cost: number = 0;
 
   constructor(species: PokemonSpecies) {
@@ -87,25 +85,9 @@ export class StarterContainer extends Phaser.GameObjects.Container {
     classicWinIcon.setVisible(false);
     this.add(classicWinIcon);
     this.classicWinIcon = classicWinIcon;
-
-    // candy upgrade icon
-    const candyUpgradeIcon = globalScene.add.image(12, 12, "candy");
-    candyUpgradeIcon.setOrigin(0, 0);
-    candyUpgradeIcon.setScale(0.25);
-    candyUpgradeIcon.setVisible(false);
-    this.add(candyUpgradeIcon);
-    this.candyUpgradeIcon = candyUpgradeIcon;
-
-    // candy upgrade overlay icon
-    const candyUpgradeOverlayIcon = globalScene.add.image(12, 12, "candy_overlay");
-    candyUpgradeOverlayIcon.setOrigin(0, 0);
-    candyUpgradeOverlayIcon.setScale(0.25);
-    candyUpgradeOverlayIcon.setVisible(false);
-    this.add(candyUpgradeOverlayIcon);
-    this.candyUpgradeOverlayIcon = candyUpgradeOverlayIcon;
   }
 
-  checkIconId(female, formIndex, shiny, variant) {
+  checkIconId(female: boolean, formIndex?: number, shiny?: boolean, variant?: number) {
     if (this.icon.frame.name !== this.species.getIconId(female, formIndex, shiny, variant)) {
       console.log(`${this.species.name}'s variant icon does not exist. Replacing with default.`);
       this.icon.setTexture(this.species.getIconAtlasKey(formIndex, false, variant));

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -484,6 +484,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     const costReductionLabels = [
       new DropDownLabel(i18next.t("filterBar:costReduction"), undefined, DropDownState.OFF),
+      new DropDownLabel(i18next.t("filterBar:costReductionPartiallyUnlocked"), undefined, DropDownState.PARTIAL),
       new DropDownLabel(i18next.t("filterBar:costReductionUnlocked"), undefined, DropDownState.ON),
       new DropDownLabel(i18next.t("filterBar:costReductionUnlockable"), undefined, DropDownState.UNLOCKABLE),
       new DropDownLabel(i18next.t("filterBar:costReductionLocked"), undefined, DropDownState.EXCLUDE),
@@ -2708,10 +2709,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
       // Cost Reduction Filter
       const isCostReduced = starterData.valueReduction > 0;
+      const isCostFullyReduced = starterData.valueReduction === valueReductionMax;
       const isCostReductionUnlockable = this.isValueReductionAvailable(container.species.speciesId);
       const fitsCostReduction = this.filterBar.getVals(DropDownColumn.UNLOCKS).some((unlocks) => {
         if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.ON) {
-          return isCostReduced;
+          return isCostFullyReduced;
+        } else if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.PARTIAL) {
+          return isCostReduced && !isCostFullyReduced;
         } else if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.EXCLUDE) {
           return isStarterProgressable && !isCostReduced;
         } else if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.UNLOCKABLE) {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -70,7 +70,6 @@ import {
   isNullOrUndefined,
   NumberHolder,
   padInt,
-  randIntRange,
   rgbHexToRgba,
   toReadableString,
 } from "#app/utils";
@@ -78,10 +77,6 @@ import type { Nature } from "#enums/nature";
 import { PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import { ChallengeType } from "#enums/challenge-type";
 import { settings } from "#app/system/settings/settings-manager";
-import { CandyUpgradeNotificationMode } from "#app/enums/candy-upgrade-notification-mode";
-import { CandyUpgradeDisplayMode } from "#app/enums/candy-upgrade-display";
-import type { SettingsUpdateEventArgs } from "#app/@types/Settings";
-import { eventBus } from "#app/event-bus";
 
 export type StarterSelectCallback = (starters: Starter[]) => void;
 
@@ -717,7 +712,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     const starterSpecies: Species[] = [];
 
-    const starterBoxContainer = globalScene.add.container(speciesContainerX + 6, 9); //115
+    const starterBoxContainer = globalScene.add.container(speciesContainerX + 6, 9);
 
     this.starterSelectScrollBar = new ScrollBar(161, 12, 5, starterContainerWindow.height - 6, 9);
 
@@ -1091,12 +1086,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.initTutorialOverlay(this.starterSelectContainer);
     this.starterSelectContainer.bringToTop(this.starterSelectMessageBoxContainer);
 
-    eventBus.on("settings/updated", ({ key, value }: SettingsUpdateEventArgs) => {
-      if (key === "candyUpgradeDisplayMode" && typeof value === "number") {
-        this.onCandyUpgradeDisplayChanged();
-      }
-    });
-
     this.updateInstructions();
   }
 
@@ -1126,8 +1115,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         } else if (dexEntry.seenAttr) {
           icon.setTint(0x808080);
         }
-
-        this.setUpgradeAnimation(icon, species);
       });
 
       this.resetFilters();
@@ -1286,27 +1273,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   }
 
   /**
-   * Determines if 'Icon' based upgrade notifications should be shown
-   * @returns true if upgrade notifications are enabled and set to display an 'Icon'
-   */
-  isUpgradeIconEnabled(): boolean {
-    return (
-      settings.display.candyUpgradeNotificationMode !== CandyUpgradeNotificationMode.OFF
-      && settings.display.candyUpgradeDisplayMode === CandyUpgradeDisplayMode.ICON
-    );
-  }
-  /**
-   * Determines if 'Animation' based upgrade notifications should be shown
-   * @returns true if upgrade notifications are enabled and set to display an 'Animation'
-   */
-  isUpgradeAnimationEnabled(): boolean {
-    return (
-      settings.display.candyUpgradeNotificationMode !== CandyUpgradeNotificationMode.OFF
-      && settings.display.candyUpgradeDisplayMode === CandyUpgradeDisplayMode.ANIMATION
-    );
-  }
-
-  /**
    * Determines if a passive upgrade is available for the given species ID
    * @param speciesId The ID of the species to check the passive of
    * @returns true if the user has enough candies and a passive has not been unlocked already
@@ -1346,134 +1312,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     const starterData = globalScene.gameData.starterData[speciesId];
 
     return starterData.candyCount >= getSameSpeciesEggCandyCounts(speciesStarterCosts[speciesId]);
-  }
-
-  /**
-   * Sets a bounce animation if enabled and the Pokemon has an upgrade
-   * @param icon {@linkcode Phaser.GameObjects.GameObject} to animate
-   * @param species {@linkcode PokemonSpecies} of the icon used to check for upgrades
-   * @param startPaused Should this animation be paused after it is added?
-   */
-  setUpgradeAnimation(icon: Phaser.GameObjects.Sprite, species: PokemonSpecies, startPaused: boolean = false): void {
-    globalScene.tweens.killTweensOf(icon);
-    // Skip animations if they are disabled
-    if (
-      settings.display.candyUpgradeDisplayMode === CandyUpgradeDisplayMode.ICON
-      || species.speciesId !== species.getRootSpeciesId(false)
-    ) {
-      return;
-    }
-
-    icon.y = 2;
-
-    const tweenChain: Phaser.Types.Tweens.TweenChainBuilderConfig = {
-      targets: icon,
-      loop: -1,
-      // Make the initial bounce a little randomly delayed
-      delay: randIntRange(0, 50) * 5,
-      loopDelay: 1000,
-      tweens: [
-        {
-          targets: icon,
-          y: 2 - 5,
-          duration: fixedNumber(125),
-          ease: "Cubic.easeOut",
-          yoyo: true,
-        },
-        {
-          targets: icon,
-          y: 2 - 3,
-          duration: fixedNumber(150),
-          ease: "Cubic.easeOut",
-          yoyo: true,
-        },
-      ],
-    };
-
-    const isPassiveAvailable = this.isPassiveAvailable(species.speciesId);
-    const isValueReductionAvailable = this.isValueReductionAvailable(species.speciesId);
-    const isSameSpeciesEggAvailable = this.isSameSpeciesEggAvailable(species.speciesId);
-
-    // 'Passives Only' mode
-    if (settings.display.candyUpgradeNotificationMode === CandyUpgradeNotificationMode.PASSIVES_ONLY) {
-      if (isPassiveAvailable) {
-        globalScene.tweens.chain(tweenChain).paused = startPaused;
-      }
-      // 'On' mode
-    } else if (settings.display.candyUpgradeNotificationMode === CandyUpgradeNotificationMode.ON) {
-      if (isPassiveAvailable || isValueReductionAvailable || isSameSpeciesEggAvailable) {
-        globalScene.tweens.chain(tweenChain).paused = startPaused;
-      }
-    }
-  }
-
-  /**
-   * Sets the visibility of a Candy Upgrade Icon
-   */
-  setUpgradeIcon(starter: StarterContainer): void {
-    const species = starter.species;
-    const slotVisible = !!species?.speciesId;
-
-    if (
-      !species
-      || settings.display.candyUpgradeNotificationMode === CandyUpgradeNotificationMode.OFF
-      || species.speciesId !== species.getRootSpeciesId(false)
-    ) {
-      starter.candyUpgradeIcon.setVisible(false);
-      starter.candyUpgradeOverlayIcon.setVisible(false);
-      return;
-    }
-
-    const isPassiveAvailable = this.isPassiveAvailable(species.speciesId);
-    const isValueReductionAvailable = this.isValueReductionAvailable(species.speciesId);
-    const isSameSpeciesEggAvailable = this.isSameSpeciesEggAvailable(species.speciesId);
-
-    // 'Passive Only' mode
-    if (settings.display.candyUpgradeNotificationMode === CandyUpgradeNotificationMode.PASSIVES_ONLY) {
-      starter.candyUpgradeIcon.setVisible(slotVisible && isPassiveAvailable);
-      starter.candyUpgradeOverlayIcon.setVisible(slotVisible && starter.candyUpgradeIcon.visible);
-
-      // 'On' mode
-    } else if (settings.display.candyUpgradeNotificationMode === CandyUpgradeNotificationMode.ON) {
-      starter.candyUpgradeIcon.setVisible(
-        slotVisible && (isPassiveAvailable || isValueReductionAvailable || isSameSpeciesEggAvailable),
-      );
-      starter.candyUpgradeOverlayIcon.setVisible(slotVisible && starter.candyUpgradeIcon.visible);
-    }
-  }
-
-  /**
-   * Update the display of candy upgrade icons or animations for the given StarterContainer
-   * @param starterContainer the container for the Pokemon to update
-   */
-  updateCandyUpgradeDisplay(starterContainer: StarterContainer) {
-    if (this.isUpgradeIconEnabled()) {
-      this.setUpgradeIcon(starterContainer);
-    }
-    if (this.isUpgradeAnimationEnabled()) {
-      this.setUpgradeAnimation(starterContainer.icon, this.lastSpecies, true);
-    }
-  }
-
-  /**
-   * Update the candy upgrade notification style based on the settings
-   */
-  onCandyUpgradeDisplayChanged(): void {
-    // Loop through all visible candy icons when set to 'Icon' mode
-    if (settings.display.candyUpgradeDisplayMode === CandyUpgradeDisplayMode.ICON) {
-      this.filteredStarterContainers.forEach((starter) => {
-        this.setUpgradeIcon(starter);
-      });
-
-      return;
-    }
-
-    // Loop through all animations when set to 'Animation' mode
-    this.filteredStarterContainers.forEach((starter, s) => {
-      const icon = this.filteredStarterContainers[s].icon;
-
-      this.setUpgradeAnimation(icon, starter.species);
-    });
   }
 
   processInput(button: Button): boolean {
@@ -2030,9 +1868,8 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     this.setSpeciesDetails(this.lastSpecies);
                     globalScene.playSound("se/buy");
 
-                    // update the passive background and icon/animation for available upgrade
+                    // update the passive background
                     if (starterContainer) {
-                      this.updateCandyUpgradeDisplay(starterContainer);
                       starterContainer.starterPassiveBgs.setVisible(
                         !!globalScene.gameData.starterData[this.lastSpecies.speciesId].passiveAttr,
                       );
@@ -2070,10 +1907,9 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                     ui.setMode(Mode.STARTER_SELECT);
                     globalScene.playSound("se/buy");
 
-                    // update the value label and icon/animation for available upgrade
+                    // update the value label
                     if (starterContainer) {
                       this.updateStarterValueLabel(starterContainer);
-                      this.updateCandyUpgradeDisplay(starterContainer);
                     }
                     return true;
                   }
@@ -2121,11 +1957,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
                   });
                   ui.setMode(Mode.STARTER_SELECT);
                   globalScene.playSound("se/buy");
-
-                  // update the icon/animation for available upgrade
-                  if (starterContainer) {
-                    this.updateCandyUpgradeDisplay(starterContainer);
-                  }
 
                   return true;
                 }
@@ -3078,23 +2909,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         );
         container.classicWinIcon.setVisible(globalScene.gameData.starterData[speciesId].classicWinCount > 0);
         container.favoriteIcon.setVisible(this.starterPreferences[speciesId]?.favorite ?? false);
-
-        // 'Candy Icon' mode
-        if (settings.display.candyUpgradeDisplayMode === CandyUpgradeDisplayMode.ICON) {
-          if (!starterColors[speciesId]) {
-            // Default to white if no colors are found
-            starterColors[speciesId] = ["ffffff", "ffffff"];
-          }
-
-          // Set the candy colors
-          container.candyUpgradeIcon.setTint(argbFromRgba(rgbHexToRgba(starterColors[speciesId][0])));
-          container.candyUpgradeOverlayIcon.setTint(argbFromRgba(rgbHexToRgba(starterColors[speciesId][1])));
-
-          this.setUpgradeIcon(container);
-        } else if (settings.display.candyUpgradeDisplayMode === CandyUpgradeDisplayMode.ANIMATION) {
-          container.candyUpgradeIcon.setVisible(false);
-          container.candyUpgradeOverlayIcon.setVisible(false);
-        }
       }
     });
   };
@@ -3313,13 +3127,6 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         // Pause the animation when the species is selected
         const speciesIndex = this.allSpecies.indexOf(species);
         const icon = this.starterContainers[speciesIndex].icon;
-
-        if (this.isUpgradeAnimationEnabled()) {
-          globalScene.tweens.getTweensOf(icon).forEach((tween) => tween.pause());
-          // Reset the position of the icon
-          icon.x = -2;
-          icon.y = 2;
-        }
 
         // Initiates the small up and down idle animation
         this.iconAnimHandler.addOrUpdate(icon, PokemonIconAnimMode.PASSIVE);
@@ -3590,7 +3397,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             species.getIconAtlasKey(formIndex, shiny, variant),
             species.getIconId(female!, formIndex, shiny, variant),
           );
-          currentFilteredContainer.checkIconId(female, formIndex, shiny, variant);
+          currentFilteredContainer.checkIconId(female!, formIndex, shiny, variant);
         }
 
         const isNonShinyCaught = !!(caughtAttr & DexAttr.NON_SHINY);


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

- Removed the icon/animation for Pokemon with purchaseable candy upgrades, and the associated setting
- Added a filter option to differentiate Pokemon with partially reduced cost and Pokemon with fully reduced cost

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

- The icon/animation is no longer useful with the filters, and is just bloating the UI and settings
- The cost reduction filter did not allow to differentiate between fully and partially upgraded starters

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

- Locale PR: https://github.com/Despair-Games/poketernity-locales/pull/20
- Remove the icon/animation setting and related code
- Added a partial option to the cost reduction dropdown

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

https://github.com/user-attachments/assets/dac7fe08-c4b4-4259-8075-7ee0016d5dac

<details><summary>Settings Before/After:</summary>

![image](https://github.com/user-attachments/assets/24b39fcc-41b6-4c68-949e-272f68494eb6)
![image](https://github.com/user-attachments/assets/a13e07f9-6062-460b-8012-c91c85994edc)

</details>

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

Open Starter Select and play with the filters

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [X] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [X] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [X] If so, please leave a link to it here: https://github.com/Despair-Games/poketernity-locales/pull/20
~~- [ ] Has the translation team been contacted for proofreading/translation?~~
