### PR TITLE
[Move] Implement gmax status moves

### DIFF
--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -3313,7 +3313,7 @@ export function initMoves() {
       .unimplemented(), // 50% of replenishing user and ally's berries (like recycle)
     new AttackMove(Moves.G_MAX_MALODOR, Type.POISON, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
-      .attr(StatusEffectAttr, StatusEffect.PARALYSIS),
+      .attr(StatusEffectAttr, StatusEffect.POISON),
     new AttackMove(Moves.G_MAX_STONESURGE, Type.WATER, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
       .attr(AddArenaTrapTagAttr, ArenaTagType.STEALTH_ROCK),

--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -3289,10 +3289,10 @@ export function initMoves() {
       .attr(AddArenaTagAttr, ArenaTagType.G_MAX_WILDFIRE),
     new AttackMove(Moves.G_MAX_BEFUDDLE, Type.BUG, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
-      .unimplemented(), // All opps become poisoned, paralyzed, or asleep
+      .attr(MultiStatusEffectAttr, [StatusEffect.POISON, StatusEffect.PARALYSIS, StatusEffect.SLEEP]),
     new AttackMove(Moves.G_MAX_VOLT_CRASH, Type.ELECTRIC, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
-      .unimplemented(), // All opps become paralyze
+      .attr(StatusEffectAttr, StatusEffect.PARALYSIS),
     new AttackMove(Moves.G_MAX_GOLD_RUSH, Type.NORMAL, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
       .unimplemented(), // Confuses all opps, gives 100x user level as money
@@ -3313,7 +3313,7 @@ export function initMoves() {
       .unimplemented(), // 50% of replenishing user and ally's berries (like recycle)
     new AttackMove(Moves.G_MAX_MALODOR, Type.POISON, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
-      .unimplemented(), // applies poison to all opps
+      .attr(StatusEffectAttr, StatusEffect.PARALYSIS),
     new AttackMove(Moves.G_MAX_STONESURGE, Type.WATER, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
       .attr(AddArenaTrapTagAttr, ArenaTagType.STEALTH_ROCK),
@@ -3326,7 +3326,7 @@ export function initMoves() {
       .attr(RemoveArenaTagsAttr, [ArenaTagType.SAFEGUARD, ArenaTagType.MIST], ArenaTagRelativeSide.TARGET),
     new AttackMove(Moves.G_MAX_STUN_SHOCK, Type.ELECTRIC, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
-      .unimplemented(), // each opp becomes either paralyzed or poisoned
+      .attr(MultiStatusEffectAttr, [StatusEffect.POISON, StatusEffect.PARALYSIS]),
     new AttackMove(Moves.G_MAX_FINALE, Type.FAIRY, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .gMaxMove()
       .unimplemented(), // heal user and ally by 1/6


### PR DESCRIPTION
## What are the changes the user will see?

None

## Why am I making these changes?

#348 allows for much easier implementation of attr's for gmax moves

## What are the changes from a developer perspective?

* Gave `MultiStatusEffectAttr` to gmax befuddle and gmax stun shock
* Gave `StatusEffectAttr` to gmax volt crash and gmax malodor

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

```ts
const overrides = {
  BATTLE_TYPE_OVERRIDE: "double",
  MOVESET_OVERRIDE: [Moves.G_MAX_BEFUDDLE, Moves.G_MAX_STUN_SHOCK, Moves.G_MAX_VOLT_CRASH, Moves.G_MAX_MALODOR],
  ENEMY_MOVESET_OVERRIDE: [Moves.G_MAX_BEFUDDLE, Moves.G_MAX_STUN_SHOCK, Moves.G_MAX_VOLT_CRASH, Moves.G_MAX_MALODOR]
}
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
