### PR TITLE
[P2][Move] Fix flail/reversal damage formula

### DIFF
--- a/src/data/move-attrs/low-hp-power-attr.ts
+++ b/src/data/move-attrs/low-hp-power-attr.ts
@@ -10,14 +10,14 @@ import { VariablePowerAttr } from "#app/data/move-attrs/variable-power-attr";
  *
  * Formula from {@link https://www.smogon.com/dex/sv/moves/flail/}
  *
- * | hp ratio | default bp |
- * |----------|------------|
- * | 0-1      | 200        |
- * | 2-4      | 150        |
- * | 5-9      | 100        |
- * | 10-16    | 80         |
- * | 17-32    | 40         |
- * | 33-48    | 20         |
+ * | hp ratio (out of 48) | default bp |
+ * |----------------------|------------|
+ * | 0-1                  | 200        |
+ * | 2-4                  | 150        |
+ * | 5-9                  | 100        |
+ * | 10-16                | 80         |
+ * | 17-32                | 40         |
+ * | 33-48                | 20         |
  *
  *
  * @extends VariablePowerAttr

--- a/src/data/move-attrs/low-hp-power-attr.ts
+++ b/src/data/move-attrs/low-hp-power-attr.ts
@@ -7,33 +7,38 @@ import { VariablePowerAttr } from "#app/data/move-attrs/variable-power-attr";
  * Attribute to set move power inversely proportional to the user's HP ratio.
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Flail_(move) | Flail}
  * and {@link https://bulbapedia.bulbagarden.net/wiki/Reversal_(move) | Reversal}.
+ *
+ * Formula from {@link https://www.smogon.com/dex/sv/moves/flail/}
+ *
+ * | hp ratio | default bp |
+ * |----------|------------|
+ * | 0-1      | 200        |
+ * | 2-4      | 150        |
+ * | 5-9      | 100        |
+ * | 10-16    | 80         |
+ * | 17-32    | 40         |
+ * | 33-48    | 20         |
+ *
+ *
  * @extends VariablePowerAttr
  */
 export class LowHpPowerAttr extends VariablePowerAttr {
   override apply(user: Pokemon, _target: Pokemon, _move: Move, power: NumberHolder): boolean {
-    const hpRatio = user.getHpRatio();
+    const hpRatio = Math.floor((48 * user.hp) / user.getMaxHp());
 
-    switch (true) {
-      case hpRatio < 0.0417:
-        power.value = 200;
-        break;
-      case hpRatio < 0.1042:
-        power.value = 150;
-        break;
-      case hpRatio < 0.2083:
-        power.value = 100;
-        break;
-      case hpRatio < 0.3542:
-        power.value = 80;
-        break;
-      case hpRatio < 0.6875:
-        power.value = 40;
-        break;
-      default:
-        power.value = 20;
-        break;
+    if (hpRatio <= 1) {
+      power.value = 200;
+    } else if (hpRatio <= 4) {
+      power.value = 150;
+    } else if (hpRatio <= 9) {
+      power.value = 100;
+    } else if (hpRatio <= 16) {
+      power.value = 80;
+    } else if (hpRatio <= 32) {
+      power.value = 40;
+    } else {
+      power.value = 20;
     }
-
     return true;
   }
 }

--- a/test/moves/flail.test.ts
+++ b/test/moves/flail.test.ts
@@ -1,0 +1,61 @@
+import { Abilities } from "#enums/abilities";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
+import { allMoves } from "#app/data/all-moves";
+import type { Move } from "#app/data/move";
+
+describe("Moves - Flail", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+  let flail: Move;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    flail = allMoves[MoveId.FLAIL];
+    game.override
+      .moveset(MoveId.FLAIL)
+      .battleType("single")
+      .startingLevel(100)
+      .enemySpecies(Species.SNORLAX)
+      .enemyLevel(100)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH);
+    vi.spyOn(flail, "calculateBattlePower");
+  });
+
+  it.each([
+    { hpRatio: 1, expectedBp: 200 },
+    { hpRatio: 4, expectedBp: 150 },
+    { hpRatio: 9, expectedBp: 100 },
+    { hpRatio: 16, expectedBp: 80 },
+    { hpRatio: 32, expectedBp: 40 },
+    { hpRatio: 48, expectedBp: 20 },
+  ])("should have $expectedBp base power at ($hpRatio / 48) health", async ({ hpRatio, expectedBp }) => {
+    await game.classicMode.startBattle([Species.BLISSEY]);
+
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    playerPokemon.hp = (playerPokemon.hp * hpRatio) / 48;
+
+    game.move.select(MoveId.FLAIL, 0);
+
+    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(flail.id);
+    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    expect(flail.calculateBattlePower).toHaveLastReturnedWith(expectedBp);
+  });
+});

--- a/test/moves/flail.test.ts
+++ b/test/moves/flail.test.ts
@@ -8,6 +8,7 @@ import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
 import { allMoves } from "#app/data/all-moves";
 import type { Move } from "#app/data/move";
+import { BattlerIndex } from "#enums/battler-index";
 
 describe("Moves - Flail", () => {
   let phaserGame: Phaser.Game;

--- a/test/moves/flail.test.ts
+++ b/test/moves/flail.test.ts
@@ -39,19 +39,27 @@ describe("Moves - Flail", () => {
   });
 
   it.each([
-    { hpRatio: 1, expectedBp: 200 },
-    { hpRatio: 4, expectedBp: 150 },
-    { hpRatio: 9, expectedBp: 100 },
-    { hpRatio: 16, expectedBp: 80 },
-    { hpRatio: 32, expectedBp: 40 },
+    { hpRatio: 0.1, expectedBp: 200 },
+    { hpRatio: 1.9, expectedBp: 200 },
+    { hpRatio: 2, expectedBp: 150 },
+    { hpRatio: 4.9, expectedBp: 150 },
+    { hpRatio: 5, expectedBp: 100 },
+    { hpRatio: 9.9, expectedBp: 100 },
+    { hpRatio: 10, expectedBp: 80 },
+    { hpRatio: 16.9, expectedBp: 80 },
+    { hpRatio: 17, expectedBp: 40 },
+    { hpRatio: 32.9, expectedBp: 40 },
+    { hpRatio: 33, expectedBp: 20 },
     { hpRatio: 48, expectedBp: 20 },
   ])("should have $expectedBp base power at ($hpRatio / 48) health", async ({ hpRatio, expectedBp }) => {
     await game.classicMode.startBattle([Species.BLISSEY]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;
-    playerPokemon.hp = (playerPokemon.hp * hpRatio) / 48;
+    vi.spyOn(playerPokemon, "getMaxHp").mockReturnValue(480);
+    playerPokemon.hp = 10 * hpRatio;
 
     game.move.select(MoveId.FLAIL, 0);
+    await game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
     await game.phaseInterceptor.to(MoveEffectPhase, false);
     expect((game.scene.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(flail.id);


### PR DESCRIPTION
## Checkup
- [x] Documentation
- [x] No other bugs/issues

## What are the changes the user will see?

Flail/Reversal now use the correct damage formula

## Why am I making these changes?

Sam's original implementation was incorrect

## What are the changes from a developer perspective?

* Rewrote the logic in `low-hp-power-attr`
* Created a `flail.test`

## Screenshots/Videos

n/a

## How to test the changes?

`npm run test flail`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
