### PR TITLE
[Dev] RNG debugger now outputs source of RNG calls

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -386,12 +386,63 @@ export default class BattleScene extends SceneBase {
       const originalRealInRange = Phaser.Math.RND.realInRange;
       Phaser.Math.RND.realInRange = (min: number, max: number): number => {
         const ret = originalRealInRange.apply(Phaser.Math.RND, [min, max]);
-        const args = ["RNG", ++this.rngCounter, ret / (max - min), `min: ${min} / max: ${max}`];
-        args.push(`seed: ${this.rngSeedOverride || this.waveSeed || this.seed}`);
+        const rngInfo = [
+          "RNG",
+          ++this.rngCounter,
+          `raw: ${ret / (max - min)}`,
+          `min: ${min} / max: ${max}`,
+          `output: ${ret}`,
+          `seed: ${this.rngSeedOverride || this.waveSeed || this.seed}`,
+        ];
         if (this.rngOffset) {
-          args.push(`offset: ${this.rngOffset}`);
+          rngInfo.push(`offset: ${this.rngOffset}`);
         }
-        console.log(...args);
+
+        const stack = Error().stack?.split("\n") as string[];
+
+        for (const line of stack) {
+          // On Chrome, each line is of the form "at <functionName> (.../<fileName>.ts?t=<timestamp>:<lineNumbers>)"
+          const chromeRegex = RegExp("at (.*?(\\w+)) \\(.*\\/(.*\\.ts).*:(\\d*:\\d*)\\)");
+          // On Firefox, each line is of the form "<functionName>@.../<fileName>.ts?t=<timestamp>:<lineNumbers>",
+          // or "<functionName>/<@.../<fileName>.ts?t=<timestamp>:<lineNumbers>"
+          const firefoxRegex = RegExp("(.*?(\\w+))(?:\\/<|)@.*\\/(.*\\.ts).*:(\\d*:\\d*)");
+          const match = line.match(chromeRegex) ?? line.match(firefoxRegex);
+          if (match) {
+            /**
+             * A list of functions that we ignore because they do not convey why the RNG call is being made.
+             * Feel free to add to this list as needed.
+             */
+            const excludedList = [
+              "realInRange",
+              "integerInRange",
+              "pick",
+              "weightedPick",
+              "shuffle",
+              "between",
+              "randSeedItem",
+              "randSeedWeightedItem",
+              "randSeedInt",
+              "randSeedIntRange",
+              "randSeedGauss",
+              "randSeedShuffle",
+              "randBattleSeedInt",
+              "randomString",
+              "executeWithSeedOffset",
+              "newBattle",
+            ];
+
+            const fullFunctionName = match[1]; // e.g., "BattleScene.getGeneratedOffsetGym"
+            const rootFunctionName = match[2]; // e.g., "getGeneratedOffsetGym"
+            const fileName = match[3]; // e.g., "battle-scene.ts"
+            // const _lineNumbers = match[4]; // e.g., "1216:10". However, this is bugged due to the browser removing empty lines from TS files.
+            if (!excludedList.includes(rootFunctionName)) {
+              rngInfo.push(`\n\nat ${fullFunctionName} (${fileName})\n `);
+              break;
+            }
+          }
+        }
+
+        console.log(...rngInfo);
         return ret;
       };
     }
@@ -956,7 +1007,7 @@ export default class BattleScene extends SceneBase {
     }
 
     if (boss && !dataSource) {
-      const secondaryIvs = getIvsFromId(randSeedInt(4294967296));
+      const secondaryIvs = getIvsFromId();
 
       for (let s = 0; s < pokemon.ivs.length; s++) {
         pokemon.ivs[s] = Math.round(

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -177,6 +177,7 @@ import { allTrainerConfigs } from "./data/balance/trainer-configs/all-trainer-co
 import { eventBus } from "./event-bus";
 import { Animation } from "./animations";
 import { resetStarterColors, starterColors } from "./data/starter-colors";
+import { CallSourceLogger } from "#app/loggers";
 
 const DEBUG_RNG = false;
 
@@ -382,7 +383,31 @@ export default class BattleScene extends SceneBase {
   }
 
   async preload() {
+    // TODO: Move all RNG-related code outside of `battle-scene.ts`.
     if (DEBUG_RNG) {
+      /**
+       * A list of functions that we ignore because they do not convey why the RNG call is being made.
+       * Feel free to add to this list as needed.
+       */
+      const ignoredRngFunctions = [
+        "realInRange",
+        "integerInRange",
+        "pick",
+        "weightedPick",
+        "shuffle",
+        "between",
+        "randSeedItem",
+        "randSeedWeightedItem",
+        "randSeedInt",
+        "randSeedIntRange",
+        "randSeedGauss",
+        "randSeedShuffle",
+        "randBattleSeedInt",
+        "randomString",
+        "executeWithSeedOffset",
+        "newBattle",
+      ];
+      const rngLogger = new CallSourceLogger(ignoredRngFunctions);
       const originalRealInRange = Phaser.Math.RND.realInRange;
       Phaser.Math.RND.realInRange = (min: number, max: number): number => {
         const ret = originalRealInRange.apply(Phaser.Math.RND, [min, max]);
@@ -398,51 +423,7 @@ export default class BattleScene extends SceneBase {
           rngInfo.push(`offset: ${this.rngOffset}`);
         }
 
-        const stack = Error().stack?.split("\n") as string[];
-
-        for (const line of stack) {
-          // On Chrome, each line is of the form "at <functionName> (.../<fileName>.ts?t=<timestamp>:<lineNumbers>)"
-          const chromeRegex = RegExp("at (.*?(\\w+)) \\(.*\\/(.*\\.ts).*:(\\d*:\\d*)\\)");
-          // On Firefox, each line is of the form "<functionName>@.../<fileName>.ts?t=<timestamp>:<lineNumbers>",
-          // or "<functionName>/<@.../<fileName>.ts?t=<timestamp>:<lineNumbers>"
-          const firefoxRegex = RegExp("(.*?(\\w+))(?:\\/<|)@.*\\/(.*\\.ts).*:(\\d*:\\d*)");
-          const match = line.match(chromeRegex) ?? line.match(firefoxRegex);
-          if (match) {
-            /**
-             * A list of functions that we ignore because they do not convey why the RNG call is being made.
-             * Feel free to add to this list as needed.
-             */
-            const excludedList = [
-              "realInRange",
-              "integerInRange",
-              "pick",
-              "weightedPick",
-              "shuffle",
-              "between",
-              "randSeedItem",
-              "randSeedWeightedItem",
-              "randSeedInt",
-              "randSeedIntRange",
-              "randSeedGauss",
-              "randSeedShuffle",
-              "randBattleSeedInt",
-              "randomString",
-              "executeWithSeedOffset",
-              "newBattle",
-            ];
-
-            const fullFunctionName = match[1]; // e.g., "BattleScene.getGeneratedOffsetGym"
-            const rootFunctionName = match[2]; // e.g., "getGeneratedOffsetGym"
-            const fileName = match[3]; // e.g., "battle-scene.ts"
-            // const _lineNumbers = match[4]; // e.g., "1216:10". However, this is bugged due to the browser removing empty lines from TS files.
-            if (!excludedList.includes(rootFunctionName)) {
-              rngInfo.push(`\n\nat ${fullFunctionName} (${fileName})\n `);
-              break;
-            }
-          }
-        }
-
-        console.log(...rngInfo);
+        rngLogger.log(...rngInfo);
         return ret;
       };
     }

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -74,6 +74,13 @@ interface TurnCommands {
   [key: number]: TurnCommand | null;
 }
 
+/**
+ * Uses the global RNG seed to generate a second seed to be used for in-battle RNG rolls.
+ */
+function generateBattleSeed() {
+  return randomString(16, true);
+}
+
 export default class Battle {
   protected gameMode: GameMode;
   public waveIndex: number;
@@ -93,7 +100,7 @@ export default class Battle {
   public postBattleLoot: PokemonHeldItemModifier[] = [];
   public escapeAttempts: number = 0;
   public lastMove: Moves;
-  public battleSeed: string = randomString(16, true);
+  public battleSeed: string = generateBattleSeed();
   private battleSeedState: string | null = null;
   public moneyScattered: number = 0;
   public lastUsedPokeball: PokeballType | null = null;

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -266,7 +266,7 @@ export class Egg {
       ret.shiny = this._isShiny;
       ret.variant = this._variantTier;
 
-      const secondaryIvs = getIvsFromId(randSeedInt(4294967295));
+      const secondaryIvs = getIvsFromId();
 
       for (let s = 0; s < ret.ivs.length; s++) {
         ret.ivs[s] = Math.max(ret.ivs[s], secondaryIvs[s]);

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -282,7 +282,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
       // Generate new id, reset status and HP in case using data source
       if (config.dataSource) {
-        enemyPokemon.id = randSeedInt(4294967296);
+        enemyPokemon.generateId();
       }
 
       // Set form

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -315,11 +315,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       throw `Cannot create a player Pokemon for species '${species.getName(formIndex)}'`;
     }
 
-    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_CHANCE);
-    if (!this.hasTrainer()) {
-      globalScene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
-    }
-
     this.species = species;
     this.pokeball = dataSource?.pokeball || PokeballType.POKEBALL;
     this.level = level;
@@ -330,15 +325,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.abilityIndex = abilityIndex; // Use the provided ability index if it is defined
     } else {
       // If abilityIndex is not provided, determine it based on species and hidden ability
-      const hasHiddenAbility = !randSeedInt(hiddenAbilityChance.value);
-      const randAbilityIndex = randSeedInt(2);
-      if (species.abilityHidden && hasHiddenAbility) {
-        // If the species has a hidden ability and the hidden ability is present
-        this.abilityIndex = 2;
-      } else {
-        // If there is no hidden ability or species does not have a hidden ability
-        this.abilityIndex = species.ability2 !== species.ability1 ? randAbilityIndex : 0; // Use random ability index if species has a second ability, otherwise use 0
-      }
+      this.generateRandomAbility();
     }
     if (formIndex !== undefined) {
       this.formIndex = formIndex;
@@ -393,7 +380,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.usedTMs = dataSource.usedTMs ?? [];
       this.customPokemonData = new CustomPokemonData(dataSource.customPokemonData);
     } else {
-      this.id = randSeedInt(4294967296);
+      this.generateId();
       this.ivs = ivs || getIvsFromId(this.id);
 
       if (this.gender === undefined) {
@@ -447,6 +434,33 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     if (!dataSource) {
       this.calculateStats();
+    }
+  }
+
+  /**
+   * Sets this Pokemon's ID to be a random integer from 0 to 2^32 - 1, inclusive.
+   */
+  generateId(): void {
+    this.id = randSeedInt(4294967296);
+  }
+
+  /**
+   * Sets this Pokemon to have a random ability, including a small chance of generating its Hidden Ability.
+   */
+  generateRandomAbility(): void {
+    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_CHANCE);
+    if (!this.hasTrainer()) {
+      globalScene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
+    }
+
+    const hasHiddenAbility = !randSeedInt(hiddenAbilityChance.value);
+    const randAbilityIndex = randSeedInt(2);
+    if (this.species.abilityHidden && hasHiddenAbility) {
+      // If the species has a hidden ability and the hidden ability is present
+      this.abilityIndex = 2;
+    } else {
+      // If there is no hidden ability or species does not have a hidden ability
+      this.abilityIndex = this.species.ability2 !== this.species.ability1 ? randAbilityIndex : 0; // Use random ability index if species has a second ability, otherwise use 0
     }
   }
 

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -1,0 +1,70 @@
+export class CallSourceLogger {
+  private readonly ignoredFnNames: string[];
+
+  /**
+   * Constructs a logger that appends a line of the current execution's stack trace to the output.
+   *
+   * The line that gets outputted is the first line whose function is not listed in
+   * {@linkcode ignoredFnNames}. (If no such line exists, the logger has no additional behaviour,
+   * and simply behaves as the regular console.)
+   *
+   * This logger can be useful for determining the source of a certain function call.
+   *
+   * Note: This extra functionality is currently only supported on Chrome and Firefox. On other
+   * browsers, it will most likely just behave as the regular console.
+   *
+   * @param ignoredFnNames A list of function names to ignore.
+   */
+  constructor(ignoredFnNames: string[]) {
+    this.ignoredFnNames = ["getStackTraceLine", "trace", "debug", "log", "info", "warn", "error", ...ignoredFnNames];
+  }
+
+  /**
+   * Return the first line in the current execution's stack trace whose function is not
+   * listed in {@linkcode ignoredFnNames}.
+   *
+   * If no such line exists, return an empty string.
+   */
+  private getStackTraceLine(): string {
+    const stack = Error().stack?.split("\n") as string[];
+
+    for (const line of stack) {
+      // On Chrome, each line is of the form "at <functionName> (.../<fileName>.ts?t=<timestamp>:<lineNumbers>)"
+      const chromeRegex = RegExp("at (.*?(\\w+)) \\(.*\\/(.*\\.ts).*:(\\d*:\\d*)\\)");
+      // On Firefox, each line is of the form "<functionName>@.../<fileName>.ts?t=<timestamp>:<lineNumbers>",
+      // or "<functionName>/<@.../<fileName>.ts?t=<timestamp>:<lineNumbers>"
+      const firefoxRegex = RegExp("(.*?(\\w+))(?:\\/<|)@.*\\/(.*\\.ts).*:(\\d*:\\d*)");
+      const match = line.match(chromeRegex) ?? line.match(firefoxRegex);
+      if (match) {
+        const fullFunctionName = match[1]; // e.g., "BattleScene.getGeneratedOffsetGym"
+        const rootFunctionName = match[2]; // e.g., "getGeneratedOffsetGym"
+        const fileName = match[3]; // e.g., "battle-scene.ts"
+        // const _lineNumbers = match[4]; // e.g., "1216:10". However, this is bugged due to the browser removing empty lines from TS files.
+        if (!this.ignoredFnNames.includes(rootFunctionName)) {
+          return `\n-- at ${fullFunctionName} (${fileName})`;
+        }
+      }
+    }
+
+    return "";
+  }
+
+  public trace(...args: any[]) {
+    console.trace(...args, this.getStackTraceLine());
+  }
+  public debug(...args: any[]) {
+    console.debug(...args, this.getStackTraceLine());
+  }
+  public log(...args: any[]) {
+    console.log(...args, this.getStackTraceLine());
+  }
+  public info(...args: any[]) {
+    console.info(...args, this.getStackTraceLine());
+  }
+  public warn(...args: any[]) {
+    console.warn(...args, this.getStackTraceLine());
+  }
+  public error(...args: any[]) {
+    console.error(...args, this.getStackTraceLine());
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,7 +161,10 @@ export function getPlayTimeString(totalSeconds: number): string {
  * @param id 32-bit number
  * @returns An array of six numbers corresponding to 5-bit chunks from {@linkcode id}
  */
-export function getIvsFromId(id: number): number[] {
+export function getIvsFromId(id?: number): number[] {
+  if (isNullOrUndefined(id)) {
+    id = randSeedInt(4294967296);
+  }
   return [
     (id & 0x3e000000) >>> 25,
     (id & 0x01f00000) >>> 20,


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the developer will see?

> [!NOTE]
> Each browser formats its stack trace differently, so the code used in this PR to find the source of RNG calls currently only supports Chrome and Firefox. Please let me know if you want these changes to also work for another browser.

<!-- Summarize what are the changes from a user perspective on the application -->

- The RNG debugger now displays the source of each RNG call.
- Ideally, no functional changes to actual gameplay.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

This should make it easier to debug RNG-related issues.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

- Added a new class `CallSourceLogger` that searches through the stack trace to find the source that called it. (Note: It currently accesses the stack trace by accessing `new Error().stack`. This may seem hacky, but according to a [Stack Overflow post](https://stackoverflow.com/questions/43236925/print-current-stack-trace-in-javascript), this is probably the most standard currently known method to access individual lines of the stack trace.)
- The RNG debugger now uses a `CallSourceLogger` to output its info.
- Some RNG calls have been separated and/or moved into the functions `generateBattleSeed()`, `getIvsFromId()`, `Pokemon.generateId()`, and `Pokemon.generateRandomAbility()` so that the RNG debugger displays them more clearly.

(The RNG debugger is currently unable to access the correct line numbers where RNG gets called. This seems to be because the browser internally uses a copy of each TS file where empty lines have been deleted, so its line numbers do not match with our source code's line numbers.)

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details><summary>Chrome: Generating an enemy Pokemon team</summary>

![20250127 Chrome Pokemon Generation](https://github.com/user-attachments/assets/8d3276f3-ea01-451c-bfd2-02fe03b85c42)

</details> 
<details><summary>Firefox: Generating an enemy Pokemon team</summary>

![20250127 Firefox Pokemon Generation](https://github.com/user-attachments/assets/e2926fc8-8d96-4784-b398-d9c145a11a18)

</details> 
<details><summary>Chrome: Using the move Thief</summary>

![20250127 Chrome Move Thief](https://github.com/user-attachments/assets/fbf224c6-9b16-4cbb-ab1c-8e5142443350)

</details> 
<details><summary>Firefox: Using the move Thief</summary>

![20250127 Firefox Move Thief](https://github.com/user-attachments/assets/37a29e66-7d83-4bd0-a68f-4eb655188396)

</details> 
<details><summary>Chrome: Using the egg gacha</summary>

![20250127 Chrome Pull Eggs](https://github.com/user-attachments/assets/58908726-dadd-42b7-b438-0a0411288dc1)

</details> 
<details><summary>Firefox: Using the egg gacha</summary>

![20250127 Firefox Pull Eggs](https://github.com/user-attachments/assets/00a84006-133b-41ad-acc7-573cd788baa5)

</details> 
<details><summary>Chrome: Generating GTS trade options</summary>

![20250127 Chrome GTS](https://github.com/user-attachments/assets/cb9f8b1e-a781-4d4f-82c0-24228526e694)

</details> 
<details><summary>Firefox: Generating GTS trade options</summary>

![20250127 Firefox GTS](https://github.com/user-attachments/assets/4586bf97-3e3b-4318-80a1-def4dbeb270e)

</details> 

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

In `battle-scene.ts`, set `DEBUG_RNG = true`. Then, start up the game, and do a bunch of stuff that calls RNG.

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?