### PR TITLE
Create `GameSprite` class to centralize `try/catch` in one spot

### DIFF
--- a/src/animations.ts
+++ b/src/animations.ts
@@ -7,6 +7,7 @@ import { PokeballType } from "#enums/pokeball";
 import type { Variant } from "./data/variant";
 import type BattleScene from "./battle-scene";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 /**
  * Class for handling general animations such as particle effects.
@@ -96,8 +97,8 @@ export class Animation {
   public doCycle(
     l: number,
     lastCycle: number,
-    pokemonTintSprite: Phaser.GameObjects.Sprite,
-    pokemonNewFormTintSprite: Phaser.GameObjects.Sprite,
+    pokemonTintSprite: GameSprite,
+    pokemonNewFormTintSprite: GameSprite,
   ): Promise<boolean> {
     return new Promise((resolve) => {
       const isLastCycle = l === lastCycle;
@@ -200,7 +201,7 @@ export class Animation {
     }
   }
 
-  public addPokeballCaptureStars(pokeball: Phaser.GameObjects.Sprite): void {
+  public addPokeballCaptureStars(pokeball: GameSprite): void {
     const addParticle = () => {
       const particle = this.scene.add.sprite(pokeball.x, pokeball.y, "pb_particles", "4.png");
       particle.setOrigin(pokeball.originX, pokeball.originY);
@@ -248,7 +249,7 @@ export class Animation {
    * @param sparkleSprite the Sprite to play the animation on
    * @param variant which shiny {@linkcode variant} to play the animation for
    */
-  public doShinySparkleAnim(sparkleSprite: Phaser.GameObjects.Sprite, variant: Variant): void {
+  public doShinySparkleAnim(sparkleSprite: GameSprite, variant: Variant): void {
     const keySuffix = variant ? `_${variant + 1}` : "";
     const spriteKey = `shiny${keySuffix}`;
     const animationKey = `sparkle${keySuffix}`;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -177,6 +177,7 @@ import { allTrainerConfigs } from "./data/balance/trainer-configs/all-trainer-co
 import { eventBus } from "./event-bus";
 import { Animation } from "./animations";
 import { resetStarterColors, starterColors } from "./data/starter-colors";
+import { GameSprite } from "#app/game-sprite";
 
 const DEBUG_RNG = false;
 
@@ -232,8 +233,8 @@ export default class BattleScene extends SceneBase {
   public abilityBar: AbilityBar;
   public partyExpBar: PartyExpBar;
   public candyBar: CandyBar;
-  public arenaBg: Phaser.GameObjects.Sprite;
-  public arenaBgTransition: Phaser.GameObjects.Sprite;
+  public arenaBg: GameSprite;
+  public arenaBgTransition: GameSprite;
   public arenaPlayer: ArenaBase;
   public arenaPlayerTransition: ArenaBase;
   public arenaEnemy: ArenaBase;
@@ -242,7 +243,7 @@ export default class BattleScene extends SceneBase {
   public gameMode: GameMode;
   public score: number;
   public lockModifierTiers: boolean;
-  public trainer: Phaser.GameObjects.Sprite;
+  public trainer: GameSprite;
   public lastEnemyTrainer: Trainer | null;
   public currentBattle: Battle;
   public pokeballCounts: PokeballCounts;
@@ -616,7 +617,7 @@ export default class BattleScene extends SceneBase {
     this.arenaNextEnemy.setVisible(false);
 
     [this.arenaPlayer, this.arenaPlayerTransition, this.arenaEnemy, this.arenaNextEnemy].forEach((a) => {
-      if (a instanceof Phaser.GameObjects.Sprite) {
+      if (a instanceof GameSprite) {
         a.setOrigin(0, 0);
       }
       field.add(a);
@@ -1743,7 +1744,7 @@ export default class BattleScene extends SceneBase {
     texture: string | Phaser.Textures.Texture,
     frame?: string | number,
     terrainColorRatio: number = 0,
-  ): Phaser.GameObjects.Sprite {
+  ): GameSprite {
     const ret = this.add.sprite(x, y, texture, frame);
     ret.setPipeline(this.fieldSpritePipeline);
     if (terrainColorRatio) {
@@ -1761,18 +1762,18 @@ export default class BattleScene extends SceneBase {
     frame?: string | number,
     hasShadow: boolean = false,
     ignoreOverride: boolean = false,
-  ): Phaser.GameObjects.Sprite {
+  ): GameSprite {
     const ret = this.addFieldSprite(x, y, texture, frame);
     this.initPokemonSprite(ret, pokemon, hasShadow, ignoreOverride);
     return ret;
   }
 
   initPokemonSprite(
-    sprite: Phaser.GameObjects.Sprite,
+    sprite: GameSprite,
     pokemon?: Pokemon,
     hasShadow: boolean = false,
     ignoreOverride: boolean = false,
-  ): Phaser.GameObjects.Sprite {
+  ): GameSprite {
     sprite.setPipeline(this.spritePipeline, {
       tone: [0.0, 0.0, 0.0, 0.0],
       hasShadow: hasShadow,
@@ -3090,7 +3091,7 @@ export default class BattleScene extends SceneBase {
   triggerPokemonBattleAnim(
     pokemon: Pokemon,
     battleAnimType: PokemonAnimType,
-    fieldAssets?: Phaser.GameObjects.Sprite[],
+    fieldAssets?: GameSprite[],
     delayed: boolean = false,
   ): boolean {
     const phase: Phase = new PokemonAnimPhase(battleAnimType, pokemon, fieldAssets);

--- a/src/data/battle-anims.ts
+++ b/src/data/battle-anims.ts
@@ -16,6 +16,7 @@ import { DelayedAttackAttr } from "./move-attrs/delayed-attack-attr";
 import { AnimFrameTarget } from "#enums/anim-frame-target";
 import { ChargeAnim } from "#enums/charge-anim";
 import { CommonAnim } from "#enums/common-anim";
+import type { GameSprite } from "#app/game-sprite";
 
 enum AnimFocus {
   TARGET = 1,
@@ -747,13 +748,13 @@ function isReversed(src1: number, src2: number, dst1: number, dst2: number) {
 }
 
 interface SpriteCache {
-  [key: number]: Phaser.GameObjects.Sprite[];
+  [key: number]: GameSprite[];
 }
 
 export abstract class BattleAnim {
   public user: Pokemon | null;
   public target: Pokemon | null;
-  public sprites: Phaser.GameObjects.Sprite[];
+  public sprites: GameSprite[];
   public bgSprite: Phaser.GameObjects.TileSprite | Phaser.GameObjects.Rectangle;
   /**
    * Will attempt to play as much of an animation as possible, even if not all targets are on the field.
@@ -1029,7 +1030,7 @@ export abstract class BattleAnim {
           } else {
             const sprites = spriteCache[AnimFrameTarget.GRAPHIC];
             if (g === sprites.length) {
-              const newSprite: Phaser.GameObjects.Sprite = globalScene.addFieldSprite(0, 0, anim!.graphic, 1); // TODO: is the bang correct?
+              const newSprite: GameSprite = globalScene.addFieldSprite(0, 0, anim!.graphic, 1); // TODO: is the bang correct?
               sprites.push(newSprite);
               globalScene.field.add(newSprite);
               spritePriorities.push(1);
@@ -1250,7 +1251,7 @@ export abstract class BattleAnim {
 
           const sprites = spriteCache[AnimFrameTarget.GRAPHIC];
           if (graphicFrameCount === sprites.length) {
-            const newSprite: Phaser.GameObjects.Sprite = globalScene.addFieldSprite(0, 0, anim!.graphic, 1);
+            const newSprite: GameSprite = globalScene.addFieldSprite(0, 0, anim!.graphic, 1);
             sprites.push(newSprite);
             globalScene.field.add(newSprite);
           }

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -41,6 +41,7 @@ import { WeatherType } from "#enums/weather-type";
 import { ReverseDrainAbAttr } from "./ab-attrs/reverse-drain-ab-attr";
 import Overrides from "#app/overrides";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
+import type { GameSprite } from "#app/game-sprite";
 
 export class BattlerTag {
   public tagType: BattlerTagType;
@@ -2867,7 +2868,7 @@ export class SubstituteTag extends BattlerTag {
   /** The substitute's remaining HP. If HP is depleted, the Substitute fades. */
   public hp: number;
   /** A reference to the sprite representing the Substitute doll */
-  public sprite: Phaser.GameObjects.Sprite;
+  public sprite: GameSprite;
   /** Is the source Pokemon "in focus," i.e. is it fully visible on the field? */
   public sourceInFocus: boolean;
 

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -39,6 +39,7 @@ import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 import { Stat } from "#enums/stat";
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import i18next from "i18next";
+import type { GameSprite } from "#app/game-sprite";
 
 /** the i18n namespace for this encounter */
 const namespace = "mysteryEncounters/absoluteAvarice";
@@ -522,7 +523,7 @@ function doBerrySpritePile(isEat: boolean = false) {
   const encounter = globalScene.currentBattle.mysteryEncounter!;
   animationOrder.forEach((berry, i) => {
     const introVisualsIndex = encounter.spriteConfigs.findIndex((config) => config.spriteKey?.includes(berry));
-    let sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite;
+    let sprite: GameSprite, tintSprite: GameSprite;
     const sprites = encounter.introVisuals?.getSpriteAtIndex(introVisualsIndex);
     if (sprites) {
       sprite = sprites[0];
@@ -546,7 +547,7 @@ function doBerrySpritePile(isEat: boolean = false) {
   });
 }
 
-function doBerryBounce(berrySprites: Phaser.GameObjects.Sprite[], yd: number, baseBounceDuration: number) {
+function doBerryBounce(berrySprites: GameSprite[], yd: number, baseBounceDuration: number) {
   let bouncePower = 1;
   let bounceYOffset = yd;
 

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -44,6 +44,7 @@ import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { addPokemonDataToDexAndValidateAchievements } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
 import type { PokeballType } from "#enums/pokeball";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/globalTradeSystem";
@@ -625,10 +626,10 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
     const tradeContainer = globalScene.fieldUI.getByName("Trade Background") as Phaser.GameObjects.Container;
     const tradeBaseBg = tradeContainer.getByName("Trade Background Image") as Phaser.GameObjects.Image;
 
-    let tradedPokemonSprite: Phaser.GameObjects.Sprite;
-    let tradedPokemonTintSprite: Phaser.GameObjects.Sprite;
-    let receivedPokemonSprite: Phaser.GameObjects.Sprite;
-    let receivedPokemonTintSprite: Phaser.GameObjects.Sprite;
+    let tradedPokemonSprite: GameSprite;
+    let tradedPokemonTintSprite: GameSprite;
+    let receivedPokemonSprite: GameSprite;
+    let receivedPokemonTintSprite: GameSprite;
 
     const getPokemonSprite = () => {
       const ret = globalScene.addPokemonSprite(
@@ -655,11 +656,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
 
     [tradedPokemonSprite, tradedPokemonTintSprite].map((sprite) => {
       const spriteKey = tradedPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -678,12 +675,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
 
     [receivedPokemonSprite, receivedPokemonTintSprite].map((sprite) => {
       const spriteKey = receivedPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
-
+      sprite.play(spriteKey);
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
         hasShadow: false,
@@ -701,7 +693,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
 
     // Traded pokemon pokeball
     const tradedPbAtlasKey = getPokeballAtlasKey(tradedPokemon.pokeball);
-    const tradedPokeball: Phaser.GameObjects.Sprite = globalScene.add.sprite(
+    const tradedPokeball: GameSprite = globalScene.add.sprite(
       tradeBaseBg.displayWidth / 2,
       tradeBaseBg.displayHeight / 2,
       "pb",
@@ -712,7 +704,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
 
     // Received pokemon pokeball
     const receivedPbAtlasKey = getPokeballAtlasKey(receivedPokemon.pokeball);
-    const receivedPokeball: Phaser.GameObjects.Sprite = globalScene.add.sprite(
+    const receivedPokeball: GameSprite = globalScene.add.sprite(
       tradeBaseBg.displayWidth / 2,
       tradeBaseBg.displayHeight / 2,
       "pb",
@@ -802,10 +794,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
   });
 }
 
-function doPokemonTradeFlyBySequence(
-  tradedPokemonSprite: Phaser.GameObjects.Sprite,
-  receivedPokemonSprite: Phaser.GameObjects.Sprite,
-) {
+function doPokemonTradeFlyBySequence(tradedPokemonSprite: GameSprite, receivedPokemonSprite: GameSprite) {
   return new Promise<void>((resolve) => {
     const tradeContainer = globalScene.fieldUI.getByName("Trade Background") as Phaser.GameObjects.Container;
     const tradeBaseBg = tradeContainer.getByName("Trade Background Image") as Phaser.GameObjects.Image;
@@ -890,9 +879,9 @@ function doPokemonTradeFlyBySequence(
 
 function doTradeReceivedSequence(
   receivedPokemon: PlayerPokemon,
-  receivedPokemonSprite: Phaser.GameObjects.Sprite,
-  receivedPokemonTintSprite: Phaser.GameObjects.Sprite,
-  receivedPokeballSprite: Phaser.GameObjects.Sprite,
+  receivedPokemonSprite: GameSprite,
+  receivedPokemonTintSprite: GameSprite,
+  receivedPokeballSprite: GameSprite,
   receivedPbAtlasKey: string,
 ) {
   return new Promise<void>((resolve) => {
@@ -911,7 +900,7 @@ function doTradeReceivedSequence(
     receivedPokeballSprite.y = tradeBaseBg.displayHeight / 2 - 100;
 
     // Received pokemon sparkles
-    let pokemonShinySparkle: Phaser.GameObjects.Sprite;
+    let pokemonShinySparkle: GameSprite;
     if (receivedPokemon.shiny) {
       pokemonShinySparkle = globalScene.add.sprite(receivedPokemonSprite.x, receivedPokemonSprite.y, "shiny");
       pokemonShinySparkle.setVisible(false);

--- a/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
+++ b/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
@@ -34,6 +34,7 @@ import { SummonPhase } from "#app/phases/summon-phase";
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
 import { SpeciesGroups } from "#enums/pokemon-species-groups";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/safariZone";
@@ -357,7 +358,7 @@ async function throwBait(pokemon: EnemyPokemon): Promise<boolean> {
   const originalY: number = pokemon.y;
 
   const fpOffset = pokemon.getFieldPositionOffset();
-  const bait: Phaser.GameObjects.Sprite = globalScene.addFieldSprite(16 + 75, 80 + 25, "safari_zone_bait", "0001.png");
+  const bait: GameSprite = globalScene.addFieldSprite(16 + 75, 80 + 25, "safari_zone_bait", "0001.png");
   bait.setOrigin(0.5, 0.625);
   globalScene.field.add(bait);
 
@@ -426,7 +427,7 @@ async function throwMud(pokemon: EnemyPokemon): Promise<boolean> {
   const originalY: number = pokemon.y;
 
   const fpOffset = pokemon.getFieldPositionOffset();
-  const mud: Phaser.GameObjects.Sprite = globalScene.addFieldSprite(16 + 75, 80 + 35, "safari_zone_mud", "0001.png");
+  const mud: GameSprite = globalScene.addFieldSprite(16 + 75, 80 + 35, "safari_zone_mud", "0001.png");
   mud.setOrigin(0.5, 0.625);
   globalScene.field.add(mud);
 

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -39,6 +39,7 @@ import type { PokeballType } from "#enums/pokeball";
 import { StatusEffect } from "#enums/status-effect";
 import type { OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 /** Will give +1 level every 10 waves */
 export const STANDARD_ENCOUNTER_BOOSTED_LEVEL_MODIFIER = 1;
@@ -454,7 +455,7 @@ export function trainerThrowPokeball(
 
   const fpOffset = pokemon.getFieldPositionOffset();
   const pokeballAtlasKey = getPokeballAtlasKey(pokeballType);
-  const pokeball: Phaser.GameObjects.Sprite = globalScene.addFieldSprite(16 + 75, 80 + 25, "pb", pokeballAtlasKey);
+  const pokeball: GameSprite = globalScene.addFieldSprite(16 + 75, 80 + 25, "pb", pokeballAtlasKey);
   pokeball.setOrigin(0.5, 0.625);
   globalScene.field.add(pokeball);
 
@@ -584,12 +585,7 @@ export function trainerThrowPokeball(
  * @param pokeball - The sprite of the Pokeball
  * @param pokeballType - The Pokeball type
  */
-function failCatch(
-  pokemon: EnemyPokemon,
-  originalY: number,
-  pokeball: Phaser.GameObjects.Sprite,
-  pokeballType: PokeballType,
-) {
+function failCatch(pokemon: EnemyPokemon, originalY: number, pokeball: GameSprite, pokeballType: PokeballType) {
   return new Promise<void>((resolve) => {
     globalScene.playSound("se/pb_rel");
     pokemon.setY(originalY);
@@ -635,7 +631,7 @@ function failCatch(
  */
 export async function catchPokemon(
   pokemon: EnemyPokemon,
-  pokeball: Phaser.GameObjects.Sprite | null,
+  pokeball: GameSprite | null,
   pokeballType: PokeballType,
   showCatchObtainMessage: boolean = true,
   isObtain: boolean = false,
@@ -807,7 +803,7 @@ export async function catchPokemon(
  * Animates pokeball disappearing then destroys the object
  * @param pokeball the Pokeball sprite
  */
-function removePb(pokeball: Phaser.GameObjects.Sprite) {
+function removePb(pokeball: GameSprite) {
   if (pokeball) {
     globalScene.tweens.add({
       targets: pokeball,

--- a/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
+++ b/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
@@ -2,6 +2,7 @@ import type { PlayerPokemon } from "#app/field/pokemon";
 import { getTypeRgb } from "#app/data/type";
 import { globalScene } from "#app/global-scene";
 import { TransformationScreenPosition } from "#enums/transformation-screen-position";
+import type { GameSprite } from "#app/game-sprite";
 
 /**
  * Initiates an "evolution-like" animation to transform a previousPokemon (presumably from the player's party) into a new one, not necessarily an evolution species.
@@ -21,10 +22,10 @@ export function doPokemonTransformationSequence(
     transformationBaseBg.setVisible(false);
     transformationContainer.add(transformationBaseBg);
 
-    let pokemonSprite: Phaser.GameObjects.Sprite;
-    let pokemonTintSprite: Phaser.GameObjects.Sprite;
-    let pokemonEvoSprite: Phaser.GameObjects.Sprite;
-    let pokemonEvoTintSprite: Phaser.GameObjects.Sprite;
+    let pokemonSprite: GameSprite;
+    let pokemonTintSprite: GameSprite;
+    let pokemonEvoSprite: GameSprite;
+    let pokemonEvoTintSprite: GameSprite;
 
     const xOffset =
       screenPosition === TransformationScreenPosition.CENTER
@@ -60,11 +61,7 @@ export function doPokemonTransformationSequence(
 
     [pokemonSprite, pokemonTintSprite, pokemonEvoSprite, pokemonEvoTintSprite].map((sprite) => {
       const spriteKey = previousPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -83,11 +80,7 @@ export function doPokemonTransformationSequence(
 
     [pokemonEvoSprite, pokemonEvoTintSprite].map((sprite) => {
       const spriteKey = transformPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipelineData("ignoreTimeTint", true);
       sprite.setPipelineData("spriteKey", transformPokemon.getSpriteKey());

--- a/src/data/pokeball.ts
+++ b/src/data/pokeball.ts
@@ -1,3 +1,4 @@
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { CriticalCatchChanceBoosterModifier } from "#app/modifier/modifier";
 import { NumberHolder } from "#app/utils";
@@ -95,7 +96,7 @@ export function getCriticalCaptureChance(modifiedCatchRate: number): number {
 }
 
 export function doPokeballBounceAnim(
-  pokeball: Phaser.GameObjects.Sprite,
+  pokeball: GameSprite,
   y1: number,
   y2: number,
   baseBounceDuration: number,

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -33,6 +33,7 @@ import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
 import { WeatherType } from "#enums/weather-type";
 import { TerrainEventTypeChangeAbAttr } from "#app/data/ab-attrs/terrain-event-type-change-ab-attr";
+import type { GameSprite } from "#app/game-sprite";
 
 export class Arena {
   public biomeType: Biome;
@@ -894,8 +895,8 @@ export class ArenaBase extends Phaser.GameObjects.Container {
   public player: boolean;
   public biome: Biome;
   public propValue: number;
-  public base: Phaser.GameObjects.Sprite;
-  public props: Phaser.GameObjects.Sprite[];
+  public base: GameSprite;
+  public props: GameSprite[];
 
   constructor(player: boolean) {
     super(globalScene, 0, 0);

--- a/src/field/mystery-encounter-intro.ts
+++ b/src/field/mystery-encounter-intro.ts
@@ -5,6 +5,7 @@ import type { Species } from "#enums/species";
 import { isNullOrUndefined } from "#app/utils";
 import { getSpriteKeysFromSpecies } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
 import type { Variant } from "#app/data/variant";
+import type { GameSprite } from "#app/game-sprite";
 import PlayAnimationConfig = Phaser.Types.Animations.PlayAnimationConfig;
 
 type KnownFileRoot =
@@ -78,7 +79,7 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
   public encounter: MysteryEncounter;
   public spriteConfigs: MysteryEncounterSpriteConfig[];
   public enterFromRight: boolean;
-  private shinySparkleSprites: { sprite: Phaser.GameObjects.Sprite; variant: Variant }[];
+  private shinySparkleSprites: { sprite: GameSprite; variant: Variant }[];
 
   constructor(encounter: MysteryEncounter) {
     super(globalScene, -72, 76);
@@ -140,7 +141,7 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
 
       let sprite: GameObjects.Sprite;
       let tintSprite: GameObjects.Sprite;
-      let pokemonShinySparkle: Phaser.GameObjects.Sprite | undefined;
+      let pokemonShinySparkle: GameSprite | undefined;
 
       if (isItem) {
         sprite = getItemSprite(spriteKey, hasShadow, yShadow);
@@ -308,16 +309,16 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
   }
 
   /**
-   * Attempts to animate a given set of {@linkcode Phaser.GameObjects.Sprite}
-   * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode Phaser.Types.Animations.PlayAnimationConfig} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
+   * Attempts to animate a given set of {@linkcode GameSprite}
+   * @see {@linkcode GameSprite.play}
+   * @param sprite {@linkcode GameSprite} to animate
+   * @param tintSprite {@linkcode GameSprite} placed on top of the sprite to add a color tint
+   * @param animConfig {@linkcode Phaser.Types.Animations.PlayAnimationConfig} to pass to {@linkcode GameSprite.play}
    * @returns true if the sprite was able to be animated
    */
   tryPlaySprite(
-    sprite: Phaser.GameObjects.Sprite,
-    tintSprite: Phaser.GameObjects.Sprite,
+    sprite: GameSprite,
+    tintSprite: GameSprite,
     animConfig: Phaser.Types.Animations.PlayAnimationConfig,
   ): boolean {
     // Show an error in the console if there isn't a texture loaded
@@ -377,12 +378,12 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
    * Returns a Sprite/TintSprite pair
    * @param index
    */
-  getSpriteAtIndex(index: number): Phaser.GameObjects.Sprite[] {
+  getSpriteAtIndex(index: number): GameSprite[] {
     if (!this.spriteConfigs) {
       return [];
     }
 
-    const ret: Phaser.GameObjects.Sprite[] = [];
+    const ret: GameSprite[] = [];
     ret.push(this.getAt(index * 2)); // Sprite
     ret.push(this.getAt(index * 2 + 1)); // Tint Sprite
 
@@ -392,12 +393,12 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
   /**
    * Gets all non-tint sprites (these are the "real" unmodified sprites)
    */
-  getSprites(): Phaser.GameObjects.Sprite[] {
+  getSprites(): GameSprite[] {
     if (!this.spriteConfigs) {
       return [];
     }
 
-    const ret: Phaser.GameObjects.Sprite[] = [];
+    const ret: GameSprite[] = [];
     this.spriteConfigs.forEach((_config, i) => {
       ret.push(this.getAt(i * 2));
     });
@@ -407,12 +408,12 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
   /**
    * Gets all tint sprites (duplicate sprites that have different alpha and fill values)
    */
-  getTintSprites(): Phaser.GameObjects.Sprite[] {
+  getTintSprites(): GameSprite[] {
     if (!this.spriteConfigs) {
       return [];
     }
 
-    const ret: Phaser.GameObjects.Sprite[] = [];
+    const ret: GameSprite[] = [];
     this.spriteConfigs.forEach((_config, i) => {
       ret.push(this.getAt(i * 2 + 1));
     });

--- a/src/field/pokemon-sprite-sparkle-handler.ts
+++ b/src/field/pokemon-sprite-sparkle-handler.ts
@@ -1,9 +1,10 @@
 import { globalScene } from "#app/global-scene";
 import { Pokemon } from "./pokemon";
 import { fixedNumber, randInt } from "#app/utils";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class PokemonSpriteSparkleHandler {
-  private sprites: Set<Phaser.GameObjects.Sprite>;
+  private sprites: Set<GameSprite>;
 
   setup(): void {
     this.sprites = new Set();
@@ -53,7 +54,7 @@ export default class PokemonSpriteSparkleHandler {
     }
   }
 
-  add(sprites: Phaser.GameObjects.Sprite | Phaser.GameObjects.Sprite[]): void {
+  add(sprites: GameSprite | GameSprite[]): void {
     if (!Array.isArray(sprites)) {
       sprites = [sprites];
     }
@@ -65,7 +66,7 @@ export default class PokemonSpriteSparkleHandler {
     }
   }
 
-  remove(sprites: Phaser.GameObjects.Sprite | Phaser.GameObjects.Sprite[]): void {
+  remove(sprites: GameSprite | GameSprite[]): void {
     if (!Array.isArray(sprites)) {
       sprites = [sprites];
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -232,6 +232,7 @@ import { FieldPosition } from "#enums/field-position";
 import { ArenaTrapAbAttr } from "#app/data/ab-attrs/arena-trap-ab-attr";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import type { AbilityFilterOptions } from "#app/data/ability-filter-options";
+import type { GameSprite } from "#app/game-sprite";
 
 export abstract class Pokemon extends Phaser.GameObjects.Container {
   public id: number;
@@ -289,11 +290,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public fieldPosition: FieldPosition;
 
   public maskEnabled: boolean;
-  public maskSprite: Phaser.GameObjects.Sprite | null;
+  public maskSprite: GameSprite | null;
 
   public usedTMs: Moves[];
 
-  private shinySparkle: Phaser.GameObjects.Sprite;
+  private shinySparkle: GameSprite;
 
   constructor(
     x: number,
@@ -798,12 +799,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.fusionSpecies?.forms[this.fusionFormIndex];
   }
 
-  getSprite(): Phaser.GameObjects.Sprite {
-    return this.getAt(0) as Phaser.GameObjects.Sprite;
+  getSprite(): GameSprite {
+    return this.getAt(0) as GameSprite;
   }
 
-  getTintSprite(): Phaser.GameObjects.Sprite | null {
-    return !this.maskEnabled ? (this.getAt(1) as Phaser.GameObjects.Sprite) : this.maskSprite;
+  getTintSprite(): GameSprite | null {
+    return !this.maskEnabled ? (this.getAt(1) as GameSprite) : this.maskSprite;
   }
 
   getSpriteScale(): number {
@@ -870,29 +871,19 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Attempts to animate a given {@linkcode Phaser.GameObjects.Sprite}
-   * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode String} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
-   * @returns true if the sprite was able to be animated
+   * Animates a given {@linkcode GameSprite}
+   * @see {@linkcode GameSprite.play}
+   * @param sprite - {@linkcode GameSprite} to animate
+   * @param tintSprite - {@linkcode GameSprite} placed on top of the sprite to add a color tint
+   * @param key - animation key to pass to {@linkcode GameSprite.play}
    */
-  tryPlaySprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite, key: string): boolean {
-    // Catch errors when trying to play an animation that doesn't exist
-    try {
-      sprite.play(key);
-      tintSprite.play(key);
-    } catch (error: unknown) {
-      console.error(`Couldn't play animation for '${key}'!\nIs the image for this Pokemon missing?\n`, error);
-
-      return false;
-    }
-
-    return true;
+  playSprite(sprite: GameSprite, tintSprite: GameSprite | null, key: string): void {
+    sprite.play(key);
+    tintSprite?.play(key);
   }
 
   playAnim(): void {
-    this.tryPlaySprite(this.getSprite(), this.getTintSprite()!, this.getBattleSpriteKey()); // TODO: is the bag correct?
+    this.playSprite(this.getSprite(), this.getTintSprite(), this.getBattleSpriteKey());
   }
 
   getFieldPositionOffset(): [number, number] {
@@ -4238,16 +4229,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   setFrameRate(frameRate: number) {
     globalScene.anims.get(this.getBattleSpriteKey()).frameRate = frameRate;
-    try {
-      this.getSprite().play(this.getBattleSpriteKey());
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${this.getBattleSpriteKey()}`, err);
-    }
-    try {
-      this.getTintSprite()?.play(this.getBattleSpriteKey());
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${this.getBattleSpriteKey()}`, err);
-    }
+    this.playAnim();
   }
 
   tint(color: number, alpha?: number, duration?: number, ease?: string) {

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -20,6 +20,7 @@ import { Species } from "#enums/species";
 import { TrainerType } from "#enums/trainer-type";
 import { allTrainerConfigs } from "#app/data/balance/trainer-configs/all-trainer-configs";
 import { TrainerVariant } from "#enums/trainer-variant";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class Trainer extends Phaser.GameObjects.Container {
   public config: TrainerConfig;
@@ -644,16 +645,16 @@ export default class Trainer extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Attempts to animate a given set of {@linkcode Phaser.GameObjects.Sprite}
-   * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode Phaser.Types.Animations.PlayAnimationConfig} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
+   * Attempts to animate a given set of {@linkcode GameSprite}
+   * @see {@linkcode GameSprite.play}
+   * @param sprite {@linkcode GameSprite} to animate
+   * @param tintSprite {@linkcode GameSprite} placed on top of the sprite to add a color tint
+   * @param animConfig {@linkcode Phaser.Types.Animations.PlayAnimationConfig} to pass to {@linkcode GameSprite.play}
    * @returns true if the sprite was able to be animated
    */
   tryPlaySprite(
-    sprite: Phaser.GameObjects.Sprite,
-    tintSprite: Phaser.GameObjects.Sprite,
+    sprite: GameSprite,
+    tintSprite: GameSprite,
     animConfig: Phaser.Types.Animations.PlayAnimationConfig,
   ): boolean {
     // Show an error in the console if there isn't a texture loaded
@@ -698,16 +699,16 @@ export default class Trainer extends Phaser.GameObjects.Container {
     }
   }
 
-  getSprites(): Phaser.GameObjects.Sprite[] {
-    const ret: Phaser.GameObjects.Sprite[] = [this.getAt(0)];
+  getSprites(): GameSprite[] {
+    const ret: GameSprite[] = [this.getAt(0)];
     if (this.variant === TrainerVariant.DOUBLE && !this.config.doubleOnly) {
       ret.push(this.getAt(2));
     }
     return ret;
   }
 
-  getTintSprites(): Phaser.GameObjects.Sprite[] {
-    const ret: Phaser.GameObjects.Sprite[] = [this.getAt(1)];
+  getTintSprites(): GameSprite[] {
+    const ret: GameSprite[] = [this.getAt(1)];
     if (this.variant === TrainerVariant.DOUBLE && !this.config.doubleOnly) {
       ret.push(this.getAt(3));
     }

--- a/src/game-sprite.ts
+++ b/src/game-sprite.ts
@@ -1,0 +1,13 @@
+export class GameSprite extends Phaser.GameObjects.Sprite {
+  public override play(
+    key: string | Phaser.Animations.Animation | Phaser.Types.Animations.PlayAnimationConfig,
+    ignoreIfPlaying?: boolean,
+  ): this {
+    try {
+      return super.play(key, ignoreIfPlaying);
+    } catch (err: unknown) {
+      console.error(`Failed to play animation for ${key}`, err);
+      return this;
+    }
+  }
+}

--- a/src/phases/abstract-form-change-base-phase.ts
+++ b/src/phases/abstract-form-change-base-phase.ts
@@ -1,5 +1,6 @@
 import { getTypeRgb } from "#app/data/type";
 import type { PlayerPokemon } from "#app/field/pokemon";
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import type FormChangeSceneHandler from "#app/ui/form-change-scene-handler";
@@ -19,10 +20,10 @@ export abstract class FormChangeBasePhase extends Phase {
   protected bgVideo: Phaser.GameObjects.Video;
   protected bgOverlay: Phaser.GameObjects.Rectangle;
   protected overlay: Phaser.GameObjects.Rectangle;
-  protected pokemonSprite: Phaser.GameObjects.Sprite;
-  protected pokemonTintSprite: Phaser.GameObjects.Sprite;
-  protected pokemonNewFormSprite: Phaser.GameObjects.Sprite;
-  protected pokemonNewFormTintSprite: Phaser.GameObjects.Sprite;
+  protected pokemonSprite: GameSprite;
+  protected pokemonTintSprite: GameSprite;
+  protected pokemonNewFormSprite: GameSprite;
+  protected pokemonNewFormTintSprite: GameSprite;
 
   constructor(pokemon: PlayerPokemon) {
     super();
@@ -69,7 +70,7 @@ export abstract class FormChangeBasePhase extends Phase {
       this.bgOverlay.setAlpha(0);
       this.container.add(this.bgOverlay);
 
-      const getPokemonSprite = (): Phaser.GameObjects.Sprite => {
+      const getPokemonSprite = (): GameSprite => {
         const ret = globalScene.addPokemonSprite(
           this.pokemon,
           this.baseBgImg.displayWidth / 2,
@@ -99,11 +100,7 @@ export abstract class FormChangeBasePhase extends Phase {
       [this.pokemonSprite, this.pokemonTintSprite, this.pokemonNewFormSprite, this.pokemonNewFormTintSprite].map(
         (sprite) => {
           const spriteKey = this.pokemon.getSpriteKey(true);
-          try {
-            sprite.play(spriteKey);
-          } catch (err: unknown) {
-            console.error(`Failed to play animation for ${spriteKey}`, err);
-          }
+          sprite.play(spriteKey);
 
           sprite.setPipeline(spritePipeline, {
             tone: [0.0, 0.0, 0.0, 0.0],

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -24,6 +24,7 @@ import { type PokeballType } from "#enums/pokeball";
 import { StatusEffect } from "#enums/status-effect";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
+import type { GameSprite } from "#app/game-sprite";
 
 /**
  * Handles catching a pokemon after the player throws a ball
@@ -31,7 +32,7 @@ import { globalScene } from "#app/global-scene";
  */
 export class AttemptCapturePhase extends PokemonPhase {
   private readonly pokeballType: PokeballType;
-  private pokeball: Phaser.GameObjects.Sprite;
+  private pokeball: GameSprite;
   private originalY: number;
 
   constructor(targetIndex: number, pokeballType: PokeballType) {

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -15,6 +15,7 @@ import i18next from "i18next";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import type { EggLapsePhase } from "./egg-lapse-phase";
 import type { EggHatchData } from "#app/data/egg-hatch-data";
+import type { GameSprite } from "#app/game-sprite";
 
 /**
  * Class that represents egg hatching
@@ -42,15 +43,15 @@ export class EggHatchPhase extends Phase {
   /** The phaser container that holds the egg */
   private eggContainer: Phaser.GameObjects.Container;
   /** The phaser sprite of the egg */
-  private eggSprite: Phaser.GameObjects.Sprite;
+  private eggSprite: GameSprite;
   /** The phaser sprite of the cracks in an egg */
-  private eggCrackSprite: Phaser.GameObjects.Sprite;
+  private eggCrackSprite: GameSprite;
   /** The phaser sprite that represents the overlaid light rays */
-  private eggLightraysOverlay: Phaser.GameObjects.Sprite;
+  private eggLightraysOverlay: GameSprite;
   /** The phaser sprite of the hatched Pokemon */
-  private pokemonSprite: Phaser.GameObjects.Sprite;
+  private pokemonSprite: GameSprite;
   /** The phaser sprite for shiny sparkles */
-  private pokemonShinySparkle: Phaser.GameObjects.Sprite;
+  private pokemonShinySparkle: GameSprite;
 
   /** The {@link PokemonInfoContainer} of the newly hatched Pokemon */
   private infoContainer: PokemonInfoContainer;
@@ -128,7 +129,7 @@ export class EggHatchPhase extends Phase {
       this.eggCounterContainer = new EggCounterContainer(this.eggsToHatchCount);
       this.eggHatchContainer.add(this.eggCounterContainer);
 
-      const getPokemonSprite = (): Phaser.GameObjects.Sprite => {
+      const getPokemonSprite = (): GameSprite => {
         const ret = globalScene.add.sprite(
           this.eggHatchBg.displayWidth / 2,
           this.eggHatchBg.displayHeight / 2,
@@ -351,11 +352,7 @@ export class EggHatchPhase extends Phase {
     this.eggContainer.setVisible(false);
 
     const spriteKey = this.pokemon.getSpriteKey(true);
-    try {
-      this.pokemonSprite.play(spriteKey);
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    this.pokemonSprite.play(spriteKey);
 
     this.pokemonSprite.setPipelineData("ignoreTimeTint", true);
     this.pokemonSprite.setPipelineData("spriteKey", this.pokemon.getSpriteKey());

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -65,11 +65,7 @@ export class EvolutionPhase extends FormChangeBasePhase {
         this.pokemon.getPossibleEvolution(this.evolution).then((evolvedPokemon) => {
           [this.pokemonNewFormSprite, this.pokemonNewFormTintSprite].map((sprite) => {
             const spriteKey = evolvedPokemon.getSpriteKey(true);
-            try {
-              sprite.play(spriteKey);
-            } catch (err: unknown) {
-              console.error(`Failed to play animation for ${spriteKey}`, err);
-            }
+            sprite.play(spriteKey);
 
             sprite.setPipelineData("ignoreTimeTint", true);
             sprite.setPipelineData("spriteKey", evolvedPokemon.getSpriteKey());

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -50,11 +50,7 @@ export class FormChangePhase extends FormChangeBasePhase {
     this.pokemon.getPossibleForm(this.formChange).then((formChangedPokemon) => {
       [this.pokemonNewFormSprite, this.pokemonNewFormTintSprite].map((sprite) => {
         const spriteKey = formChangedPokemon.getSpriteKey(true);
-        try {
-          sprite.play(spriteKey);
-        } catch (err: unknown) {
-          console.error(`Failed to play animation for ${spriteKey}`, err);
-        }
+        sprite.play(spriteKey);
 
         sprite.setPipelineData("ignoreTimeTint", true);
         sprite.setPipelineData("spriteKey", formChangedPokemon.getSpriteKey());

--- a/src/phases/pokemon-anim-phase.ts
+++ b/src/phases/pokemon-anim-phase.ts
@@ -1,5 +1,6 @@
 import { SubstituteTag } from "#app/data/battler-tags";
 import type { Pokemon } from "#app/field/pokemon";
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { BattlePhase } from "#app/phases/abstract-battle-phase";
 import { isNullOrUndefined } from "#app/utils";
@@ -13,9 +14,9 @@ export class PokemonAnimPhase extends BattlePhase {
   /** The Pokemon to which this animation applies */
   protected readonly pokemon: Pokemon;
   /** Any other field sprites affected by this animation */
-  protected readonly fieldAssets: Phaser.GameObjects.Sprite[];
+  protected readonly fieldAssets: GameSprite[];
 
-  constructor(key: PokemonAnimType, pokemon: Pokemon, fieldAssets: Phaser.GameObjects.Sprite[] = []) {
+  constructor(key: PokemonAnimType, pokemon: Pokemon, fieldAssets: GameSprite[] = []) {
     super();
 
     this.key = key;
@@ -58,7 +59,7 @@ export class PokemonAnimPhase extends BattlePhase {
       return this.end();
     }
 
-    const getSprite = (): Phaser.GameObjects.Sprite => {
+    const getSprite = (): GameSprite => {
       const sprite = globalScene.addFieldSprite(
         this.pokemon.x + this.pokemon.getSprite().x,
         this.pokemon.y + this.pokemon.getSprite().y,
@@ -186,7 +187,7 @@ export class PokemonAnimPhase extends BattlePhase {
       return this.end();
     }
 
-    const getSprite = (): Phaser.GameObjects.Sprite => {
+    const getSprite = (): GameSprite => {
       const sprite = globalScene.addFieldSprite(
         subSprite.x,
         subSprite.y,
@@ -261,7 +262,7 @@ export class PokemonAnimPhase extends BattlePhase {
     const tatsugiriX = this.pokemon.x + this.pokemon.getSprite().x;
     const tatsugiriY = this.pokemon.y + this.pokemon.getSprite().y;
 
-    const getSourceSprite = (): Phaser.GameObjects.Sprite => {
+    const getSourceSprite = (): GameSprite => {
       const sprite = globalScene.addPokemonSprite(
         this.pokemon,
         tatsugiriX,

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -1,6 +1,7 @@
 import { getSpeciesFormChangeMessage, type SpeciesFormChange } from "#app/data/pokemon-forms";
 import { getTypeRgb } from "#app/data/type";
 import { type Pokemon } from "#app/field/pokemon";
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -44,7 +45,7 @@ export class QuietFormChangePhase extends BattlePhase {
       return;
     }
 
-    const getPokemonSprite = (): Phaser.GameObjects.Sprite => {
+    const getPokemonSprite = (): GameSprite => {
       const sprite = globalScene.addPokemonSprite(
         this.pokemon,
         this.pokemon.x + this.pokemon.getSprite().x,
@@ -54,11 +55,7 @@ export class QuietFormChangePhase extends BattlePhase {
       sprite.setOrigin(0.5, 1);
 
       const spriteKey = this.pokemon.getBattleSpriteKey();
-      try {
-        sprite.play(spriteKey).stop();
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey).stop();
 
       sprite.setPipeline(spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -105,11 +102,7 @@ export class QuietFormChangePhase extends BattlePhase {
           pokemonFormTintSprite.setScale(0.01);
 
           const spriteKey = this.pokemon.getBattleSpriteKey();
-          try {
-            pokemonFormTintSprite.play(spriteKey).stop();
-          } catch (err: unknown) {
-            console.error(`Failed to play animation for ${spriteKey}`, err);
-          }
+          pokemonFormTintSprite.play(spriteKey).stop();
 
           pokemonFormTintSprite.setVisible(true);
 

--- a/src/phases/scan-ivs-phase.ts
+++ b/src/phases/scan-ivs-phase.ts
@@ -11,6 +11,7 @@ import { Stat } from "#enums/stat";
 import i18next from "i18next";
 import { settings } from "#app/system/settings/settings-manager";
 import { PokemonPhase } from "./abstract-pokemon-phase";
+import type { GameSprite } from "#app/game-sprite";
 
 export class ScanIvsPhase extends PokemonPhase {
   private readonly shownIvs: number;
@@ -33,8 +34,8 @@ export class ScanIvsPhase extends PokemonPhase {
     const pokemon = this.getPokemon();
 
     let enemyIvs: number[] = [];
-    let statsContainer: Phaser.GameObjects.Sprite[] = [];
-    let statsContainerLabels: Phaser.GameObjects.Sprite[] = [];
+    let statsContainer: GameSprite[] = [];
+    let statsContainerLabels: GameSprite[] = [];
 
     const enemyField = globalScene.getEnemyField();
     const uiTheme = settings.display.uiTheme; // Assuming uiTheme is accessible
@@ -44,7 +45,7 @@ export class ScanIvsPhase extends PokemonPhase {
       const currentIvs = gameData.dexData[enemyField[e].species.getRootSpeciesId()].ivs;
       const ivsToShow = ui.getMessageHandler().getTopIvs(enemyIvs, this.shownIvs);
 
-      statsContainer = enemyField[e].getBattleInfo().getStatsValueContainer().list as Phaser.GameObjects.Sprite[];
+      statsContainer = enemyField[e].getBattleInfo().getStatsValueContainer().list as GameSprite[];
       statsContainerLabels = statsContainer.filter((m) => m.name.indexOf("icon_stat_label") >= 0);
 
       for (let s = 0; s < statsContainerLabels.length; s++) {

--- a/src/pipelines/field-sprite.ts
+++ b/src/pipelines/field-sprite.ts
@@ -2,6 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { getTerrainColor } from "#app/data/terrain";
 import { TerrainType } from "#enums/terrain-type";
 import { getCurrentTime } from "#app/utils";
+import type { GameSprite } from "#app/game-sprite";
 
 const spriteFragShader = `
 #ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -229,7 +230,7 @@ export default class FieldSpritePipeline extends Phaser.Renderer.WebGL.Pipelines
   override onBind(gameObject: Phaser.GameObjects.GameObject): void {
     super.onBind();
 
-    const sprite = gameObject as Phaser.GameObjects.Sprite | Phaser.GameObjects.NineSlice;
+    const sprite = gameObject as GameSprite | Phaser.GameObjects.NineSlice;
 
     const data = sprite.pipelineData;
     const ignoreTimeTint = data["ignoreTimeTint"] as boolean;

--- a/src/pipelines/sprite.ts
+++ b/src/pipelines/sprite.ts
@@ -3,6 +3,7 @@ import Trainer from "#app/field/trainer";
 import FieldSpritePipeline from "#app/pipelines/field-sprite";
 import MysteryEncounterIntroVisuals from "#app/field/mystery-encounter-intro";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 const spriteFragShader = `
 #ifdef GL_FRAGMENT_PRECISION_HIGH
@@ -334,7 +335,7 @@ export default class SpritePipeline extends FieldSpritePipeline {
   override onBind(gameObject: Phaser.GameObjects.GameObject): void {
     super.onBind(gameObject);
 
-    const sprite = gameObject as Phaser.GameObjects.Sprite;
+    const sprite = gameObject as GameSprite;
 
     const data = sprite.pipelineData;
     const tone = data["tone"] as number[];
@@ -430,7 +431,7 @@ export default class SpritePipeline extends FieldSpritePipeline {
     texture?: Phaser.Renderer.WebGL.Wrappers.WebGLTextureWrapper,
     unit?: number,
   ): boolean {
-    const sprite = gameObject as Phaser.GameObjects.Sprite;
+    const sprite = gameObject as GameSprite;
 
     this.set1f("vCutoff", v1);
 

--- a/src/ui/abstract-option-select-ui-handler.ts
+++ b/src/ui/abstract-option-select-ui-handler.ts
@@ -11,6 +11,7 @@ import type BBCodeText from "phaser3-rex-plugins/plugins/gameobjects/tagtext/bbc
 import type { UIOptionSelectItem } from "./interfaces/option-select-ui-item";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
+import type { GameSprite } from "#app/game-sprite";
 
 const SCROLLBAR_PADDING = 5;
 const SCROLLBAR_WIDTH = 3;
@@ -42,7 +43,7 @@ export default abstract class AbstractOptionSelectUiHandler<T extends OptionSele
   protected optionSelectContainer: Phaser.GameObjects.Container;
   protected optionSelectBg: Phaser.GameObjects.NineSlice;
   protected optionSelectText: BBCodeText;
-  protected optionSelectIcons: Phaser.GameObjects.Sprite[];
+  protected optionSelectIcons: GameSprite[];
   protected cursorObj: Phaser.GameObjects.Image | null;
   protected scrollBar: ScrollBar | null;
 
@@ -223,11 +224,7 @@ export default abstract class AbstractOptionSelectUiHandler<T extends OptionSele
    * @param singleSpaceWidth the width of a single space, used to offset the label if there is a icon to show
    * @param tempSprite a Sprite object that can be used to measure the needed space of the item's icon, if any
    */
-  protected initializeOption(
-    option: UIOptionSelectItem & T,
-    singleSpaceWidth: number,
-    tempSprite: Phaser.GameObjects.Sprite,
-  ) {
+  protected initializeOption(option: UIOptionSelectItem & T, singleSpaceWidth: number, tempSprite: GameSprite) {
     let label = option.displayLabel ?? option.label;
 
     // Measure the width of the icon(s) to show before the label

--- a/src/ui/achv-bar.ts
+++ b/src/ui/achv-bar.ts
@@ -1,3 +1,4 @@
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { Achv } from "#app/system/achv";
 import type { Voucher } from "#app/system/voucher";
@@ -9,7 +10,7 @@ export default class AchvBar extends Phaser.GameObjects.Container {
   private defaultHeight: number;
 
   private bg: Phaser.GameObjects.NineSlice;
-  private icon: Phaser.GameObjects.Sprite;
+  private icon: GameSprite;
   private titleText: Phaser.GameObjects.Text;
   private scoreText: Phaser.GameObjects.Text;
   private descriptionText: Phaser.GameObjects.Text;

--- a/src/ui/achvs-ui-handler.ts
+++ b/src/ui/achvs-ui-handler.ts
@@ -13,6 +13,7 @@ import { ScrollBar } from "#app/ui/scroll-bar";
 import { PlayerGender } from "#enums/player-gender";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
+import { GameSprite } from "#app/game-sprite";
 
 enum Page {
   ACHIEVEMENTS,
@@ -39,10 +40,10 @@ export default class AchvsUiHandler extends MessageUiHandler {
   private headerBg: Phaser.GameObjects.NineSlice;
   private headerText: Phaser.GameObjects.Text;
   private headerActionText: Phaser.GameObjects.Text;
-  private headerActionButton: Phaser.GameObjects.Sprite;
+  private headerActionButton: GameSprite;
   private headerBgX: number;
   private iconsBg: Phaser.GameObjects.NineSlice;
-  private icons: Phaser.GameObjects.Sprite[];
+  private icons: GameSprite[];
 
   private titleBg: Phaser.GameObjects.NineSlice;
   private titleText: Phaser.GameObjects.Text;
@@ -85,7 +86,7 @@ export default class AchvsUiHandler extends MessageUiHandler {
     this.headerText = addTextObject(0, 0, "", TextStyle.SETTINGS_LABEL);
     this.headerText.setOrigin(0, 0);
     this.headerText.setPositionRelative(this.headerBg, 8, 4);
-    this.headerActionButton = new Phaser.GameObjects.Sprite(globalScene, 0, 0, "keyboard", "ACTION.png");
+    this.headerActionButton = new GameSprite(globalScene, 0, 0, "keyboard", "ACTION.png");
     this.headerActionButton.setOrigin(0, 0);
     this.headerActionButton.setPositionRelative(this.headerBg, 236, 6);
     this.headerActionText = addTextObject(0, 0, "", TextStyle.WINDOW, { fontSize: "60px" });

--- a/src/ui/battle-flyout.ts
+++ b/src/ui/battle-flyout.ts
@@ -11,6 +11,7 @@ import { Moves } from "#enums/moves";
 import { UiTheme } from "#enums/ui-theme";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 /** Container for info about a {@linkcode Move} */
 interface MoveInfo {
@@ -45,8 +46,8 @@ export default class BattleFlyout extends Phaser.GameObjects.Container {
 
   /** The initial container which defines where the flyout should be attached */
   private flyoutParent: Phaser.GameObjects.Container;
-  /** The background {@linkcode Phaser.GameObjects.Sprite;} for the flyout */
-  private flyoutBackground: Phaser.GameObjects.Sprite;
+  /** The background {@linkcode GameSprite;} for the flyout */
+  private flyoutBackground: GameSprite;
 
   /** The container which defines the drawable dimensions of the flyout */
   private flyoutContainer: Phaser.GameObjects.Container;

--- a/src/ui/battle-info.ts
+++ b/src/ui/battle-info.ts
@@ -17,6 +17,7 @@ import { WindowVariant } from "#enums/window-variant";
 import i18next from "i18next";
 import { ExpGainsSpeed } from "#enums/exp-gains-speed";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class BattleInfo extends Phaser.GameObjects.Container {
   public static readonly EXP_GAINS_DURATION_BASE = 1650;
@@ -40,24 +41,24 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
   private lastLevelCapped: boolean;
   private lastStats: string;
 
-  private box: Phaser.GameObjects.Sprite;
+  private box: GameSprite;
   private nameText: Phaser.GameObjects.Text;
   private genderText: Phaser.GameObjects.Text;
-  private ownedIcon: Phaser.GameObjects.Sprite;
-  private championRibbon: Phaser.GameObjects.Sprite;
-  private teraIcon: Phaser.GameObjects.Sprite;
-  private shinyIcon: Phaser.GameObjects.Sprite;
-  private fusionShinyIcon: Phaser.GameObjects.Sprite;
-  private splicedIcon: Phaser.GameObjects.Sprite;
-  private statusIndicator: Phaser.GameObjects.Sprite;
+  private ownedIcon: GameSprite;
+  private championRibbon: GameSprite;
+  private teraIcon: GameSprite;
+  private shinyIcon: GameSprite;
+  private fusionShinyIcon: GameSprite;
+  private splicedIcon: GameSprite;
+  private statusIndicator: GameSprite;
   private levelContainer: Phaser.GameObjects.Container;
   private hpBar: Phaser.GameObjects.Image;
   private hpBarSegmentDividers: Phaser.GameObjects.Rectangle[];
   private levelNumbersContainer: Phaser.GameObjects.Container;
   private hpNumbersContainer: Phaser.GameObjects.Container;
-  private type1Icon: Phaser.GameObjects.Sprite;
-  private type2Icon: Phaser.GameObjects.Sprite;
-  private type3Icon: Phaser.GameObjects.Sprite;
+  private type1Icon: GameSprite;
+  private type2Icon: GameSprite;
+  private type3Icon: GameSprite;
   private expBar: Phaser.GameObjects.Image;
 
   // #region Type effectiveness hint objects
@@ -70,9 +71,9 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
   public expMaskRect: Phaser.GameObjects.Graphics;
 
   private statsContainer: Phaser.GameObjects.Container;
-  private statsBox: Phaser.GameObjects.Sprite;
+  private statsBox: GameSprite;
   private statValuesContainer: Phaser.GameObjects.Container;
-  private statNumbers: Phaser.GameObjects.Sprite[];
+  private statNumbers: GameSprite[];
 
   public flyoutMenu?: BattleFlyout;
 
@@ -226,7 +227,7 @@ export default class BattleInfo extends Phaser.GameObjects.Container {
     this.statsBox.setOrigin(1, 0.5);
     this.statsContainer.add(this.statsBox);
 
-    const statLabels: Phaser.GameObjects.Sprite[] = [];
+    const statLabels: GameSprite[] = [];
     this.statNumbers = [];
 
     this.statValuesContainer = globalScene.add.container(0, 0);

--- a/src/ui/battle-message-ui-handler.ts
+++ b/src/ui/battle-message-ui-handler.ts
@@ -10,6 +10,7 @@ import i18next from "i18next";
 import type { Stat } from "#enums/stat";
 import { PERMANENT_STATS, getStatKey } from "#enums/stat";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class BattleMessageUiHandler extends MessageUiHandler {
   private readonly wordWrapWidth: number = 1780;
@@ -20,7 +21,7 @@ export default class BattleMessageUiHandler extends MessageUiHandler {
   private nameBox: Phaser.GameObjects.NineSlice;
   private nameText: Phaser.GameObjects.Text;
 
-  public bg: Phaser.GameObjects.Sprite;
+  public bg: GameSprite;
   public commandWindow: Phaser.GameObjects.NineSlice;
   public movesWindowContainer: Phaser.GameObjects.Container;
   public nameBoxContainer: Phaser.GameObjects.Container;

--- a/src/ui/candy-bar.ts
+++ b/src/ui/candy-bar.ts
@@ -5,11 +5,12 @@ import { TextStyle } from "#enums/text-style";
 import { argbFromRgba } from "@material/material-color-utilities";
 import { rgbHexToRgba } from "#app/utils";
 import type { Species } from "#enums/species";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class CandyBar extends Phaser.GameObjects.Container {
   private bg: Phaser.GameObjects.NineSlice;
-  private candyIcon: Phaser.GameObjects.Sprite;
-  private candyOverlayIcon: Phaser.GameObjects.Sprite;
+  private candyIcon: GameSprite;
+  private candyOverlayIcon: GameSprite;
   private countText: Phaser.GameObjects.Text;
   private speciesId: Species;
 

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -13,6 +13,7 @@ import { Color, ShadowColor } from "#enums/color";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
 import { TitlePhase } from "#app/phases/title-phase";
 import { globalScene } from "#app/global-scene";
+import type { GameSprite } from "#app/game-sprite";
 
 /**
  * Handles all the UI for choosing optional challenges.
@@ -35,7 +36,7 @@ export default class GameChallengesUiHandler extends UiHandler {
     leftArrow: Phaser.GameObjects.Image;
     rightArrow: Phaser.GameObjects.Image;
   }>;
-  private monoTypeValue: Phaser.GameObjects.Sprite;
+  private monoTypeValue: GameSprite;
 
   private cursorObj: Phaser.GameObjects.NineSlice | null;
 

--- a/src/ui/char-sprite.ts
+++ b/src/ui/char-sprite.ts
@@ -1,9 +1,10 @@
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { MissingTextureKey } from "#app/utils";
 
 export default class CharSprite extends Phaser.GameObjects.Container {
-  private sprite: Phaser.GameObjects.Sprite;
-  private transitionSprite: Phaser.GameObjects.Sprite;
+  private sprite: GameSprite;
+  private transitionSprite: GameSprite;
 
   public key: string;
   public variant: string;

--- a/src/ui/daily-run-scoreboard.ts
+++ b/src/ui/daily-run-scoreboard.ts
@@ -7,6 +7,7 @@ import { addWindow } from "./ui-theme";
 import { WindowVariant } from "#enums/window-variant";
 import { api } from "#app/plugins/api/api";
 import { ScoreboardCategory } from "#enums/scoreboard-category";
+import type { GameSprite } from "#app/game-sprite";
 
 export interface RankingEntry {
   rank: number;
@@ -19,11 +20,11 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
   private loadingLabel: Phaser.GameObjects.Text;
   private titleLabel: Phaser.GameObjects.Text;
   private rankingsContainer: Phaser.GameObjects.Container;
-  private prevCategoryButton: Phaser.GameObjects.Sprite;
-  private nextCategoryButton: Phaser.GameObjects.Sprite;
-  private prevPageButton: Phaser.GameObjects.Sprite;
+  private prevCategoryButton: GameSprite;
+  private nextCategoryButton: GameSprite;
+  private prevPageButton: GameSprite;
   private pageNumberLabel: Phaser.GameObjects.Text;
-  private nextPageButton: Phaser.GameObjects.Sprite;
+  private nextPageButton: GameSprite;
 
   private pageCount: number;
   private page: number;

--- a/src/ui/dropdown.ts
+++ b/src/ui/dropdown.ts
@@ -4,6 +4,7 @@ import { TextStyle } from "#enums/text-style";
 import { addWindow } from "./ui-theme";
 import { WindowVariant } from "#enums/window-variant";
 import i18next from "i18next";
+import type { GameSprite } from "#app/game-sprite";
 
 export enum DropDownState {
   ON,
@@ -36,9 +37,9 @@ export enum SortCriteria {
 export class DropDownLabel {
   public state: DropDownState;
   public text: string;
-  public sprite?: Phaser.GameObjects.Sprite;
+  public sprite?: GameSprite;
 
-  constructor(label: string, sprite?: Phaser.GameObjects.Sprite, state: DropDownState = DropDownState.OFF) {
+  constructor(label: string, sprite?: GameSprite, state: DropDownState = DropDownState.OFF) {
     this.text = label || "";
     this.sprite = sprite;
     this.state = state;
@@ -47,7 +48,7 @@ export class DropDownLabel {
 
 export class DropDownOption extends Phaser.GameObjects.Container {
   public override state: DropDownState = DropDownState.ON;
-  public toggle: Phaser.GameObjects.Sprite;
+  public toggle: GameSprite;
   public text: Phaser.GameObjects.Text;
   public val: any;
   public dir: SortDirection = SortDirection.ASC;

--- a/src/ui/egg-gacha-ui-handler.ts
+++ b/src/ui/egg-gacha-ui-handler.ts
@@ -18,6 +18,7 @@ import i18next from "i18next";
 import { EggTier } from "#enums/egg-type";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class EggGachaUiHandler extends MessageUiHandler {
   private eggGachaContainer: Phaser.GameObjects.Container;
@@ -26,8 +27,8 @@ export default class EggGachaUiHandler extends MessageUiHandler {
   private eggGachaOptionSelectBg: Phaser.GameObjects.NineSlice;
 
   private gachaContainers: Phaser.GameObjects.Container[];
-  private gachaKnobs: Phaser.GameObjects.Sprite[];
-  private gachaHatches: Phaser.GameObjects.Sprite[];
+  private gachaKnobs: GameSprite[];
+  private gachaHatches: GameSprite[];
   private gachaInfoContainers: Phaser.GameObjects.Container[];
   private eggGachaOverlay: Phaser.GameObjects.Rectangle;
   private eggGachaSummaryContainer: Phaser.GameObjects.Container;
@@ -596,7 +597,7 @@ export default class EggGachaUiHandler extends MessageUiHandler {
     switch (gachaType as GachaType) {
       case GachaType.LEGENDARY:
         const species = getPokemonSpecies(getLegendaryGachaSpeciesForTimestamp(new Date().getTime()));
-        const pokemonIcon = infoContainer.getAt(1) as Phaser.GameObjects.Sprite;
+        const pokemonIcon = infoContainer.getAt(1) as GameSprite;
         pokemonIcon.setTexture(species.getIconAtlasKey(), species.getIconId(false));
         break;
     }

--- a/src/ui/egg-list-ui-handler.ts
+++ b/src/ui/egg-list-ui-handler.ts
@@ -10,6 +10,7 @@ import i18next from "i18next";
 import ScrollableGridUiHandler from "#app/ui/scrollable-grid-handler";
 import { ScrollBar } from "#app/ui/scroll-bar";
 import { globalScene } from "#app/global-scene";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class EggListUiHandler extends MessageUiHandler {
   private readonly ROWS = 9;
@@ -17,8 +18,8 @@ export default class EggListUiHandler extends MessageUiHandler {
 
   private eggListContainer: Phaser.GameObjects.Container;
   private eggListIconContainer: Phaser.GameObjects.Container;
-  private eggIcons: Phaser.GameObjects.Sprite[];
-  private eggSprite: Phaser.GameObjects.Sprite;
+  private eggIcons: GameSprite[];
+  private eggSprite: GameSprite;
   private eggNameText: Phaser.GameObjects.Text;
   private eggDateText: Phaser.GameObjects.Text;
   private eggHatchWavesText: Phaser.GameObjects.Text;

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -18,13 +18,14 @@ import MoveInfoOverlay from "./move-info-overlay";
 import { BattleType } from "#enums/battle-type";
 import { settings } from "#app/system/settings/settings-manager";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class FightUiHandler extends UiHandler implements InfoToggle {
   public static readonly MOVES_CONTAINER_NAME = "moves";
 
   private movesContainer: Phaser.GameObjects.Container;
   private moveInfoContainer: Phaser.GameObjects.Container;
-  private typeIcon: Phaser.GameObjects.Sprite;
+  private typeIcon: GameSprite;
   private ppLabel: Phaser.GameObjects.Text;
   private ppText: Phaser.GameObjects.Text;
   private powerLabel: Phaser.GameObjects.Text;
@@ -32,7 +33,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
   private accuracyLabel: Phaser.GameObjects.Text;
   private accuracyText: Phaser.GameObjects.Text;
   private cursorObj: Phaser.GameObjects.Image | null;
-  private moveCategoryIcon: Phaser.GameObjects.Sprite;
+  private moveCategoryIcon: GameSprite;
   private moveInfoOverlay: MoveInfoOverlay;
 
   protected fieldIndex: number = 0;

--- a/src/ui/game-stats-ui-handler.ts
+++ b/src/ui/game-stats-ui-handler.ts
@@ -13,6 +13,7 @@ import i18next from "i18next";
 import { UiTheme } from "#enums/ui-theme";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 interface DisplayStat {
   label_key?: string;
@@ -222,8 +223,8 @@ export default class GameStatsUiHandler extends UiHandler {
   private statLabels: Phaser.GameObjects.Text[];
   private statValues: Phaser.GameObjects.Text[];
 
-  private arrowUp: Phaser.GameObjects.Sprite;
-  private arrowDown: Phaser.GameObjects.Sprite;
+  private arrowUp: GameSprite;
+  private arrowDown: GameSprite;
 
   constructor(mode: UiMode | null = null) {
     super(mode);

--- a/src/ui/hatched-pokemon-container.ts
+++ b/src/ui/hatched-pokemon-container.ts
@@ -6,6 +6,7 @@ import { globalScene } from "#app/global-scene";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import type PokemonIconAnimHandler from "./pokemon-icon-anim-handler";
 import { PokemonIconAnimMode } from "#enums/pokemon-icon-anim-mode";
+import type { GameSprite } from "#app/game-sprite";
 
 /**
  * A container for a Pokemon's sprite and icons to get displayed in the egg summary screen
@@ -14,7 +15,7 @@ import { PokemonIconAnimMode } from "#enums/pokemon-icon-anim-mode";
  */
 export class HatchedPokemonContainer extends Phaser.GameObjects.Container {
   public species: PokemonSpecies;
-  public icon: Phaser.GameObjects.Sprite;
+  public icon: GameSprite;
   public shinyIcon: Phaser.GameObjects.Image;
   public hiddenAbilityIcon: Phaser.GameObjects.Image;
   public pokeballIcon: Phaser.GameObjects.Image;

--- a/src/ui/message-ui-handler.ts
+++ b/src/ui/message-ui-handler.ts
@@ -2,6 +2,7 @@ import AwaitableUiHandler from "./awaitable-ui-handler";
 import type { UiMode } from "#enums/ui-mode";
 import { getFrameMs } from "#app/utils";
 import { globalScene } from "#app/global-scene";
+import type { GameSprite } from "#app/game-sprite";
 
 export default abstract class MessageUiHandler extends AwaitableUiHandler {
   protected textTimer: Phaser.Time.TimerEvent | null;
@@ -9,7 +10,7 @@ export default abstract class MessageUiHandler extends AwaitableUiHandler {
   public pendingPrompt: boolean;
 
   public message: Phaser.GameObjects.Text;
-  public prompt: Phaser.GameObjects.Sprite;
+  public prompt: GameSprite;
 
   constructor(mode: UiMode | null = null) {
     super(mode);

--- a/src/ui/modal-ui-handler.ts
+++ b/src/ui/modal-ui-handler.ts
@@ -6,6 +6,7 @@ import { addWindow } from "./ui-theme";
 import { WindowVariant } from "#enums/window-variant";
 import type { Button } from "#enums/buttons";
 import { globalScene } from "#app/global-scene";
+import type { GameSprite } from "#app/game-sprite";
 
 export interface ModalConfig {
   buttonActions: Function[];
@@ -186,7 +187,7 @@ export abstract class ModalUiHandler extends UiHandler {
    * @param gameObject the game object to add hover events/effects to
    */
   protected addInteractionHoverEffect(
-    gameObject: Phaser.GameObjects.Image | Phaser.GameObjects.NineSlice | Phaser.GameObjects.Sprite,
+    gameObject: Phaser.GameObjects.Image | Phaser.GameObjects.NineSlice | GameSprite,
   ) {
     gameObject.on("pointerover", () => {
       this.setMouseCursorStyle("pointer");

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -21,6 +21,7 @@ import Phaser from "phaser";
 import { PokeballType } from "#enums/pokeball";
 import { ModifierTier } from "#enums/modifier-tier";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 export const SHOP_OPTIONS_ROW_LIMIT = 7;
 const SINGLE_SHOP_ROW_YOFFSET = 12;
@@ -711,11 +712,11 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
 
 class ModifierOption extends Phaser.GameObjects.Container {
   public modifierTypeOption: ModifierTypeOption;
-  private pb: Phaser.GameObjects.Sprite;
-  private pbTint: Phaser.GameObjects.Sprite;
+  private pb: GameSprite;
+  private pbTint: GameSprite;
   private itemContainer: Phaser.GameObjects.Container;
-  private item: Phaser.GameObjects.Sprite;
-  private itemTint: Phaser.GameObjects.Sprite;
+  private item: GameSprite;
+  private itemTint: GameSprite;
   private itemText: Phaser.GameObjects.Text;
   private itemCostText: Phaser.GameObjects.Text;
 
@@ -729,7 +730,7 @@ class ModifierOption extends Phaser.GameObjects.Container {
 
   setup() {
     if (!this.modifierTypeOption.cost) {
-      const getPb = (): Phaser.GameObjects.Sprite => {
+      const getPb = (): GameSprite => {
         const pb = globalScene.add.sprite(0, -182, "pb", this.getPbAtlasKey(-this.modifierTypeOption.upgradeCount));
         pb.setScale(2);
         return pb;

--- a/src/ui/move-info-overlay.ts
+++ b/src/ui/move-info-overlay.ts
@@ -9,6 +9,7 @@ import { MoveCategory } from "#enums/move-category";
 import { Type } from "#enums/type";
 import i18next from "i18next";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 export interface MoveInfoOverlaySettings {
   delayVisibility?: boolean; // if true, showing the overlay will only set it to active and populate the fields and the handler using this field has to manually call setVisible later.
@@ -44,8 +45,8 @@ export default class MoveInfoOverlay extends Phaser.GameObjects.Container implem
   private pp: Phaser.GameObjects.Text;
   private pow: Phaser.GameObjects.Text;
   private acc: Phaser.GameObjects.Text;
-  private typ: Phaser.GameObjects.Sprite;
-  private cat: Phaser.GameObjects.Sprite;
+  private typ: GameSprite;
+  private cat: GameSprite;
   private descBg: Phaser.GameObjects.NineSlice;
 
   private options: MoveInfoOverlaySettings;

--- a/src/ui/mystery-encounter-ui-handler.ts
+++ b/src/ui/mystery-encounter-ui-handler.ts
@@ -17,6 +17,7 @@ import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import type BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
 import { globalScene } from "#app/global-scene";
+import type { GameSprite } from "#app/game-sprite";
 
 export default class MysteryEncounterUiHandler extends UiHandler {
   private cursorContainer: Phaser.GameObjects.Container;
@@ -33,7 +34,7 @@ export default class MysteryEncounterUiHandler extends UiHandler {
   private descriptionWindow: Phaser.GameObjects.NineSlice;
   private descriptionContainer: Phaser.GameObjects.Container;
   private descriptionScrollTween?: Phaser.Tweens.Tween;
-  private rarityBall: Phaser.GameObjects.Sprite;
+  private rarityBall: GameSprite;
 
   private dexProgressWindow: Phaser.GameObjects.NineSlice;
   private dexProgressContainer: Phaser.GameObjects.Container;

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -38,6 +38,7 @@ import { ForceSwitchOutAttr } from "#app/data/move-attrs/force-switch-out-attr";
 import type { ConfirmModeConfig } from "#app/ui/interfaces/confirm-menu-config";
 import { PartyUiMode } from "#enums/party-ui-mode";
 import { PartyOption } from "#enums/party-option";
+import type { GameSprite } from "#app/game-sprite";
 
 const defaultMessage = i18next.t("partyUiHandler:choosePokemon");
 
@@ -1267,10 +1268,10 @@ class PartySlot extends Phaser.GameObjects.Container {
   private pokemon: PlayerPokemon;
 
   private slotBg: Phaser.GameObjects.Image;
-  private slotPb: Phaser.GameObjects.Sprite;
+  private slotPb: GameSprite;
   public slotName: Phaser.GameObjects.Text;
   public slotHpBar: Phaser.GameObjects.Image;
-  public slotHpOverlay: Phaser.GameObjects.Sprite;
+  public slotHpOverlay: GameSprite;
   public slotHpText: Phaser.GameObjects.Text;
   public slotDescriptionLabel: Phaser.GameObjects.Text; // this is used to show text instead of the HP bar i.e. for showing "Able"/"Not Able" for TMs when you try to learn them
 
@@ -1535,8 +1536,8 @@ class PartySlot extends Phaser.GameObjects.Container {
 class PartyCancelButton extends Phaser.GameObjects.Container {
   private selected: boolean;
 
-  private partyCancelBg: Phaser.GameObjects.Sprite;
-  private partyCancelPb: Phaser.GameObjects.Sprite;
+  private partyCancelBg: GameSprite;
+  private partyCancelPb: GameSprite;
 
   constructor(x: number, y: number) {
     super(globalScene, x, y);

--- a/src/ui/pokeball-tray.ts
+++ b/src/ui/pokeball-tray.ts
@@ -1,3 +1,4 @@
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import type { Pokemon } from "../field/pokemon";
 
@@ -5,7 +6,7 @@ export default class PokeballTray extends Phaser.GameObjects.Container {
   private player: boolean;
 
   private bg: Phaser.GameObjects.NineSlice;
-  private balls: Phaser.GameObjects.Sprite[];
+  private balls: GameSprite[];
 
   public shown: boolean;
 

--- a/src/ui/pokemon-hatch-info-container.ts
+++ b/src/ui/pokemon-hatch-info-container.ts
@@ -14,23 +14,24 @@ import { argbFromRgba } from "@material/material-color-utilities";
 import type { EggHatchData } from "#app/data/egg-hatch-data";
 import type { PlayerPokemon } from "#app/field/pokemon";
 import { getPokemonSpeciesForm } from "#app/data/pokemon-species";
+import type { GameSprite } from "#app/game-sprite";
 
 /**
  * Class for the hatch info summary of each pokemon
  * Holds an info container as well as an additional egg sprite, name, egg moves and main sprite
  */
 export default class PokemonHatchInfoContainer extends PokemonInfoContainer {
-  private currentPokemonSprite: Phaser.GameObjects.Sprite;
+  private currentPokemonSprite: GameSprite;
   private pokemonNumberText: Phaser.GameObjects.Text;
   private pokemonNameText: Phaser.GameObjects.Text;
   private pokemonEggMovesContainer: Phaser.GameObjects.Container;
   private pokemonEggMoveContainers: Phaser.GameObjects.Container[];
   private pokemonEggMoveBgs: Phaser.GameObjects.NineSlice[];
   private pokemonEggMoveLabels: Phaser.GameObjects.Text[];
-  private pokemonHatchedIcon: Phaser.GameObjects.Sprite;
+  private pokemonHatchedIcon: GameSprite;
   private pokemonListContainer: Phaser.GameObjects.Container;
-  private pokemonCandyIcon: Phaser.GameObjects.Sprite;
-  private pokemonCandyOverlayIcon: Phaser.GameObjects.Sprite;
+  private pokemonCandyIcon: GameSprite;
+  private pokemonCandyOverlayIcon: GameSprite;
   private pokemonCandyCountText: Phaser.GameObjects.Text;
 
   constructor(listContainer: Phaser.GameObjects.Container, x: number = 115, y: number = 9) {

--- a/src/ui/pokemon-icon-anim-handler.ts
+++ b/src/ui/pokemon-icon-anim-handler.ts
@@ -1,8 +1,9 @@
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { fixedNumber } from "#app/utils";
 import { PokemonIconAnimMode } from "#enums/pokemon-icon-anim-mode";
 
-type PokemonIcon = Phaser.GameObjects.Container | Phaser.GameObjects.Sprite;
+type PokemonIcon = Phaser.GameObjects.Container | GameSprite;
 
 export default class PokemonIconAnimHandler {
   private icons: Map<PokemonIcon, PokemonIconAnimMode>;

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -35,6 +35,7 @@ import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
 import { RunDisplayMode } from "#enums/run-display-mode";
+import { GameSprite } from "#app/game-sprite";
 
 /**
  * RunInfoUiMode indicates possible overlays of RunInfoUiHandler.
@@ -186,11 +187,11 @@ export default class RunInfoUiHandler extends UiHandler {
         fontSize: "34px",
       });
       const gamepadType = this.getUi().getGamepadType();
-      let abilityButtonElement: Phaser.GameObjects.Sprite;
+      let abilityButtonElement: GameSprite;
       if (gamepadType === "touch") {
-        abilityButtonElement = new Phaser.GameObjects.Sprite(globalScene, 0, 2, "keyboard", "E.png");
+        abilityButtonElement = new GameSprite(globalScene, 0, 2, "keyboard", "E.png");
       } else {
-        abilityButtonElement = new Phaser.GameObjects.Sprite(
+        abilityButtonElement = new GameSprite(
           globalScene,
           0,
           2,
@@ -243,20 +244,20 @@ export default class RunInfoUiHandler extends UiHandler {
         fontSize: "65px",
       });
       const gamepadType = this.getUi().getGamepadType();
-      let shinyButtonElement: Phaser.GameObjects.Sprite;
-      let formButtonElement: Phaser.GameObjects.Sprite;
+      let shinyButtonElement: GameSprite;
+      let formButtonElement: GameSprite;
       if (gamepadType === "touch") {
-        shinyButtonElement = new Phaser.GameObjects.Sprite(globalScene, 0, 4, "keyboard", "R.png");
-        formButtonElement = new Phaser.GameObjects.Sprite(globalScene, 0, 16, "keyboard", "F.png");
+        shinyButtonElement = new GameSprite(globalScene, 0, 4, "keyboard", "R.png");
+        formButtonElement = new GameSprite(globalScene, 0, 16, "keyboard", "F.png");
       } else {
-        shinyButtonElement = new Phaser.GameObjects.Sprite(
+        shinyButtonElement = new GameSprite(
           globalScene,
           0,
           4,
           gamepadType,
           globalScene.inputController?.getIconForLatestInputRecorded(SettingKeyboard.Button_Cycle_Shiny),
         );
-        formButtonElement = new Phaser.GameObjects.Sprite(
+        formButtonElement = new GameSprite(
           globalScene,
           0,
           16,
@@ -542,8 +543,8 @@ export default class RunInfoUiHandler extends UiHandler {
       const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
       // Applying Terastallizing Type tint to Pokemon icon
       // If the Pokemon is a fusion, it has two sprites and so, the tint has to be applied to each icon separately
-      const enemySprite1 = enemyIcon.list[0] as Phaser.GameObjects.Sprite;
-      const enemySprite2 = enemyIcon.list.length > 1 ? (enemyIcon.list[1] as Phaser.GameObjects.Sprite) : undefined;
+      const enemySprite1 = enemyIcon.list[0] as GameSprite;
+      const enemySprite2 = enemyIcon.list.length > 1 ? (enemyIcon.list[1] as GameSprite) : undefined;
       if (teraPokemon[enemyData.id]) {
         const teraTint = getTypeRgb(teraPokemon[enemyData.id]);
         const teraColor = new Phaser.Display.Color(teraTint[0], teraTint[1], teraTint[2]);
@@ -1039,7 +1040,7 @@ export default class RunInfoUiHandler extends UiHandler {
       const formIndex = pkmn.formIndex;
       const variant = pkmn.variant;
       const species = pkmn.getSpeciesForm();
-      const pokemonSprite: Phaser.GameObjects.Sprite = globalScene.add.sprite(60 + 40 * i, 40 + row * 80, "pkmn__sub");
+      const pokemonSprite: GameSprite = globalScene.add.sprite(60 + 40 * i, 40 + row * 80, "pkmn__sub");
       pokemonSprite.setPipeline(globalScene.spritePipeline, { tone: [0.0, 0.0, 0.0, 0.0], ignoreTimeTint: true });
       this.hallofFameContainer.add(pokemonSprite);
       const speciesLoaded: Map<Species, boolean> = new Map<Species, boolean>();

--- a/src/ui/saving-icon-handler.ts
+++ b/src/ui/saving-icon-handler.ts
@@ -1,8 +1,9 @@
+import type { GameSprite } from "#app/game-sprite";
 import { globalScene } from "#app/global-scene";
 import { fixedNumber } from "#app/utils";
 
 export default class SavingIconHandler extends Phaser.GameObjects.Container {
-  private icon: Phaser.GameObjects.Sprite;
+  private icon: GameSprite;
 
   private animActive: boolean;
   private shown: boolean;

--- a/src/ui/settings/abstract-binding-ui-handler.ts
+++ b/src/ui/settings/abstract-binding-ui-handler.ts
@@ -7,6 +7,7 @@ import { Button } from "#enums/buttons";
 import { NavigationManager } from "#app/ui/settings/navigationMenu";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
+import type { GameSprite } from "#app/game-sprite";
 
 type CancelFn = (succes?: boolean) => boolean;
 
@@ -34,8 +35,8 @@ export default abstract class AbstractBindingUiHandler extends UiHandler {
   protected buttonPressed: number | null = null;
 
   // Icons for displaying current and new button assignments.
-  protected newButtonIcon: Phaser.GameObjects.Sprite;
-  protected targetButtonIcon: Phaser.GameObjects.Sprite;
+  protected newButtonIcon: GameSprite;
+  protected targetButtonIcon: GameSprite;
 
   // Function to call on cancel or completion of binding.
   protected cancelFn: CancelFn | null;

--- a/src/ui/settings/abstract-control-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-control-settings-ui-handler.ts
@@ -12,9 +12,10 @@ import { Button } from "#enums/buttons";
 import i18next from "i18next";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 export interface InputsIcons {
-  [key: string]: Phaser.GameObjects.Sprite;
+  [key: string]: GameSprite;
 }
 
 export interface LayoutConfig {

--- a/src/ui/settings/navigationMenu.ts
+++ b/src/ui/settings/navigationMenu.ts
@@ -6,6 +6,7 @@ import { TextStyle } from "#enums/text-style";
 import { addWindow } from "#app/ui/ui-theme";
 import { Button } from "#enums/buttons";
 import i18next from "i18next";
+import type { GameSprite } from "#app/game-sprite";
 
 const LEFT = "LEFT";
 const RIGHT = "RIGHT";
@@ -135,7 +136,7 @@ export default class NavigationMenu extends Phaser.GameObjects.Container {
     iconNextTab.setPositionRelative(headerBg, headerBg.width - 20, 4);
     this.navigationIcons["BUTTON_CYCLE_SHINY"] = iconNextTab;
 
-    let relative: Phaser.GameObjects.Sprite | Phaser.GameObjects.Text = iconPreviousTab;
+    let relative: GameSprite | Phaser.GameObjects.Text = iconPreviousTab;
     let relativeWidth: number = iconPreviousTab.width * 6;
     for (const label of navigationManager.labels) {
       const labelText = addTextObject(0, 0, label, TextStyle.SETTINGS_LABEL);

--- a/src/ui/starter-container.ts
+++ b/src/ui/starter-container.ts
@@ -2,10 +2,11 @@ import { globalScene } from "#app/global-scene";
 import type PokemonSpecies from "../data/pokemon-species";
 import { addTextObject } from "./text";
 import { TextStyle } from "#enums/text-style";
+import type { GameSprite } from "#app/game-sprite";
 
 export class StarterContainer extends Phaser.GameObjects.Container {
   public species: PokemonSpecies;
-  public icon: Phaser.GameObjects.Sprite;
+  public icon: GameSprite;
   public shinyIcons: Phaser.GameObjects.Image[] = [];
   public label: Phaser.GameObjects.Text;
   public starterPassiveBgs: Phaser.GameObjects.Image;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -85,6 +85,7 @@ import { DropDownColumn } from "#enums/drop-down-column";
 import { DropDownType } from "#enums/drop-down-type";
 import { SortCriteria } from "#enums/sort-criteria";
 import { SettingKeyboard } from "#enums/setting-keyboard";
+import { GameSprite } from "#app/game-sprite";
 
 export type StarterSelectCallback = (starters: Starter[]) => void;
 
@@ -252,12 +253,12 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   private filteredStarterContainers: StarterContainer[] = [];
   private validStarterContainers: StarterContainer[] = [];
   private pokemonNumberText: Phaser.GameObjects.Text;
-  private pokemonSprite: Phaser.GameObjects.Sprite;
+  private pokemonSprite: GameSprite;
   private pokemonNameText: Phaser.GameObjects.Text;
   private pokemonGrowthRateLabelText: Phaser.GameObjects.Text;
   private pokemonGrowthRateText: Phaser.GameObjects.Text;
-  private type1Icon: Phaser.GameObjects.Sprite;
-  private type2Icon: Phaser.GameObjects.Sprite;
+  private type1Icon: GameSprite;
+  private type2Icon: GameSprite;
   private pokemonLuckLabelText: Phaser.GameObjects.Text;
   private pokemonLuckText: Phaser.GameObjects.Text;
   private pokemonGenderText: Phaser.GameObjects.Text;
@@ -278,28 +279,28 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   private pokemonEggMoveBgs: Phaser.GameObjects.NineSlice[];
   private pokemonEggMoveLabels: Phaser.GameObjects.Text[];
   private pokemonCandyContainer: Phaser.GameObjects.Container;
-  private pokemonCandyIcon: Phaser.GameObjects.Sprite;
-  private pokemonCandyDarknessOverlay: Phaser.GameObjects.Sprite;
-  private pokemonCandyOverlayIcon: Phaser.GameObjects.Sprite;
+  private pokemonCandyIcon: GameSprite;
+  private pokemonCandyDarknessOverlay: GameSprite;
+  private pokemonCandyOverlayIcon: GameSprite;
   private pokemonCandyCountText: Phaser.GameObjects.Text;
   private pokemonCaughtHatchedContainer: Phaser.GameObjects.Container;
   private pokemonCaughtCountText: Phaser.GameObjects.Text;
   private pokemonFormText: Phaser.GameObjects.Text;
-  private pokemonHatchedIcon: Phaser.GameObjects.Sprite;
+  private pokemonHatchedIcon: GameSprite;
   private pokemonHatchedCountText: Phaser.GameObjects.Text;
-  private pokemonShinyIcon: Phaser.GameObjects.Sprite;
-  private pokemonPassiveDisabledIcon: Phaser.GameObjects.Sprite;
-  private pokemonPassiveLockedIcon: Phaser.GameObjects.Sprite;
+  private pokemonShinyIcon: GameSprite;
+  private pokemonPassiveDisabledIcon: GameSprite;
+  private pokemonPassiveLockedIcon: GameSprite;
 
   private activeTooltip: "ABILITY" | "PASSIVE" | "CANDY" | undefined;
   private instructionsContainer: Phaser.GameObjects.Container;
   private filterInstructionsContainer: Phaser.GameObjects.Container;
-  private shinyIconElement: Phaser.GameObjects.Sprite;
-  private formIconElement: Phaser.GameObjects.Sprite;
-  private abilityIconElement: Phaser.GameObjects.Sprite;
-  private genderIconElement: Phaser.GameObjects.Sprite;
-  private natureIconElement: Phaser.GameObjects.Sprite;
-  private goFilterIconElement: Phaser.GameObjects.Sprite;
+  private shinyIconElement: GameSprite;
+  private formIconElement: GameSprite;
+  private abilityIconElement: GameSprite;
+  private genderIconElement: GameSprite;
+  private natureIconElement: GameSprite;
+  private goFilterIconElement: GameSprite;
   private shinyLabel: Phaser.GameObjects.Text;
   private formLabel: Phaser.GameObjects.Text;
   private genderLabel: Phaser.GameObjects.Text;
@@ -346,7 +347,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   public cursorObj: Phaser.GameObjects.Image;
   private starterCursorObjs: Phaser.GameObjects.Image[];
   private pokerusCursorObjs: Phaser.GameObjects.Image[];
-  private starterIcons: Phaser.GameObjects.Sprite[];
+  private starterIcons: GameSprite[];
   private starterIconsCursorObj: Phaser.GameObjects.Image;
   private valueLimitLabel: Phaser.GameObjects.Text;
   private startCursorObj: Phaser.GameObjects.NineSlice;
@@ -937,7 +938,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
 
     // instruction rows that will be pushed into the container dynamically based on need
     // creating new sprites since they will be added to the scene later
-    this.shinyIconElement = new Phaser.GameObjects.Sprite(
+    this.shinyIconElement = new GameSprite(
       globalScene,
       this.instructionRowX,
       this.instructionRowY,
@@ -956,13 +957,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     );
     this.shinyLabel.setName("text-shiny-label");
 
-    this.formIconElement = new Phaser.GameObjects.Sprite(
-      globalScene,
-      this.instructionRowX,
-      this.instructionRowY,
-      "keyboard",
-      "F.png",
-    );
+    this.formIconElement = new GameSprite(globalScene, this.instructionRowX, this.instructionRowY, "keyboard", "F.png");
     this.formIconElement.setName("sprite-form-icon-element");
     this.formIconElement.setScale(0.675);
     this.formIconElement.setOrigin(0.0, 0.0);
@@ -975,7 +970,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     );
     this.formLabel.setName("text-form-label");
 
-    this.genderIconElement = new Phaser.GameObjects.Sprite(
+    this.genderIconElement = new GameSprite(
       globalScene,
       this.instructionRowX,
       this.instructionRowY,
@@ -994,7 +989,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     );
     this.genderLabel.setName("text-gender-label");
 
-    this.abilityIconElement = new Phaser.GameObjects.Sprite(
+    this.abilityIconElement = new GameSprite(
       globalScene,
       this.instructionRowX,
       this.instructionRowY,
@@ -1013,7 +1008,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     );
     this.abilityLabel.setName("text-ability-label");
 
-    this.natureIconElement = new Phaser.GameObjects.Sprite(
+    this.natureIconElement = new GameSprite(
       globalScene,
       this.instructionRowX,
       this.instructionRowY,
@@ -1032,7 +1027,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     );
     this.natureLabel.setName("text-nature-label");
 
-    this.goFilterIconElement = new Phaser.GameObjects.Sprite(
+    this.goFilterIconElement = new GameSprite(
       globalScene,
       this.filterInstructionRowX,
       this.filterInstructionRowY,
@@ -2655,7 +2650,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     // this updates icons for previously saved pokemon
     for (let i = 0; i < this.validStarterContainers.length; i++) {
       const currentFilteredContainer = this.validStarterContainers[i];
-      const starterSprite = currentFilteredContainer.icon as Phaser.GameObjects.Sprite;
+      const starterSprite = currentFilteredContainer.icon as GameSprite;
 
       const currentDexAttr = this.getCurrentDexProps(currentFilteredContainer.species.speciesId);
       const props = globalScene.gameData.getSpeciesDexAttrProps(currentFilteredContainer.species, currentDexAttr);
@@ -3411,7 +3406,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           (p) => p.species.speciesId === species.speciesId,
         );
         if (currentFilteredContainer) {
-          const starterSprite = currentFilteredContainer.icon as Phaser.GameObjects.Sprite;
+          const starterSprite = currentFilteredContainer.icon as GameSprite;
           starterSprite.setTexture(
             species.getIconAtlasKey(formIndex, shiny, variant),
             species.getIconId(female!, formIndex, shiny, variant),
@@ -3790,7 +3785,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     for (let s = 0; s < this.allSpecies.length; s++) {
       /** Cost of pokemon species */
       const speciesStarterValue = globalScene.gameData.getSpeciesStarterValue(this.allSpecies[s].speciesId);
-      /** {@linkcode Phaser.GameObjects.Sprite} object of Pokémon for setting the alpha value */
+      /** {@linkcode GameSprite} object of Pokémon for setting the alpha value */
       const speciesSprite = this.starterContainers[s].icon;
 
       /**
@@ -4100,7 +4095,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
   }
 
   checkIconId(
-    icon: Phaser.GameObjects.Sprite,
+    icon: GameSprite,
     species: PokemonSpecies,
     female: boolean,
     formIndex: number,

--- a/src/ui/summary-ui-handler.ts
+++ b/src/ui/summary-ui-handler.ts
@@ -39,6 +39,7 @@ import { Stat, PERMANENT_STATS, getStatKey } from "#enums/stat";
 import { Nature } from "#enums/nature";
 import { settings } from "#app/system/settings/settings-manager";
 import { SummaryUiMode } from "#enums/summary-ui-mode";
+import type { GameSprite } from "#app/game-sprite";
 
 enum Page {
   PROFILE,
@@ -62,20 +63,20 @@ export default class SummaryUiHandler extends UiHandler {
   private summaryUiMode: SummaryUiMode;
 
   private summaryContainer: Phaser.GameObjects.Container;
-  private tabSprite: Phaser.GameObjects.Sprite;
+  private tabSprite: GameSprite;
   private shinyOverlay: Phaser.GameObjects.Image;
   private numberText: Phaser.GameObjects.Text;
-  private pokemonSprite: Phaser.GameObjects.Sprite;
+  private pokemonSprite: GameSprite;
   private nameText: Phaser.GameObjects.Text;
-  private splicedIcon: Phaser.GameObjects.Sprite;
-  private pokeball: Phaser.GameObjects.Sprite;
+  private splicedIcon: GameSprite;
+  private pokeball: GameSprite;
   private levelText: Phaser.GameObjects.Text;
   private genderText: Phaser.GameObjects.Text;
   private shinyIcon: Phaser.GameObjects.Image;
   private fusionShinyIcon: Phaser.GameObjects.Image;
-  private candyShadow: Phaser.GameObjects.Sprite;
-  private candyIcon: Phaser.GameObjects.Sprite;
-  private candyOverlay: Phaser.GameObjects.Sprite;
+  private candyShadow: GameSprite;
+  private candyIcon: GameSprite;
+  private candyOverlay: GameSprite;
   private candyCountText: Phaser.GameObjects.Text;
   private championRibbon: Phaser.GameObjects.Image;
   private statusContainer: Phaser.GameObjects.Container;
@@ -89,19 +90,19 @@ export default class SummaryUiHandler extends UiHandler {
   private summaryPageContainer: Phaser.GameObjects.Container;
   private movesContainer: Phaser.GameObjects.Container;
   private moveDescriptionText: Phaser.GameObjects.Text;
-  private moveCursorObj: Phaser.GameObjects.Sprite | null;
-  private selectedMoveCursorObj: Phaser.GameObjects.Sprite | null;
+  private moveCursorObj: GameSprite | null;
+  private selectedMoveCursorObj: GameSprite | null;
   private moveRowsContainer: Phaser.GameObjects.Container;
   private extraMoveRowContainer: Phaser.GameObjects.Container;
   private moveEffectContainer: Phaser.GameObjects.Container;
   private movePowerText: Phaser.GameObjects.Text;
   private moveAccuracyText: Phaser.GameObjects.Text;
-  private moveCategoryIcon: Phaser.GameObjects.Sprite;
+  private moveCategoryIcon: GameSprite;
   private summaryPageTransitionContainer: Phaser.GameObjects.Container;
-  private friendshipShadow: Phaser.GameObjects.Sprite;
+  private friendshipShadow: GameSprite;
   private friendshipText: Phaser.GameObjects.Text;
-  private friendshipIcon: Phaser.GameObjects.Sprite;
-  private friendshipOverlay: Phaser.GameObjects.Sprite;
+  private friendshipIcon: GameSprite;
+  private friendshipOverlay: GameSprite;
 
   private descriptionScrollTween: Phaser.Tweens.Tween | null;
   private moveCursorBlinkTimer: Phaser.Time.TimerEvent | null;
@@ -337,11 +338,7 @@ export default class SummaryUiHandler extends UiHandler {
       this.getTextColor(!this.pokemon.isShiny() ? TextStyle.SUMMARY : TextStyle.SUMMARY_GOLD, true),
     );
     const spriteKey = this.pokemon.getSpriteKey(true);
-    try {
-      this.pokemonSprite.play(spriteKey);
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    this.pokemonSprite.play(spriteKey);
     this.pokemonSprite.setPipelineData("teraColor", getTypeRgb(this.pokemon.getTeraType()));
     this.pokemonSprite.setPipelineData("ignoreTimeTint", true);
     this.pokemonSprite.setPipelineData("spriteKey", this.pokemon.getSpriteKey());
@@ -768,7 +765,7 @@ export default class SummaryUiHandler extends UiHandler {
       });
       pageContainer.removeBetween(1, undefined, true);
     }
-    const pageBg = pageContainer.getAt(0) as Phaser.GameObjects.Sprite;
+    const pageBg = pageContainer.getAt(0) as GameSprite;
     pageBg.setTexture(this.getPageKey(page));
 
     if (this.descriptionScrollTween) {

--- a/src/ui/time-of-day-widget.ts
+++ b/src/ui/time-of-day-widget.ts
@@ -4,21 +4,22 @@ import { BattleSceneEventType } from "#enums/battle-scene-event-type";
 import { EaseType } from "#enums/ease-type";
 import { TimeOfDay } from "#enums/time-of-day";
 import { settings } from "#app/system/settings/settings-manager";
+import type { GameSprite } from "#app/game-sprite";
 
 /** A small self contained UI element that displays the time of day as an icon */
 export default class TimeOfDayWidget extends Phaser.GameObjects.Container {
-  /** The {@linkcode Phaser.GameObjects.Sprite} that represents the foreground of the current time of day */
-  private readonly timeOfDayIconFgs: Phaser.GameObjects.Sprite[] = new Array(2);
-  /** The {@linkcode Phaser.GameObjects.Sprite} that represents the middle-ground of the current time of day */
-  private readonly timeOfDayIconMgs: Phaser.GameObjects.Sprite[] = new Array(2);
-  /** The {@linkcode Phaser.GameObjects.Sprite} that represents the background of the current time of day */
-  private readonly timeOfDayIconBgs: Phaser.GameObjects.Sprite[] = new Array(2);
+  /** The {@linkcode GameSprite} that represents the foreground of the current time of day */
+  private readonly timeOfDayIconFgs: GameSprite[] = new Array(2);
+  /** The {@linkcode GameSprite} that represents the middle-ground of the current time of day */
+  private readonly timeOfDayIconMgs: GameSprite[] = new Array(2);
+  /** The {@linkcode GameSprite} that represents the background of the current time of day */
+  private readonly timeOfDayIconBgs: GameSprite[] = new Array(2);
 
   /** An array containing all timeOfDayIcon objects for easier iteration */
-  private timeOfDayIcons: Phaser.GameObjects.Sprite[];
+  private timeOfDayIcons: GameSprite[];
 
   /** A map containing all timeOfDayIcon arrays with a matching string key for easier iteration */
-  private timeOfDayIconPairs: Map<string, Phaser.GameObjects.Sprite[]> = new Map([
+  private timeOfDayIconPairs: Map<string, GameSprite[]> = new Map([
     ["bg", this.timeOfDayIconBgs],
     ["mg", this.timeOfDayIconMgs],
     ["fg", this.timeOfDayIconFgs],

--- a/src/ui/ui-theme.ts
+++ b/src/ui/ui-theme.ts
@@ -2,6 +2,7 @@ import { legacyCompatibleImages } from "#app/scene-base";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
 import { WindowVariant } from "#enums/window-variant";
+import { GameSprite } from "#app/game-sprite";
 
 export function getWindowVariantSuffix(windowVariant: WindowVariant): string {
   switch (windowVariant) {
@@ -95,7 +96,7 @@ export function updateWindowType(windowTypeIndex: number): void {
       } else if (object.texture?.key === "namebox") {
         themedObjects.push(object);
       }
-    } else if (object instanceof Phaser.GameObjects.Sprite) {
+    } else if (object instanceof GameSprite) {
       if (object.texture?.key === "bg") {
         themedObjects.push(object);
       }
@@ -147,13 +148,13 @@ export function addUiThemeOverrides(): void {
     y: number,
     texture: string | Phaser.Textures.Texture,
     frame?: string | number,
-  ): Phaser.GameObjects.Sprite {
+  ): GameSprite {
     let legacy = false;
     if (typeof texture === "string" && settings.display.uiTheme && legacyCompatibleImages.includes(texture)) {
       legacy = true;
       texture += "_legacy";
     }
-    const ret: Phaser.GameObjects.Sprite = originalAddSprite.apply(this, [x, y, texture, frame]);
+    const ret: GameSprite = originalAddSprite.apply(this, [x, y, texture, frame]);
     if (legacy) {
       const originalSetTexture = ret.setTexture;
       ret.setTexture = function (key: string, frame?: string | number) {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To remove the need to add a `try/catch` to every usage of `sprite.play()`.

## What are the changes from a developer perspective?
See: `src/game-sprite.ts`, `src/field/pokemon.ts` for code changes.

Try/catch removed in: `src/data/mystery-encounters/encounters/global-trade-system-encounter.ts`, `src/data/mystery-encounters/utils/encounter-transformation-sequence.ts`, `src/phases/abstract-form-change-base-phase.ts`, `src/phases/egg-hatch-phase.ts`, `src/phases/evolution-phase.ts`, `src/phases/form-change-phase.ts`, `src/phases/quiet-form-change-phase.ts`, `src/ui/summary-ui-handler.ts`.

All other files changed should just be import changes.

## Checklist
- [ ] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
