### PR TITLE
[Move][P2] Bouncy bubble is single target and heals 100%

### DIFF
--- a/src/data/all-moves.ts
+++ b/src/data/all-moves.ts
@@ -3144,9 +3144,8 @@ export function initMoves() {
       FriendshipPowerAttr,
     ),
     new AttackMove(MoveId.BOUNCY_BUBBLE, ElementalType.WATER, MoveCategory.SPECIAL, 60, 100, 20, -1, 0, 7)
-      .attr(HitHealAttr) // Custom
-      .triageMove()
-      .target(MoveTarget.ALL_NEAR_ENEMIES),
+      .attr(HitHealAttr, 1)
+      .triageMove(),
     new AttackMove(MoveId.BUZZY_BUZZ, ElementalType.ELECTRIC, MoveCategory.SPECIAL, 60, 100, 20, 100, 0, 7).attr(
       StatusEffectAttr,
       StatusEffect.PARALYSIS,

--- a/test/moves/bouncy_bubble.test.ts
+++ b/test/moves/bouncy_bubble.test.ts
@@ -1,0 +1,49 @@
+import { Abilities } from "#enums/abilities";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { BattlerIndex } from "#enums/battler-index";
+
+describe("Moves - Bouncy Bubble", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({ type: Phaser.HEADLESS });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+
+    game.override
+      .battleType("double")
+      .enemySpecies(Species.ARCEUS)
+      .enemyLevel(100)
+      .enemyMoveset([MoveId.SPLASH])
+      .enemyAbility(Abilities.BALL_FETCH)
+      .startingLevel(100)
+      .moveset([MoveId.BOUNCY_BUBBLE])
+      .ability(Abilities.BALL_FETCH);
+  });
+
+  it("should heal 100% of damage dealt and be single target", async () => {
+    await game.classicMode.startBattle([Species.SHUCKLE]);
+    const user = game.scene.getPlayerPokemon()!;
+    const enemy1 = game.scene.getEnemyField()[0];
+    const enemy2 = game.scene.getEnemyField()[1];
+
+    user.damageAndUpdate(user.getMaxHp() - 1);
+
+    game.move.select(MoveId.BOUNCY_BUBBLE, 0, BattlerIndex.ENEMY);
+    await game.toNextTurn();
+
+    expect(enemy1.getMaxHp() - enemy1.hp).toBe(user.hp - 1);
+    expect(enemy2.hp).toBe(enemy2.getMaxHp());
+  });
+});

--- a/test/moves/bouncy_bubble.test.ts
+++ b/test/moves/bouncy_bubble.test.ts
@@ -33,7 +33,7 @@ describe("Moves - Bouncy Bubble", () => {
   });
 
   it("should heal 100% of damage dealt and be single target", async () => {
-    await game.classicMode.startBattle([Species.SHUCKLE]);
+    await game.classicMode.startBattle([Species.CHANSEY]);
     const user = game.scene.getPlayerPokemon()!;
     const enemy1 = game.scene.getEnemyField()[0];
     const enemy2 = game.scene.getEnemyField()[1];


### PR DESCRIPTION
## What are the changes the user will see?

* Bouncy bubble is single target
* Bouncy bubble heals 100% of damage dealt

## Why am I making these changes?

Reported in https://github.com/pagefaultgames/pokerogue/issues/1397 but incorrectly closed

Bouncy bubble is not supposed to be a spread move. 

## What are the changes from a developer perspective?

* Removed `.target(MoveTarget.ALL_NEAR_ENEMIES)`
* Added a `1` to the move's hit heal attr

## Screenshots/Videos

https://github.com/user-attachments/assets/9f439fc3-f8d6-433a-a699-2c2924bdace8

## How to test the changes?

### Overrides:

```ts
  MOVESET_OVERRIDE: MoveId.BOUNCY_BUBBLE,
  BATTLE_TYPE_OVERRIDE: "double",
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
