### PR TITLE
[AI-Rework] Add move-property-based scoring

### DIFF
--- a/src/data/move-attrs/move-attr.ts
+++ b/src/data/move-attrs/move-attr.ts
@@ -68,7 +68,7 @@ export abstract class MoveAttr {
     return 0;
   }
 
-  getEffectScore(_user: Pokemon, _target?: Pokemon, _move?: Move): number {
+  getEffectScore(_user: Pokemon, _target: Pokemon, _move: Move): number {
     return 0;
   }
 }

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -47,6 +47,11 @@ import { HealStatusEffectAttr } from "./move-attrs/heal-status-effect-attr";
 import { ChargeAnim } from "#enums/charge-anim";
 import { allMoves } from "#app/data/all-moves";
 import { StatStageChangeAttr } from "#app/data/move-attrs/stat-stage-change-attr";
+import { AlwaysHitAbAttr } from "./ab-attrs/always-hit-ab-attr";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import { MultiHitPowerIncrementAttr } from "./move-attrs/multi-hit-power-increment-attr";
+import { MultiHitType } from "#enums/multi-hit-type";
+import { MaxMultiHitAbAttr } from "./ab-attrs/max-multi-hit-ab-attr";
 
 export abstract class Move implements Localizable {
   public id: MoveId;
@@ -724,7 +729,7 @@ export abstract class Move implements Localizable {
    * @returns a score value accumulated from effect score modifiers.
    * @todo Add Low Accuracy Penalty and Ally Target Penalty
    */
-  public getEffectScore(user: EnemyPokemon, target?: Pokemon): number {
+  public getEffectScore(user: EnemyPokemon, target: Pokemon): number {
     // penalize targeting Pokemon that are hidden by Commander
     if (
       (target && target.getAlly()?.getTag(BattlerTagType.COMMANDED)?.getSourcePokemon() === target)
@@ -739,9 +744,10 @@ export abstract class Move implements Localizable {
     /** The combined score from all conditions of the move */
     const conditionScores = this.conditions.map((cond) => cond.getConditionScore(user, target, this));
 
-    const totalScore = attrScores.concat(conditionScores).reduce((total, score) => total + score, 0);
+    /** The penalty given if the move is inaccurate */
+    const accuracyPenalty = this.getBattleAccuracyPenalty(user, target);
 
-    // @todo apply low accuracy penalty + ally target penalty to totalScore
+    const totalScore = attrScores.concat(conditionScores).reduce((total, score) => total + score, 0) + accuracyPenalty;
 
     return totalScore;
   }
@@ -782,6 +788,62 @@ export abstract class Move implements Localizable {
     }
 
     return moveAccuracy.value;
+  }
+
+  /**
+   * Calculates the score penalty granted to this move based on its accuracy, according
+   * to the table below:
+   *   ```
+   *   +--------+-------+
+   *   | Acc    | Score |
+   *   +--------+-------+
+   *   | 80-100 |     0 |
+   *   | 70-79  |    -1 |
+   *   | 50-69  |    -2 |
+   *   | 0-49   |    -3 |
+   *   +--------+-------+
+   *   ```
+   * This penalty is negated if any ongoing effect would cause the move to bypass accuracy checks,
+   * and it becomes (-5) if the target is semi-invulnerable.
+   * @param user the {@linkcode EnemyPokemon} using this move
+   * @param target the {@linkcode Pokemon} targeted by this move
+   * @returns the score penalty from accuracy
+   * @see {@linkcode getEffectScore}
+   */
+  protected getBattleAccuracyPenalty(user: EnemyPokemon, target: Pokemon): number {
+    /**
+     * If any ongoing effect would cause the move to bypass accuracy checks, assign no penalty.
+     * @todo the target's No Guard can be discovered prematurely here
+     */
+    if (
+      [user, target].some((p) => p.hasAbilityWithAttr(AlwaysHitAbAttr))
+      || user.getTag(BattlerTagType.IGNORE_ACCURACY)
+      || target.getTag(BattlerTagType.ALWAYS_GET_HIT)
+      || target.getTag(BattlerTagType.TELEKINESIS)
+    ) {
+      return 0;
+    }
+
+    /**
+     * If the user is faster than the target, and the target is semi-invulnerable,
+     * assign a (-5) penalty.
+     */
+    const userSpd = user.getEffectiveStat(Stat.SPD);
+    const targetSpd = target.getEffectiveStat(Stat.SPD, undefined, undefined, AbilityApplyMode.REVEALED);
+    if (target.isSemiInvulnerable() && userSpd > targetSpd) {
+      return -5;
+    }
+
+    const accuracy = this.calculateBattleAccuracy(user, target, true);
+    if (accuracy < 0 || accuracy >= 80) {
+      return 0;
+    } else if (accuracy >= 70) {
+      return -1;
+    } else if (accuracy >= 50) {
+      return -2;
+    } else {
+      return -3;
+    }
   }
 
   /**
@@ -857,6 +919,45 @@ export abstract class Move implements Localizable {
     }
 
     return power.value;
+  }
+
+  /**
+   * Obtains an approximate damage multiplier accounting for multi-hit
+   * move and ability modifiers relative to the move's first strike.
+   * @param user the {@linkcode Pokemon} using this move
+   * @returns a damage modifier to be used for move scoring
+   * @see {@linkcode Pokemon.getAttackScore}
+   */
+  public getMultiHitAttackScoreMultiplier(user: Pokemon): number {
+    let multiHitMultiplier = 1;
+    const skillLink = user.hasAbilityWithAttr(MaxMultiHitAbAttr);
+    if (this.hasAttr(MultiHitPowerIncrementAttr)) {
+      multiHitMultiplier *= 6; // assumes 3 hits: 1x + 2x + 3x
+    } else {
+      const multiHitType = this.getAttrs(MultiHitAttr)?.[0]?.getMultiHitType();
+      switch (multiHitType) {
+        case MultiHitType._2:
+          multiHitMultiplier *= 2;
+          break;
+        case MultiHitType._2_TO_5:
+          multiHitMultiplier *= skillLink ? 5 : 3; // Expected hit count is ~3.1
+          break;
+        case MultiHitType._3:
+          multiHitMultiplier *= 3;
+          break;
+        case MultiHitType._10:
+          multiHitMultiplier *= skillLink ? 10 : 6; // Population Bomb hits ~5.8 times on average
+          break;
+        case MultiHitType.BEAT_UP:
+          multiHitMultiplier *= user.getParty().length;
+      }
+    }
+
+    if (user.hasAbility(Abilities.PARENTAL_BOND)) {
+      multiHitMultiplier += 0.25;
+    }
+
+    return multiHitMultiplier;
   }
 
   getPriority(user: Pokemon, simulated: boolean = true) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -929,35 +929,28 @@ export abstract class Move implements Localizable {
    * @see {@linkcode Pokemon.getAttackScore}
    */
   public getMultiHitAttackScoreMultiplier(user: Pokemon): number {
-    let multiHitMultiplier = 1;
-    const skillLink = user.hasAbilityWithAttr(MaxMultiHitAbAttr);
+    const userHasSkillLink = user.hasAbilityWithAttr(MaxMultiHitAbAttr);
     if (this.hasAttr(MultiHitPowerIncrementAttr)) {
-      multiHitMultiplier *= 6; // assumes 3 hits: 1x + 2x + 3x
-    } else {
-      const multiHitType = this.getAttrs(MultiHitAttr)?.[0]?.getMultiHitType();
+      return 6; // assumes 3 hits: 1x + 2x + 3x
+    } else if (this.hasAttr(MultiHitAttr)) {
+      const multiHitType = this.getAttrs(MultiHitAttr)[0].getMultiHitType();
       switch (multiHitType) {
         case MultiHitType._2:
-          multiHitMultiplier *= 2;
-          break;
+          return 2;
         case MultiHitType._2_TO_5:
-          multiHitMultiplier *= skillLink ? 5 : 3; // Expected hit count is ~3.1
-          break;
+          return userHasSkillLink ? 5 : 3; // Expected hit count is ~3.1
         case MultiHitType._3:
-          multiHitMultiplier *= 3;
-          break;
+          return 3;
         case MultiHitType._10:
-          multiHitMultiplier *= skillLink ? 10 : 6; // Population Bomb hits ~5.8 times on average
-          break;
+          return userHasSkillLink ? 10 : 6; // Population Bomb hits ~5.8 times on average
         case MultiHitType.BEAT_UP:
-          multiHitMultiplier *= user.getParty().length;
+          return user.getParty().length;
       }
+    } else if (this.canBeMultiStrikeEnhanced(user) && user.hasAbility(Abilities.PARENTAL_BOND)) {
+      return 1.25;
+    } else {
+      return 1;
     }
-
-    if (user.hasAbility(Abilities.PARENTAL_BOND)) {
-      multiHitMultiplier += 0.25;
-    }
-
-    return multiHitMultiplier;
   }
 
   getPriority(user: Pokemon, simulated: boolean = true) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -931,7 +931,12 @@ export abstract class Move implements Localizable {
   public getMultiHitAttackScoreMultiplier(user: Pokemon): number {
     const userHasSkillLink = user.hasAbilityWithAttr(MaxMultiHitAbAttr);
     if (this.hasAttr(MultiHitPowerIncrementAttr)) {
-      return 6; // assumes 3 hits: 1x + 2x + 3x
+      /**
+       * Triple Axel / Triple Kick have a combined power of 6x the first strike,
+       * assuming all strikes hit (~72.9% at 90 accuracy). Accounting for accuracy,
+       * their average damage output is ~4.7x the first strike.
+       */
+      return 5;
     } else if (this.hasAttr(MultiHitAttr)) {
       const multiHitType = this.getAttrs(MultiHitAttr)[0].getMultiHitType();
       switch (multiHitType) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2183,6 +2183,20 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
+   * Obtains the estimated damage of a move against this Pokemon, accounting
+   * for revealed abilities and multi-hit modifiers (if applicable).
+   * @param source the {@linkcode Pokemon} using the move
+   * @param move the {@linkcode Move} being evaluated
+   * @returns the given move's estimated damage output.
+   */
+  protected getEstimatedAttackDamage(source: Pokemon, move: Move): number {
+    return (
+      this.getAttackDamage(source, move, AbilityApplyMode.REVEALED).damage
+      * move.getMultiHitAttackScoreMultiplier(source)
+    );
+  }
+
+  /**
    * Obtains this Pokemon's Attack Score (AS) against the given opponent
    * for the given move. This score ranges from (-1) to (+4) depending on the
    * move's forecasted damage against the opponent:
@@ -2210,16 +2224,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return 0;
     }
 
-    const damage =
-      opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED).damage
-      * move.getMultiHitAttackScoreMultiplier(this);
+    const damage = opponent.getEstimatedAttackDamage(this, move);
 
     if (damage >= opponent.hp) {
-      if (move.getPriority(this, true) > 0) {
-        return 6;
-      } else {
-        return 4;
-      }
+      return this.getAttackScoreOnKnockOut(move);
     } else if (damage <= 0) {
       return -1;
     }
@@ -2253,21 +2261,29 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @see {@linkcode getAttackScore}
    */
   public getExpectedAttackScore(opponent: Pokemon, move: Move): number {
-    const damage =
-      opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED).damage
-      * move.getMultiHitAttackScoreMultiplier(this);
+    const damage = opponent.getEstimatedAttackDamage(this, move);
 
     if (damage >= opponent.hp) {
-      if (move.getPriority(this, true) > 0) {
-        return 6;
-      } else {
-        return 4;
-      }
+      return this.getAttackScoreOnKnockOut(move);
     } else if (damage <= 0) {
       return -1;
     } else {
       const damagePct = Math.floor((damage / opponent.getMaxHp()) * 100);
       return damagePct / 40;
+    }
+  }
+
+  /**
+   * Obtains the Attack Score of a move assuming the move can KO its opponent.
+   * @param move the {@linkcode Move} being evaluated
+   * @returns the move's calculated Attack Score
+   * @see {@linkcode getAttackScore}
+   */
+  protected getAttackScoreOnKnockOut(move: Move): number {
+    if (move.getPriority(this) > 0) {
+      return 6;
+    } else {
+      return 4;
     }
   }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2188,6 +2188,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * for the given move. This score ranges from (-1) to (+4) depending on the
    * move's forecasted damage against the opponent:
    * - If the move is forecasted to KO the opponent, AS = (+4)
+   *   - (+6) if the move has increased priority in the current game state
    * - If the move deals at least 80% of the opponent's maximum HP but does not KO, AS = (+2)
    * - If the move deals damage in the interval of (0, 80)% max HP, and does not KO, AS
    * is determined randomly based on the damage forecasted:
@@ -2210,10 +2211,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return 0;
     }
 
-    const { damage } = opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED);
+    const damage =
+      opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED).damage
+      * move.getMultiHitAttackScoreMultiplier(this);
 
     if (damage >= opponent.hp) {
-      return 4;
+      if (move.getPriority(this, true) > 0) {
+        return 6;
+      } else {
+        return 4;
+      }
     } else if (damage <= 0) {
       return -1;
     }
@@ -2247,10 +2254,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @see {@linkcode getAttackScore}
    */
   public getExpectedAttackScore(opponent: Pokemon, move: Move): number {
-    const { damage } = opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED);
+    const damage =
+      opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED).damage
+      * move.getMultiHitAttackScoreMultiplier(this);
 
     if (damage >= opponent.hp) {
-      return 4;
+      if (move.getPriority(this, true) > 0) {
+        return 6;
+      } else {
+        return 4;
+      }
     } else if (damage <= 0) {
       return -1;
     } else {
@@ -3594,7 +3607,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     applyMoveAttrs(CritOnlyAttr, source, this, move, isCritical);
     applyAbAttrs(ConditionalCritAbAttr, source, simulated, isCritical, this, move);
     if (!isCritical.value) {
-      const critChance = [24, 8, 2, 1][Math.max(0, Math.min(this.getCritStage(source, move, false), 3))];
+      const critChance = [24, 8, 2, 1][Math.max(0, Math.min(this.getCritStage(source, move, simulated), 3))];
       isCritical.value = critChance === 1 || !globalScene.randBattleSeedInt(critChance);
     }
 
@@ -5642,7 +5655,65 @@ export class EnemyPokemon extends Pokemon {
       return -5;
     }
 
-    return attackScore + move.getEffectScore(this, opponent);
+    const critBonus = this.getCriticalHitBonus(opponent, move, attackScore);
+
+    return attackScore + critBonus + move.getEffectScore(this, opponent);
+  }
+
+  /**
+   * Calculates the bonus granted to the given move based on its critical hit chance
+   * when used by this Pokemon against the given opponent.
+   * @param opponent the {@linkcode Pokemon} targeted by the move
+   * @param move the {@linkcode Move} being evaluated
+   * @param attackScore the pre
+   * @returns
+   */
+  protected getCriticalHitBonus(opponent: Pokemon, move: Move, attackScore?: number) {
+    const { damage: critDamage } = opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED, true);
+    if ((isNullOrUndefined(attackScore) || attackScore < 4) && critDamage >= opponent.hp) {
+      const critChance = this.getSimulatedCriticalHitChance(opponent, move);
+      /**
+       * Only grant a bonus if the calculated critical hit chance is over 10%
+       * (i.e. the user has 1 or more crit stages)
+       */
+      if (critChance > 10) {
+        return 1 + (this.randSeedInt(100) < critChance ? 1 : 0);
+      }
+    }
+
+    return 0;
+  }
+
+  /**
+   * Calculates the chance (%, rounded down) of the given move critically hitting
+   * the given target when used by this Pokemon.
+   * @param target the {@linkcode Pokemon} targeted by the move
+   * @param move the {@linkcode Move} being evaluated
+   * @returns the chance of the move hitting
+   */
+  protected getSimulatedCriticalHitChance(target: Pokemon, move: Move): number {
+    const defendingSide = this.getArenaTagSide();
+    const noCritTag = globalScene.arena.getTagOnSide(NoCritTag, defendingSide);
+
+    if (
+      noCritTag
+      || move.hasAttr(FixedDamageAttr)
+      || target.hasAbilityWithAttr(BlockCritAbAttr)
+      || Overrides.NEVER_CRIT_OVERRIDE
+    ) {
+      return -1;
+    }
+
+    const isCritical = new BooleanHolder(!!this.getTag(BattlerTagType.ALWAYS_CRIT));
+    applyMoveAttrs(CritOnlyAttr, this, target, move, isCritical);
+    applyAbAttrs(ConditionalCritAbAttr, this, true, isCritical, target, move);
+
+    if (isCritical.value) {
+      return 100;
+    }
+
+    const critChance = [24, 8, 2, 1][Phaser.Math.Clamp(target.getCritStage(this, move, true), 0, 3)];
+    return Math.floor(100 / critChance);
   }
 
   /**
@@ -5803,7 +5874,7 @@ export class EnemyPokemon extends Pokemon {
        * Counter-attacks (e.g. Metal Burst) are scored entirely
        * based on their effect score.
        */
-      const score = move.getEffectScore(this);
+      const score = move.getEffectScore(this, this.getOpponents()[0]);
 
       return {
         moveId: move.id,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -5680,8 +5680,8 @@ export class EnemyPokemon extends Pokemon {
    * when used by this Pokemon against the given opponent.
    * @param opponent the {@linkcode Pokemon} targeted by the move
    * @param move the {@linkcode Move} being evaluated
-   * @param attackScore the pre
-   * @returns
+   * @param attackScore the previously calculated attack score (optional)
+   * @returns the score bonus from critical hit chance
    */
   protected getCriticalHitBonus(opponent: Pokemon, move: Move, attackScore?: number) {
     const { damage: critDamage } = opponent.getAttackDamage(this, move, AbilityApplyMode.REVEALED, true);
@@ -5710,12 +5710,7 @@ export class EnemyPokemon extends Pokemon {
     const defendingSide = this.getArenaTagSide();
     const noCritTag = globalScene.arena.getTagOnSide(NoCritTag, defendingSide);
 
-    if (
-      noCritTag
-      || move.hasAttr(FixedDamageAttr)
-      || target.hasAbilityWithAttr(BlockCritAbAttr)
-      || Overrides.NEVER_CRIT_OVERRIDE
-    ) {
+    if (noCritTag || move.hasAttr(FixedDamageAttr) || target.hasAbilityWithAttr(BlockCritAbAttr)) {
       return -1;
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1124,7 +1124,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       critStage.value += critBoostStackableTag.stackCount;
     }
 
-    console.log(`crit stage: +${critStage.value}`);
     return critStage.value;
   }
 

--- a/test/ai/enemy_command.test.ts
+++ b/test/ai/enemy_command.test.ts
@@ -1,35 +1,16 @@
-import type BattleScene from "#app/battle-scene";
 import { allMoves } from "#app/data/all-moves";
 import { MoveCategory } from "#enums/move-category";
 import { Abilities } from "#enums/abilities";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
-import type { EnemyPokemon } from "#app/field/pokemon";
 import { AiType } from "#enums/ai-type";
-import { randSeedInt } from "#app/utils";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getEnemyMoveChoices, type MoveChoiceSet } from "./utils/enemy_command_utils";
+import type BattleScene from "#app/battle-scene";
 
 let globalScene: BattleScene;
-const NUM_TRIALS = 300;
-
-type MoveChoiceSet = { [key: number]: number };
-
-function getEnemyMoveChoices(pokemon: EnemyPokemon, moveChoices: MoveChoiceSet): void {
-  // Use an unseeded random number generator in place of the mocked-out randBattleSeedInt
-  vi.spyOn(globalScene, "randBattleSeedInt").mockImplementation((range, min?) => {
-    return randSeedInt(range, min);
-  });
-  for (let i = 0; i < NUM_TRIALS; i++) {
-    const queuedMove = pokemon.getNextMove();
-    moveChoices[queuedMove.moveId]++;
-  }
-
-  for (const [moveId, count] of Object.entries(moveChoices)) {
-    console.log(`Move: ${allMoves[moveId].name}   Count: ${count} (${Math.round((count / NUM_TRIALS) * 100)}%)`);
-  }
-}
 
 describe("Enemy Commands - Move Selection", () => {
   let phaserGame: Phaser.Game;
@@ -67,7 +48,7 @@ describe("Enemy Commands - Move Selection", () => {
     const moveChoices: MoveChoiceSet = {};
     const enemyMoveset = enemyPokemon.getMoveset();
     enemyMoveset.forEach((mv) => (moveChoices[mv!.moveId] = 0));
-    getEnemyMoveChoices(enemyPokemon, moveChoices);
+    getEnemyMoveChoices(globalScene, enemyPokemon, moveChoices);
 
     enemyMoveset.forEach((mv) => {
       if (mv?.getMove().category === MoveCategory.STATUS) {
@@ -91,7 +72,7 @@ describe("Enemy Commands - Move Selection", () => {
     const moveChoices: MoveChoiceSet = {};
     const enemyMoveset = enemyPokemon.getMoveset();
     enemyMoveset.forEach((mv) => (moveChoices[mv!.moveId] = 0));
-    getEnemyMoveChoices(enemyPokemon, moveChoices);
+    getEnemyMoveChoices(globalScene, enemyPokemon, moveChoices);
 
     enemyMoveset.forEach((mv) => {
       if (mv?.getMove().category === MoveCategory.STATUS || mv?.moveId === MoveId.LAST_RESORT) {
@@ -115,7 +96,7 @@ describe("Enemy Commands - Move Selection", () => {
     const moveChoices: MoveChoiceSet = {};
     const enemyMoveset = enemyPokemon.getMoveset();
     enemyMoveset.forEach((mv) => (moveChoices[mv.moveId] = 0));
-    getEnemyMoveChoices(enemyPokemon, moveChoices);
+    getEnemyMoveChoices(globalScene, enemyPokemon, moveChoices);
 
     expect(moveChoices[MoveId.SPLASH]).toBe(0);
     expect(moveChoices[MoveId.COVET]).toBe(0);
@@ -131,10 +112,10 @@ describe("Enemy Commands - Move Selection", () => {
     for (const move of Object.values(allMoves)) {
       const eas = offFieldEnemy.getExpectedAttackScore(player, move);
       expect(eas).toBeGreaterThanOrEqual(-1);
-      expect(eas).toBeLessThanOrEqual(4);
+      expect(eas).toBeLessThanOrEqual(6);
       const eas2 = player.getExpectedAttackScore(offFieldEnemy, move);
       expect(eas2).toBeGreaterThanOrEqual(-1);
-      expect(eas2).toBeLessThanOrEqual(4);
+      expect(eas2).toBeLessThanOrEqual(6);
     }
   });
 });

--- a/test/ai/low_accuracy.test.ts
+++ b/test/ai/low_accuracy.test.ts
@@ -1,0 +1,52 @@
+import type BattleScene from "#app/battle-scene";
+import { Abilities } from "#enums/abilities";
+import { AiType } from "#enums/ai-type";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import { describe, beforeAll, afterEach, beforeEach, it, expect } from "vitest";
+import { type MoveChoiceSet, getEnemyMoveChoices } from "./utils/enemy_command_utils";
+
+let globalScene: BattleScene;
+
+describe("Enemy Commands - Low Accuracy", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    globalScene = game.scene;
+
+    game.override.ability(Abilities.BALL_FETCH).enemyAbility(Abilities.BALL_FETCH);
+  });
+
+  it("AI should prefer accurate moves over inaccurate", async () => {
+    game.override.enemySpecies(Species.ETERNATUS).enemyMoveset([MoveId.HYPNOSIS, MoveId.SLEEP_POWDER, MoveId.SPORE]);
+
+    await game.classicMode.startBattle([Species.MAGIKARP]);
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    enemyPokemon.aiType = AiType.SMART_RANDOM;
+
+    const moveChoices: MoveChoiceSet = {};
+    const enemyMoveset = enemyPokemon.getMoveset();
+    enemyMoveset.forEach((mv) => (moveChoices[mv.moveId] = 0));
+    getEnemyMoveChoices(globalScene, enemyPokemon, moveChoices);
+
+    enemyMoveset.forEach((mv) => {
+      if (mv.moveId !== MoveId.SPORE) {
+        expect(moveChoices[mv.moveId]).toBe(0);
+      }
+    });
+  });
+});

--- a/test/ai/priority.test.ts
+++ b/test/ai/priority.test.ts
@@ -1,0 +1,56 @@
+import type BattleScene from "#app/battle-scene";
+import { Abilities } from "#enums/abilities";
+import { AiType } from "#enums/ai-type";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import { describe, beforeAll, afterEach, beforeEach, it, expect } from "vitest";
+import { type MoveChoiceSet, getEnemyMoveChoices } from "./utils/enemy_command_utils";
+
+let globalScene: BattleScene;
+
+describe("Enemy Commands - Priority", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    globalScene = game.scene;
+
+    game.override.ability(Abilities.BALL_FETCH).enemyAbility(Abilities.BALL_FETCH);
+  });
+
+  it("AI should always select priority moves if they KO", async () => {
+    game.override
+      .enemySpecies(Species.ETERNATUS)
+      .enemyMoveset([MoveId.FLAMETHROWER, MoveId.QUICK_ATTACK, MoveId.ETERNABEAM, MoveId.SWORDS_DANCE])
+      .enemyLevel(100)
+      .startingLevel(1);
+
+    await game.classicMode.startBattle([Species.MAGIKARP]);
+
+    const enemyPokemon = game.field.getEnemyPokemon();
+    enemyPokemon.aiType = AiType.SMART_RANDOM;
+
+    const moveChoices: MoveChoiceSet = {};
+    const enemyMoveset = enemyPokemon.getMoveset();
+    enemyMoveset.forEach((mv) => (moveChoices[mv.moveId] = 0));
+    getEnemyMoveChoices(globalScene, enemyPokemon, moveChoices);
+
+    enemyMoveset.forEach((mv) => {
+      if (mv.moveId !== MoveId.QUICK_ATTACK) {
+        expect(moveChoices[mv.moveId]).toBe(0);
+      }
+    });
+  });
+});

--- a/test/ai/utils/enemy_command_utils.ts
+++ b/test/ai/utils/enemy_command_utils.ts
@@ -1,0 +1,24 @@
+import type BattleScene from "#app/battle-scene";
+import { allMoves } from "#app/data/all-moves";
+import type { EnemyPokemon } from "#app/field/pokemon";
+import { randSeedInt } from "#app/utils";
+import { vi } from "vitest";
+
+const NUM_TRIALS = 300;
+
+export type MoveChoiceSet = { [key: number]: number };
+
+export function getEnemyMoveChoices(scene: BattleScene, pokemon: EnemyPokemon, moveChoices: MoveChoiceSet): void {
+  // Use an unseeded random number generator in place of the mocked-out randBattleSeedInt
+  vi.spyOn(scene, "randBattleSeedInt").mockImplementation((range, min?) => {
+    return randSeedInt(range, min);
+  });
+  for (let i = 0; i < NUM_TRIALS; i++) {
+    const queuedMove = pokemon.getNextMove();
+    moveChoices[queuedMove.moveId]++;
+  }
+
+  for (const [moveId, count] of Object.entries(moveChoices)) {
+    console.log(`Move: ${allMoves[moveId].name}   Count: ${count} (${Math.round((count / NUM_TRIALS) * 100)}%)`);
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This PR targets the `ai-rework` branch and should not be considered a complete feature 

## What are the changes the user will see?

The AI now properly evaluates priority, critical-hit ratio, and multi-hit moves, and it should use inaccurate moves less often.

## Why am I making these changes?

Part of the AI Rework

## What are the changes from a developer perspective?

Logic has been added for the AI to recognize and evaluate the following properties.

### Priority

If a move with increased priority is expected to KO, its Attack Score (AS) is now (+6) instead of (+4). This means that the AI should always prefer priority moves that KO over non-priority moves that KO. No other bonuses are given to priority moves.

### Critical Hits

Moves gain a bonus if:
1. The move is not expected to KO without a critical hit, but KOs with a critical hit.
2. The move has an increased critical hit ratio or is guaranteed to critically hit.

This bonus is equal to (+1), with a chance of an additional (+1) equal to the critical hit rate of the move (%, rounded down).

### Accuracy

Moves are given a penalty if their accuracy is low. The penalty is based on the move's perceived final accuracy:

| Accuracy | Penalty | Examples |
|--------|--------|--------|
| 80-100 | 0 | - |
| 70-79 | -1 | Focus Blast |
| 50-69 | -2 | Zap Cannon |
| 0-49 | -3 | Fissure |

Effects that cause the move to bypass accuracy (e.g. either the user or target's No Guard) negate this penalty, and if the target is semi-invulnerable, moves are given a (-5) penalty instead.

### Multi-Hit Moves

When the AI calculates damage, it now multiplies the damage of a single strike by a multiplier according to the move's multi-hit type. For multi-hit types that have a range in hit count, this multiplier is approximately equal to the expected hit count. For example, moves that hit 2-5 times are given a 3x multiplier (they hit 3.1 times on average)

For more information, see the Property-based Score Modifiers on the [AI Rework Effect Score Sheet](https://docs.google.com/spreadsheets/d/12UprXLHyLdw-ESls6pAQecyBFCG2tVg5cllAiUbp6KA/edit?usp=sharing)

## How to test the changes?

`npm run test ai/[priority | low_accuracy]`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (default and legacy)?
