### PR TITLE
[Ability] Revert Perish Body to previous behavior and add tests

### DIFF
--- a/src/data/ab-attrs/post-defend-perish-song-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-perish-song-ab-attr.ts
@@ -13,22 +13,14 @@ import { PostDefendAbAttr } from "./post-defend-ab-attr";
  * @extends PostDefendAbAttr
  */
 export class PostDefendPerishSongAbAttr extends PostDefendAbAttr {
-  private readonly turns: number;
-
-  constructor(turns: number) {
-    super();
-
-    this.turns = turns;
-  }
-
   override apply(pokemon: Pokemon, simulated: boolean, attacker: Pokemon, move: Move): boolean {
     if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
-      if (pokemon.getTag(BattlerTagType.PERISH_SONG) && attacker.getTag(BattlerTagType.PERISH_SONG)) {
+      if (attacker.getTag(BattlerTagType.PERISH_SONG)) {
         return false;
       } else {
         if (!simulated) {
-          attacker.addTag(BattlerTagType.PERISH_SONG, this.turns);
-          pokemon.addTag(BattlerTagType.PERISH_SONG, this.turns);
+          attacker.addTag(BattlerTagType.PERISH_SONG, 4);
+          pokemon.addTag(BattlerTagType.PERISH_SONG, 4);
         }
         return true;
       }

--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -1371,7 +1371,7 @@ export function initAbilities() {
       ArenaTagType.REFLECT,
     ]),
     new Ability(Abilities.STEELY_SPIRIT, 8).attr(UserFieldMoveTypePowerBoostAbAttr, ElementType.STEEL),
-    new Ability(Abilities.PERISH_BODY, 8).attr(PostDefendPerishSongAbAttr, 4),
+    new Ability(Abilities.PERISH_BODY, 8).attr(PostDefendPerishSongAbAttr),
     new Ability(Abilities.WANDERING_SPIRIT, 8).attr(PostDefendAbilitySwapAbAttr).bypassFaint().edgeCase(), //  interacts incorrectly with rock head. It's meant to switch abilities before recoil would apply so that a pokemon with rock head would lose rock head first and still take the recoil
     new Ability(Abilities.GORILLA_TACTICS, 8).attr(GorillaTacticsAbAttr),
     new Ability(Abilities.NEUTRALIZING_GAS, 8)

--- a/test/abilities/perish_body.test.ts
+++ b/test/abilities/perish_body.test.ts
@@ -1,0 +1,72 @@
+import type { PerishSongTag } from "#app/data/battler-tags";
+import { Abilities } from "#enums/abilities";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Perish Body", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([MoveId.PECK, MoveId.SPLASH])
+      .ability(Abilities.PERISH_BODY)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.PERISH_BODY)
+      .enemyMoveset(MoveId.PECK)
+      .enemyLevel(8);
+  });
+
+  it("should not trigger if the attacker is afflicted with Perish", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS, Species.MILOTIC]);
+
+    const [, milotic] = game.scene.getPlayerParty();
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.select(MoveId.SPLASH);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    expect(milotic.getTag(BattlerTagType.PERISH_SONG)).toBeUndefined();
+    expect((enemy.getTag(BattlerTagType.PERISH_SONG) as PerishSongTag).turnCount).toBe(2);
+  });
+
+  it("should trigger if only the defender is afflicted with Perish", async () => {
+    game.override.enemyMoveset(MoveId.SPLASH);
+    await game.classicMode.startBattle([Species.FEEBAS, Species.MILOTIC]);
+
+    const [, milotic] = game.scene.getPlayerParty();
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.select(MoveId.PECK);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    game.move.select(MoveId.PECK);
+    await game.toNextTurn();
+
+    expect((milotic.getTag(BattlerTagType.PERISH_SONG) as PerishSongTag).turnCount).toBe(3);
+    expect((enemy.getTag(BattlerTagType.PERISH_SONG) as PerishSongTag).turnCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Perish Body will not trigger if the attacker is already afflicted with Perish.

## Why am I making these changes?
Proper behavior was confirmed via cart.
<details><summary>Attacker afflicted with Perish</summary>
<p>

https://github.com/user-attachments/assets/d43cd143-ca66-485d-b8ab-cfd8698c16bf

</p>
</details>
<details><summary>Defender afflicted with Perish</summary>
<p>

https://github.com/user-attachments/assets/9dba3459-5fc9-4f49-bf23-1631cb9f620b

</p>
</details> 

## What are the changes from a developer perspective?
The `if` check in Perish Body's `AbAttr` now only checks the attacker for the Perish tag.
Also the unnecessary constructor parameter for Perish Body's `AbAttr` to set turn count is removed (this `AbAttr` cannot meaningfully be extended).

## How to test the changes?
`npm run test perish_body`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?