### PR TITLE
[Ability][Checkup] Huge Power Checkup + Self-Inflicted Confusion Damage now ignores abilities 

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -41,6 +41,7 @@ import { WeatherType } from "#enums/weather-type";
 import { ReverseDrainAbAttr } from "./ab-attrs/reverse-drain-ab-attr";
 import Overrides from "#app/overrides";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
 
 export class BattlerTag {
   public tagType: BattlerTagType;
@@ -740,8 +741,8 @@ export class ConfusedTag extends BattlerTag {
       (pokemon.randSeedInt(100) < this.ACTIVATION_CHANCE && Overrides.STATUS_ACTIVATION_OVERRIDE !== false)
       || Overrides.STATUS_ACTIVATION_OVERRIDE === true
     ) {
-      const atk = pokemon.getEffectiveStat(Stat.ATK);
-      const def = pokemon.getEffectiveStat(Stat.DEF);
+      const atk = pokemon.getEffectiveStat(Stat.ATK, undefined, undefined, AbilityApplyMode.IGNORE);
+      const def = pokemon.getEffectiveStat(Stat.DEF, undefined, undefined, AbilityApplyMode.IGNORE);
       return toDmgValue(
         ((((2 * pokemon.level) / 5 + 2) * 40 * atk) / def / 50 + 2) * (pokemon.randSeedIntRange(85, 100) / 100),
       );

--- a/test/abilities/huge_power.test.ts
+++ b/test/abilities/huge_power.test.ts
@@ -60,7 +60,7 @@ describe("Abilities - Huge Power/Pure Power", () => {
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase");
 
-    expect(playerPokemon.getEffectiveStat).toHaveReturnedWith(playerPokemon.getStat(Stat.ATK) * 2);
+    expect(playerPokemon.getEffectiveStat).toHaveReturnedWith(playerPokemon.getStat(Stat.DEF) * 2);
   });
   // Note: Huge Power/Pure Power's interaction with Foul Play is tested in moves/foul_play.test.ts
 

--- a/test/abilities/huge_power.test.ts
+++ b/test/abilities/huge_power.test.ts
@@ -6,7 +6,10 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { Stat } from "#enums/stat";
 
-describe("Abilities - Huge Power/Pure Power", () => {
+describe.each([
+  { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },
+  { abilityName: "Pure Power", ability: Abilities.PURE_POWER },
+])("Abilities - $abilityName", ({ ability }) => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
@@ -23,6 +26,7 @@ describe("Abilities - Huge Power/Pure Power", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
+      .ability(ability)
       .battleType("single")
       .disableCrits()
       .enemySpecies(Species.MAGIKARP)
@@ -31,11 +35,8 @@ describe("Abilities - Huge Power/Pure Power", () => {
       .enemyMoveset(Moves.SPLASH);
   });
 
-  it.each([
-    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },
-    { abilityName: "Pure Power", ability: Abilities.PURE_POWER },
-  ])("$abilityName should double the attack stat of the ability-holder", async ({ ability }) => {
-    game.override.ability(ability).moveset(Moves.TACKLE);
+  it("should double the attack stat of the ability-holder", async () => {
+    game.override.moveset(Moves.TACKLE);
     await game.classicMode.startBattle([Species.FEEBAS]);
     const playerPokemon = game.scene.getPlayerPokemon()!;
     vi.spyOn(playerPokemon, "getEffectiveStat");
@@ -47,10 +48,7 @@ describe("Abilities - Huge Power/Pure Power", () => {
     expect(playerPokemon.getEffectiveStat).toHaveReturnedWith(playerPokemon.getStat(Stat.ATK) * 2);
   });
 
-  it.each([
-    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },
-    { abilityName: "Pure Power", ability: Abilities.PURE_POWER },
-  ])("$abilityName should double the attack stat when using Body Press", async ({ ability }) => {
+  it("should double the attack stat when using Body Press", async () => {
     game.override.ability(ability).moveset(Moves.BODY_PRESS);
     await game.classicMode.startBattle([Species.FEEBAS]);
     const playerPokemon = game.scene.getPlayerPokemon()!;
@@ -64,10 +62,7 @@ describe("Abilities - Huge Power/Pure Power", () => {
   });
   // Note: Huge Power/Pure Power's interaction with Foul Play is tested in moves/foul_play.test.ts
 
-  it.each([
-    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },
-    { abilityName: "Pure Power", ability: Abilities.PURE_POWER },
-  ])("$abilityName should not double the attack stat when calculating confusion damage", async ({ ability }) => {
+  it("should not double the attack stat when calculating confusion damage", async () => {
     game.override.ability(ability).moveset(Moves.SPLASH).enemyMoveset(Moves.SUPERSONIC).statusActivation(true);
     await game.classicMode.startBattle([Species.FEEBAS]);
     const playerPokemon = game.scene.getPlayerPokemon()!;

--- a/test/abilities/huge_power.test.ts
+++ b/test/abilities/huge_power.test.ts
@@ -1,0 +1,83 @@
+import { Abilities } from "#enums/abilities";
+import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Stat } from "#enums/stat";
+
+describe("Abilities - Huge Power/Pure Power", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyLevel(20)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(Moves.SPLASH);
+  });
+
+  it.each([
+    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },
+    { abilityName: "Pure Power", ability: Abilities.PURE_POWER },
+  ])("$abilityName should double the attack stat of the ability-holder", async ({ ability }) => {
+    game.override.ability(ability).moveset(Moves.TACKLE);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    vi.spyOn(playerPokemon, "getEffectiveStat");
+
+    game.move.select(Moves.TACKLE);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon.getEffectiveStat).toHaveReturnedWith(playerPokemon.getStat(Stat.ATK) * 2);
+  });
+
+  it.each([
+    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER, moveName: "Body Press", move: Moves.BODY_PRESS },
+    { abilityName: "Pure Power", ability: Abilities.PURE_POWER, moveName: "Body Press", move: Moves.BODY_PRESS },
+    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER, moveName: "Foul Play", move: Moves.FOUL_PLAY },
+    { abilityName: "Pure Power", ability: Abilities.PURE_POWER, moveName: "Foul Play", move: Moves.FOUL_PLAY },
+  ])("$abilityName should double the attack stat when using $moveName", async ({ ability, move }) => {
+    game.override.ability(ability).moveset(move);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    vi.spyOn(playerPokemon, "getEffectiveStat");
+
+    game.move.select(move);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon.getEffectiveStat).toHaveReturnedWith(playerPokemon.getStat(Stat.ATK) * 2);
+  });
+
+  it.each([
+    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },
+    { abilityName: "Pure Power", ability: Abilities.PURE_POWER },
+  ])("$abilityName should not double the attack stat when calculating confusion damage", async ({ ability }) => {
+    game.override.ability(ability).moveset(Moves.SPLASH).enemyMoveset(Moves.SUPERSONIC).statusActivation(true);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    vi.spyOn(playerPokemon, "getEffectiveStat");
+
+    game.move.select(Moves.SPLASH);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("BerryPhase");
+
+    expect(playerPokemon.getEffectiveStat).toHaveReturnedWith(playerPokemon.getStat(Stat.ATK));
+  });
+});

--- a/test/abilities/huge_power.test.ts
+++ b/test/abilities/huge_power.test.ts
@@ -48,22 +48,21 @@ describe("Abilities - Huge Power/Pure Power", () => {
   });
 
   it.each([
-    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER, moveName: "Body Press", move: Moves.BODY_PRESS },
-    { abilityName: "Pure Power", ability: Abilities.PURE_POWER, moveName: "Body Press", move: Moves.BODY_PRESS },
-    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER, moveName: "Foul Play", move: Moves.FOUL_PLAY },
-    { abilityName: "Pure Power", ability: Abilities.PURE_POWER, moveName: "Foul Play", move: Moves.FOUL_PLAY },
-  ])("$abilityName should double the attack stat when using $moveName", async ({ ability, move }) => {
-    game.override.ability(ability).moveset(move);
+    { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },
+    { abilityName: "Pure Power", ability: Abilities.PURE_POWER },
+  ])("$abilityName should double the attack stat when using Body Press", async ({ ability }) => {
+    game.override.ability(ability).moveset(Moves.BODY_PRESS);
     await game.classicMode.startBattle([Species.FEEBAS]);
     const playerPokemon = game.scene.getPlayerPokemon()!;
     vi.spyOn(playerPokemon, "getEffectiveStat");
 
-    game.move.select(move);
+    game.move.select(Moves.BODY_PRESS);
     await game.move.forceHit();
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(playerPokemon.getEffectiveStat).toHaveReturnedWith(playerPokemon.getStat(Stat.ATK) * 2);
   });
+  // Note: Huge Power/Pure Power's interaction with Foul Play is tested in moves/foul_play.test.ts
 
   it.each([
     { abilityName: "Huge Power", ability: Abilities.HUGE_POWER },


### PR DESCRIPTION
## What are the changes the user will see?

Self-inflicted confusion damage now ignores abilities. 

## Why am I making these changes?

A checkup a day...

## What are the changes from a developer perspective?

A test has been written for Huge Power/Pure Power. 
getDamage() in ConfusedTag now ignores DEF/ATK-multiplying abilities. 

## How to test the changes?

`npm run test huge_power`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?