### PR TITLE
[Checkup] Overcoat / Bulletproof / Soundproof

### DIFF
--- a/src/data/ab-attrs/block-weather-damage-attr.ts
+++ b/src/data/ab-attrs/block-weather-damage-attr.ts
@@ -27,7 +27,7 @@ export class BlockWeatherDamageAttr extends PreWeatherDamageAbAttr {
   }
 
   override apply(_pokemon: Pokemon, _simulated: boolean, weather: Weather, cancelled: BooleanHolder): boolean {
-    if (!this.weatherTypes.length || this.weatherTypes.indexOf(weather?.weatherType) > -1) {
+    if (this.weatherTypes.includes(weather.weatherType)) {
       cancelled.value = true;
     }
 

--- a/src/data/ab-attrs/move-flag-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/move-flag-immunity-ab-attr.ts
@@ -4,7 +4,15 @@ import type { MoveFlags } from "#enums/move-flags";
 
 /**
  * This ability attribute provides the ability holder immunity to moves of a specified move flag category
- * Soundproof, Bulletproof, Powder
+ * ```
++-------------+-------------+
+|   Ability   |  Move Flag  |
++-------------+-------------+
+| Soundproof  | SOUND_BASED |
+| Overcoat    | POWDER_MOVE |
+| Bulletproof | BULLET_MOVE |
++-------------+-------------+
+ * ```
  */
 export class MoveFlagImmunityAbAttr extends MoveImmunityAbAttr {
   /**

--- a/src/data/ab-attrs/move-flag-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/move-flag-immunity-ab-attr.ts
@@ -1,0 +1,19 @@
+import type { PreDefendAbAttrCondition } from "#app/@types/PreDefendAbAttrCondition";
+import { MoveImmunityAbAttr } from "./move-immunity-ab-attr";
+import type { MoveFlags } from "#enums/move-flags";
+
+/**
+ * This ability attribute provides the ability holder immunity to moves of a specified move flag category
+ * Soundproof, Bulletproof, Powder
+ */
+export class MoveFlagImmunityAbAttr extends MoveImmunityAbAttr {
+  /**
+   * Extends MoveImmunityAbAttr
+   * @param moveFlag the move flag the Pokemon is immune to
+   */
+  constructor(moveFlag: MoveFlags) {
+    const immuneCondition: PreDefendAbAttrCondition = (pokemon, attacker, move) =>
+      pokemon !== attacker && move.checkFlag(moveFlag, attacker, pokemon);
+    super(immuneCondition);
+  }
+}

--- a/src/data/ab-attrs/move-flag-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/move-flag-immunity-ab-attr.ts
@@ -8,7 +8,7 @@ import type { MoveFlags } from "#enums/move-flags";
 +-------------+-------------+
 |   Ability   |  Move Flag  |
 +-------------+-------------+
-| Soundproof  | SOUND_BASED |
+| Soundproof  | SOUND_MOVE  |
 | Overcoat    | POWDER_MOVE |
 | Bulletproof | BULLET_MOVE |
 +-------------+-------------+

--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -199,6 +199,7 @@ import { BypassSpeedChanceAbAttr } from "./ab-attrs/bypass-speed-chance-ab-attr"
 import { TerrainEventTypeChangeAbAttr } from "./ab-attrs/terrain-event-type-change-ab-attr";
 import { WeatherBasedSpeedDoublerAbAttr } from "./ab-attrs/weather-based-speed-doubler-ab-attr";
 import { MoveFlagPowerBoostAbAttr } from "./ab-attrs/move-flag-power-boost-ab-attr";
+import { MoveFlagImmunityAbAttr } from "./ab-attrs/move-flag-immunity-ab-attr";
 
 function getTerrainCondition(...terrainTypes: TerrainType[]): AbAttrCondition {
   return (_pokemon: Pokemon) => {
@@ -450,12 +451,7 @@ export function initAbilities() {
       }
       return false;
     }),
-    new Ability(Abilities.SOUNDPROOF, 3)
-      .attr(
-        MoveImmunityAbAttr,
-        (pokemon, attacker, move) => pokemon !== attacker && move.hasFlag(MoveFlags.SOUND_BASED),
-      )
-      .ignorable(),
+    new Ability(Abilities.SOUNDPROOF, 3).attr(MoveFlagImmunityAbAttr, MoveFlags.SOUND_BASED).ignorable(),
     new Ability(Abilities.RAIN_DISH, 3).attr(PostWeatherLapseHealAbAttr, 1, WeatherType.RAIN, WeatherType.HEAVY_RAIN),
     new Ability(Abilities.SAND_STREAM, 3)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.SANDSTORM)
@@ -810,10 +806,7 @@ export function initAbilities() {
     new Ability(Abilities.MOODY, 5).attr(MoodyAbAttr),
     new Ability(Abilities.OVERCOAT, 5)
       .attr(BlockWeatherDamageAttr)
-      .attr(
-        MoveImmunityAbAttr,
-        (pokemon, attacker, move) => pokemon !== attacker && move.hasFlag(MoveFlags.POWDER_MOVE),
-      )
+      .attr(MoveFlagImmunityAbAttr, MoveFlags.POWDER_MOVE)
       .ignorable(),
     new Ability(Abilities.POISON_TOUCH, 5)
       .attr(PostAttackApplyStatusEffectAbAttr, true, 30, StatusEffect.POISON)
@@ -906,12 +899,7 @@ export function initAbilities() {
     //.condition((p) => !p.summonData?.abilitiesApplied.includes(Abilities.PROTEAN)), //Gen 9 Implementation
     new Ability(Abilities.FUR_COAT, 6).attr(StatMultiplierAbAttr, Stat.DEF, 2, (_user, target) => !!target).ignorable(),
     new Ability(Abilities.MAGICIAN, 6).attr(PostAttackStealHeldItemAbAttr),
-    new Ability(Abilities.BULLETPROOF, 6)
-      .attr(
-        MoveImmunityAbAttr,
-        (pokemon, attacker, move) => pokemon !== attacker && move.hasFlag(MoveFlags.BALLBOMB_MOVE),
-      )
-      .ignorable(),
+    new Ability(Abilities.BULLETPROOF, 6).attr(MoveFlagImmunityAbAttr, MoveFlags.BULLET_MOVE).ignorable(),
     new Ability(Abilities.COMPETITIVE, 6)
       .attr(PostStatStageChangeStatStageChangeAbAttr, (_target, _statsChanged, stages) => stages < 0, [Stat.SPATK], 2)
       .edgeCase(), // Should not boost stats if switching into court changed sticky web

--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -805,7 +805,7 @@ export function initAbilities() {
       .ignorable(),
     new Ability(Abilities.MOODY, 5).attr(MoodyAbAttr),
     new Ability(Abilities.OVERCOAT, 5)
-      .attr(BlockWeatherDamageAttr)
+      .attr(BlockWeatherDamageAttr, WeatherType.HAIL, WeatherType.SANDSTORM)
       .attr(MoveFlagImmunityAbAttr, MoveFlags.POWDER_MOVE)
       .ignorable(),
     new Ability(Abilities.POISON_TOUCH, 5)

--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -451,7 +451,7 @@ export function initAbilities() {
       }
       return false;
     }),
-    new Ability(Abilities.SOUNDPROOF, 3).attr(MoveFlagImmunityAbAttr, MoveFlags.SOUND_BASED).ignorable(),
+    new Ability(Abilities.SOUNDPROOF, 3).attr(MoveFlagImmunityAbAttr, MoveFlags.SOUND_MOVE).ignorable(),
     new Ability(Abilities.RAIN_DISH, 3).attr(PostWeatherLapseHealAbAttr, 1, WeatherType.RAIN, WeatherType.HEAVY_RAIN),
     new Ability(Abilities.SAND_STREAM, 3)
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.SANDSTORM)
@@ -1063,7 +1063,7 @@ export function initAbilities() {
       MoveTypeChangeAbAttr,
       Type.WATER,
       1,
-      (_user, _target, move) => !!move?.hasFlag(MoveFlags.SOUND_BASED),
+      (_user, _target, move) => !!move?.hasFlag(MoveFlags.SOUND_MOVE),
     ),
     new Ability(Abilities.TRIAGE, 7).attr(
       ChangeMovePriorityAbAttr,
@@ -1298,8 +1298,8 @@ export function initAbilities() {
       6,
     ),
     new Ability(Abilities.PUNK_ROCK, 8)
-      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.SOUND_BASED, 1.3)
-      .attr(ReceivedMoveDamageMultiplierAbAttr, (_target, _user, move) => move.hasFlag(MoveFlags.SOUND_BASED), 0.5)
+      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.SOUND_MOVE, 1.3)
+      .attr(ReceivedMoveDamageMultiplierAbAttr, (_target, _user, move) => move.hasFlag(MoveFlags.SOUND_MOVE), 0.5)
       .ignorable(),
     new Ability(Abilities.SAND_SPIT, 8).attr(
       PostDefendWeatherChangeAbAttr,

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -582,7 +582,7 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new AttackMove(Moves.EGG_BOMB, Type.NORMAL, MoveCategory.PHYSICAL, 100, 75, 10, -1, 0, 1)
       .makesContact(false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.LICK, Type.GHOST, MoveCategory.PHYSICAL, 30, 100, 30, 30, 0, 1).attr(
       StatusEffectAttr,
       StatusEffect.PARALYSIS,
@@ -641,7 +641,7 @@ export function initMoves() {
     new AttackMove(Moves.BARRAGE, Type.NORMAL, MoveCategory.PHYSICAL, 15, 85, 20, -1, 0, 1)
       .attr(MultiHitAttr)
       .makesContact(false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.LEECH_LIFE, Type.BUG, MoveCategory.PHYSICAL, 80, 100, 10, -1, 0, 1)
       .attr(HitHealAttr)
       .triageMove(),
@@ -781,7 +781,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.SLUDGE_BOMB, Type.POISON, MoveCategory.SPECIAL, 90, 100, 10, 30, 0, 2)
       .attr(StatusEffectAttr, StatusEffect.POISON)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.MUD_SLAP, Type.GROUND, MoveCategory.SPECIAL, 20, 100, 10, 100, 0, 2).attr(
       StatStageChangeAttr,
       [Stat.ACC],
@@ -789,13 +789,13 @@ export function initMoves() {
     ),
     new AttackMove(Moves.OCTAZOOKA, Type.WATER, MoveCategory.SPECIAL, 65, 85, 10, 50, 0, 2)
       .attr(StatStageChangeAttr, [Stat.ACC], -1)
-      .ballBombMove(),
+      .bulletMove(),
     new StatusMove(Moves.SPIKES, Type.GROUND, -1, 20, -1, 0, 2)
       .attr(AddArenaTrapTagAttr, ArenaTagType.SPIKES)
       .target(MoveTarget.ENEMY_SIDE),
     new AttackMove(Moves.ZAP_CANNON, Type.ELECTRIC, MoveCategory.SPECIAL, 120, 50, 5, 100, 0, 2)
       .attr(StatusEffectAttr, StatusEffect.PARALYSIS)
-      .ballBombMove(),
+      .bulletMove(),
     new StatusMove(Moves.FORESIGHT, Type.NORMAL, -1, 40, -1, 0, 2)
       .attr(ExposedMoveAttr, BattlerTagType.IGNORE_GHOST)
       .ignoresSubstitute(),
@@ -996,7 +996,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.SHADOW_BALL, Type.GHOST, MoveCategory.SPECIAL, 80, 100, 15, 20, 0, 2)
       .attr(StatStageChangeAttr, [Stat.SPDEF], -1)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.FUTURE_SIGHT, Type.PSYCHIC, MoveCategory.SPECIAL, 120, 100, 10, -1, 0, 2)
       .partial() // hits immediately when called by Metronome/etc, should not apply abilities or held items if user is off the field
       .ignoresProtect()
@@ -1176,7 +1176,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.MIST_BALL, Type.PSYCHIC, MoveCategory.SPECIAL, 95, 100, 5, 50, 0, 3)
       .attr(StatStageChangeAttr, [Stat.SPATK], -1)
-      .ballBombMove(),
+      .bulletMove(),
     new StatusMove(Moves.FEATHER_DANCE, Type.FLYING, 100, 15, -1, 0, 3)
       .attr(StatStageChangeAttr, [Stat.ATK], -2)
       .danceMove(),
@@ -1194,7 +1194,7 @@ export function initMoves() {
     new AttackMove(Moves.ICE_BALL, Type.ICE, MoveCategory.PHYSICAL, 30, 90, 20, -1, 0, 3)
       .partial() // Does not lock the user properly, does not increase damage correctly
       .attr(ConsecutiveUseDoublePowerAttr, 5, true, true, Moves.DEFENSE_CURL)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.NEEDLE_ARM, Type.GRASS, MoveCategory.PHYSICAL, 60, 100, 15, 30, 0, 3).attr(FlinchAttr),
     new SelfStatusMove(Moves.SLACK_OFF, Type.NORMAL, -1, 5, -1, 0, 3).attr(HealAttr, 0.5).triageMove(),
     new AttackMove(Moves.HYPER_VOICE, Type.NORMAL, MoveCategory.SPECIAL, 90, 100, 10, -1, 0, 3)
@@ -1236,7 +1236,7 @@ export function initMoves() {
         }
         return 1;
       })
-      .ballBombMove(),
+      .bulletMove(),
     new StatusMove(Moves.AROMATHERAPY, Type.GRASS, -1, 5, -1, 0, 3)
       .attr(PartyStatusCureAttr, i18next.t("moveTriggers:soothingAromaWaftedThroughArea"), Abilities.SAP_SIPPER)
       .target(MoveTarget.PARTY),
@@ -1294,7 +1294,7 @@ export function initMoves() {
     new AttackMove(Moves.BULLET_SEED, Type.GRASS, MoveCategory.PHYSICAL, 25, 100, 30, -1, 0, 3)
       .attr(MultiHitAttr)
       .makesContact(false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.AERIAL_ACE, Type.FLYING, MoveCategory.PHYSICAL, 60, -1, 20, -1, 0, 3).slicingMove(),
     new AttackMove(Moves.ICICLE_SPEAR, Type.ICE, MoveCategory.PHYSICAL, 25, 100, 30, -1, 0, 3)
       .attr(MultiHitAttr)
@@ -1358,7 +1358,7 @@ export function initMoves() {
     new AttackMove(Moves.ROCK_BLAST, Type.ROCK, MoveCategory.PHYSICAL, 25, 90, 10, -1, 0, 3)
       .attr(MultiHitAttr)
       .makesContact(false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.SHOCK_WAVE, Type.ELECTRIC, MoveCategory.SPECIAL, 60, -1, 20, -1, 0, 3),
     new AttackMove(Moves.WATER_PULSE, Type.WATER, MoveCategory.SPECIAL, 60, 100, 20, 20, 0, 3)
       .attr(ConfuseAttr)
@@ -1398,7 +1398,7 @@ export function initMoves() {
       .punchingMove(),
     new AttackMove(Moves.GYRO_BALL, Type.STEEL, MoveCategory.PHYSICAL, -1, 100, 5, -1, 0, 4)
       .attr(GyroBallPowerAttr)
-      .ballBombMove(),
+      .bulletMove(),
     new SelfStatusMove(Moves.HEALING_WISH, Type.PSYCHIC, -1, 10, -1, 0, 4)
       .attr(SacrificialFullRestoreAttr, false, "moveTriggers:sacrificialFullRestore")
       .triageMove()
@@ -1549,7 +1549,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.AURA_SPHERE, Type.FIGHTING, MoveCategory.SPECIAL, 80, -1, 20, -1, 0, 4)
       .pulseMove()
-      .ballBombMove(),
+      .bulletMove(),
     new SelfStatusMove(Moves.ROCK_POLISH, Type.ROCK, -1, 20, -1, 0, 4).attr(StatStageChangeAttr, [Stat.SPD], 2, true),
     new AttackMove(Moves.POISON_JAB, Type.POISON, MoveCategory.PHYSICAL, 80, 100, 20, 30, 0, 4).attr(
       StatusEffectAttr,
@@ -1564,7 +1564,7 @@ export function initMoves() {
     new AttackMove(Moves.AQUA_TAIL, Type.WATER, MoveCategory.PHYSICAL, 90, 90, 10, -1, 0, 4),
     new AttackMove(Moves.SEED_BOMB, Type.GRASS, MoveCategory.PHYSICAL, 80, 100, 15, -1, 0, 4)
       .makesContact(false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.AIR_SLASH, Type.FLYING, MoveCategory.SPECIAL, 75, 95, 15, 30, 0, 4)
       .attr(FlinchAttr)
       .slicingMove(),
@@ -1585,10 +1585,10 @@ export function initMoves() {
     new AttackMove(Moves.VACUUM_WAVE, Type.FIGHTING, MoveCategory.SPECIAL, 40, 100, 30, -1, 1, 4),
     new AttackMove(Moves.FOCUS_BLAST, Type.FIGHTING, MoveCategory.SPECIAL, 120, 70, 5, 10, 0, 4)
       .attr(StatStageChangeAttr, [Stat.SPDEF], -1)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.ENERGY_BALL, Type.GRASS, MoveCategory.SPECIAL, 90, 100, 10, 10, 0, 4)
       .attr(StatStageChangeAttr, [Stat.SPDEF], -1)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.BRAVE_BIRD, Type.FLYING, MoveCategory.PHYSICAL, 120, 100, 15, -1, 0, 4)
       .attr(RecoilAttr, false, 0.33)
       .recklessMove(),
@@ -1621,7 +1621,7 @@ export function initMoves() {
     new AttackMove(Moves.SHADOW_SNEAK, Type.GHOST, MoveCategory.PHYSICAL, 40, 100, 30, -1, 1, 4),
     new AttackMove(Moves.MUD_BOMB, Type.GROUND, MoveCategory.SPECIAL, 65, 85, 10, 30, 0, 4)
       .attr(StatStageChangeAttr, [Stat.ACC], -1)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.PSYCHO_CUT, Type.PSYCHIC, MoveCategory.PHYSICAL, 70, 100, 20, -1, 0, 4)
       .attr(HighCritAttr)
       .slicingMove()
@@ -1671,7 +1671,7 @@ export function initMoves() {
     new AttackMove(Moves.ROCK_WRECKER, Type.ROCK, MoveCategory.PHYSICAL, 150, 90, 5, -1, 0, 4)
       .attr(RechargeAttr)
       .makesContact(false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.CROSS_POISON, Type.POISON, MoveCategory.PHYSICAL, 70, 100, 20, 10, 0, 4)
       .attr(HighCritAttr)
       .attr(StatusEffectAttr, StatusEffect.POISON)
@@ -1682,7 +1682,7 @@ export function initMoves() {
     new AttackMove(Moves.IRON_HEAD, Type.STEEL, MoveCategory.PHYSICAL, 80, 100, 15, 30, 0, 4).attr(FlinchAttr),
     new AttackMove(Moves.MAGNET_BOMB, Type.STEEL, MoveCategory.PHYSICAL, 60, -1, 20, -1, 0, 4)
       .makesContact(false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.STONE_EDGE, Type.ROCK, MoveCategory.PHYSICAL, 100, 80, 5, -1, 0, 4)
       .attr(HighCritAttr)
       .makesContact(false),
@@ -1856,7 +1856,7 @@ export function initMoves() {
       .attr(HitsSameTypeAttr),
     new AttackMove(Moves.ELECTRO_BALL, Type.ELECTRIC, MoveCategory.SPECIAL, -1, 100, 10, -1, 0, 5)
       .attr(ElectroBallPowerAttr)
-      .ballBombMove(),
+      .bulletMove(),
     new StatusMove(Moves.SOAK, Type.WATER, 100, 20, -1, 0, 5).attr(ChangeTypeAttr, Type.WATER),
     new AttackMove(Moves.FLAME_CHARGE, Type.FIRE, MoveCategory.PHYSICAL, 50, 100, 20, 100, 0, 5).attr(
       StatStageChangeAttr,
@@ -1877,7 +1877,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.ACID_SPRAY, Type.POISON, MoveCategory.SPECIAL, 40, 100, 20, 100, 0, 5)
       .attr(StatStageChangeAttr, [Stat.SPDEF], -2)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.FOUL_PLAY, Type.DARK, MoveCategory.PHYSICAL, 95, 100, 15, -1, 0, 5)
       .attr(TargetAtkUserAtkAttr)
       .edgeCase(), // Does not consider Huge Power/other attack stat modifiers correctly + disables Unaware during use
@@ -2087,7 +2087,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.SEARING_SHOT, Type.FIRE, MoveCategory.SPECIAL, 100, 100, 5, 30, 0, 5)
       .attr(StatusEffectAttr, StatusEffect.BURN)
-      .ballBombMove()
+      .bulletMove()
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new AttackMove(Moves.TECHNO_BLAST, Type.NORMAL, MoveCategory.SPECIAL, 120, 100, 5, -1, 0, 5).attr(
       TechnoBlastTypeAttr,
@@ -2565,7 +2565,7 @@ export function initMoves() {
     new AttackMove(Moves.POLLEN_PUFF, Type.BUG, MoveCategory.SPECIAL, 90, 100, 15, -1, 0, 7)
       .attr(StatusCategoryOnAllyAttr)
       .attr(HealOnAllyAttr, 0.5, true, false)
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.ANCHOR_SHOT, Type.STEEL, MoveCategory.PHYSICAL, 80, 100, 20, 100, 0, 7).attr(
       AddBattlerTagAttr,
       BattlerTagType.TRAPPED,
@@ -2626,7 +2626,7 @@ export function initMoves() {
     new StatusMove(Moves.INSTRUCT, Type.PSYCHIC, -1, 15, -1, 0, 7).ignoresSubstitute().attr(RepeatMoveAttr).edgeCase(), // incorrect interactions with Gigaton Hammer, Blood Moon & Torment
     new AttackMove(Moves.BEAK_BLAST, Type.FLYING, MoveCategory.PHYSICAL, 100, 100, 15, -1, -3, 7)
       .attr(BeakBlastHeaderAttr)
-      .ballBombMove()
+      .bulletMove()
       .makesContact(false),
     new AttackMove(Moves.CLANGING_SCALES, Type.DRAGON, MoveCategory.SPECIAL, 110, 100, 5, -1, 0, 7)
       .attr(StatStageChangeAttr, [Stat.DEF], -1, true, { firstTargetOnly: true })
@@ -2995,7 +2995,7 @@ export function initMoves() {
     new AttackMove(Moves.PYRO_BALL, Type.FIRE, MoveCategory.PHYSICAL, 120, 90, 5, 10, 0, 8)
       .attr(HealStatusEffectAttr, true, StatusEffect.FREEZE)
       .attr(StatusEffectAttr, StatusEffect.BURN)
-      .ballBombMove()
+      .bulletMove()
       .makesContact(false),
     new AttackMove(Moves.BEHEMOTH_BLADE, Type.STEEL, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 8).slicingMove(),
     new AttackMove(Moves.BEHEMOTH_BASH, Type.STEEL, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 8),
@@ -3622,7 +3622,7 @@ export function initMoves() {
       .triageMove(),
     new AttackMove(Moves.SYRUP_BOMB, Type.GRASS, MoveCategory.SPECIAL, 60, 85, 10, 100, 0, 9)
       .attr(AddBattlerTagAttr, BattlerTagType.SYRUP_BOMB, false, { turnCountMin: 3 })
-      .ballBombMove(),
+      .bulletMove(),
     new AttackMove(Moves.IVY_CUDGEL, Type.GRASS, MoveCategory.PHYSICAL, 100, 100, 10, -1, 0, 9)
       .attr(IvyCudgelTypeAttr)
       .attr(HighCritAttr)

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -366,14 +366,14 @@ export function initMoves() {
     new AttackMove(Moves.BITE, Type.DARK, MoveCategory.PHYSICAL, 60, 100, 25, 30, 0, 1).attr(FlinchAttr).bitingMove(),
     new StatusMove(Moves.GROWL, Type.NORMAL, 100, 40, -1, 0, 1)
       .attr(StatStageChangeAttr, [Stat.ATK], -1)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(Moves.ROAR, Type.NORMAL, -1, 20, -1, -6, 1)
       .attr(ForceSwitchOutAttr, false, SwitchType.FORCE_SWITCH)
-      .soundBased()
+      .soundMove()
       .hidesTarget(),
-    new StatusMove(Moves.SING, Type.NORMAL, 55, 15, -1, 0, 1).attr(StatusEffectAttr, StatusEffect.SLEEP).soundBased(),
-    new StatusMove(Moves.SUPERSONIC, Type.NORMAL, 55, 20, -1, 0, 1).attr(ConfuseAttr).soundBased(),
+    new StatusMove(Moves.SING, Type.NORMAL, 55, 15, -1, 0, 1).attr(StatusEffectAttr, StatusEffect.SLEEP).soundMove(),
+    new StatusMove(Moves.SUPERSONIC, Type.NORMAL, 55, 20, -1, 0, 1).attr(ConfuseAttr).soundMove(),
     new AttackMove(Moves.SONIC_BOOM, Type.NORMAL, MoveCategory.SPECIAL, -1, 90, 20, -1, 0, 1).attr(FixedDamageAttr, 20),
     new StatusMove(Moves.DISABLE, Type.NORMAL, 100, 20, -1, 0, 1)
       .attr(AddBattlerTagAttr, BattlerTagType.DISABLED, false, { failOnOverlap: true })
@@ -539,7 +539,7 @@ export function initMoves() {
       .attr(MovesetCopyMoveAttr)
       .ignoresSubstitute()
       .ignoresVirtual(),
-    new StatusMove(Moves.SCREECH, Type.NORMAL, 85, 40, -1, 0, 1).attr(StatStageChangeAttr, [Stat.DEF], -2).soundBased(),
+    new StatusMove(Moves.SCREECH, Type.NORMAL, 85, 40, -1, 0, 1).attr(StatStageChangeAttr, [Stat.DEF], -2).soundMove(),
     new SelfStatusMove(Moves.DOUBLE_TEAM, Type.NORMAL, -1, 15, -1, 0, 1).attr(StatStageChangeAttr, [Stat.EVA], 1, true),
     new SelfStatusMove(Moves.RECOVER, Type.NORMAL, -1, 5, -1, 0, 1).attr(HealAttr, 0.5).triageMove(),
     new SelfStatusMove(Moves.HARDEN, Type.NORMAL, -1, 30, -1, 0, 1).attr(StatStageChangeAttr, [Stat.DEF], 1, true),
@@ -737,7 +737,7 @@ export function initMoves() {
       .attr(BypassSleepAttr)
       .attr(FlinchAttr)
       .condition(userSleptOrComatoseCondition)
-      .soundBased(),
+      .soundMove(),
     new StatusMove(Moves.CURSE, Type.GHOST, -1, 10, -1, 0, 2)
       .attr(CurseAttr)
       .ignoresSubstitute()
@@ -816,7 +816,7 @@ export function initMoves() {
     new StatusMove(Moves.PERISH_SONG, Type.NORMAL, -1, 5, -1, 0, 2)
       .attr(FaintCountdownAttr)
       .ignoresProtect()
-      .soundBased()
+      .soundMove()
       .condition(failOnBossCondition)
       .target(MoveTarget.ALL),
     new AttackMove(Moves.ICY_WIND, Type.ICE, MoveCategory.SPECIAL, 55, 95, 15, 100, 0, 2)
@@ -882,7 +882,7 @@ export function initMoves() {
       .ignoresVirtual(),
     new StatusMove(Moves.HEAL_BELL, Type.NORMAL, -1, 5, -1, 0, 2)
       .attr(PartyStatusCureAttr, i18next.t("moveTriggers:bellChimed"), Abilities.SOUNDPROOF)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.PARTY),
     new AttackMove(Moves.RETURN, Type.NORMAL, MoveCategory.PHYSICAL, -1, 100, 20, -1, 0, 2).attr(FriendshipPowerAttr),
     new AttackMove(Moves.PRESENT, Type.NORMAL, MoveCategory.PHYSICAL, -1, 90, 15, -1, 0, 2)
@@ -1022,7 +1022,7 @@ export function initMoves() {
       .condition(new FirstMoveCondition()),
     new AttackMove(Moves.UPROAR, Type.NORMAL, MoveCategory.SPECIAL, 90, 100, 10, -1, 0, 3)
       .ignoresVirtual()
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.RANDOM_NEAR_ENEMY)
       .partial(), // Does not lock the user, does not stop Pokemon from sleeping
     new SelfStatusMove(Moves.STOCKPILE, Type.NORMAL, -1, 20, -1, 0, 3)
@@ -1198,7 +1198,7 @@ export function initMoves() {
     new AttackMove(Moves.NEEDLE_ARM, Type.GRASS, MoveCategory.PHYSICAL, 60, 100, 15, 30, 0, 3).attr(FlinchAttr),
     new SelfStatusMove(Moves.SLACK_OFF, Type.NORMAL, -1, 5, -1, 0, 3).attr(HealAttr, 0.5).triageMove(),
     new AttackMove(Moves.HYPER_VOICE, Type.NORMAL, MoveCategory.SPECIAL, 90, 100, 10, -1, 0, 3)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.POISON_FANG, Type.POISON, MoveCategory.PHYSICAL, 50, 100, 15, 50, 0, 3)
       .attr(StatusEffectAttr, StatusEffect.TOXIC)
@@ -1260,10 +1260,10 @@ export function initMoves() {
       .windMove(),
     new StatusMove(Moves.METAL_SOUND, Type.STEEL, 85, 40, -1, 0, 3)
       .attr(StatStageChangeAttr, [Stat.SPDEF], -2)
-      .soundBased(),
+      .soundMove(),
     new StatusMove(Moves.GRASS_WHISTLE, Type.GRASS, 55, 15, -1, 0, 3)
       .attr(StatusEffectAttr, StatusEffect.SLEEP)
-      .soundBased(),
+      .soundMove(),
     new StatusMove(Moves.TICKLE, Type.NORMAL, 100, 20, -1, 0, 3).attr(StatStageChangeAttr, [Stat.ATK, Stat.DEF], -1),
     new SelfStatusMove(Moves.COSMIC_POWER, Type.PSYCHIC, -1, 20, -1, 0, 3).attr(
       StatStageChangeAttr,
@@ -1306,7 +1306,7 @@ export function initMoves() {
       .ignoresProtect(),
     new StatusMove(Moves.HOWL, Type.NORMAL, -1, 40, -1, 0, 3)
       .attr(StatStageChangeAttr, [Stat.ATK], 1)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.USER_AND_ALLIES),
     new AttackMove(Moves.DRAGON_CLAW, Type.DRAGON, MoveCategory.PHYSICAL, 80, 100, 15, -1, 0, 3),
     new AttackMove(Moves.FRENZY_PLANT, Type.GRASS, MoveCategory.SPECIAL, 150, 90, 5, -1, 0, 3).attr(RechargeAttr),
@@ -1571,7 +1571,7 @@ export function initMoves() {
     new AttackMove(Moves.X_SCISSOR, Type.BUG, MoveCategory.PHYSICAL, 80, 100, 15, -1, 0, 4).slicingMove(),
     new AttackMove(Moves.BUG_BUZZ, Type.BUG, MoveCategory.SPECIAL, 90, 100, 10, 10, 0, 4)
       .attr(StatStageChangeAttr, [Stat.SPDEF], -1)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.DRAGON_PULSE, Type.DRAGON, MoveCategory.SPECIAL, 85, 100, 10, -1, 0, 4).pulseMove(),
     new AttackMove(Moves.DRAGON_RUSH, Type.DRAGON, MoveCategory.PHYSICAL, 100, 75, 10, 20, 0, 4)
       .attr(AlwaysHitMinimizeAttr)
@@ -1698,7 +1698,7 @@ export function initMoves() {
       .makesContact(),
     new AttackMove(Moves.CHATTER, Type.FLYING, MoveCategory.SPECIAL, 65, 100, 20, 100, 0, 4)
       .attr(ConfuseAttr)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.JUDGMENT, Type.NORMAL, MoveCategory.SPECIAL, 100, 100, 10, -1, 0, 4).attr(
       FormChangeItemTypeAttr,
     ),
@@ -1893,10 +1893,10 @@ export function initMoves() {
     new AttackMove(Moves.ROUND, Type.NORMAL, MoveCategory.SPECIAL, 60, 100, 15, -1, 0, 5)
       .attr(CueNextRoundAttr)
       .attr(RoundPowerAttr)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.ECHOED_VOICE, Type.NORMAL, MoveCategory.SPECIAL, 40, 100, 15, -1, 0, 5)
       .attr(ConsecutiveUseMultiBasePowerAttr, 5, false)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.CHIP_AWAY, Type.NORMAL, MoveCategory.PHYSICAL, 70, 100, 20, -1, 0, 5).attr(
       IgnoreOpponentStatStagesAttr,
     ),
@@ -2094,7 +2094,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.RELIC_SONG, Type.NORMAL, MoveCategory.SPECIAL, 75, 100, 10, 10, 0, 5)
       .attr(StatusEffectAttr, StatusEffect.SLEEP)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.SECRET_SWORD, Type.FIGHTING, MoveCategory.SPECIAL, 85, 100, 10, -1, 0, 5)
       .attr(DealsPhysicalDamageAttr)
@@ -2123,7 +2123,7 @@ export function initMoves() {
       .ignoresVirtual(),
     new AttackMove(Moves.SNARL, Type.DARK, MoveCategory.SPECIAL, 55, 95, 15, 100, 0, 5)
       .attr(StatStageChangeAttr, [Stat.SPATK], -1)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.ICICLE_CRASH, Type.ICE, MoveCategory.PHYSICAL, 85, 90, 10, 30, 0, 5)
       .attr(FlinchAttr)
@@ -2181,7 +2181,7 @@ export function initMoves() {
     new StatusMove(Moves.TRICK_OR_TREAT, Type.GHOST, 100, 20, -1, 0, 6).attr(AddTypeAttr, Type.GHOST),
     new StatusMove(Moves.NOBLE_ROAR, Type.NORMAL, 100, 30, -1, 0, 6)
       .attr(StatStageChangeAttr, [Stat.ATK, Stat.SPATK], -1)
-      .soundBased(),
+      .soundMove(),
     new StatusMove(Moves.ION_DELUGE, Type.ELECTRIC, -1, 25, -1, 1, 6)
       .attr(AddArenaTagAttr, ArenaTagType.ION_DELUGE, { turnCount: 1 })
       .target(MoveTarget.BOTH_SIDES),
@@ -2198,12 +2198,12 @@ export function initMoves() {
       .attr(StatusEffectAttr, StatusEffect.FREEZE)
       .attr(FreezeDryAttr),
     new AttackMove(Moves.DISARMING_VOICE, Type.FAIRY, MoveCategory.SPECIAL, 40, -1, 15, -1, 0, 6)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(Moves.PARTING_SHOT, Type.DARK, 100, 20, -1, 0, 6)
       .attr(StatStageChangeAttr, [Stat.ATK, Stat.SPATK], -1, false, { trigger: MoveEffectTrigger.PRE_APPLY })
       .attr(ForceSwitchOutAttr, true)
-      .soundBased(),
+      .soundMove(),
     new StatusMove(Moves.TOPSY_TURVY, Type.DARK, -1, 20, -1, 0, 6).attr(InvertStatsAttr),
     new AttackMove(Moves.DRAINING_KISS, Type.FAIRY, MoveCategory.SPECIAL, 50, 100, 10, -1, 0, 6)
       .attr(HitHealAttr, 0.75)
@@ -2243,7 +2243,7 @@ export function initMoves() {
       -1,
     ),
     new AttackMove(Moves.BOOMBURST, Type.NORMAL, MoveCategory.SPECIAL, 140, 100, 10, -1, 0, 6)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new StatusMove(Moves.FAIRY_LOCK, Type.FAIRY, -1, 10, -1, 0, 6)
       .ignoresSubstitute()
@@ -2258,7 +2258,7 @@ export function initMoves() {
       .ignoresSubstitute(),
     new StatusMove(Moves.CONFIDE, Type.NORMAL, -1, 20, -1, 0, 6)
       .attr(StatStageChangeAttr, [Stat.SPATK], -1)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.DIAMOND_STORM, Type.ROCK, MoveCategory.PHYSICAL, 100, 95, 5, 50, 0, 6)
       .attr(StatStageChangeAttr, [Stat.DEF], 2, true, { firstTargetOnly: true })
       .makesContact(false)
@@ -2507,7 +2507,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.SPARKLING_ARIA, Type.WATER, MoveCategory.SPECIAL, 90, 100, 10, 100, 0, 7)
       .attr(HealStatusEffectAttr, false, StatusEffect.BURN)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_OTHERS),
     new AttackMove(Moves.ICE_HAMMER, Type.ICE, MoveCategory.PHYSICAL, 100, 90, 10, -1, 0, 7)
       .attr(StatStageChangeAttr, [Stat.SPD], -1, true)
@@ -2630,7 +2630,7 @@ export function initMoves() {
       .makesContact(false),
     new AttackMove(Moves.CLANGING_SCALES, Type.DRAGON, MoveCategory.SPECIAL, 110, 100, 5, -1, 0, 7)
       .attr(StatStageChangeAttr, [Stat.DEF], -1, true, { firstTargetOnly: true })
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.DRAGON_HAMMER, Type.DRAGON, MoveCategory.PHYSICAL, 90, 100, 15, -1, 0, 7),
     new AttackMove(Moves.BRUTAL_SWING, Type.DARK, MoveCategory.PHYSICAL, 60, 100, 20, -1, 0, 7).target(
@@ -2777,7 +2777,7 @@ export function initMoves() {
       .attr(StatStageChangeAttr, [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD], 1, true, {
         firstTargetOnly: true,
       })
-      .soundBased()
+      .soundMove()
       .unimplemented()
       .target(MoveTarget.ALL_NEAR_ENEMIES)
       .edgeCase() // I assume it needs clanging scales and Kommo-O
@@ -2977,7 +2977,7 @@ export function initMoves() {
     /* End Unused */
     new SelfStatusMove(Moves.CLANGOROUS_SOUL, Type.DRAGON, 100, 5, -1, 0, 8)
       .attr(CutHpStatStageBoostAttr, [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD], 1, 3)
-      .soundBased()
+      .soundMove()
       .danceMove(),
     new AttackMove(Moves.BODY_PRESS, Type.FIGHTING, MoveCategory.PHYSICAL, 80, 100, 10, -1, 0, 8)
       .attr(DefAtkAttr)
@@ -3008,7 +3008,7 @@ export function initMoves() {
       .attr(StatStageChangeAttr, [Stat.ATK], -1),
     new AttackMove(Moves.BRANCH_POKE, Type.GRASS, MoveCategory.PHYSICAL, 40, 100, 40, -1, 0, 8),
     new AttackMove(Moves.OVERDRIVE, Type.ELECTRIC, MoveCategory.SPECIAL, 80, 100, 10, -1, 0, 8)
-      .soundBased()
+      .soundMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(Moves.APPLE_ACID, Type.GRASS, MoveCategory.SPECIAL, 80, 100, 10, 100, 0, 8).attr(
       StatStageChangeAttr,
@@ -3165,7 +3165,7 @@ export function initMoves() {
     ),
     new AttackMove(Moves.EERIE_SPELL, Type.PSYCHIC, MoveCategory.SPECIAL, 80, 100, 5, 100, 0, 8)
       .attr(AttackReducePpMoveAttr, 3)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.DIRE_CLAW, Type.POISON, MoveCategory.PHYSICAL, 80, 100, 15, 50, 0, 8).attr(
       MultiStatusEffectAttr,
       [StatusEffect.POISON, StatusEffect.PARALYSIS, StatusEffect.SLEEP],
@@ -3473,7 +3473,7 @@ export function initMoves() {
       .makesContact(false),
     new AttackMove(Moves.TORCH_SONG, Type.FIRE, MoveCategory.SPECIAL, 80, 100, 10, 100, 0, 9)
       .attr(StatStageChangeAttr, [Stat.SPATK], 1, true)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.AQUA_STEP, Type.WATER, MoveCategory.PHYSICAL, 80, 100, 10, 100, 0, 9)
       .attr(StatStageChangeAttr, [Stat.SPD], 1, true)
       .makesContact()
@@ -3676,7 +3676,7 @@ export function initMoves() {
       .target(MoveTarget.NEAR_ALLY),
     new AttackMove(Moves.ALLURING_VOICE, Type.FAIRY, MoveCategory.SPECIAL, 80, 100, 10, 100, 0, 9)
       .attr(AddBattlerTagIfBoostedAttr, BattlerTagType.CONFUSED)
-      .soundBased(),
+      .soundMove(),
     new AttackMove(Moves.TEMPER_FLARE, Type.FIRE, MoveCategory.PHYSICAL, 75, 100, 10, -1, 0, 9).attr(
       MovePowerMultiplierAttr,
       (user, _target, _move) =>
@@ -3689,7 +3689,7 @@ export function initMoves() {
       .attr(NoEffectAttr, crashDamageFunc)
       .recklessMove(),
     new AttackMove(Moves.PSYCHIC_NOISE, Type.PSYCHIC, MoveCategory.SPECIAL, 75, 100, 10, 100, 0, 9)
-      .soundBased()
+      .soundMove()
       .attr(AddBattlerTagAttr, BattlerTagType.HEAL_BLOCK, false, { turnCountMin: 2 }),
     new AttackMove(Moves.UPPER_HAND, Type.FIGHTING, MoveCategory.PHYSICAL, 65, 100, 15, 100, 3, 9)
       .attr(FlinchAttr)

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -227,7 +227,7 @@ export class ThroatChoppedTag extends MoveRestrictionBattlerTag {
    * @returns `true` if the move is sound-based, `false` otherwise
    */
   override isMoveRestricted(move: Moves): boolean {
-    return allMoves[move].hasFlag(MoveFlags.SOUND_BASED);
+    return allMoves[move].hasFlag(MoveFlags.SOUND_MOVE);
   }
 
   /**

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -312,7 +312,7 @@ export abstract class Move implements Localizable {
     // TODO: Allow this to be simulated
     applyAbAttrs(InfiltratorAbAttr, user, false, bypassed);
 
-    return !bypassed.value && !this.hasFlag(MoveFlags.SOUND_BASED) && !this.hasFlag(MoveFlags.IGNORE_SUBSTITUTE);
+    return !bypassed.value && !this.hasFlag(MoveFlags.SOUND_MOVE) && !this.hasFlag(MoveFlags.IGNORE_SUBSTITUTE);
   }
 
   /**
@@ -401,12 +401,12 @@ export abstract class Move implements Localizable {
   }
 
   /**
-   * Sets the {@linkcode MoveFlags.SOUND_BASED} flag for the calling Move
+   * Sets the {@linkcode MoveFlags.SOUND_MOVE} flag for the calling Move
    * @see {@linkcode Moves.UPROAR}
    * @returns The {@linkcode Move} that called this function
    */
-  soundBased(): this {
-    this.setFlag(MoveFlags.SOUND_BASED, true);
+  soundMove(): this {
+    this.setFlag(MoveFlags.SOUND_MOVE, true);
     return this;
   }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -481,12 +481,12 @@ export abstract class Move implements Localizable {
   }
 
   /**
-   * Sets the {@linkcode MoveFlags.BALLBOMB_MOVE} flag for the calling Move
+   * Sets the {@linkcode MoveFlags.BULLET_MOVE} flag for the calling Move
    * @see {@linkcode Moves.ELECTRO_BALL}
    * @returns The {@linkcode Move} that called this function
    */
-  ballBombMove(): this {
-    this.setFlag(MoveFlags.BALLBOMB_MOVE, true);
+  bulletMove(): this {
+    this.setFlag(MoveFlags.BULLET_MOVE, true);
     return this;
   }
 

--- a/src/enums/move-flags.ts
+++ b/src/enums/move-flags.ts
@@ -26,7 +26,7 @@ export enum MoveFlags {
    */
   RECKLESS_MOVE = 1 << 10,
   /** Indicates a move should be affected by {@linkcode Abilities.BULLETPROOF} */
-  BALLBOMB_MOVE = 1 << 11,
+  BULLET_MOVE = 1 << 11,
   /** Grass types and pokemon with {@linkcode Abilities.OVERCOAT} are immune to powder moves */
   POWDER_MOVE = 1 << 12,
   /** Indicates a move should trigger {@linkcode Abilities.DANCER} */

--- a/src/enums/move-flags.ts
+++ b/src/enums/move-flags.ts
@@ -13,7 +13,7 @@ export enum MoveFlags {
    *
    * cf https://bulbapedia.bulbagarden.net/wiki/Sound-based_move
    */
-  SOUND_BASED = 1 << 3,
+  SOUND_MOVE = 1 << 3,
   HIDE_USER = 1 << 4,
   HIDE_TARGET = 1 << 5,
   BITING_MOVE = 1 << 6,

--- a/test/abilities/bulletproof.test.ts
+++ b/test/abilities/bulletproof.test.ts
@@ -1,0 +1,50 @@
+import { Abilities } from "#enums/abilities";
+import { BattlerIndex } from "#enums/battler-index";
+import { MoveResult } from "#enums/move-result";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Bulletproof", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BULLETPROOF)
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should prevent HP recovery from ally-directed Pollen Puff", async () => {
+    game.override.moveset([Moves.POLLEN_PUFF, Moves.SPLASH]).battleType("double");
+    await game.classicMode.startBattle([Species.FEEBAS, Species.SLAKOTH]);
+    const playerParty = game.scene.getPlayerField();
+    const playerPokemon1 = playerParty[0];
+    const playerPokemon2 = playerParty[1];
+    playerPokemon2.hp = 1;
+
+    game.move.select(Moves.POLLEN_PUFF, 0, BattlerIndex.PLAYER_2);
+    game.move.select(Moves.SPLASH, 1);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const player1LastMove = playerPokemon1.getLastXMoves()[0];
+    expect(player1LastMove.result).toBe(MoveResult.FAIL);
+    expect(playerPokemon2.hp).toBe(1);
+  });
+});

--- a/test/abilities/bulletproof.test.ts
+++ b/test/abilities/bulletproof.test.ts
@@ -34,9 +34,7 @@ describe("Abilities - Bulletproof", () => {
   it("should prevent HP recovery from ally-directed Pollen Puff", async () => {
     game.override.moveset([Moves.POLLEN_PUFF, Moves.SPLASH]).battleType("double");
     await game.classicMode.startBattle([Species.FEEBAS, Species.SLAKOTH]);
-    const playerParty = game.scene.getPlayerField();
-    const playerPokemon1 = playerParty[0];
-    const playerPokemon2 = playerParty[1];
+    const [playerPokemon1, playerPokemon2] = game.scene.getPlayerField();
     playerPokemon2.hp = 1;
 
     game.move.select(Moves.POLLEN_PUFF, 0, BattlerIndex.PLAYER_2);

--- a/test/abilities/move_flag_immunity.test.ts
+++ b/test/abilities/move_flag_immunity.test.ts
@@ -1,0 +1,69 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { MoveFlags } from "#enums/move-flags";
+import { MoveResult } from "#enums/move-result";
+import { allMoves } from "#app/data/all-moves";
+
+describe("Ability Attribute - Move Flag Immunity", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.SPLASH])
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH);
+  });
+
+  // Flagged moves verified by the all_moves test in the `moves` directory
+  it.each([
+    {
+      abilityName: "Soundproof",
+      ability: Abilities.SOUNDPROOF,
+      moveFlag: MoveFlags.SOUND_MOVE,
+      enemyMove: Moves.UPROAR,
+    },
+    {
+      abilityName: "Overcoat",
+      ability: Abilities.OVERCOAT,
+      moveFlag: MoveFlags.POWDER_MOVE,
+      enemyMove: Moves.STUN_SPORE,
+    },
+    {
+      abilityName: "Bulletproof",
+      ability: Abilities.BULLETPROOF,
+      moveFlag: MoveFlags.BULLET_MOVE,
+      enemyMove: Moves.AURA_SPHERE,
+    },
+  ])("$abilityName should provide immunity against the flagged moves", async ({ ability, moveFlag, enemyMove }) => {
+    game.override.ability(ability).enemyMoveset(enemyMove);
+
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+
+    game.move.select(Moves.SPLASH);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const lastEnemyMove = enemyPokemon.getLastXMoves()[0];
+    expect(lastEnemyMove.result).toBe(MoveResult.FAIL);
+    expect(allMoves[enemyMove].checkFlag(moveFlag, enemyPokemon, null)).toBe(true);
+  });
+});

--- a/test/abilities/move_flag_power_boost.test.ts
+++ b/test/abilities/move_flag_power_boost.test.ts
@@ -58,7 +58,7 @@ describe("Abilities - Move Flag Power Boost Ability Attr", () => {
       ability: Abilities.PUNK_ROCK,
       abilityName: "Punk Rock",
       move: Moves.UPROAR,
-      moveFlag: MoveFlags.SOUND_BASED,
+      moveFlag: MoveFlags.SOUND_MOVE,
       factor: 1.3,
     },
     {

--- a/test/abilities/overcoat.test.ts
+++ b/test/abilities/overcoat.test.ts
@@ -1,0 +1,48 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { WeatherType } from "#enums/weather-type";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Overcoat", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([Moves.SPLASH])
+      .ability(Abilities.OVERCOAT)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it.each([
+    { weatherName: "Sandstorm", weather: WeatherType.SANDSTORM },
+    { weatherName: "Hail", weather: WeatherType.HAIL },
+  ])("should prevent damage from $weatherName", async ({ weather }) => {
+    game.override.weather(weather);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    game.move.select(Moves.SPLASH);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    expect(playerPokemon.isFullHp()).toBe(true);
+  });
+});

--- a/test/abilities/soundproof.test.ts
+++ b/test/abilities/soundproof.test.ts
@@ -1,0 +1,50 @@
+import { allMoves } from "#app/data/all-moves";
+import { Abilities } from "#enums/abilities";
+import { MoveFlags } from "#enums/move-flags";
+import { MoveResult } from "#enums/move-result";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Soundproof", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.SOUNDPROOF)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it("should not provide immunity to the ability holder's own sound moves", async () => {
+    game.override.moveset(Moves.CLANGOROUS_SOUL);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+
+    game.move.select(Moves.CLANGOROUS_SOUL);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    const soundMove = allMoves[Moves.CLANGOROUS_SOUL];
+    const lastMove = playerPokemon.getLastXMoves()[0];
+
+    expect(lastMove.result).toBe(MoveResult.SUCCESS);
+    expect(soundMove.checkFlag(MoveFlags.SOUND_MOVE, playerPokemon, null)).toBe(true);
+  });
+});

--- a/test/moves/all_moves.test.ts
+++ b/test/moves/all_moves.test.ts
@@ -35,7 +35,7 @@ describe("All Moves", async () => {
     15: MoveFlags.POWDER_MOVE,
     16: MoveFlags.BITING_MOVE,
     17: MoveFlags.PULSE_MOVE,
-    18: MoveFlags.BALLBOMB_MOVE,
+    18: MoveFlags.BULLET_MOVE,
     21: MoveFlags.DANCE_MOVE,
     22: MoveFlags.SLICING_MOVE,
   };

--- a/test/moves/all_moves.test.ts
+++ b/test/moves/all_moves.test.ts
@@ -30,7 +30,7 @@ describe("All Moves", async () => {
   const flagsToCheck = {
     1: MoveFlags.MAKES_CONTACT,
     8: MoveFlags.PUNCHING_MOVE,
-    9: MoveFlags.SOUND_BASED,
+    9: MoveFlags.SOUND_MOVE,
     13: MoveFlags.TRIAGE_MOVE,
     15: MoveFlags.POWDER_MOVE,
     16: MoveFlags.BITING_MOVE,


### PR DESCRIPTION
## What are the changes the user will see?

None.

## Why am I making these changes?

Ability Checkups.

## What are the changes from a developer perspective?

A new ability attribute `MoveFlagImmunityAbAttr', which extends `MoveImmunityAbAttr', has been created for abilities that provide immunity against moves of a certain flag category.
Tests for this attribute + Bulletproof/Overcoat/Soundproof's unique attributes have been created.
Two MoveFlags have been renamed. 
MoveFlags.SOUND_BASED --> MoveFlags.SOUND_MOVE 
MoveFlags.BALLBOMB_MOVE --> MoveFlags.BULLET_MOVE (Smogon tags this move category as 'bullet')
Overcoat's BlockWeatherDamageAbAttr now takes WeatherType.HAIL and WeatherType.SANDSTORM so the ability attribute doesn't use an awkward conditional where it assumes no weather list = all damaging weathers

## How to test the changes?

`npm run test move_flag_immunity`
`npm run test bulletproof`
`npm run test soundproof`
`npm run test overcoat`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?=
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?