### PR TITLE
[Bug] `PreSetStatusEffectImmunityAbAttr` no longer prevents fainting

### DIFF
--- a/src/data/ab-attrs/pre-set-status-effect-immunity-ab-attr.ts
+++ b/src/data/ab-attrs/pre-set-status-effect-immunity-ab-attr.ts
@@ -2,7 +2,7 @@ import { getStatusEffectDescriptor } from "#app/data/status-effect";
 import type { Pokemon } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { BooleanHolder } from "#app/utils";
-import type { StatusEffect } from "#enums/status-effect";
+import { StatusEffect } from "#enums/status-effect";
 import i18next from "i18next";
 import { PreSetStatusAbAttr } from "./pre-set-status-ab-attr";
 
@@ -21,6 +21,9 @@ export class PreSetStatusEffectImmunityAbAttr extends PreSetStatusAbAttr {
   }
 
   override apply(_pokemon: Pokemon, _simulated: boolean, effect: StatusEffect, cancelled: BooleanHolder): boolean {
+    if (effect === StatusEffect.FAINT) {
+      return false;
+    }
     if (this.immuneEffects.length < 1 || this.immuneEffects.includes(effect)) {
       cancelled.value = true;
       return true;


### PR DESCRIPTION
## What are the changes the user will see?
Shields Down won't crash the game when it is implemented in the future.

## Why am I making these changes?
Fixes an issue discovered when Pokerogue implemented Shields Down (see PR5252).

## What are the changes from a developer perspective?
An if statement was added to `PreSetStatusEffectImmunityAbAttr` that checks if the effect passed to the `AbAttr` is `StatusEffect.FAINT` and returns early if so.

## How to test the changes?
We have not yet implemented Shields Down which combines this `AbAttr` with `.bypassFaint()`, so there is no situation where it could have occurred yet.

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?