### PR TITLE
[Bug][Misc] Update create-test to use the new move enum name

### DIFF
--- a/create-test-boilerplate.js
+++ b/create-test-boilerplate.js
@@ -115,7 +115,7 @@ async function runInteractive() {
 
   // Define the content template
   const content = `import { Abilities } from "#enums/abilities";
-import { Moves } from "#enums/moves";
+import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
@@ -138,19 +138,19 @@ describe("${description}", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([ Moves.SPLASH ])
+      .moveset([ MoveId.SPLASH ])
       .ability(Abilities.BALL_FETCH)
       .battleType("single")
       .disableCrits()
       .enemySpecies(Species.MAGIKARP)
       .enemyAbility(Abilities.BALL_FETCH)
-      .enemyMoveset(Moves.SPLASH);
+      .enemyMoveset(MoveId.SPLASH);
   });
 
   it("should do X", async () => {
     await game.classicMode.startBattle([ Species.FEEBAS ]);
 
-    game.move.select(Moves.SPLASH);
+    game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(true).toBe(true);


### PR DESCRIPTION
## What are the changes the user will see?

The test generated when the user uses `npm run create-test` will use the correct move enum import. 

## Why am I making these changes?

Useful tool.

## What are the changes from a developer perspective?

The text written has been changed slightly to use MoveId instead of Moves. 

## How to test the changes?

`npm run create-test`
The test created should be valid and usable. 

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?