### PR TITLE
[Move] Remove edge case notes from Foul Play + Body Press

### DIFF
--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -2020,9 +2020,9 @@ export function initMoves() {
     new AttackMove(Moves.ACID_SPRAY, ElementType.POISON, MoveCategory.SPECIAL, 40, 100, 20, 100, 0, 5)
       .attr(StatStageChangeAttr, [Stat.SPDEF], -2)
       .bulletMove(),
-    new AttackMove(Moves.FOUL_PLAY, ElementType.DARK, MoveCategory.PHYSICAL, 95, 100, 15, -1, 0, 5)
-      .attr(TargetAtkUserAtkAttr)
-      .edgeCase(), // Does not consider Huge Power/other attack stat modifiers correctly + disables Unaware during use
+    new AttackMove(Moves.FOUL_PLAY, ElementType.DARK, MoveCategory.PHYSICAL, 95, 100, 15, -1, 0, 5).attr(
+      TargetAtkUserAtkAttr,
+    ),
     new StatusMove(Moves.SIMPLE_BEAM, ElementType.NORMAL, 100, 15, -1, 0, 5).attr(AbilityChangeAttr, Abilities.SIMPLE),
     new StatusMove(Moves.ENTRAINMENT, ElementType.NORMAL, 100, 15, -1, 0, 5)
       .condition(failOnMaxCondition)
@@ -3185,9 +3185,9 @@ export function initMoves() {
       .attr(CutHpStatStageBoostAttr, [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD], 1, 3)
       .soundMove()
       .danceMove(),
-    new AttackMove(Moves.BODY_PRESS, ElementType.FIGHTING, MoveCategory.PHYSICAL, 80, 100, 10, -1, 0, 8)
-      .attr(DefAtkAttr)
-      .edgeCase(), // Does not consider Huge Power or other attack stat modifiers correctly + disables Unaware during use
+    new AttackMove(Moves.BODY_PRESS, ElementType.FIGHTING, MoveCategory.PHYSICAL, 80, 100, 10, -1, 0, 8).attr(
+      DefAtkAttr,
+    ),
     new StatusMove(Moves.DECORATE, ElementType.FAIRY, -1, 15, -1, 0, 8)
       .attr(StatStageChangeAttr, [Stat.ATK, Stat.SPATK], 2)
       .ignoresProtect(),


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

I forgot to update these when I made #358 😶 

## What are the changes from a developer perspective?

Foul Play and Body Press no longer have an `edgeCase` note.

## How to test the changes?

`npm run test [foul_play | body_press]` to verify edge cases have been resolved

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?+
