### PR TITLE
[Move][Checkup] Reimplement Body Press, Foul Play, and Psyshock et al.

### DIFF
--- a/src/data/move-attrs/deals-physical-damage-attr.ts
+++ b/src/data/move-attrs/deals-physical-damage-attr.ts
@@ -14,8 +14,8 @@ export class DealsPhysicalDamageAttr extends VariableDefAttr {
     super();
   }
 
-  override apply(user: Pokemon, target: Pokemon, _move: Move, defendingStat: NumberHolder): boolean {
-    defendingStat.value = target.getEffectiveStat(Stat.DEF, user);
+  override apply(_user: Pokemon, _target: Pokemon, _move: Move, defendingStat: NumberHolder): boolean {
+    defendingStat.value = Stat.DEF;
     return true;
   }
 }

--- a/src/data/move-attrs/def-atk-attr.ts
+++ b/src/data/move-attrs/def-atk-attr.ts
@@ -1,6 +1,5 @@
 import { Stat } from "#enums/stat";
 import type { Pokemon } from "#app/field/pokemon";
-import type { NumberHolder } from "#app/utils";
 import type { Move } from "#app/data/move";
 import { VariableAtkAttr } from "#app/data/move-attrs/variable-atk-attr";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
@@ -15,12 +14,7 @@ export class DefAtkAttr extends VariableAtkAttr {
     super();
   }
 
-  /**
-   * @todo This wrongly ignores Unaware and does not preserve the effects of Huge Power and other Attack multipliers.
-   * @see {@link https://github.com/Despair-Games/poketernity/issues/184 | #184}
-   */
-  override apply(user: Pokemon, target: Pokemon, move: Move, attackingStat: NumberHolder): boolean {
-    attackingStat.value = user.getEffectiveStat(Stat.DEF, target, move, AbilityApplyMode.IGNORE);
-    return true;
+  override getStatOverride(user: Pokemon, target: Pokemon, move: Move, isCritical: boolean) {
+    return user.getStageMultipliedStat(Stat.DEF, target, move, AbilityApplyMode.DEFAULT, isCritical);
   }
 }

--- a/src/data/move-attrs/target-atk-user-atk-attr.ts
+++ b/src/data/move-attrs/target-atk-user-atk-attr.ts
@@ -1,6 +1,5 @@
 import { Stat } from "#enums/stat";
 import type { Pokemon } from "#app/field/pokemon";
-import type { NumberHolder } from "#app/utils";
 import type { Move } from "#app/data/move";
 import { VariableAtkAttr } from "#app/data/move-attrs/variable-atk-attr";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
@@ -15,12 +14,7 @@ export class TargetAtkUserAtkAttr extends VariableAtkAttr {
     super();
   }
 
-  /**
-   * @todo This wrongly ignores the user's Unaware and does not preserve the effects of Huge Power, etc.
-   * @see {@link https://github.com/Despair-Games/poketernity/issues/184 | #184}
-   */
-  override apply(_user: Pokemon, target: Pokemon, move: Move, attackingStat: NumberHolder): boolean {
-    attackingStat.value = target.getEffectiveStat(Stat.ATK, target, move, AbilityApplyMode.IGNORE);
-    return true;
+  override getStatOverride(user: Pokemon, target: Pokemon, move: Move, isCritical: boolean) {
+    return target.getStageMultipliedStat(Stat.ATK, user, move, AbilityApplyMode.DEFAULT, isCritical);
   }
 }

--- a/src/data/move-attrs/variable-atk-attr.ts
+++ b/src/data/move-attrs/variable-atk-attr.ts
@@ -5,6 +5,10 @@ import type { NumberHolder } from "#app/utils";
 
 /**
  * Attribute to change the offensive stat used for a move's damage calculations.
+ * Moves with this attribute alter the permanent stat and stat stage-modifier
+ * used when obtaining the user's attacking stat. Other stat modifiers, e.g.
+ * multipliers from items and abilities, still apply based on the original stat
+ * checked.
  * @extends MoveAttr
  */
 export abstract class VariableAtkAttr extends MoveAttr {
@@ -14,14 +18,33 @@ export abstract class VariableAtkAttr extends MoveAttr {
 
   /**
    * Changes the offensive stat used for the current attack's damage calculation
-   * @param _user the {@linkcode Pokemon} using the move
-   * @param _target the {@linkcode Pokemon} targeted by the move
-   * @param _move the {@linkcode Move} being used
-   * @param _attackingStat a {@linkcode NumberHolder} containing the offensive stat
+   * @param user the {@linkcode Pokemon} using the move
+   * @param target the {@linkcode Pokemon} targeted by the move
+   * @param move the {@linkcode Move} being used
+   * @param attackingStat a {@linkcode NumberHolder} containing the offensive stat
+   * @param isCritical `true` if the attack should be treated as a critical strike
    * for the current attack's damage calculation
    * @returns `true` if the offensive stat is modified by this attribute
    */
-  override apply(_user: Pokemon, _target: Pokemon, _move: Move, _attackingStat: NumberHolder): boolean {
-    return false;
+  override apply(
+    user: Pokemon,
+    target: Pokemon,
+    move: Move,
+    attackingStat: NumberHolder,
+    isCritical: boolean,
+  ): boolean {
+    attackingStat.value = this.getStatOverride(user, target, move, isCritical);
+    return true;
   }
+
+  /**
+   * Obtains the stat value to override {@linkcode Pokemon.getStageMultipliedStat}
+   * for offensive stat calculations during an attack.
+   * @param user the {@linkcode Pokemon} using the move
+   * @param target the {@linkcode Pokemon} targeted by the move
+   * @param move the {@linkcode Move} being used
+   * @param isCritical `true` if the attack should be treated as a critical strike
+   * @returns the overriding stat value
+   */
+  abstract getStatOverride(user: Pokemon, target: Pokemon, move: Move, isCritical: boolean): number;
 }

--- a/src/data/move-attrs/variable-def-attr.ts
+++ b/src/data/move-attrs/variable-def-attr.ts
@@ -1,3 +1,8 @@
+// -- start tsdoc imports --
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { Stat } from "#enums/stat";
+// -- end tsdoc imports --
+
 import type { Pokemon } from "#app/field/pokemon";
 import type { Move } from "#app/data/move";
 import { MoveAttr } from "#app/data/move-attrs/move-attr";
@@ -13,8 +18,8 @@ export abstract class VariableDefAttr extends MoveAttr {
    * @param _user the {@linkcode Pokemon} using the move
    * @param _target the {@linkcode Pokemon} targeted by the move
    * @param _move the {@linkcode Move} being used
-   * @param _defendingStat a {@linkcode NumberHolder} containing the defensive stat
-   * used in the current attack's damage calculation.
+   * @param _defendingStat a {@linkcode NumberHolder} containing the defensive {@linkcode Stat}
+   * (originally `DEF` or `SPDEF`) used in the current attack's damage calculation.
    * @returns `true` if the defensive stat is modified by this attribute
    */
   override apply(_user: Pokemon, _target: Pokemon, _move: Move, _defendingStat: NumberHolder): boolean {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -48,7 +48,6 @@ import { MoveCondition } from "./move-conditions";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { HealStatusEffectAttr } from "./move-attrs/heal-status-effect-attr";
-import { VariableAtkAttr } from "./move-attrs/variable-atk-attr";
 import { ChargeAnim } from "#enums/charge-anim";
 import { allMoves } from "#app/data/all-moves";
 
@@ -874,7 +873,6 @@ export class AttackMove extends Move {
     if (attackScore) {
       if (this.category === MoveCategory.PHYSICAL) {
         const atk = new NumberHolder(user.getEffectiveStat(Stat.ATK, target));
-        applyMoveAttrs(VariableAtkAttr, user, target, move, atk);
         if (atk.value > user.getEffectiveStat(Stat.SPATK, target)) {
           const statRatio = user.getEffectiveStat(Stat.SPATK, target) / atk.value;
           if (statRatio <= 0.75) {
@@ -885,7 +883,6 @@ export class AttackMove extends Move {
         }
       } else {
         const spAtk = new NumberHolder(user.getEffectiveStat(Stat.SPATK, target));
-        applyMoveAttrs(VariableAtkAttr, user, target, move, spAtk);
         if (spAtk.value > user.getEffectiveStat(Stat.ATK, target)) {
           const statRatio = user.getEffectiveStat(Stat.ATK, target) / spAtk.value;
           if (statRatio <= 0.75) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1103,6 +1103,20 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return critStage.value;
   }
 
+  getStageMultipliedStat(
+    stat: EffectiveStat,
+    opponent?: Pokemon,
+    move?: Move,
+    abilityApplyMode: AbilityApplyMode = AbilityApplyMode.DEFAULT,
+    isCritical: boolean = false,
+    simulated: boolean = true,
+  ): number {
+    return (
+      this.getStat(stat, false)
+      * this.getStatStageMultiplier(stat, opponent, move, abilityApplyMode, isCritical, simulated)
+    );
+  }
+
   /**
    * Calculates and retrieves the final value of a stat considering any held
    * items, move effects, opponent abilities, and whether there was a critical
@@ -1125,7 +1139,21 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   ): number {
     const applyAbFunc = getAbApplyFunc(abilityApplyMode);
 
-    const statValue = new NumberHolder(this.getStat(stat, false));
+    const statValue = new NumberHolder(-1);
+
+    /**
+     * Variable Attack attributes are applied only to the raw stat
+     * value and associated stat stage multiplier. Other stat modifiers,
+     * e.g. items and abilities, apply based on the original {@linkcode stat}.
+     */
+    if (move && opponent && [Stat.ATK, Stat.SPATK].includes(stat)) {
+      applyMoveAttrs(VariableAtkAttr, this, opponent, move, statValue, isCritical);
+    }
+
+    if (statValue.value === -1) {
+      statValue.value = this.getStageMultipliedStat(stat, opponent, move, abilityApplyMode, isCritical, simulated);
+    }
+
     globalScene.applyModifiers(StatBoosterModifier, this.isPlayer(), this, stat, statValue);
 
     const fieldApplied = new BooleanHolder(false);
@@ -1138,8 +1166,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     applyAbFunc(StatMultiplierAbAttr, this, simulated, stat, statValue, move, opponent);
 
-    let ret =
-      statValue.value * this.getStatStageMultiplier(stat, opponent, move, abilityApplyMode, isCritical, simulated);
+    let ret = statValue.value;
 
     switch (stat) {
       case Stat.ATK:
@@ -3050,29 +3077,37 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
      * The attacker's offensive stat for the given move's category.
      * Critical hits cause negative stat stages to be ignored.
      */
-    const sourceAtk = new NumberHolder(
-      source.getEffectiveStat(isPhysical ? Stat.ATK : Stat.SPATK, this, move, abilityApplyMode, isCritical, simulated),
+    const sourceAtk = source.getEffectiveStat(
+      isPhysical ? Stat.ATK : Stat.SPATK,
+      this,
+      move,
+      abilityApplyMode,
+      isCritical,
+      simulated,
     );
-    applyMoveAttrs(VariableAtkAttr, source, this, move, sourceAtk);
+
+    /**
+     * The {@linkcode EffectiveStat} used to defend against the given move.
+     * Can be altered by move attributes, e.g. from Psyshock.
+     */
+    const defendingStat = new NumberHolder(isPhysical ? Stat.DEF : Stat.SPDEF);
+    applyMoveAttrs(VariableDefAttr, source, this, move, defendingStat);
 
     /**
      * This Pokemon's defensive stat for the given move's category.
      * Critical hits cause positive stat stages to be ignored.
      */
-    const targetDef = new NumberHolder(
-      this.getEffectiveStat(isPhysical ? Stat.DEF : Stat.SPDEF, source, move, abilityApplyMode, isCritical, simulated),
-    );
-    applyMoveAttrs(VariableDefAttr, source, this, move, targetDef);
+    const targetDef = this.getEffectiveStat(defendingStat.value, source, move, abilityApplyMode, isCritical, simulated);
 
     /**
      * The attack's base damage, as determined by the source's level, move power
      * and Attack stat as well as this Pokemon's Defense stat
      */
-    const baseDamage = (levelMultiplier * power * sourceAtk.value) / targetDef.value / 50 + 2;
+    const baseDamage = (levelMultiplier * power * sourceAtk) / targetDef / 50 + 2;
 
     /** Debug message for non-simulated calls (i.e. when damage is actually dealt) */
     if (!simulated) {
-      console.log("base damage", baseDamage, move.name, power, sourceAtk.value, targetDef.value);
+      console.log("base damage", baseDamage, move.name, power, sourceAtk, targetDef);
     }
 
     return baseDamage;

--- a/test/abilities/unaware.test.ts
+++ b/test/abilities/unaware.test.ts
@@ -109,11 +109,7 @@ describe("Abilities - Unaware", () => {
     expect(punishmentMove.calculateBattlePower).toHaveLastReturnedWith(180);
   });
 
-  /**
-   * Body Press currently ignores all Abilities in its stat calculation.
-   * @todo fix this interaction to pass this test.
-   */
-  it.todo("should cause the opponent's Body Press to ignore the opponent's Defense stages", async () => {
+  it("should cause the opponent's Body Press to ignore the opponent's Defense stages", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     const enemyPokemon = game.field.getEnemyPokemon();

--- a/test/moves/body_press.test.ts
+++ b/test/moves/body_press.test.ts
@@ -1,0 +1,93 @@
+import { allMoves } from "#app/data/all-moves";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Body Press", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should use the user's Defense stat to calculate damage", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const bodyPress = allMoves[Moves.BODY_PRESS];
+
+    const player = game.field.getPlayerPokemon();
+    vi.spyOn(player, "stats", "get").mockReturnValue(Array(6).fill(100));
+
+    const enemy = game.field.getEnemyPokemon();
+
+    const { damage: preDamage } = enemy.getAttackDamage(player, bodyPress);
+
+    // double the player's Defense
+    vi.spyOn(player, "stats", "get").mockReturnValue([100, 100, 200, 100, 100, 100]);
+
+    const { damage: postDamage } = enemy.getAttackDamage(player, bodyPress);
+
+    // 1.7 is the estimated lower bound based on random damage spread (2 * 0.85).
+    // It might be generous, but it avoids flakiness from rounding error.
+    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+  });
+
+  it("should use Defense stat stages during damage calculation", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const bodyPress = allMoves[Moves.BODY_PRESS];
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    const { damage: preDamage } = enemy.getAttackDamage(player, bodyPress);
+
+    game.move.use(Moves.IRON_DEFENSE);
+
+    await game.toNextTurn();
+
+    const { damage: postDamage } = enemy.getAttackDamage(player, bodyPress);
+
+    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+  });
+
+  it("should only apply Attack stat multipliers from abilities for damage", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const bodyPress = allMoves[Moves.BODY_PRESS];
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    const { damage: preDamage } = enemy.getAttackDamage(player, bodyPress);
+
+    game.override.ability(Abilities.HUSTLE).passiveAbility(Abilities.FUR_COAT);
+
+    const { damage: postDamage } = enemy.getAttackDamage(player, bodyPress);
+
+    // 1.275 is the estimated lower bound based on damage spread
+    // if only Hustle applies (1.5 * 0.85)
+    expect(postDamage).toBeGreaterThan(1.275 * preDamage);
+    expect(postDamage).toBeLessThan(1.7 * preDamage);
+  });
+});

--- a/test/moves/body_press.test.ts
+++ b/test/moves/body_press.test.ts
@@ -49,9 +49,8 @@ describe("Moves - Body Press", () => {
 
     const { damage: postDamage } = enemy.getAttackDamage(player, bodyPress);
 
-    // 1.7 is the estimated lower bound based on random damage spread (2 * 0.85).
-    // It might be generous, but it avoids flakiness from rounding error.
-    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+    expect(postDamage).toBeGreaterThan(2 * preDamage - 3);
+    expect(postDamage).toBeLessThan(2 * preDamage + 3);
   });
 
   it("should use Defense stat stages during damage calculation", async () => {
@@ -69,7 +68,8 @@ describe("Moves - Body Press", () => {
 
     const { damage: postDamage } = enemy.getAttackDamage(player, bodyPress);
 
-    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+    expect(postDamage).toBeGreaterThan(2 * preDamage - 3);
+    expect(postDamage).toBeLessThan(2 * preDamage + 3);
   });
 
   it("should only apply Attack stat multipliers from abilities for damage", async () => {
@@ -85,9 +85,7 @@ describe("Moves - Body Press", () => {
 
     const { damage: postDamage } = enemy.getAttackDamage(player, bodyPress);
 
-    // 1.275 is the estimated lower bound based on damage spread
-    // if only Hustle applies (1.5 * 0.85)
-    expect(postDamage).toBeGreaterThan(1.275 * preDamage);
-    expect(postDamage).toBeLessThan(1.7 * preDamage);
+    expect(postDamage).toBeGreaterThan(1.5 * preDamage - 3);
+    expect(postDamage).toBeLessThan(1.5 * preDamage + 3);
   });
 });

--- a/test/moves/foul_play.test.ts
+++ b/test/moves/foul_play.test.ts
@@ -1,0 +1,91 @@
+import { allMoves } from "#app/data/all-moves";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Foul Play", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should use the target's Attack stat to calculate damage", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const foulPlay = allMoves[Moves.FOUL_PLAY];
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    vi.spyOn(enemy, "stats", "get").mockReturnValue(Array(6).fill(100));
+
+    const { damage: preDamage } = enemy.getAttackDamage(player, foulPlay);
+
+    // double the enemy's Attack
+    vi.spyOn(enemy, "stats", "get").mockReturnValue([100, 200, 100, 100, 100, 100]);
+
+    const { damage: postDamage } = enemy.getAttackDamage(player, foulPlay);
+
+    // 1.7 is the estimated lower bound with damage spread (2 * 0.85)
+    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+  });
+
+  it("should use the target's Attack stat stages during damage calculation", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const foulPlay = allMoves[Moves.FOUL_PLAY];
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    const { damage: preDamage } = player.getAttackDamage(enemy, foulPlay);
+
+    game.move.use(Moves.SWORDS_DANCE);
+
+    await game.toNextTurn();
+
+    const { damage: postDamage } = player.getAttackDamage(enemy, foulPlay);
+
+    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+  });
+
+  it("should only apply the user's Attack stat multipliers from abilities for damage", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const foulPlay = allMoves[Moves.FOUL_PLAY];
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    const { damage: preDamage } = enemy.getAttackDamage(player, foulPlay);
+
+    game.override.ability(Abilities.HUSTLE).enemyAbility(Abilities.HUGE_POWER);
+
+    const { damage: postDamage } = enemy.getAttackDamage(player, foulPlay);
+
+    // 1.275 is the estimated lower bound based on damage spread
+    // if only Hustle applies (1.5 * 0.85)
+    expect(postDamage).toBeGreaterThan(1.275 * preDamage);
+    expect(postDamage).toBeLessThan(1.7 * preDamage);
+  });
+});

--- a/test/moves/foul_play.test.ts
+++ b/test/moves/foul_play.test.ts
@@ -48,8 +48,8 @@ describe("Moves - Foul Play", () => {
 
     const { damage: postDamage } = enemy.getAttackDamage(player, foulPlay);
 
-    // 1.7 is the estimated lower bound with damage spread (2 * 0.85)
-    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+    expect(postDamage).toBeGreaterThan(2 * preDamage - 3);
+    expect(postDamage).toBeLessThan(2 * preDamage + 3);
   });
 
   it("should use the target's Attack stat stages during damage calculation", async () => {
@@ -67,7 +67,8 @@ describe("Moves - Foul Play", () => {
 
     const { damage: postDamage } = player.getAttackDamage(enemy, foulPlay);
 
-    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+    expect(postDamage).toBeGreaterThan(2 * preDamage - 3);
+    expect(postDamage).toBeLessThan(2 * preDamage + 3);
   });
 
   it("should only apply the user's Attack stat multipliers from abilities for damage", async () => {
@@ -83,9 +84,33 @@ describe("Moves - Foul Play", () => {
 
     const { damage: postDamage } = enemy.getAttackDamage(player, foulPlay);
 
-    // 1.275 is the estimated lower bound based on damage spread
-    // if only Hustle applies (1.5 * 0.85)
-    expect(postDamage).toBeGreaterThan(1.275 * preDamage);
-    expect(postDamage).toBeLessThan(1.7 * preDamage);
+    expect(postDamage).toBeGreaterThan(1.5 * preDamage - 3);
+    expect(postDamage).toBeLessThan(1.5 * preDamage + 3);
+  });
+
+  it("should apply damage reduction from the user's burn and not the target's", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const foulPlay = allMoves[Moves.FOUL_PLAY];
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    const { damage: preDamage } = enemy.getAttackDamage(player, foulPlay);
+
+    game.move.use(Moves.SIZZLY_SLIDE);
+    await game.toNextTurn();
+
+    const { damage: oppBurnedDamage } = enemy.getAttackDamage(player, foulPlay);
+
+    expect(oppBurnedDamage).toBe(preDamage);
+
+    game.move.use(Moves.SPLASH);
+    await game.move.forceEnemyMove(Moves.SIZZLY_SLIDE);
+    await game.toNextTurn();
+
+    const { damage: userBurnedDamage } = enemy.getAttackDamage(player, foulPlay);
+
+    expect(userBurnedDamage).toBeGreaterThan(0.5 * preDamage - 3);
+    expect(userBurnedDamage).toBeLessThan(0.5 * preDamage + 3);
   });
 });

--- a/test/moves/psyshock.test.ts
+++ b/test/moves/psyshock.test.ts
@@ -58,6 +58,7 @@ describe("Moves - Psyshock", () => {
 
     const { damage: postDamage } = enemy.getAttackDamage(player, psyshock);
 
-    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+    expect(postDamage).toBeGreaterThan(2 * preDamage - 3);
+    expect(postDamage).toBeLessThan(2 * preDamage + 3);
   });
 });

--- a/test/moves/psyshock.test.ts
+++ b/test/moves/psyshock.test.ts
@@ -1,0 +1,63 @@
+import { allMoves } from "#app/data/all-moves";
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Psyshock", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.FUR_COAT)
+      .enemyMoveset(Moves.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should deal physical damage", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.use(Moves.PSYSHOCK);
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(enemy.battleData.abilitiesApplied).toContain(Abilities.FUR_COAT);
+  });
+
+  it("should use the user's Sp. Atk stat stages during damage calculation", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const psyshock = allMoves[Moves.PSYSHOCK];
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    const { damage: preDamage } = enemy.getAttackDamage(player, psyshock);
+
+    game.move.use(Moves.NASTY_PLOT);
+    await game.toNextTurn();
+
+    const { damage: postDamage } = enemy.getAttackDamage(player, psyshock);
+
+    expect(postDamage).toBeGreaterThan(1.7 * preDamage);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

- Body Press should now correctly apply the user's Defense stat, Defense stages, and non-stage-based Attack modifiers (e.g. Huge Power). Its interaction with Unaware has also been fixed
- Foul Play should now correctly apply the target's Attack stat, the target's Attack stages, and the *user's* non-stage-based Attack modifiers.

## Why am I making these changes?

Fixing up moves I partially broke with #329 

## What are the changes from a developer perspective?

- `Pokemon#getEffectiveStat`, the permanent stat fetching and stat stage multiplier are now grouped into `Pokemon.getStageMultipliedStat`. `VariableAtkAttr` is now applied within `getEffectiveStat` and provides a value to be used in place of `getStageMultipliedStat`.
- `VariableAtkAttr` and its subclasses have been rewritten to override `getStageMultipliedStat` instead of the entire effective stat calculation
- `VariableDefAttr` and its subclasses have been rewritten to override the defensive type fed into effective stat calculation instead of overriding the entire calculation.

## Screenshots/Videos

## How to test the changes?

`npm run test body_press`
`npm run test foul_play`
`npm run test psyshock`
`npm run test unaware` (Body Press test re-enabled)

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [?] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?
