### PR TITLE
[Test] `toNextTurn` now takes double battles into account

### DIFF
--- a/test/abilities/arena_trap.test.ts
+++ b/test/abilities/arena_trap.test.ts
@@ -74,13 +74,7 @@ describe("Abilities - Arena Trap", () => {
 
     game.move.select(Moves.ROAR);
     game.move.select(Moves.SPLASH, 1);
-
-    // This runs the fist command phase where the moves are selected
-    await game.toNextTurn();
-    // During the next command phase the player pokemons should not be trapped anymore
-    game.move.select(Moves.SPLASH);
-    game.move.select(Moves.SPLASH, 1);
-    await game.toNextTurn();
+    await game.toNextTurn(true);
 
     expect(player1.isTrapped()).toBe(false);
     expect(player2.isTrapped()).toBe(false);

--- a/test/abilities/arena_trap.test.ts
+++ b/test/abilities/arena_trap.test.ts
@@ -74,7 +74,7 @@ describe("Abilities - Arena Trap", () => {
 
     game.move.select(Moves.ROAR);
     game.move.select(Moves.SPLASH, 1);
-    await game.toNextTurn(true);
+    await game.toNextTurn();
 
     expect(player1.isTrapped()).toBe(false);
     expect(player2.isTrapped()).toBe(false);

--- a/test/abilities/forecast.test.ts
+++ b/test/abilities/forecast.test.ts
@@ -2,11 +2,6 @@ import { BattlerIndex } from "#enums/battler-index";
 import { allAbilities } from "#app/data/ability";
 import { Abilities } from "#enums/abilities";
 import { WeatherType } from "#enums/weather-type";
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
-import { MovePhase } from "#app/phases/move-phase";
-import { PostSummonPhase } from "#app/phases/post-summon-phase";
-import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { Moves } from "#enums/moves";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
@@ -30,7 +25,7 @@ describe("Abilities - Forecast", () => {
    */
   const testWeatherFormChange = async (game: GameManager, weather: WeatherType, form: number, initialForm?: number) => {
     game.override.weather(weather).starterForms({ [Species.CASTFORM]: initialForm });
-    await game.startBattle([Species.CASTFORM]);
+    await game.classicMode.startBattle([Species.CASTFORM]);
 
     game.move.select(Moves.SPLASH);
 
@@ -44,7 +39,7 @@ describe("Abilities - Forecast", () => {
    */
   const testRevertFormAgainstAbility = async (game: GameManager, ability: Abilities) => {
     game.override.starterForms({ [Species.CASTFORM]: SUNNY_FORM }).enemyAbility(ability);
-    await game.startBattle([Species.CASTFORM]);
+    await game.classicMode.startBattle([Species.CASTFORM]);
 
     game.move.select(Moves.SPLASH);
 
@@ -70,6 +65,7 @@ describe("Abilities - Forecast", () => {
       .enemyAbility(Abilities.BALL_FETCH);
   });
 
+  // TODO: Break apart into individual tests again now that the test framework has been optimized
   it(
     "changes form based on weather",
     async () => {
@@ -81,7 +77,7 @@ describe("Abilities - Forecast", () => {
           [Species.GROUDON]: 1,
           [Species.RAYQUAZA]: 1,
         });
-      await game.startBattle([
+      await game.classicMode.startBattle([
         Species.CASTFORM,
         Species.FEEBAS,
         Species.KYOGRE,
@@ -97,21 +93,18 @@ describe("Abilities - Forecast", () => {
 
       game.move.select(Moves.RAIN_DANCE);
       game.move.select(Moves.SPLASH, 1);
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(RAINY_FORM);
 
       game.move.select(Moves.SUNNY_DAY);
       game.move.select(Moves.SPLASH, 1);
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SUNNY_FORM);
 
       game.move.select(Moves.SNOWSCAPE);
       game.move.select(Moves.SPLASH, 1);
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SNOWY_FORM);
@@ -120,63 +113,54 @@ describe("Abilities - Forecast", () => {
 
       game.move.select(Moves.SANDSTORM);
       game.move.select(Moves.SPLASH, 1);
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(NORMAL_FORM);
 
       game.move.select(Moves.HAIL);
       game.move.select(Moves.SPLASH, 1);
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SNOWY_FORM);
 
       game.move.select(Moves.SPLASH);
       game.doSwitchPokemon(2); // Feebas now 2, Kyogre 1
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(RAINY_FORM);
 
       game.move.select(Moves.SPLASH);
       game.doSwitchPokemon(3); // Kyogre now 3, Groudon 1
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SUNNY_FORM);
 
       game.move.select(Moves.SPLASH);
       game.doSwitchPokemon(4); // Groudon now 4, Rayquaza 1
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(NORMAL_FORM);
 
       game.move.select(Moves.SPLASH);
       game.doSwitchPokemon(2); // Rayquaza now 2, Feebas 1
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(NORMAL_FORM);
 
       game.move.select(Moves.SNOWSCAPE);
       game.move.select(Moves.SPLASH, 1);
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SNOWY_FORM);
 
       game.move.select(Moves.SPLASH);
       game.doSwitchPokemon(5); // Feebas now 5, Altaria 1
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(NORMAL_FORM);
 
       game.move.select(Moves.SPLASH);
       game.doSwitchPokemon(5); // Altaria now 5, Feebas 1
-      await game.phaseInterceptor.to("MovePhase");
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SNOWY_FORM);
@@ -201,10 +185,10 @@ describe("Abilities - Forecast", () => {
 
   it("has no effect on Pokémon other than Castform", async () => {
     game.override.enemyAbility(Abilities.FORECAST).enemySpecies(Species.SHUCKLE);
-    await game.startBattle([Species.CASTFORM]);
+    await game.classicMode.startBattle([Species.CASTFORM]);
 
     game.move.select(Moves.RAIN_DANCE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(game.scene.getPlayerPokemon()?.formIndex).toBe(RAINY_FORM);
     expect(game.scene.getEnemyPokemon()?.formIndex).not.toBe(RAINY_FORM);
@@ -243,8 +227,8 @@ describe("Abilities - Forecast", () => {
 
   it("reverts to Normal Form when Forecast is suppressed, changes form to match the weather when it regains it", async () => {
     game.override.enemyMoveset([Moves.GASTRO_ACID]).weather(WeatherType.RAIN);
-    await game.startBattle([Species.CASTFORM, Species.PIKACHU]);
-    const castform = game.scene.getPlayerPokemon()!;
+    await game.classicMode.startBattle([Species.CASTFORM, Species.PIKACHU]);
+    const castform = game.field.getPlayerPokemon();
 
     expect(castform.formIndex).toBe(RAINY_FORM);
 
@@ -253,7 +237,7 @@ describe("Abilities - Forecast", () => {
     await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.move.forceHit();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(castform.summonData.abilitySuppressed).toBe(true);
     expect(castform.formIndex).toBe(NORMAL_FORM);
@@ -266,7 +250,7 @@ describe("Abilities - Forecast", () => {
 
     // Third turn - switch in Castform
     game.doSwitchPokemon(1);
-    await game.phaseInterceptor.to(MovePhase);
+    await game.phaseInterceptor.to("MovePhase");
 
     expect(castform.summonData.abilitySuppressed).toBe(false);
     expect(castform.formIndex).toBe(RAINY_FORM);
@@ -274,7 +258,7 @@ describe("Abilities - Forecast", () => {
 
   it("does not change Castform's form until after Stealth Rock deals damage", async () => {
     game.override.weather(WeatherType.RAIN).enemyMoveset([Moves.STEALTH_ROCK]);
-    await game.startBattle([Species.PIKACHU, Species.CASTFORM]);
+    await game.classicMode.startBattle([Species.PIKACHU, Species.CASTFORM]);
 
     // First turn - set up stealth rock
     game.move.select(Moves.SPLASH);
@@ -282,24 +266,24 @@ describe("Abilities - Forecast", () => {
 
     // Second turn - switch in Castform, regains Forecast
     game.doSwitchPokemon(1);
-    await game.phaseInterceptor.to(PostSummonPhase);
+    await game.phaseInterceptor.to("PostSummonPhase");
 
-    const castform = game.scene.getPlayerPokemon()!;
+    const castform = game.field.getPlayerPokemon();
 
     // Damage phase should come first
-    await game.phaseInterceptor.to(DamageAnimPhase);
+    await game.phaseInterceptor.to("DamageAnimPhase");
     expect(castform.hp).toBeLessThan(castform.getMaxHp());
 
     // Then change form
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
     expect(castform.formIndex).toBe(RAINY_FORM);
   });
 
   it("should be in Normal Form after the user is switched out", async () => {
     game.override.weather(WeatherType.RAIN);
 
-    await game.startBattle([Species.CASTFORM, Species.MAGIKARP]);
-    const castform = game.scene.getPlayerPokemon()!;
+    await game.classicMode.startBattle([Species.CASTFORM, Species.MAGIKARP]);
+    const castform = game.field.getPlayerPokemon();
 
     expect(castform.formIndex).toBe(RAINY_FORM);
 

--- a/test/moves/powder.test.ts
+++ b/test/moves/powder.test.ts
@@ -162,7 +162,6 @@ describe("Moves - Powder", () => {
     game.move.select(Moves.ROAR, 0, BattlerIndex.ENEMY_2);
     game.move.select(Moves.SPLASH, 1);
     await game.toNextTurn();
-    await game.toNextTurn(); // Requires game.toNextTurn() twice due to double battle
 
     // Turn 2: Enemy should activate Powder twice: From using Ember, and from copying Fiery Dance via Dancer
     playerPokemon.hp = playerPokemon.getMaxHp();

--- a/test/testUtils/gameManager.ts
+++ b/test/testUtils/gameManager.ts
@@ -420,15 +420,10 @@ export class GameManager {
     };
   }
 
-  /**
-   * Transition to the next upcoming {@linkcode CommandPhase}
-   * @param doubles - If `true`, will run `.to(CommandPhase)` twice to account for the extra `CommandPhase` in doubles
-   */
-  async toNextTurn(doubles: boolean = false) {
+  /** Transition to the next upcoming {@linkcode CommandPhase}. */
+  async toNextTurn() {
+    await this.phaseInterceptor.to(TurnInitPhase);
     await this.phaseInterceptor.to(CommandPhase);
-    if (doubles) {
-      await this.phaseInterceptor.to(CommandPhase);
-    }
   }
 
   /** Emulate selecting a modifier (item) and transition to the next upcoming {@linkcode CommandPhase} */

--- a/test/testUtils/gameManager.ts
+++ b/test/testUtils/gameManager.ts
@@ -420,9 +420,15 @@ export class GameManager {
     };
   }
 
-  /** Transition to the next upcoming {@linkcode CommandPhase} */
-  async toNextTurn() {
+  /**
+   * Transition to the next upcoming {@linkcode CommandPhase}
+   * @param doubles - If `true`, will run `.to(CommandPhase)` twice to account for the extra `CommandPhase` in doubles
+   */
+  async toNextTurn(doubles: boolean = false) {
     await this.phaseInterceptor.to(CommandPhase);
+    if (doubles) {
+      await this.phaseInterceptor.to(CommandPhase);
+    }
   }
 
   /** Emulate selecting a modifier (item) and transition to the next upcoming {@linkcode CommandPhase} */

--- a/test/testUtils/gameManager.ts
+++ b/test/testUtils/gameManager.ts
@@ -420,7 +420,7 @@ export class GameManager {
     };
   }
 
-  /** Transition to the next upcoming {@linkcode CommandPhase}. */
+  /** Transition to the first {@linkcode CommandPhase} of the next turn. */
   async toNextTurn() {
     await this.phaseInterceptor.to(TurnInitPhase);
     await this.phaseInterceptor.to(CommandPhase);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To make writing tests easier.

## What are the changes from a developer perspective?
`await game.toNextTurn(true);` will account for the extra `CommandPhase` in double battles and properly advance to the next turn.

## How to test the changes?
One of the Arena Trap tests was updated as a proof of concept: `npm run test arena_trap`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?