### PR TITLE
[Security] update vite to `6.0.11` (security patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typedoc": "^0.26.4",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.0-alpha.54",
-        "vite": "^6.0.7",
+        "vite": "^6.0.11",
         "vite-tsconfig-paths": "^4.3.2",
         "vitest": "^2.1.8",
         "vitest-canvas-mock": "^0.3.3"
@@ -6511,9 +6511,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
-      "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typedoc": "^0.26.4",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.0-alpha.54",
-    "vite": "^6.0.7",
+    "vite": "^6.0.11",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^2.1.8",
     "vitest-canvas-mock": "^0.3.3"


### PR DESCRIPTION
Seems that the bot is struggling to create this:

> [!NOTE]
> For more information see Dependabot:
> https://github.com/Despair-Games/poketernity/security/dependabot/2