### PR TITLE
[Refactor] `SelfStatusMove` now extends `StatusMove`

### DIFF
--- a/src/data/ab-attrs/post-dancing-move-ab-attr.ts
+++ b/src/data/ab-attrs/post-dancing-move-ab-attr.ts
@@ -1,7 +1,5 @@
 import type { BattlerIndex } from "#enums/battler-index";
 import { SelfStatusMove } from "../move";
-import { StatusMove } from "../move";
-import { AttackMove } from "../move";
 import type { Pokemon } from "#app/field/pokemon";
 import type { PokemonMove } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
@@ -34,13 +32,13 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
       && !pokemon.summonData.tags.some((tag) => forbiddenTags.includes(tag.tagType))
     ) {
       if (!simulated) {
-        // If the move is an AttackMove or a StatusMove the Dancer must replicate the move on the source of the Dance
-        if (move.getMove() instanceof AttackMove || move.getMove() instanceof StatusMove) {
+        if (move.getMove() instanceof SelfStatusMove) {
+          // If the move is a SelfStatusMove (ie. Swords Dance), the Dancer should replicate it on itself
+          globalScene.unshiftPhase(new MovePhase(pokemon, [pokemon.getBattlerIndex()], move, true, true));
+        } else {
+          // Otherwise, the Dancer must replicate the move on the source of the Dance
           const target = this.getTarget(pokemon, source, targets);
           globalScene.unshiftPhase(new MovePhase(pokemon, target, move, true, true));
-        } else if (move.getMove() instanceof SelfStatusMove) {
-          // If the move is a SelfStatusMove (ie. Swords Dance) the Dancer should replicate it on itself
-          globalScene.unshiftPhase(new MovePhase(pokemon, [pokemon.getBattlerIndex()], move, true, true));
         }
       }
       return true;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -930,7 +930,7 @@ export class StatusMove extends Move {
   }
 }
 
-export class SelfStatusMove extends Move {
+export class SelfStatusMove extends StatusMove {
   constructor(
     id: Moves,
     type: Type,
@@ -940,7 +940,8 @@ export class SelfStatusMove extends Move {
     priority: number,
     generation: number,
   ) {
-    super(id, type, MoveCategory.STATUS, MoveTarget.USER, -1, accuracy, pp, chance, priority, generation);
+    super(id, type, accuracy, pp, chance, priority, generation);
+    this.target(MoveTarget.USER);
   }
 }
 

--- a/test/abilities/dancer.test.ts
+++ b/test/abilities/dancer.test.ts
@@ -25,7 +25,7 @@ describe("Abilities - Dancer", () => {
     game = new GameManager(phaserGame);
     game.override
       .battleType("double")
-      .moveset([Moves.SWORDS_DANCE, Moves.SPLASH])
+      .moveset([Moves.FEATHER_DANCE, Moves.SPLASH])
       .enemySpecies(Species.MAGIKARP)
       .enemyAbility(Abilities.DANCER)
       .enemyMoveset([Moves.VICTORY_DANCE]);
@@ -39,20 +39,22 @@ describe("Abilities - Dancer", () => {
     const [oricorio] = game.scene.getPlayerField();
 
     game.move.select(Moves.SPLASH);
-    game.move.select(Moves.SWORDS_DANCE, 1);
+    game.move.select(Moves.FEATHER_DANCE, 1, BattlerIndex.ENEMY);
     await game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.PLAYER, BattlerIndex.ENEMY_2]);
     await game.phaseInterceptor.to("MovePhase");
-    // immediately copies ally move
+    // immediately copies ally move Feather Dance, and uses it on opponent
     await game.phaseInterceptor.to("MovePhase", false);
     let currentPhase = game.scene.getCurrentPhase() as MovePhase;
     expect(currentPhase.pokemon).toBe(oricorio);
-    expect(currentPhase.move.moveId).toBe(Moves.SWORDS_DANCE);
+    expect(currentPhase.targets).toEqual([BattlerIndex.ENEMY]);
+    expect(currentPhase.move.moveId).toBe(Moves.FEATHER_DANCE);
     await game.phaseInterceptor.to("MoveEndPhase");
     await game.phaseInterceptor.to("MovePhase");
-    // immediately copies enemy move
+    // immediately copies enemy move Victory Dance, and uses it on itself
     await game.phaseInterceptor.to("MovePhase", false);
     currentPhase = game.scene.getCurrentPhase() as MovePhase;
     expect(currentPhase.pokemon).toBe(oricorio);
+    expect(currentPhase.targets).toEqual([BattlerIndex.PLAYER]);
     expect(currentPhase.move.moveId).toBe(Moves.VICTORY_DANCE);
     await game.phaseInterceptor.to("BerryPhase");
 


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

Forewarn no longer warns about self-status moves.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

It is far more intuitive for self-status moves to also be treated as status moves.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

1. `SelfStatusMove` now extends `StatusMove` and manually resets the target to `MoveTarget.USER` in the constructor.
2. Reshuffled some of Dancer's code, since it actually used `move instanceof StatusMove` to check that a status move is not self-targeting.
3. Updated Dancer's test to also check that moves copied by Dancer have the correct targets.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details><summary>Swords Dance still correctly targets the user</summary>

https://github.com/user-attachments/assets/32be5e40-c52c-4415-8fa6-549c549750d7

</details> 
<details><summary>Forewarn no longer warns about self-status moves</summary>

https://github.com/user-attachments/assets/9ed3da1c-a3e2-4fb0-90cc-4cfe1782e4a3

</details> 
<details><summary>Moves copied by Dancer still have the correct targets</summary>

https://github.com/user-attachments/assets/964aeafd-61be-4536-a09a-8960445a5a63

</details> 

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Use self-status moves.

## Checklist

- [x] **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR?
  - Some small conflicts with #361.
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?