### PR TITLE
[Ability][Checkup] Anticipation + New overridesHelper for Enemy IVs

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -988,18 +988,12 @@ export default class BattleScene extends SceneBase {
     }
 
     let ENEMY_IVS_OVERRIDE_VALIDATED: number[] = [];
-    if (
-      Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)
-      && Overrides.ENEMY_IVS_OVERRIDE.length === 6
-      && Overrides.ENEMY_IVS_OVERRIDE.every((i) => i >= 0 && i <= 31)
-    ) {
-      ENEMY_IVS_OVERRIDE_VALIDATED = Overrides.ENEMY_IVS_OVERRIDE as number[];
-    } else if (
-      typeof Overrides.ENEMY_IVS_OVERRIDE === "number"
-      && Overrides.ENEMY_IVS_OVERRIDE >= 0
-      && Overrides.ENEMY_IVS_OVERRIDE <= 31
-    ) {
-      ENEMY_IVS_OVERRIDE_VALIDATED = new Array(6).fill(Overrides.ENEMY_ABILITY_OVERRIDE);
+    if (Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)) {
+      ENEMY_IVS_OVERRIDE_VALIDATED = (Overrides.ENEMY_IVS_OVERRIDE as number[]).map(
+        (iv) => Phaser.Math.Clamp(iv, 0, 31)
+      );
+    } else if (typeof Overrides.ENEMY_IVS_OVERRIDE === "number") {
+      ENEMY_IVS_OVERRIDE_VALIDATED = new Array(6).fill(Phaser.Math.Clamp(Overrides.ENEMY_IVS_OVERRIDE, 0, 31));
     }
     if (ENEMY_IVS_OVERRIDE_VALIDATED.length === 6) {
       pokemon.ivs = ENEMY_IVS_OVERRIDE_VALIDATED;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -989,14 +989,12 @@ export default class BattleScene extends SceneBase {
 
     let ENEMY_IVS_OVERRIDE_VALIDATED: number[] = [];
     if (Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)) {
-      ENEMY_IVS_OVERRIDE_VALIDATED = (Overrides.ENEMY_IVS_OVERRIDE as number[]).map(
-        (iv) => Phaser.Math.Clamp(iv, 0, 31)
-      );
+      ENEMY_IVS_OVERRIDE_VALIDATED = Overrides.ENEMY_IVS_OVERRIDE;
     } else if (typeof Overrides.ENEMY_IVS_OVERRIDE === "number") {
-      ENEMY_IVS_OVERRIDE_VALIDATED = new Array(6).fill(Phaser.Math.Clamp(Overrides.ENEMY_IVS_OVERRIDE, 0, 31));
+      ENEMY_IVS_OVERRIDE_VALIDATED = new Array(6).fill(Overrides.ENEMY_IVS_OVERRIDE);
     }
     if (ENEMY_IVS_OVERRIDE_VALIDATED.length === 6) {
-      pokemon.ivs = ENEMY_IVS_OVERRIDE_VALIDATED;
+      pokemon.ivs = ENEMY_IVS_OVERRIDE_VALIDATED.map(iv => Phaser.Math.Clamp(iv, 0, 31));
     }
 
     pokemon.init();

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -182,12 +182,6 @@ import { CANVAS_SCALE, GAME_HEIGHT, GAME_WIDTH } from "#app/ui-constants";
 
 const DEBUG_RNG = false;
 
-const ENEMY_IVS_OVERRIDE_VALIDATED: number[] = (
-  Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)
-    ? Overrides.ENEMY_IVS_OVERRIDE
-    : new Array(6).fill(Overrides.ENEMY_IVS_OVERRIDE)
-).map((iv) => (isNaN(iv) || iv === null || iv > 31 ? -1 : iv));
-
 export const startingWave = Overrides.STARTING_WAVE_OVERRIDE || 1;
 
 export interface PokeballCounts {
@@ -993,10 +987,22 @@ export default class BattleScene extends SceneBase {
       postProcess(pokemon);
     }
 
-    for (let i = 0; i < pokemon.ivs.length; i++) {
-      if (ENEMY_IVS_OVERRIDE_VALIDATED[i] > -1) {
-        pokemon.ivs[i] = ENEMY_IVS_OVERRIDE_VALIDATED[i];
-      }
+    let ENEMY_IVS_OVERRIDE_VALIDATED: number[] = [];
+    if (
+      Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)
+      && Overrides.ENEMY_IVS_OVERRIDE.length === 6
+      && Overrides.ENEMY_IVS_OVERRIDE.every((i) => i >= 0 && i <= 31)
+    ) {
+      ENEMY_IVS_OVERRIDE_VALIDATED = Overrides.ENEMY_IVS_OVERRIDE as number[];
+    } else if (
+      typeof Overrides.ENEMY_IVS_OVERRIDE === "number"
+      && Overrides.ENEMY_IVS_OVERRIDE >= 0
+      && Overrides.ENEMY_IVS_OVERRIDE <= 31
+    ) {
+      ENEMY_IVS_OVERRIDE_VALIDATED = new Array(6).fill(Overrides.ENEMY_ABILITY_OVERRIDE);
+    }
+    if (ENEMY_IVS_OVERRIDE_VALIDATED.length === 6) {
+      pokemon.ivs = ENEMY_IVS_OVERRIDE_VALIDATED;
     }
 
     pokemon.init();

--- a/src/data/ab-attrs/anticipation-ab-attr.ts
+++ b/src/data/ab-attrs/anticipation-ab-attr.ts
@@ -15,8 +15,8 @@ export class AnticipationAbAttr extends PostSummonMessageAbAttr {
 
   override apply(pokemon: Pokemon, simulated: boolean): boolean {
     for (const opponent of pokemon.getOpponents()) {
-      for (const pkmMove of opponent.moveset) {
-        const move = pkmMove ? pkmMove.getMove() : undefined;
+      for (const pkmMove of opponent.getMoveset()) {
+        const move = pkmMove.getMove();
         if (!move || move.id === MoveId.NONE) {
           continue;
         }

--- a/src/data/ab-attrs/anticipation-ab-attr.ts
+++ b/src/data/ab-attrs/anticipation-ab-attr.ts
@@ -17,9 +17,6 @@ export class AnticipationAbAttr extends PostSummonMessageAbAttr {
     for (const opponent of pokemon.getOpponents()) {
       for (const pkmMove of opponent.getMoveset()) {
         const move = pkmMove.getMove();
-        if (!move || move.id === MoveId.NONE) {
-          continue;
-        }
         if (move.isAttackMove()) {
           // Hidden Power is the only exception to Anticipation's interactions with variable type moves. Anticipation considers the type of most other variable-type moves to be their default type.
           const moveType = move.id !== MoveId.HIDDEN_POWER ? move.type : opponent.getMoveType(move, simulated);

--- a/src/data/ab-attrs/anticipation-ab-attr.ts
+++ b/src/data/ab-attrs/anticipation-ab-attr.ts
@@ -21,7 +21,7 @@ export class AnticipationAbAttr extends PostSummonMessageAbAttr {
           // Hidden Power is the only exception to Anticipation's interactions with variable type moves. Anticipation considers the type of most other variable-type moves to be their default type.
           const moveType = move.id !== MoveId.HIDDEN_POWER ? move.type : opponent.getMoveType(move, simulated);
           // Anticipation does not consider the effects of Strong Winds and Gravity on moves or opponent move type-changing abilities
-          if (pokemon.getAttackTypeEffectiveness(moveType, undefined, true, true) >= 2) {
+          if (pokemon.getAttackTypeEffectiveness(moveType, undefined, true, simulated) >= 2) {
             return super.apply(pokemon, simulated);
           } else if (move.hasAttr(OneHitKOAttr)) {
             return super.apply(pokemon, simulated);

--- a/src/data/ab-attrs/anticipation-ab-attr.ts
+++ b/src/data/ab-attrs/anticipation-ab-attr.ts
@@ -1,0 +1,37 @@
+import type { Pokemon } from "#app/field/pokemon";
+import { MoveId } from "#enums/move-id";
+import { OneHitKOAttr } from "../move-attrs/one-hit-ko-attr";
+import { PostSummonMessageAbAttr } from "./post-summon-message-ab-attr";
+
+/**
+ * Ability Attribute for Anticipation
+ * When a Pokémon with Anticipation enters the battle or a Pokémon gains the Ability Anticipation, it causes the Pokémon to "shudder" if an opponent has a damaging move that is super effective against the Pokémon with Anticipation or a one-hit knockout move.
+ * Shuddering has no actual effect, except that the presence of the Ability message is meant to provide information about possible moves the opponent might have.
+ */
+export class AnticipationAbAttr extends PostSummonMessageAbAttr {
+  constructor(messageFunc: (pokemon: Pokemon) => string) {
+    super(messageFunc);
+  }
+
+  override apply(pokemon: Pokemon, simulated: boolean): boolean {
+    for (const opponent of pokemon.getOpponents()) {
+      for (const pkmMove of opponent.moveset) {
+        const move = pkmMove ? pkmMove.getMove() : undefined;
+        if (!move || move.id === MoveId.NONE) {
+          continue;
+        }
+        if (move.isAttackMove()) {
+          // Hidden Power is the only exception to Anticipation's interactions with variable type moves. Anticipation considers the type of most other variable-type moves to be their default type.
+          const moveType = move.id !== MoveId.HIDDEN_POWER ? move.type : opponent.getMoveType(move, simulated);
+          // Anticipation does not consider the effects of Strong Winds on moves or opponent move type-changing abilities
+          if (pokemon.getAttackTypeEffectiveness(moveType, undefined, true) >= 2) {
+            return super.apply(pokemon, simulated);
+          } else if (move.hasAttr(OneHitKOAttr)) {
+            return super.apply(pokemon, simulated);
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/src/data/ab-attrs/anticipation-ab-attr.ts
+++ b/src/data/ab-attrs/anticipation-ab-attr.ts
@@ -20,8 +20,8 @@ export class AnticipationAbAttr extends PostSummonMessageAbAttr {
         if (move.isAttackMove()) {
           // Hidden Power is the only exception to Anticipation's interactions with variable type moves. Anticipation considers the type of most other variable-type moves to be their default type.
           const moveType = move.id !== MoveId.HIDDEN_POWER ? move.type : opponent.getMoveType(move, simulated);
-          // Anticipation does not consider the effects of Strong Winds on moves or opponent move type-changing abilities
-          if (pokemon.getAttackTypeEffectiveness(moveType, undefined, true) >= 2) {
+          // Anticipation does not consider the effects of Strong Winds and Gravity on moves or opponent move type-changing abilities
+          if (pokemon.getAttackTypeEffectiveness(moveType, undefined, true, true) >= 2) {
             return super.apply(pokemon, simulated);
           } else if (move.hasAttr(OneHitKOAttr)) {
             return super.apply(pokemon, simulated);

--- a/src/data/ab-attrs/anticipation-ab-attr.ts
+++ b/src/data/ab-attrs/anticipation-ab-attr.ts
@@ -4,7 +4,7 @@ import { OneHitKOAttr } from "../move-attrs/one-hit-ko-attr";
 import { PostSummonMessageAbAttr } from "./post-summon-message-ab-attr";
 
 /**
- * Ability Attribute for Anticipation
+ * Ability Attribute for Anticipation.
  * When a Pokémon with Anticipation enters the battle or a Pokémon gains the Ability Anticipation, it causes the Pokémon to "shudder" if an opponent has a damaging move that is super effective against the Pokémon with Anticipation or a one-hit knockout move.
  * Shuddering has no actual effect, except that the presence of the Ability message is meant to provide information about possible moves the opponent might have.
  * @extends PostSummonMessageAbAttr

--- a/src/data/ab-attrs/anticipation-ab-attr.ts
+++ b/src/data/ab-attrs/anticipation-ab-attr.ts
@@ -7,6 +7,7 @@ import { PostSummonMessageAbAttr } from "./post-summon-message-ab-attr";
  * Ability Attribute for Anticipation
  * When a Pokémon with Anticipation enters the battle or a Pokémon gains the Ability Anticipation, it causes the Pokémon to "shudder" if an opponent has a damaging move that is super effective against the Pokémon with Anticipation or a one-hit knockout move.
  * Shuddering has no actual effect, except that the presence of the Ability message is meant to provide information about possible moves the opponent might have.
+ * @extends PostSummonMessageAbAttr
  */
 export class AnticipationAbAttr extends PostSummonMessageAbAttr {
   constructor(messageFunc: (pokemon: Pokemon) => string) {

--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -609,7 +609,8 @@ export function initAbilities() {
     new Ability(Abilities.AFTERMATH, 4).attr(PostFaintContactDamageAbAttr, 4).bypassFaint(),
     new Ability(Abilities.ANTICIPATION, 4).attr(AnticipationAbAttr, (pokemon: Pokemon) =>
       i18next.t("abilityTriggers:postSummonAnticipation", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
-    ),
+    )
+    .edgeCase(), // Does not activate upon acquiring the Ability (e.g., via Skill Swap)
     new Ability(Abilities.FOREWARN, 4).attr(ForewarnAbAttr),
     new Ability(Abilities.UNAWARE, 4)
       .attr(IgnoreOpponentStatStagesAbAttr, [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA])

--- a/src/data/all-abilities.ts
+++ b/src/data/all-abilities.ts
@@ -130,7 +130,6 @@ import { allMoves } from "#app/data/all-moves";
 import { FlinchAttr } from "./move-attrs/flinch-attr";
 import { VariableMoveTypeAttr } from "./move-attrs/variable-move-type-attr";
 import { VariablePowerAttr } from "./move-attrs/variable-power-attr";
-import { OneHitKOAttr } from "./move-attrs/one-hit-ko-attr";
 import { MoveFlags } from "#enums/move-flags";
 import { MoveCategory } from "#enums/move-category";
 import { getNonVolatileStatusEffects } from "./status-effect";
@@ -198,6 +197,7 @@ import { TerrainEventTypeChangeAbAttr } from "./ab-attrs/terrain-event-type-chan
 import { WeatherBasedSpeedDoublerAbAttr } from "./ab-attrs/weather-based-speed-doubler-ab-attr";
 import { MoveFlagPowerBoostAbAttr } from "./ab-attrs/move-flag-power-boost-ab-attr";
 import { MoveFlagImmunityAbAttr } from "./ab-attrs/move-flag-immunity-ab-attr";
+import { AnticipationAbAttr } from "./ab-attrs/anticipation-ab-attr";
 
 function getTerrainCondition(...terrainTypes: TerrainType[]): AbAttrCondition {
   return (_pokemon: Pokemon) => {
@@ -246,67 +246,6 @@ function getSheerForceHitDisableAbCondition(): AbAttrCondition {
       allMoves[lastReceivedAttack.moveId].chance >= 0 && lastAttacker.hasAbility(Abilities.SHEER_FORCE);
 
     return !SheerForceAffected;
-  };
-}
-
-function getAnticipationCondition(): AbAttrCondition {
-  return (pokemon: Pokemon) => {
-    for (const opponent of pokemon.getOpponents()) {
-      for (const move of opponent.moveset) {
-        // ignore null/undefined moves
-        if (!move) {
-          continue;
-        }
-        // the move's base type (not accounting for variable type changes) is super effective
-        if (
-          move.getMove().isAttackMove()
-          && pokemon.getAttackTypeEffectiveness(move.getMove().type, opponent, true, undefined, move.getMove()) >= 2
-        ) {
-          return true;
-        }
-        // move is a OHKO
-        if (move.getMove().hasAttr(OneHitKOAttr)) {
-          return true;
-        }
-        // edge case for hidden power, type is computed
-        if (move.getMove().id === MoveId.HIDDEN_POWER) {
-          const iv_val = Math.floor(
-            (((opponent.ivs[Stat.HP] & 1)
-              + (opponent.ivs[Stat.ATK] & 1) * 2
-              + (opponent.ivs[Stat.DEF] & 1) * 4
-              + (opponent.ivs[Stat.SPD] & 1) * 8
-              + (opponent.ivs[Stat.SPATK] & 1) * 16
-              + (opponent.ivs[Stat.SPDEF] & 1) * 32)
-              * 15)
-              / 63,
-          );
-
-          const type = [
-            ElementalType.FIGHTING,
-            ElementalType.FLYING,
-            ElementalType.POISON,
-            ElementalType.GROUND,
-            ElementalType.ROCK,
-            ElementalType.BUG,
-            ElementalType.GHOST,
-            ElementalType.STEEL,
-            ElementalType.FIRE,
-            ElementalType.WATER,
-            ElementalType.GRASS,
-            ElementalType.ELECTRIC,
-            ElementalType.PSYCHIC,
-            ElementalType.ICE,
-            ElementalType.DRAGON,
-            ElementalType.DARK,
-          ][iv_val];
-
-          if (pokemon.getAttackTypeEffectiveness(type, opponent) >= 2) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
   };
 }
 
@@ -668,11 +607,8 @@ export function initAbilities() {
       .attr(MoveAbilityBypassAbAttr),
     new Ability(Abilities.SUPER_LUCK, 4).attr(BonusCritAbAttr),
     new Ability(Abilities.AFTERMATH, 4).attr(PostFaintContactDamageAbAttr, 4).bypassFaint(),
-    new Ability(Abilities.ANTICIPATION, 4).conditionalAttr(
-      getAnticipationCondition(),
-      PostSummonMessageAbAttr,
-      (pokemon: Pokemon) =>
-        i18next.t("abilityTriggers:postSummonAnticipation", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
+    new Ability(Abilities.ANTICIPATION, 4).attr(AnticipationAbAttr, (pokemon: Pokemon) =>
+      i18next.t("abilityTriggers:postSummonAnticipation", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
     ),
     new Ability(Abilities.FOREWARN, 4).attr(ForewarnAbAttr),
     new Ability(Abilities.UNAWARE, 4)

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -896,7 +896,7 @@ export class AttackMove extends Move {
 
     let attackScore = 0;
 
-    const effectiveness = target.getAttackTypeEffectiveness(this.type, user, undefined, undefined, undefined, this);
+    const effectiveness = target.getAttackTypeEffectiveness(this.type, user, undefined, undefined, this);
     attackScore = Math.pow(effectiveness - 1, 2) * effectiveness < 1 ? -2 : 2;
     if (attackScore) {
       if (this.category === MoveCategory.PHYSICAL) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -896,7 +896,7 @@ export class AttackMove extends Move {
 
     let attackScore = 0;
 
-    const effectiveness = target.getAttackTypeEffectiveness(this.type, user, undefined, undefined, this);
+    const effectiveness = target.getAttackTypeEffectiveness(this.type, user, undefined, undefined, undefined, this);
     attackScore = Math.pow(effectiveness - 1, 2) * effectiveness < 1 ? -2 : 2;
     if (attackScore) {
       if (this.category === MoveCategory.PHYSICAL) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1980,7 +1980,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const typeMultiplier = new NumberHolder(
       move.category !== MoveCategory.STATUS || move.hasAttr(RespectAttackTypeImmunityAttr)
-        ? this.getAttackTypeEffectiveness(moveType, source, false, simulated, move)
+        ? this.getAttackTypeEffectiveness(moveType, source, false, false, simulated, move)
         : 1,
     );
 
@@ -2033,6 +2033,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param moveType {@linkcode ElementalType} the type of the move being used
    * @param source {@linkcode Pokemon} the Pokemon using the move
    * @param ignoreStrongWinds whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
+   * @param ignoreGravity whether or not the function should consider gravity
    * @param simulated tag to only apply the strong winds effect message when the move is used
    * @param move (optional) the move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
    * @returns a multiplier for the type effectiveness
@@ -2041,6 +2042,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     moveType: ElementalType,
     source?: Pokemon,
     ignoreStrongWinds: boolean = false,
+    ignoreGravity: boolean = false,
     simulated: boolean = true,
     move?: Move,
   ): TypeDamageMultiplier {
@@ -2051,7 +2053,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const arena = globalScene.arena;
 
     // Handle flying v ground type immunity without removing flying type so effective types are still effective
-    if (moveType === ElementalType.GROUND && (this.isGrounded() || arena.hasTag(ArenaTagType.GRAVITY))) {
+    if (
+      moveType === ElementalType.GROUND
+      && (this.isGrounded() || arena.hasTag(ArenaTagType.GRAVITY))
+      && !ignoreGravity
+    ) {
       const flyingIndex = types.indexOf(ElementalType.FLYING);
       if (flyingIndex > -1) {
         types.splice(flyingIndex, 1);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1980,7 +1980,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const typeMultiplier = new NumberHolder(
       move.category !== MoveCategory.STATUS || move.hasAttr(RespectAttackTypeImmunityAttr)
-        ? this.getAttackTypeEffectiveness(moveType, source, false, false, simulated, move)
+        ? this.getAttackTypeEffectiveness(moveType, source, false, simulated, move)
         : 1,
     );
 
@@ -2032,8 +2032,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Calculates the move's type effectiveness multiplier based on the target's type/s.
    * @param moveType {@linkcode ElementalType} the type of the move being used
    * @param source {@linkcode Pokemon} the Pokemon using the move
-   * @param ignoreStrongWinds whether or not this ignores strong winds (anticipation, forewarn, stealth rocks)
-   * @param ignoreGravity whether or not the function should consider gravity
+   * @param ignoreFieldConditions whether or not this ignores strong winds/gravity (anticipation, forewarn, stealth rocks)
    * @param simulated tag to only apply the strong winds effect message when the move is used
    * @param move (optional) the move whose type effectiveness is to be checked. Used for applying {@linkcode VariableMoveTypeChartAttr}
    * @returns a multiplier for the type effectiveness
@@ -2041,8 +2040,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   getAttackTypeEffectiveness(
     moveType: ElementalType,
     source?: Pokemon,
-    ignoreStrongWinds: boolean = false,
-    ignoreGravity: boolean = false,
+    ignoreFieldConditions: boolean = false,
     simulated: boolean = true,
     move?: Move,
   ): TypeDamageMultiplier {
@@ -2056,7 +2054,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (
       moveType === ElementalType.GROUND
       && (this.isGrounded() || arena.hasTag(ArenaTagType.GRAVITY))
-      && !ignoreGravity
+      && !ignoreFieldConditions
     ) {
       const flyingIndex = types.indexOf(ElementalType.FLYING);
       if (flyingIndex > -1) {
@@ -2097,7 +2095,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     applyChallenges(globalScene.gameMode, ChallengeType.TYPE_EFFECTIVENESS, typeMultiplierAgainstFlying);
     // Handle strong winds lowering effectiveness of types super effective against pure flying
     if (
-      !ignoreStrongWinds
+      !ignoreFieldConditions
       && arena.weather?.weatherType === WeatherType.STRONG_WINDS
       && !arena.weather.isEffectSuppressed()
       && this.isOfType(ElementalType.FLYING)

--- a/test/abilities/anticipation.test.ts
+++ b/test/abilities/anticipation.test.ts
@@ -1,6 +1,7 @@
 import { AnticipationAbAttr } from "#app/data/ab-attrs/anticipation-ab-attr";
 import { allAbilities } from "#app/data/ability";
 import { Abilities } from "#enums/abilities";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
@@ -64,16 +65,20 @@ describe("Abilities - Anticipation", () => {
     const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
     vi.spyOn(anticipationAbility, "apply");
     await game.classicMode.startBattle([Species.FEEBAS]);
-
+    const enemyPokemon = game.scene.getEnemyPokemon();
+    expect(enemyPokemon?.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
     expect(anticipationAbility.apply).toHaveLastReturnedWith(true);
   });
 
   it("should not consider most variable-type moves' calculated type", async () => {
-    game.override.enemyMoveset(MoveId.REVELATION_DANCE);
+    game.override.enemySpecies(Species.PIKACHU).enemyMoveset(MoveId.REVELATION_DANCE);
+
     const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
     vi.spyOn(anticipationAbility, "apply");
     await game.classicMode.startBattle([Species.FEEBAS]);
+    const enemyPokemon = game.scene.getEnemyPokemon();
 
+    expect(enemyPokemon?.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
     expect(anticipationAbility.apply).toHaveLastReturnedWith(false);
   });
 });

--- a/test/abilities/anticipation.test.ts
+++ b/test/abilities/anticipation.test.ts
@@ -1,12 +1,10 @@
-import { AnticipationAbAttr } from "#app/data/ab-attrs/anticipation-ab-attr";
-import { allAbilities } from "#app/data/ability";
 import { Abilities } from "#enums/abilities";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Abilities - Anticipation", () => {
   let phaserGame: Phaser.Game;
@@ -34,51 +32,47 @@ describe("Abilities - Anticipation", () => {
 
   it("should activate when the opponent has a super-effective move", async () => {
     game.override.enemyMoveset(MoveId.ABSORB);
-    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
-    vi.spyOn(anticipationAbility, "apply");
     await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(anticipationAbility.apply).toHaveLastReturnedWith(true);
+    expect(playerPokemon.battleData.abilitiesApplied[0]).toBe(Abilities.ANTICIPATION);
   });
 
   it("should activate when the opponent has a 1HKO move", async () => {
     game.override.enemyMoveset(MoveId.FISSURE);
-    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
-    vi.spyOn(anticipationAbility, "apply");
     await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(anticipationAbility.apply).toHaveLastReturnedWith(true);
+    expect(playerPokemon.battleData.abilitiesApplied[0]).toBe(Abilities.ANTICIPATION);
   });
 
   it("should not activate when the opponent does not have a super-effective or 1HKO move", async () => {
     game.override.enemyMoveset(MoveId.SPLASH);
-    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
-    vi.spyOn(anticipationAbility, "apply");
     await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(anticipationAbility.apply).toHaveLastReturnedWith(false);
+    expect(playerPokemon.battleData.abilitiesApplied.length).toBe(0);
   });
 
   it("should consider Hidden Power's calculated type, not its default Normal type", async () => {
     game.override.enemyMoveset(MoveId.HIDDEN_POWER).enemyIVs([31, 31, 31, 30, 31, 31]);
     // Hidden Power type set to Electric here
-    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
-    vi.spyOn(anticipationAbility, "apply");
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const enemyPokemon = game.scene.getEnemyPokemon();
-    expect(enemyPokemon?.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
-    expect(anticipationAbility.apply).toHaveLastReturnedWith(true);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+
+    expect(enemyPokemon.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
+    expect(playerPokemon.battleData.abilitiesApplied[0]).toBe(Abilities.ANTICIPATION);
   });
 
   it("should not consider most variable-type moves' calculated type", async () => {
     game.override.enemySpecies(Species.PIKACHU).enemyMoveset(MoveId.REVELATION_DANCE);
 
-    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
-    vi.spyOn(anticipationAbility, "apply");
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const enemyPokemon = game.scene.getEnemyPokemon();
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(enemyPokemon?.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
-    expect(anticipationAbility.apply).toHaveLastReturnedWith(false);
+    expect(enemyPokemon.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
+    expect(playerPokemon.battleData.abilitiesApplied.length).toBe(0);
   });
 });

--- a/test/abilities/anticipation.test.ts
+++ b/test/abilities/anticipation.test.ts
@@ -1,0 +1,79 @@
+import { AnticipationAbAttr } from "#app/data/ab-attrs/anticipation-ab-attr";
+import { allAbilities } from "#app/data/ability";
+import { Abilities } from "#enums/abilities";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Abilities - Anticipation", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.ANTICIPATION)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH);
+  });
+
+  it("should activate when the opponent has a super-effective move", async () => {
+    game.override.enemyMoveset(MoveId.ABSORB);
+    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
+    vi.spyOn(anticipationAbility, "apply");
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    expect(anticipationAbility.apply).toHaveLastReturnedWith(true);
+  });
+
+  it("should activate when the opponent has a 1HKO move", async () => {
+    game.override.enemyMoveset(MoveId.FISSURE);
+    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
+    vi.spyOn(anticipationAbility, "apply");
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    expect(anticipationAbility.apply).toHaveLastReturnedWith(true);
+  });
+
+  it("should not activate when the opponent does not have a super-effective or 1HKO move", async () => {
+    game.override.enemyMoveset(MoveId.SPLASH);
+    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
+    vi.spyOn(anticipationAbility, "apply");
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    expect(anticipationAbility.apply).toHaveLastReturnedWith(false);
+  });
+
+  it("should consider Hidden Power's calculated type, not its default Normal type", async () => {
+    game.override.enemyMoveset(MoveId.HIDDEN_POWER).enemyIVs([31, 31, 31, 30, 31, 31]);
+    // Hidden Power type set to Electric here
+    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
+    vi.spyOn(anticipationAbility, "apply");
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    expect(anticipationAbility.apply).toHaveLastReturnedWith(true);
+  });
+
+  it("should not consider most variable-type moves' calculated type", async () => {
+    game.override.enemyMoveset(MoveId.REVELATION_DANCE);
+    const anticipationAbility = allAbilities[Abilities.ANTICIPATION].getAttrs(AnticipationAbAttr)[0];
+    vi.spyOn(anticipationAbility, "apply");
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    expect(anticipationAbility.apply).toHaveLastReturnedWith(false);
+  });
+});

--- a/test/abilities/anticipation.test.ts
+++ b/test/abilities/anticipation.test.ts
@@ -54,6 +54,40 @@ describe("Abilities - Anticipation", () => {
     expect(playerPokemon.battleData.abilitiesApplied.length).toBe(0);
   });
 
+  it("should not activate against status moves", async () => {
+    game.override.enemyMoveset(MoveId.THUNDER_WAVE);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+
+    expect(playerPokemon.battleData.abilitiesApplied.length).toBe(0);
+  });
+
+  it("should work correctly in Inverse Battles", async () => {
+    game.override.enemyMoveset(MoveId.EMBER);
+    game.challengeMode.addChallenge(Challenges.INVERSE_BATTLE, 1, 1);
+    await game.challengeMode.startBattle([Species.FEEBAS]);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+
+    expect(playerPokemon.battleData.abilitiesApplied[0]).toBe(Abilities.ANTICIPATION);
+  });
+
+  it("should ignore Gravity when evaluating move effectiveness", async () => {
+    game.override.enemyMoveset(MoveId.EARTHQUAKE);
+    await game.classicMode.startBattle([Species.FEEBAS, Species.SKARMORY]);
+
+    const playerPokemon = game.scene.getPlayerParty()[1];
+    vi.spyOn(playerPokemon, "getMoveEffectiveness");
+    
+    game.move.use(MoveId.GRAVITY);
+    await game.toNextTurn();
+    game.doSwitchPokemon(1);
+    await game.toNextTurn();
+
+    // Should not have activated Anticipation despite taking super-effective damage
+    expect(playerPokemon.getMoveEffectiveness).toHaveLastReturnedWith(2);
+    expect(playerPokemon.battleData.abilitiesApplied.length).toBe(0);
+  });
+
   it("should consider Hidden Power's calculated type, not its default Normal type", async () => {
     game.override.enemyMoveset(MoveId.HIDDEN_POWER).enemyIVs([31, 31, 31, 30, 31, 31]);
     // Hidden Power type set to Electric here

--- a/test/abilities/anticipation.test.ts
+++ b/test/abilities/anticipation.test.ts
@@ -3,8 +3,9 @@ import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
+import { Challenges } from "#enums/challenges";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Abilities - Anticipation", () => {
   let phaserGame: Phaser.Game;
@@ -77,7 +78,7 @@ describe("Abilities - Anticipation", () => {
 
     const playerPokemon = game.scene.getPlayerParty()[1];
     vi.spyOn(playerPokemon, "getMoveEffectiveness");
-    
+
     game.move.use(MoveId.GRAVITY);
     await game.toNextTurn();
     game.doSwitchPokemon(1);

--- a/test/testUtils/helpers/overridesHelper.ts
+++ b/test/testUtils/helpers/overridesHelper.ts
@@ -333,6 +333,17 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
+   * Overrides the enemy (pokemon)'s IVs
+   * @param ivs an array of 6 numbers ranging from 1-31
+   * @returns
+   */
+  public enemyIVs(ivs: number[]): this {
+    vi.spyOn(Overrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);
+    this.log(`Enemy Pokemon IVs set to ${ivs}`);
+    return this;
+  }
+
+  /**
    * Override the enemy (pokemon) held items
    * @param items the items to hold
    * @returns `this`

--- a/test/testUtils/helpers/overridesHelper.ts
+++ b/test/testUtils/helpers/overridesHelper.ts
@@ -334,10 +334,10 @@ export class OverridesHelper extends GameManagerHelper {
 
   /**
    * Overrides the enemy (pokemon)'s IVs
-   * @param ivs an array of 6 numbers ranging from 1-31
+   * @param ivs a number or array of 6 numbers ranging from 0-31
    * @returns
    */
-  public enemyIVs(ivs: number[]): this {
+  public enemyIVs(ivs: number ! number[]): this {
     vi.spyOn(Overrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);
     this.log(`Enemy Pokemon IVs set to ${ivs}`);
     return this;

--- a/test/testUtils/helpers/overridesHelper.ts
+++ b/test/testUtils/helpers/overridesHelper.ts
@@ -337,7 +337,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @param ivs a number or array of 6 numbers ranging from 0-31
    * @returns
    */
-  public enemyIVs(ivs: number ! number[]): this {
+  public enemyIVs(ivs: number | number[]): this {
     vi.spyOn(Overrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);
     this.log(`Enemy Pokemon IVs set to ${ivs}`);
     return this;

--- a/test/testUtils/helpers/overridesHelper.ts
+++ b/test/testUtils/helpers/overridesHelper.ts
@@ -335,7 +335,7 @@ export class OverridesHelper extends GameManagerHelper {
   /**
    * Overrides the enemy (pokemon)'s IVs
    * @param ivs a number or array of 6 numbers ranging from 0-31
-   * @returns
+   * @returns `this`
    */
   public enemyIVs(ivs: number | number[]): this {
     vi.spyOn(Overrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);


### PR DESCRIPTION
## What are the changes the user will see?

None.

## Why am I making these changes?

Ability Checkups. Anticipation's implementation seems outdated and messy. 

## What are the changes from a developer perspective?

- Replaced the AbAttrCondition with AnticipationAbAttr, which extends upon PostSummonMessageAbAttr
- Cleaned up the code to use more current utilities for determining move type and type effectiveness
- Added an overridesHelper for setting Enemy IVs.
- When overrides for setting Enemy IVs are used, they are applied when the enemy Pokemon is in the process of being generated, not in the soup of battle-scene.ts. This prevents their asynchronous retrieval which can lead to the Enemy IV Override being ignored.
- Added new parameter in getAttackTypeEffectiveness - 'ignoreGravity' 

## How to test the changes?
`npm run test anticipation`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?