### PR TITLE
[Test] Add eslint rule enforcing proper `await` usage in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import prettierConfig from "eslint-config-prettier";
 
 export default [
   {
+    name: "eslint-config",
     files: ["src/**/*.{ts,tsx,js,jsx}", "test/**/*.{ts,tsx,js,jsx}"],
     ignores: ["dist/*", "build/*", "coverage/*", "public/*", ".github/*", "node_modules/*", ".vscode/*"],
     languageOptions: {
@@ -55,6 +56,23 @@ export default [
       "space-infix-ops": ["error", { int32Hint: false }], // Enforces spacing around infix operators
       "no-multiple-empty-lines": ["error", { max: 2, maxEOF: 1, maxBOF: 0 }], // Disallows multiple empty lines
       "@typescript-eslint/consistent-type-imports": "error", // Enforces type-only imports wherever possible
+    },
+  },
+  {
+    name: "eslint-tests",
+    files: ["test/**/**.test.ts"],
+    languageOptions: {
+      parser: parser,
+      parserOptions: {
+        project: ["./tsconfig.json"],
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint,
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error", // Require Promise-like statements to be handled appropriately. - https://typescript-eslint.io/rules/no-floating-promises/
+      "@typescript-eslint/no-misused-promises": "error", // Disallow Promises in places not designed to handle them. - https://typescript-eslint.io/rules/no-misused-promises/
     },
   },
   prettierConfig,

--- a/test/moves/dragon_rage.test.ts
+++ b/test/moves/dragon_rage.test.ts
@@ -1,11 +1,10 @@
-import { Stat } from "#enums/stat";
-import { ElementType } from "#enums/element-type";
-import { Species } from "#enums/species";
 import type { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { Abilities } from "#enums/abilities";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import { ElementType } from "#enums/element-type";
 import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,28 +30,20 @@ describe("Moves - Dragon Rage", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
 
-    game.override.battleType("single");
+    game.override
+      .battleType("single")
+      .moveset([Moves.DRAGON_RAGE])
+      .ability(Abilities.BALL_FETCH)
+      .startingLevel(100)
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyLevel(100);
 
-    game.override.starterSpecies(Species.SNORLAX);
-    game.override.moveset([Moves.DRAGON_RAGE]);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.passiveAbility(Abilities.BALL_FETCH);
-    game.override.startingLevel(100);
+    await game.classicMode.startBattle([Species.SNORLAX]);
 
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
-    game.override.enemyLevel(100);
-
-    await game.startBattle();
-
-    partyPokemon = game.scene.getPlayerParty()[0];
-    enemyPokemon = game.scene.getEnemyPokemon()!;
-
-    // remove berries
-    game.scene.removePartyMemberModifiers(0);
-    game.scene.clearEnemyHeldItemModifiers();
+    partyPokemon = game.field.getPlayerPokemon();
+    enemyPokemon = game.field.getEnemyPokemon();
   });
 
   it("ignores weaknesses", async () => {
@@ -60,7 +51,7 @@ describe("Moves - Dragon Rage", () => {
     vi.spyOn(enemyPokemon, "getTypes").mockReturnValue([ElementType.DRAGON]);
 
     game.move.select(Moves.DRAGON_RAGE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getInverseHp()).toBe(dragonRageDamage);
   });
@@ -70,7 +61,7 @@ describe("Moves - Dragon Rage", () => {
     vi.spyOn(enemyPokemon, "getTypes").mockReturnValue([ElementType.STEEL]);
 
     game.move.select(Moves.DRAGON_RAGE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getInverseHp()).toBe(dragonRageDamage);
   });
@@ -80,7 +71,7 @@ describe("Moves - Dragon Rage", () => {
     partyPokemon.setStatStage(Stat.SPATK, 2);
 
     game.move.select(Moves.DRAGON_RAGE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getInverseHp()).toBe(dragonRageDamage);
   });
@@ -90,7 +81,7 @@ describe("Moves - Dragon Rage", () => {
     vi.spyOn(partyPokemon, "getTypes").mockReturnValue([ElementType.DRAGON]);
 
     game.move.select(Moves.DRAGON_RAGE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getInverseHp()).toBe(dragonRageDamage);
   });
@@ -110,7 +101,7 @@ describe("Moves - Dragon Rage", () => {
     game.override.enemyAbility(Abilities.ICE_SCALES);
 
     game.move.select(Moves.DRAGON_RAGE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getInverseHp()).toBe(dragonRageDamage);
   });

--- a/test/moves/fissure.test.ts
+++ b/test/moves/fissure.test.ts
@@ -1,10 +1,8 @@
-import { Stat } from "#enums/stat";
-import { Species } from "#enums/species";
 import type { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { Abilities } from "#enums/abilities";
 import { Moves } from "#enums/moves";
+import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -28,27 +26,22 @@ describe("Moves - Fissure", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
 
-    game.override.battleType("single");
-    game.override.disableCrits();
+    game.override
+      .battleType("single")
+      .disableCrits()
+      .starterSpecies(Species.SNORLAX)
+      .ability(Abilities.BALL_FETCH)
+      .moveset([Moves.FISSURE])
+      .startingLevel(100)
+      .enemySpecies(Species.SNORLAX)
+      .enemyMoveset(Moves.SPLASH)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyLevel(100);
 
-    game.override.starterSpecies(Species.SNORLAX);
-    game.override.moveset([Moves.FISSURE]);
-    game.override.passiveAbility(Abilities.BALL_FETCH);
-    game.override.startingLevel(100);
+    await game.classicMode.startBattle();
 
-    game.override.enemySpecies(Species.SNORLAX);
-    game.override.enemyMoveset(Moves.SPLASH);
-    game.override.enemyPassiveAbility(Abilities.BALL_FETCH);
-    game.override.enemyLevel(100);
-
-    await game.startBattle();
-
-    partyPokemon = game.scene.getPlayerParty()[0];
-    enemyPokemon = game.scene.getEnemyPokemon()!;
-
-    // remove berries
-    game.scene.removePartyMemberModifiers(0);
-    game.scene.clearEnemyHeldItemModifiers();
+    partyPokemon = game.field.getPlayerPokemon();
+    enemyPokemon = game.field.getEnemyPokemon();
   });
 
   it("ignores damage modification from abilities, for example FUR_COAT", async () => {
@@ -56,7 +49,7 @@ describe("Moves - Fissure", () => {
     game.override.enemyAbility(Abilities.FUR_COAT);
 
     game.move.select(Moves.FISSURE);
-    await game.phaseInterceptor.to(DamageAnimPhase, true);
+    await game.phaseInterceptor.to("BerryPhase");
 
     expect(enemyPokemon.isFainted()).toBe(true);
   });
@@ -69,7 +62,7 @@ describe("Moves - Fissure", () => {
     game.move.select(Moves.FISSURE);
 
     // wait for TurnEndPhase instead of DamagePhase as fissure might not actually inflict damage
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(partyPokemon.getAccuracyMultiplier).toHaveReturnedWith(1);
   });
@@ -82,7 +75,7 @@ describe("Moves - Fissure", () => {
     game.move.select(Moves.FISSURE);
 
     // wait for TurnEndPhase instead of DamagePhase as fissure might not actually inflict damage
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(partyPokemon.getAccuracyMultiplier).toHaveReturnedWith(1);
   });

--- a/test/mystery-encounter/mystery-encounter-utils.test.ts
+++ b/test/mystery-encounter/mystery-encounter-utils.test.ts
@@ -64,7 +64,7 @@ describe("Mystery Encounter Utils", () => {
       scene.getPlayerParty().forEach((p) => {
         p.hp = 0;
         p.trySetStatus(StatusEffect.FAINT);
-        p.updateInfo();
+        void p.updateInfo();
       });
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
@@ -79,12 +79,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.ARCEUS);
     });
 
-    it("gets an unfainted legal pokemon from player party if isAllowed is true and isFainted is false", () => {
+    it("gets an unfainted legal pokemon from player party if isAllowed is true and isFainted is false", async () => {
       // Only faint 1st pokemon
       const party = scene.getPlayerParty();
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
       game.override.seed("random");
@@ -98,12 +98,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.MANAPHY);
     });
 
-    it("returns last unfainted pokemon if doNotReturnLastAbleMon is false", () => {
+    it("returns last unfainted pokemon if doNotReturnLastAbleMon is false", async () => {
       // Only faint 1st pokemon
       const party = scene.getPlayerParty();
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
       game.override.seed("random");
@@ -117,12 +117,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.MANAPHY);
     });
 
-    it("never returns last unfainted pokemon if doNotReturnLastAbleMon is true", () => {
+    it("never returns last unfainted pokemon if doNotReturnLastAbleMon is true", async () => {
       // Only faint 1st pokemon
       const party = scene.getPlayerParty();
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
 
       // Seeds are calculated to return index 0 first, 1 second (if both pokemon are legal)
       game.override.seed("random");
@@ -163,12 +163,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.ARCEUS);
     });
 
-    it("returns highest level unfainted if unfainted is true", () => {
+    it("returns highest level unfainted if unfainted is true", async () => {
       const party = scene.getPlayerParty();
       party[0].level = 100;
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
       party[1].level = 10;
 
       const result = getHighestLevelPlayerPokemon(true);
@@ -202,12 +202,12 @@ describe("Mystery Encounter Utils", () => {
       expect(result.species.speciesId).toBe(Species.ARCEUS);
     });
 
-    it("returns lowest level unfainted if unfainted is true", () => {
+    it("returns lowest level unfainted if unfainted is true", async () => {
       const party = scene.getPlayerParty();
       party[0].level = 10;
       party[0].hp = 0;
       party[0].trySetStatus(StatusEffect.FAINT);
-      party[0].updateInfo();
+      await party[0].updateInfo();
       party[1].level = 100;
 
       const result = getLowestLevelPlayerPokemon(true);

--- a/test/pokemon/evolution.test.ts
+++ b/test/pokemon/evolution.test.ts
@@ -42,10 +42,10 @@ describe("Evolution", () => {
     eevee.abilityIndex = 2;
     trapinch.abilityIndex = 2;
 
-    eevee.evolve(pokemonEvolutions[Species.EEVEE][6], eevee.getSpeciesForm());
+    await eevee.evolve(pokemonEvolutions[Species.EEVEE][6], eevee.getSpeciesForm());
     expect(eevee.abilityIndex).toBe(2);
 
-    trapinch.evolve(pokemonEvolutions[Species.TRAPINCH][0], trapinch.getSpeciesForm());
+    await trapinch.evolve(pokemonEvolutions[Species.TRAPINCH][0], trapinch.getSpeciesForm());
     expect(trapinch.abilityIndex).toBe(1);
   });
 
@@ -57,10 +57,10 @@ describe("Evolution", () => {
     bulbasaur.abilityIndex = 0;
     charmander.abilityIndex = 1;
 
-    bulbasaur.evolve(pokemonEvolutions[Species.BULBASAUR][0], bulbasaur.getSpeciesForm());
+    await bulbasaur.evolve(pokemonEvolutions[Species.BULBASAUR][0], bulbasaur.getSpeciesForm());
     expect(bulbasaur.abilityIndex).toBe(0);
 
-    charmander.evolve(pokemonEvolutions[Species.CHARMANDER][0], charmander.getSpeciesForm());
+    await charmander.evolve(pokemonEvolutions[Species.CHARMANDER][0], charmander.getSpeciesForm());
     expect(charmander.abilityIndex).toBe(1);
   });
 
@@ -70,7 +70,7 @@ describe("Evolution", () => {
     const squirtle = game.scene.getPlayerPokemon()!;
     squirtle.abilityIndex = 5;
 
-    squirtle.evolve(pokemonEvolutions[Species.SQUIRTLE][0], squirtle.getSpeciesForm());
+    await squirtle.evolve(pokemonEvolutions[Species.SQUIRTLE][0], squirtle.getSpeciesForm());
     expect(squirtle.abilityIndex).toBe(0);
   });
 
@@ -82,7 +82,7 @@ describe("Evolution", () => {
     nincada.metBiome = -1;
     nincada.gender = Gender.FEMALE;
 
-    nincada.evolve(pokemonEvolutions[Species.NINCADA][0], nincada.getSpeciesForm());
+    await nincada.evolve(pokemonEvolutions[Species.NINCADA][0], nincada.getSpeciesForm());
     const ninjask = game.scene.getPlayerParty()[0];
     const shedinja = game.scene.getPlayerParty()[1];
     expect(ninjask.abilityIndex).toBe(2);

--- a/test/ui/transfer-item.test.ts
+++ b/test/ui/transfer-item.test.ts
@@ -1,12 +1,10 @@
+import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
+import PartyUiHandler from "#app/ui/party-ui-handler";
 import { BerryType } from "#enums/berry-type";
 import { Button } from "#enums/buttons";
 import { Moves } from "#enums/moves";
-import { Species } from "#enums/species";
-import { BattleEndPhase } from "#app/phases/battle-end-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
-import PartyUiHandler from "#app/ui/party-ui-handler";
 import { PartyUiMode } from "#enums/party-ui-mode";
+import { Species } from "#enums/species";
 import { UiMode } from "#enums/ui-mode";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
@@ -41,7 +39,7 @@ describe("UI - Transfer Items", () => {
     game.override.enemySpecies(Species.MAGIKARP);
     game.override.enemyMoveset([Moves.SPLASH]);
 
-    await game.startBattle([Species.RAYQUAZA, Species.RAYQUAZA, Species.RAYQUAZA]);
+    await game.classicMode.startBattle([Species.RAYQUAZA, Species.RAYQUAZA, Species.RAYQUAZA]);
 
     game.move.select(Moves.DRAGON_CLAW);
 
@@ -52,10 +50,10 @@ describe("UI - Transfer Items", () => {
       handler.setCursor(1);
       handler.processInput(Button.ACTION);
 
-      game.scene.ui.setModeWithoutClear(UiMode.PARTY, PartyUiMode.MODIFIER_TRANSFER);
+      void game.scene.ui.setModeWithoutClear(UiMode.PARTY, PartyUiMode.MODIFIER_TRANSFER);
     });
 
-    await game.phaseInterceptor.to(BattleEndPhase);
+    await game.phaseInterceptor.to("BattleEndPhase");
   });
 
   it("check red tint for held item limit in transfer menu", async () => {
@@ -80,7 +78,7 @@ describe("UI - Transfer Items", () => {
       game.phaseInterceptor.unlock();
     });
 
-    await game.phaseInterceptor.to(SelectModifierPhase);
+    await game.phaseInterceptor.to("SelectModifierPhase");
   }, 20000);
 
   it("check transfer option for pokemon to transfer to", async () => {
@@ -101,6 +99,6 @@ describe("UI - Transfer Items", () => {
       game.phaseInterceptor.unlock();
     });
 
-    await game.phaseInterceptor.to(SelectModifierPhase);
+    await game.phaseInterceptor.to("SelectModifierPhase");
   }, 20000);
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To prevent mistakes in tests from forgotten `await`s.

## What are the changes from a developer perspective?
ESLint will display an error if a promise is misused (ie: an `await` is forgotten, such as someone writing `game.classicMode.startBattle();` instead of `await game.classicMode.startBattle();`). This will reduce mistakes in test writing.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?