### PR TITLE
[Balance] Bring back gmax immunities

### DIFF
--- a/src/data/ab-attrs/post-defend-ability-give-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-ability-give-ab-attr.ts
@@ -20,6 +20,7 @@ export class PostDefendAbilityGiveAbAttr extends PostDefendAbAttr {
       move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)
       && !attacker.getAbility().hasAttr(UnsuppressableAbilityAbAttr)
       && !attacker.getAbility().hasAttr(PostDefendAbilityGiveAbAttr)
+      && !attacker.isMax()
     ) {
       if (!simulated) {
         attacker.summonData.ability = this.ability;

--- a/src/data/ab-attrs/post-defend-ability-swap-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-ability-swap-ab-attr.ts
@@ -11,6 +11,7 @@ export class PostDefendAbilitySwapAbAttr extends PostDefendAbAttr {
     if (
       move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)
       && !attacker.getAbility().hasAttr(UnswappableAbilityAbAttr)
+      && !attacker.isMax()
     ) {
       if (!simulated) {
         const sourceAbilityId = pokemon.getAbility().id;

--- a/src/data/ab-attrs/post-defend-move-disable-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-move-disable-ab-attr.ts
@@ -18,6 +18,7 @@ export class PostDefendMoveDisableAbAttr extends PostDefendAbAttr {
       if (
         move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)
         && (this.chance === -1 || pokemon.randSeedInt(100) < this.chance)
+        && !attacker.isMax()
       ) {
         if (simulated) {
           return true;

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -234,6 +234,7 @@ import {
   failIfSingleBattle,
   unknownTypeCondition,
   UpperHandCondition,
+  failOnMaxCondition,
 } from "./move-conditions";
 import { SelfStatusMove } from "./move";
 import { isNonVolatileStatusEffect, getNonVolatileStatusEffects } from "./status-effect";
@@ -377,6 +378,7 @@ export function initMoves() {
     new AttackMove(Moves.SONIC_BOOM, Type.NORMAL, MoveCategory.SPECIAL, -1, 90, 20, -1, 0, 1).attr(FixedDamageAttr, 20),
     new StatusMove(Moves.DISABLE, Type.NORMAL, 100, 20, -1, 0, 1)
       .attr(AddBattlerTagAttr, BattlerTagType.DISABLED, false, { failOnOverlap: true })
+      .condition(failOnMaxCondition)
       .condition(
         (_user, target, _move) =>
           target
@@ -431,7 +433,9 @@ export function initMoves() {
     new AttackMove(Moves.SUBMISSION, Type.FIGHTING, MoveCategory.PHYSICAL, 80, 80, 20, -1, 0, 1)
       .attr(RecoilAttr)
       .recklessMove(),
-    new AttackMove(Moves.LOW_KICK, Type.FIGHTING, MoveCategory.PHYSICAL, -1, 100, 20, -1, 0, 1).attr(WeightPowerAttr),
+    new AttackMove(Moves.LOW_KICK, Type.FIGHTING, MoveCategory.PHYSICAL, -1, 100, 20, -1, 0, 1)
+      .condition(failOnMaxCondition)
+      .attr(WeightPowerAttr),
     new AttackMove(Moves.COUNTER, Type.FIGHTING, MoveCategory.PHYSICAL, -1, 100, 20, -1, -5, 1)
       .attr(CounterDamageAttr, (move: Move) => move.category === MoveCategory.PHYSICAL, 2)
       .target(MoveTarget.ATTACKER),
@@ -1694,6 +1698,7 @@ export function initMoves() {
       .attr(AddArenaTrapTagAttr, ArenaTagType.STEALTH_ROCK)
       .target(MoveTarget.ENEMY_SIDE),
     new AttackMove(Moves.GRASS_KNOT, Type.GRASS, MoveCategory.SPECIAL, -1, 100, 20, -1, 0, 4)
+      .condition(failOnMaxCondition)
       .attr(WeightPowerAttr)
       .makesContact(),
     new AttackMove(Moves.CHATTER, Type.FLYING, MoveCategory.SPECIAL, 65, 100, 20, 100, 0, 4)
@@ -1847,6 +1852,7 @@ export function initMoves() {
       .attr(StatStageChangeAttr, [Stat.SPATK, Stat.SPDEF, Stat.SPD], 1, true)
       .danceMove(),
     new AttackMove(Moves.HEAVY_SLAM, Type.STEEL, MoveCategory.PHYSICAL, -1, 100, 10, -1, 0, 5)
+      .condition(failOnMaxCondition)
       .attr(AlwaysHitMinimizeAttr)
       .attr(CompareWeightPowerAttr)
       .attr(HitsTagForDoubleDamageAttr, BattlerTagType.MINIMIZED),
@@ -2050,6 +2056,7 @@ export function initMoves() {
       .attr(StatStageChangeAttr, [Stat.DEF], -1)
       .slicingMove(),
     new AttackMove(Moves.HEAT_CRASH, Type.FIRE, MoveCategory.PHYSICAL, -1, 100, 10, -1, 0, 5)
+      .condition(failOnMaxCondition)
       .attr(AlwaysHitMinimizeAttr)
       .attr(CompareWeightPowerAttr)
       .attr(HitsTagForDoubleDamageAttr, BattlerTagType.MINIMIZED),

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -1138,7 +1138,10 @@ export function initMoves() {
     new AttackMove(Moves.ERUPTION, Type.FIRE, MoveCategory.SPECIAL, 150, 100, 5, -1, 0, 3)
       .attr(HpPowerAttr)
       .target(MoveTarget.ALL_NEAR_ENEMIES),
-    new StatusMove(Moves.SKILL_SWAP, Type.PSYCHIC, -1, 10, -1, 0, 3).ignoresSubstitute().attr(SwitchAbilitiesAttr),
+    new StatusMove(Moves.SKILL_SWAP, Type.PSYCHIC, -1, 10, -1, 0, 3)
+      .condition(failOnMaxCondition)
+      .ignoresSubstitute()
+      .attr(SwitchAbilitiesAttr),
     new StatusMove(Moves.IMPRISON, Type.PSYCHIC, 100, 10, -1, 0, 3)
       .ignoresSubstitute()
       .attr(AddArenaTagAttr, ArenaTagType.IMPRISON, { failOnOverlap: true })
@@ -1888,7 +1891,9 @@ export function initMoves() {
       .attr(TargetAtkUserAtkAttr)
       .edgeCase(), // Does not consider Huge Power/other attack stat modifiers correctly + disables Unaware during use
     new StatusMove(Moves.SIMPLE_BEAM, Type.NORMAL, 100, 15, -1, 0, 5).attr(AbilityChangeAttr, Abilities.SIMPLE),
-    new StatusMove(Moves.ENTRAINMENT, Type.NORMAL, 100, 15, -1, 0, 5).attr(AbilityGiveAttr),
+    new StatusMove(Moves.ENTRAINMENT, Type.NORMAL, 100, 15, -1, 0, 5)
+      .condition(failOnMaxCondition)
+      .attr(AbilityGiveAttr),
     new StatusMove(Moves.AFTER_YOU, Type.NORMAL, -1, 15, -1, 0, 5)
       .ignoresProtect()
       .ignoresSubstitute()

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -615,6 +615,10 @@ export class FlinchedTag extends BattlerTag {
     super(BattlerTagType.FLINCHED, [BattlerTagLapseType.PRE_MOVE, BattlerTagLapseType.TURN_END], 0, sourceMove);
   }
 
+  override canAdd(pokemon: Pokemon): boolean {
+    return !pokemon.isMax();
+  }
+
   override onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
 
@@ -1099,6 +1103,10 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
   }
 
   override canAdd(pokemon: Pokemon): boolean {
+    if (pokemon.isMax()) {
+      return false;
+    }
+
     const lastMoves = pokemon.getLastXMoves(1);
     if (!lastMoves.length) {
       return false;
@@ -1304,11 +1312,19 @@ export class MinimizeTag extends BattlerTag {
     super(BattlerTagType.MINIMIZED, BattlerTagLapseType.TURN_END, 1, Moves.MINIMIZE);
   }
 
+  override canAdd(pokemon: Pokemon): boolean {
+    return !pokemon.isMax();
+  }
+
   override onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
   }
 
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
+    //If a pokemon dynamaxes they lose minimized status
+    if (pokemon.isMax()) {
+      return false;
+    }
     return lapseType !== BattlerTagLapseType.CUSTOM || super.lapse(pokemon, lapseType);
   }
 

--- a/src/data/move-attrs/force-switch-out-attr.ts
+++ b/src/data/move-attrs/force-switch-out-attr.ts
@@ -222,7 +222,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 
         const blockedByAbility = new BooleanHolder(false);
         applyAbAttrs(ForceSwitchOutImmunityAbAttr, target, false, blockedByAbility);
-        return !blockedByAbility.value;
+        return !blockedByAbility.value && !target.isMax();
       }
 
       if (!player && globalScene.currentBattle.battleType === BattleType.WILD) {

--- a/src/data/move-conditions.ts
+++ b/src/data/move-conditions.ts
@@ -102,6 +102,8 @@ export const failOnGravityCondition: MoveConditionFunc = (_user, _target, _move)
 
 export const failOnBossCondition: MoveConditionFunc = (_user, target, _move) => !target.isBossImmune();
 
+export const failOnMaxCondition: MoveConditionFunc = (_user, target, _move) => !target.isMax();
+
 export const failIfSingleBattle: MoveConditionFunc = (_user, _target, _move) => globalScene.currentBattle.double;
 
 /** @todo Add simulated support */


### PR DESCRIPTION
## What are the changes the user will see?

Max Pokemon now retain their immunities to:
* Flinch
* Phazing
* Encore
* Disable
* Minimize
* Weight based moves
* Losing their abilities

## Why am I making these changes?

The max immunities were a pretty unique feature that was interesting and should not have been removed in my opinion. 

## What are the changes from a developer perspective?

This mainly undoes pr#4200

## Screenshots/Videos

n/a

## How to test the changes?

Override with a max pokemon

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
