### PR TITLE
[Test] Fix `allMoves` being empty before `beforeAll` gets run

### DIFF
--- a/test/testUtils/testFileInitialization.ts
+++ b/test/testUtils/testFileInitialization.ts
@@ -1,4 +1,15 @@
+import { initLoggedInUser } from "#app/account";
 import { SESSION_ID_COOKIE } from "#app/constants";
+import { initAbilities } from "#app/data/all-abilities";
+import { allMoves, initMoves } from "#app/data/all-moves";
+import { initBiomes } from "#app/data/balance/biomes";
+import { initEggMoves } from "#app/data/balance/egg-moves";
+import { initPokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
+import { initMysteryEncounters } from "#app/data/mystery-encounters/mystery-encounters";
+import { initPokemonForms } from "#app/data/pokemon-forms";
+import { initSpecies } from "#app/data/init-species";
+import { initAchievements } from "#app/system/achv";
+import { initStatsKeys } from "#app/ui/game-stats-ui-handler";
 import { setCookie } from "#app/utils";
 import { blobToString } from "#test/testUtils/gameManagerUtils";
 import { MockConsoleLog } from "#test/testUtils/mocks/mockConsoleLog";
@@ -7,6 +18,28 @@ import { mockLocalStorage } from "#test/testUtils/mocks/mockLocalStorage";
 import { MockImage } from "#test/testUtils/mocks/mocksContainer/mockImage";
 import Phaser from "phaser";
 import { manageListeners } from "./listenersManager";
+import { initVouchers } from "#app/system/init-vouchers";
+
+/**
+ * A function to initialize game data before running any other test-related code.
+ */
+export function initDataForTests() {
+  // Initialize all of these things if and only if they have not been initialized yet
+  if (Object.values(allMoves).length === 0) {
+    initMoves();
+    initVouchers();
+    initAchievements();
+    initStatsKeys();
+    initPokemonPrevolutions();
+    initBiomes();
+    initEggMoves();
+    initPokemonForms();
+    initSpecies();
+    initAbilities();
+    initLoggedInUser();
+    initMysteryEncounters();
+  }
+}
 
 /**
  * An initialization function that is run at the beginning of every test file (via `beforeAll()`).

--- a/test/testUtils/testFileInitialization.ts
+++ b/test/testUtils/testFileInitialization.ts
@@ -1,15 +1,4 @@
-import { initLoggedInUser } from "#app/account";
 import { SESSION_ID_COOKIE } from "#app/constants";
-import { initAbilities } from "#app/data/all-abilities";
-import { allMoves, initMoves } from "#app/data/all-moves";
-import { initBiomes } from "#app/data/balance/biomes";
-import { initEggMoves } from "#app/data/balance/egg-moves";
-import { initPokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
-import { initMysteryEncounters } from "#app/data/mystery-encounters/mystery-encounters";
-import { initPokemonForms } from "#app/data/pokemon-forms";
-import { initSpecies } from "#app/data/init-species";
-import { initAchievements } from "#app/system/achv";
-import { initStatsKeys } from "#app/ui/game-stats-ui-handler";
 import { setCookie } from "#app/utils";
 import { blobToString } from "#test/testUtils/gameManagerUtils";
 import { MockConsoleLog } from "#test/testUtils/mocks/mockConsoleLog";
@@ -18,7 +7,6 @@ import { mockLocalStorage } from "#test/testUtils/mocks/mockLocalStorage";
 import { MockImage } from "#test/testUtils/mocks/mocksContainer/mockImage";
 import Phaser from "phaser";
 import { manageListeners } from "./listenersManager";
-import { initVouchers } from "#app/system/init-vouchers";
 
 /**
  * An initialization function that is run at the beginning of every test file (via `beforeAll()`).
@@ -74,22 +62,6 @@ export function initTestFile() {
   Phaser.GameObjects.Text.prototype.setPositionRelative = setPositionRelative;
   Phaser.GameObjects.Rectangle.prototype.setPositionRelative = setPositionRelative;
   HTMLCanvasElement.prototype.getContext = () => mockContext;
-
-  // Initialize all of these things if and only if they have not been initialized yet
-  if (Object.values(allMoves).length === 0) {
-    initMoves();
-    initVouchers();
-    initAchievements();
-    initStatsKeys();
-    initPokemonPrevolutions();
-    initBiomes();
-    initEggMoves();
-    initPokemonForms();
-    initSpecies();
-    initAbilities();
-    initLoggedInUser();
-    initMysteryEncounters();
-  }
 
   manageListeners();
 }

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,7 +1,19 @@
 import "vitest-canvas-mock";
 
-import { afterAll, beforeAll, vi } from "vitest";
+import { initLoggedInUser } from "#app/account";
+import { initAbilities } from "#app/data/all-abilities";
+import { allMoves, initMoves } from "#app/data/all-moves";
+import { initBiomes } from "#app/data/balance/biomes";
+import { initEggMoves } from "#app/data/balance/egg-moves";
+import { initPokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
+import { initSpecies } from "#app/data/init-species";
+import { initMysteryEncounters } from "#app/data/mystery-encounters/mystery-encounters";
+import { initPokemonForms } from "#app/data/pokemon-forms";
+import { initAchievements } from "#app/system/achv";
+import { initVouchers } from "#app/system/init-vouchers";
+import { initStatsKeys } from "#app/ui/game-stats-ui-handler";
 import { initTestFile } from "#test/testUtils/testFileInitialization";
+import { afterAll, beforeAll, vi } from "vitest";
 
 //#region Mocking
 
@@ -62,7 +74,26 @@ vi.mock("#app/plugins/i18n", async (importOriginal) => {
 
 //#region
 
+function initData() {
+  // Initialize all of these things if and only if they have not been initialized yet
+  if (Object.values(allMoves).length === 0) {
+    initMoves();
+    initVouchers();
+    initAchievements();
+    initStatsKeys();
+    initPokemonPrevolutions();
+    initBiomes();
+    initEggMoves();
+    initPokemonForms();
+    initSpecies();
+    initAbilities();
+    initLoggedInUser();
+    initMysteryEncounters();
+  }
+}
+
 global.testFailed = false;
+initData();
 
 beforeAll(() => {
   initTestFile();

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,19 +1,7 @@
 import "vitest-canvas-mock";
 
-import { initLoggedInUser } from "#app/account";
-import { initAbilities } from "#app/data/all-abilities";
-import { allMoves, initMoves } from "#app/data/all-moves";
-import { initBiomes } from "#app/data/balance/biomes";
-import { initEggMoves } from "#app/data/balance/egg-moves";
-import { initPokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
-import { initSpecies } from "#app/data/init-species";
-import { initMysteryEncounters } from "#app/data/mystery-encounters/mystery-encounters";
-import { initPokemonForms } from "#app/data/pokemon-forms";
-import { initAchievements } from "#app/system/achv";
-import { initVouchers } from "#app/system/init-vouchers";
-import { initStatsKeys } from "#app/ui/game-stats-ui-handler";
-import { initTestFile } from "#test/testUtils/testFileInitialization";
 import { afterAll, beforeAll, vi } from "vitest";
+import { initDataForTests, initTestFile } from "#test/testUtils/testFileInitialization";
 
 //#region Mocking
 
@@ -74,26 +62,8 @@ vi.mock("#app/plugins/i18n", async (importOriginal) => {
 
 //#region
 
-function initData() {
-  // Initialize all of these things if and only if they have not been initialized yet
-  if (Object.values(allMoves).length === 0) {
-    initMoves();
-    initVouchers();
-    initAchievements();
-    initStatsKeys();
-    initPokemonPrevolutions();
-    initBiomes();
-    initEggMoves();
-    initPokemonForms();
-    initSpecies();
-    initAbilities();
-    initLoggedInUser();
-    initMysteryEncounters();
-  }
-}
-
 global.testFailed = false;
-initData();
+initDataForTests();
 
 beforeAll(() => {
   initTestFile();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -60,7 +60,7 @@ class MySequencer extends BaseSequencer {
 function getTestOrder(testName: string): number {
   if (testName.includes("battle_scene.test.ts")) {
     return 1;
-  } else if (testName.includes("inputs.test.ts")) {
+  } else if (testName.includes("inputs.test.ts") || testName.includes("all_moves.test.ts")) {
     return 2;
   } else {
     return 3;


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

In #247, `initMoves()` et al were moved from `vitest.setup.ts` to a new function `initTestFile()` that gets run during a global `beforeAll()`. However, this caused problems where some test files try to access `allMoves` before `initTestFile()` gets run. (This issue only occurs when running an individual test file; when running the full test suite, `initTestfile()` will have been called by a previous test.)

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

1. Separated `initMoves()` et al into a function `initDataForTests()`, which now gets run in `vitest.setup.ts` so that they should always get run early enough.
2. Also took the opportunity to move `all_moves.test.ts` to be run earlier, to prevent it from breaking due to other tests causing Shell Side Arm to make contact.

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

`npm run test photon_geyser` (one of the affected test files)

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)