### PR TITLE
[Refactor] Make use of color enums

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="A Pokémon fangame heavily inspired by the roguelite genre. Battle endlessly while gathering stacking items, exploring many different biomes, and reaching Pokémon stats you never thought possible."
     />
-    <meta name="theme-color" content="#da3838" />
+    <meta name="theme-color" content="#e13d3d" />
     <meta name="keywords" content="poketernity, pokemon, roguelite" />
     <meta name="news_keywords" content="poketernity, pokemon, roguelite" />
     <meta name="distribution" content="Global" />

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="A Pokémon fangame heavily inspired by the roguelite genre. Battle endlessly while gathering stacking items, exploring many different biomes, and reaching Pokémon stats you never thought possible."
     />
+    <!-- #e13d3d is CommonColor.WARM_RED -->
     <meta name="theme-color" content="#e13d3d" />
     <meta name="keywords" content="poketernity, pokemon, roguelite" />
     <meta name="news_keywords" content="poketernity, pokemon, roguelite" />

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -174,6 +174,7 @@ import { Animation } from "./animations";
 import { resetStarterColors, starterColors } from "./data/starter-colors";
 import { CallSourceLogger } from "#app/loggers";
 import { CANVAS_SCALE, GAME_HEIGHT, GAME_WIDTH } from "#app/ui-constants";
+import { CommonColor, ShadowColor } from "#enums/color";
 import { BattleEndPhase } from "#app/phases/battle-end-phase";
 import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { GameOverPhase } from "#app/phases/game-over-phase";
@@ -1933,8 +1934,8 @@ export default class BattleScene extends SceneBase {
     const biomeString: string = getBiomeName(this.arena.biomeType);
     this.fieldUI.moveAbove(this.biomeWaveText, this.luckText);
     this.biomeWaveText.setText(biomeString + " - " + this.currentBattle.waveIndex.toString());
-    this.biomeWaveText.setColor(!isBoss ? "#ffffff" : "#f89890");
-    this.biomeWaveText.setShadowColor(!isBoss ? "#636363" : "#984038");
+    this.biomeWaveText.setColor(isBoss ? CommonColor.SOFT_PINK : CommonColor.WHITE);
+    this.biomeWaveText.setShadowColor(isBoss ? ShadowColor.DEEP_RED : ShadowColor.GREY);
     this.biomeWaveText.setVisible(true);
   }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1956,7 +1956,7 @@ export default class BattleScene extends SceneBase {
       return;
     }
     const deltaScale = this.moneyText.scale * 0.14 * (positiveChange ? 1 : -1);
-    this.moneyText.setShadowColor(positiveChange ? "#008000" : "#FF0000");
+    this.moneyText.setShadowColor(positiveChange ? CommonColor.PURE_GREEN : CommonColor.PURE_RED);
     this.tweens.add({
       targets: this.moneyText,
       duration: 250,

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -20,7 +20,7 @@ import { Species } from "#enums/species";
 import { TrainerType } from "#enums/trainer-type";
 import { Nature } from "#enums/nature";
 import type { MoveId } from "#enums/move-id";
-import { TypeColor, TypeShadow } from "#enums/color";
+import { TypeColor, TypeShadowColor } from "#enums/color";
 import { pokemonEvolutions } from "#app/data/balance/pokemon-evolutions";
 import { pokemonFormChanges } from "#app/data/pokemon-forms";
 import type { MoveSourceType } from "#enums/move-source-type";
@@ -637,7 +637,7 @@ export class SingleTypeChallenge extends Challenge {
   override getDescription(overrideValue?: number): string {
     const value = overrideValue ?? this.value;
     const type = i18next.t(`pokemonInfo:Type.${ElementalType[value - 1]}`);
-    const typeColor = `[color=${TypeColor[ElementalType[value - 1]]}][shadow=${TypeShadow[ElementalType[value - 1]]}]${type}[/shadow][/color]`;
+    const typeColor = `[color=${TypeColor[ElementalType[value - 1]]}][shadow=${TypeShadowColor[ElementalType[value - 1]]}]${type}[/shadow][/color]`;
     const defaultDesc = i18next.t(`challenges:${this.geti18nKey()}.desc_default`);
     const typeDesc = i18next.t(`challenges:${this.geti18nKey()}.desc`, { type: typeColor });
     return value === 0 ? defaultDesc : typeDesc;

--- a/src/data/exp.ts
+++ b/src/data/exp.ts
@@ -1,3 +1,4 @@
+import { CommonColor, ShadowColor } from "#enums/color";
 import { GrowthRate } from "#enums/growth-rates";
 
 const expLevels = [
@@ -103,16 +104,16 @@ export function getLevelRelExp(level: number, growthRate: GrowthRate): number {
 export function getGrowthRateColor(growthRate: GrowthRate, shadow?: boolean) {
   switch (growthRate) {
     case GrowthRate.ERRATIC:
-      return !shadow ? "#f85888" : "#906060";
+      return shadow ? ShadowColor.DUSTY_ROSE : CommonColor.SOFT_PINK;
     case GrowthRate.FAST:
-      return !shadow ? "#f8d030" : "#b8a038";
+      return shadow ? ShadowColor.MUTED_GOLD : CommonColor.GOLD_YELLOW;
     case GrowthRate.MEDIUM_FAST:
-      return !shadow ? "#78c850" : "#588040";
+      return shadow ? ShadowColor.MUTED_GREEN : CommonColor.LIGHT_GREEN;
     case GrowthRate.MEDIUM_SLOW:
-      return !shadow ? "#6890f0" : "#807870";
+      return shadow ? ShadowColor.DARK_GREY : CommonColor.SOFT_BLUE;
     case GrowthRate.SLOW:
-      return !shadow ? "#f08030" : "#c03028";
+      return shadow ? ShadowColor.DARK_RED : CommonColor.BRIGHT_ORANGE;
     case GrowthRate.FLUCTUATING:
-      return !shadow ? "#a040a0" : "#483850";
+      return shadow ? ShadowColor.DARK_PURPLE : CommonColor.VIBRANT_PURPLE;
   }
 }

--- a/src/data/gender.ts
+++ b/src/data/gender.ts
@@ -1,3 +1,4 @@
+import { CommonColor, ShadowColor } from "#enums/color";
 import { Gender } from "#enums/gender";
 
 /**
@@ -23,11 +24,11 @@ export function getGenderSymbol(gender: Gender) {
 export function getGenderColor(gender: Gender) {
   switch (gender) {
     case Gender.MALE:
-      return "#40c8f8"; // light blue
+      return CommonColor.LIGHT_BLUE;
     case Gender.FEMALE:
-      return "#f89890"; // pink
+      return CommonColor.SOFT_PINK;
   }
-  return "#ffffff"; // White
+  return CommonColor.WHITE;
 }
 
 /**
@@ -38,9 +39,9 @@ export function getGenderColor(gender: Gender) {
 export function getGenderShadowColor(gender: Gender) {
   switch (gender) {
     case Gender.MALE:
-      return "#006090"; // Dark blue
+      return ShadowColor.LIGHT_BLUE;
     case Gender.FEMALE:
-      return "#984038"; // Red
+      return ShadowColor.DEEP_RED;
   }
-  return "#ffffff"; // White
+  return CommonColor.WHITE;
 }

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -1,3 +1,4 @@
+import { TypeEffectivenessColor } from "#enums/color";
 import { ElementalType } from "#enums/elemental-type";
 
 export type TypeDamageMultiplier = 0 | 0.125 | 0.25 | 0.5 | 1 | 2 | 4 | 8;
@@ -278,40 +279,40 @@ export function getTypeDamageMultiplierColor(
   if (side === "offense") {
     switch (multiplier) {
       case 0:
-        return "#929292";
+        return TypeEffectivenessColor.NO_EFFECT;
       case 0.125:
-        return "#FF5500";
+        return TypeEffectivenessColor.VERY_RESISTED;
       case 0.25:
-        return "#FF7400";
+        return TypeEffectivenessColor.RESISTED;
       case 0.5:
-        return "#FE8E00";
+        return TypeEffectivenessColor.NOT_VERY_EFFECTIVE;
       case 1:
         return undefined;
       case 2:
-        return "#4AA500";
+        return TypeEffectivenessColor.SUPER_EFFECTIVE;
       case 4:
-        return "#4BB400";
+        return TypeEffectivenessColor.VERY_SUPER_EFFECTIVE;
       case 8:
-        return "#52C200";
+        return TypeEffectivenessColor.MAX_SUPER_EFFECTIVE;
     }
   } else if (side === "defense") {
     switch (multiplier) {
       case 0:
-        return "#B1B100";
+        return TypeEffectivenessColor.DEFENSE_NO_EFFECT;
       case 0.125:
-        return "#2DB4FF";
+        return TypeEffectivenessColor.DEFENSE_VERY_RESISTED;
       case 0.25:
-        return "#00A4FF";
+        return TypeEffectivenessColor.DEFENSE_RESISTED;
       case 0.5:
-        return "#0093FF";
+        return TypeEffectivenessColor.DEFENSE_NOT_VERY_EFFECTIVE;
       case 1:
         return undefined;
       case 2:
-        return "#FE8E00";
+        return TypeEffectivenessColor.SUPER_EFFECTIVE;
       case 4:
-        return "#FF7400";
+        return TypeEffectivenessColor.VERY_SUPER_EFFECTIVE;
       case 8:
-        return "#FF5500";
+        return TypeEffectivenessColor.MAX_SUPER_EFFECTIVE;
     }
   }
 }

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -276,45 +276,21 @@ export function getTypeDamageMultiplierColor(
   multiplier: TypeDamageMultiplier,
   side: "defense" | "offense",
 ): string | undefined {
-  if (side === "offense") {
-    switch (multiplier) {
-      case 0:
-        return TypeEffectivenessColor.NO_EFFECT;
-      case 0.125:
-        return TypeEffectivenessColor.VERY_RESISTED;
-      case 0.25:
-        return TypeEffectivenessColor.RESISTED;
-      case 0.5:
-        return TypeEffectivenessColor.NOT_VERY_EFFECTIVE;
-      case 1:
-        return undefined;
-      case 2:
-        return TypeEffectivenessColor.SUPER_EFFECTIVE;
-      case 4:
-        return TypeEffectivenessColor.VERY_SUPER_EFFECTIVE;
-      case 8:
-        return TypeEffectivenessColor.MAX_SUPER_EFFECTIVE;
-    }
-  } else if (side === "defense") {
-    switch (multiplier) {
-      case 0:
-        return TypeEffectivenessColor.DEFENSE_NO_EFFECT;
-      case 0.125:
-        return TypeEffectivenessColor.DEFENSE_VERY_RESISTED;
-      case 0.25:
-        return TypeEffectivenessColor.DEFENSE_RESISTED;
-      case 0.5:
-        return TypeEffectivenessColor.DEFENSE_NOT_VERY_EFFECTIVE;
-      case 1:
-        return undefined;
-      case 2:
-        return TypeEffectivenessColor.SUPER_EFFECTIVE;
-      case 4:
-        return TypeEffectivenessColor.VERY_SUPER_EFFECTIVE;
-      case 8:
-        return TypeEffectivenessColor.MAX_SUPER_EFFECTIVE;
-    }
-  }
+  const effectivenessMap: Record<TypeDamageMultiplier, string | undefined> = {
+    0: side === "offense" ? TypeEffectivenessColor.NO_EFFECT : TypeEffectivenessColor.DEFENSE_NO_EFFECT,
+    0.125: side === "offense" ? TypeEffectivenessColor.VERY_RESISTED : TypeEffectivenessColor.DEFENSE_VERY_RESISTED,
+    0.25: side === "offense" ? TypeEffectivenessColor.RESISTED : TypeEffectivenessColor.DEFENSE_RESISTED,
+    0.5:
+      side === "offense"
+        ? TypeEffectivenessColor.NOT_VERY_EFFECTIVE
+        : TypeEffectivenessColor.DEFENSE_NOT_VERY_EFFECTIVE,
+    1: undefined,
+    2: TypeEffectivenessColor.SUPER_EFFECTIVE,
+    4: TypeEffectivenessColor.VERY_SUPER_EFFECTIVE,
+    8: TypeEffectivenessColor.MAX_SUPER_EFFECTIVE,
+  };
+
+  return effectivenessMap[multiplier];
 }
 
 export function getTypeRgb(type: ElementalType): [number, number, number] {

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -7,9 +7,9 @@ export enum CommonColor {
 
   // Reds & Pinks
   SOFT_PINK = "#f89890",
-  CORAL_PINK = "#F88880",
+  CORAL_PINK = "#f88880",
   BRIGHT_PINK = "#f85888",
-  PURE_RED = "#FF0000",
+  PURE_RED = "#ff0000",
   WARM_RED = "#e13d3d",
   DEEP_RED = "#e70808",
 
@@ -39,42 +39,42 @@ export enum CommonColor {
 }
 
 export enum TypeColor {
-  NORMAL = "#ADA594",
-  FIGHTING = "#A55239",
-  FLYING = "#9CADF7",
-  POISON = "#9141CB",
-  GROUND = "#AE7A3B",
-  ROCK = "#BDA55A",
-  BUG = "#ADBD21",
-  GHOST = "#6363B5",
-  STEEL = "#81A6BE",
-  FIRE = "#F75231",
-  WATER = "#399CFF",
-  GRASS = "#7BCE52",
-  ELECTRIC = "#FFC631",
-  PSYCHIC = "#EF4179",
-  ICE = "#5ACEE7",
-  DRAGON = "#7B63E7",
-  DARK = "#735A4A",
-  FAIRY = "#EF70EF",
+  NORMAL = "#ada594",
+  FIGHTING = "#a55239",
+  FLYING = "#9cadf7",
+  POISON = "#9141cb",
+  GROUND = "#ae7a3b",
+  ROCK = "#bda55a",
+  BUG = "#adbd21",
+  GHOST = "#6363b5",
+  STEEL = "#81a6be",
+  FIRE = "#f75231",
+  WATER = "#399cff",
+  GRASS = "#7bce52",
+  ELECTRIC = "#ffc631",
+  PSYCHIC = "#ef4179",
+  ICE = "#5acee7",
+  DRAGON = "#7b63e7",
+  DARK = "#735a4a",
+  FAIRY = "#ef70ef",
 }
 
 export enum TypeShadowColor {
-  NORMAL = "#574F4A",
-  FIGHTING = "#4E637C",
-  FLYING = "#4E637C",
+  NORMAL = "#574f4a",
+  FIGHTING = "#4e637c",
+  FLYING = "#4e637c",
   POISON = "#352166",
-  GROUND = "#572D1E",
-  ROCK = "#5F442D",
-  BUG = "#5F5010",
-  GHOST = "#323D5B",
-  STEEL = "#415C5F",
-  FIRE = "#7C1818",
-  WATER = "#1C4E80",
-  GRASS = "#4F6729",
+  GROUND = "#572d1e",
+  ROCK = "#5f442d",
+  BUG = "#5f5010",
+  GHOST = "#323d5b",
+  STEEL = "#415c5f",
+  FIRE = "#7c1818",
+  WATER = "#1c4e80",
+  GRASS = "#4f6729",
   ELECTRIC = "#804618",
   PSYCHIC = "#782155",
-  ICE = "#2D5C74",
+  ICE = "#2d5c74",
   DRAGON = "#313874",
   DARK = "#392725",
   FAIRY = "#663878",
@@ -113,7 +113,7 @@ export enum ShadowColor {
   LIGHT_YELLOW = "#ded6b5",
   YELLOW = "#ebd773",
   DARK_YELLOW = "#a0a060",
-  MUTED_GOLD = "b8a038",
+  MUTED_GOLD = "#b8a038",
   ORANGE = "#c07800",
   LIGHT_ORANGE = "#ffbd73",
   PEACH_SAND = "#f7b18b",
@@ -122,16 +122,16 @@ export enum ShadowColor {
 export enum TypeEffectivenessColor {
   NO_EFFECT = "#929292", // Grey (0x)
 
-  VERY_RESISTED = "#FF5500", // Deep Orange (0.125x)
-  RESISTED = "#FF7400", // Bright Orange (0.25x)
-  NOT_VERY_EFFECTIVE = "#FE8E00", // Warm Orange (0.5x)
+  VERY_RESISTED = "#ff5500", // Deep Orange (0.125x)
+  RESISTED = "#ff7400", // Bright Orange (0.25x)
+  NOT_VERY_EFFECTIVE = "#fe8e00", // Warm Orange (0.5x)
 
-  SUPER_EFFECTIVE = "#4AA500", // Deep Green (2x)
-  VERY_SUPER_EFFECTIVE = "#4BB400", // Brighter Green (4x)
-  MAX_SUPER_EFFECTIVE = "#52C200", // Most vibrant Green (8x)
+  SUPER_EFFECTIVE = "#4aa500", // Deep Green (2x)
+  VERY_SUPER_EFFECTIVE = "#4bb400", // Brighter Green (4x)
+  MAX_SUPER_EFFECTIVE = "#52c200", // Most vibrant Green (8x)
 
-  DEFENSE_NO_EFFECT = "#B1B100", // Mustard Yellow (0x)
-  DEFENSE_VERY_RESISTED = "#2DB4FF", // Light Blue (0.125x)
-  DEFENSE_RESISTED = "#00A4FF", // Brighter Blue (0.25x)
-  DEFENSE_NOT_VERY_EFFECTIVE = "#0093FF", // Deep Blue (0.5x)
+  DEFENSE_NO_EFFECT = "#b1b100", // Mustard Yellow (0x)
+  DEFENSE_VERY_RESISTED = "#2db4ff", // Light Blue (0.125x)
+  DEFENSE_RESISTED = "#00a4ff", // Brighter Blue (0.25x)
+  DEFENSE_NOT_VERY_EFFECTIVE = "#0093ff", // Deep Blue (0.5x)
 }

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -1,20 +1,35 @@
-export enum Color {
+export enum CommonColor {
   WHITE = "#ffffff",
   OFF_WHITE = "#f8f8f8",
   LIGHT_GREY = "#a0a0a0",
   GREY = "#484848",
   DARK_GREY = "#404040",
-  PINK = "#f89890",
-  RED = "#e13d3d",
-  RED2 = "#e70808",
-  REDORANGE = "#d64b00",
-  ORANGE = "#f8b050",
-  LIGHT_YELLOW = "#e8e8a8",
-  YELLOW = "#ccbe00",
+
+  // Reds & Pinks
+  SOFT_PINK = "#f89890",
+  CORAL_PINK = "#F88880",
+  BRIGHT_PINK = "#f85888",
+  WARM_RED = "#e13d3d",
+  DEEP_RED = "#e70808",
+
+  VIBRANT_PURPLE = "#a040a0",
+
+  // Oranges & Yellows
+  SOFT_ORANGE = "#f8b050",
+  BRIGHT_ORANGE = "#f08030",
+  DEEP_ORANGE = "#d64b00",
+  GOLD_YELLOW = "#f8d030",
+  MUTED_YELLOW = "#e8e8a8",
+  DEEP_YELLOW = "#ccbe00",
   DARK_YELLOW = "#a68e17",
-  GREEN = "#78c850",
-  BLUE = "#40c8f8",
-  COMMON = "#ffffff",
+
+  // Greens
+  LIGHT_GREEN = "#78c850",
+
+  // Blues
+  LIGHT_BLUE = "#40c8f8",
+  SOFT_BLUE = "#6890f0",
+
   GREAT = "#3890f8",
   ULTRA = "#f8d038",
   MASTER = "#e020c0",
@@ -42,7 +57,7 @@ export enum TypeColor {
   FAIRY = "#EF70EF",
 }
 
-export enum TypeShadow {
+export enum TypeShadowColor {
   NORMAL = "#574F4A",
   FIGHTING = "#4E637C",
   FLYING = "#4E637C",
@@ -64,19 +79,57 @@ export enum TypeShadow {
 }
 
 export enum ShadowColor {
-  GREY = "#636363",
-  PURPLE = "#6b5a73",
   LIGHT_GREY = "#d0d0c8",
-  BROWN = "#69402a",
-  PINK = "#fca2a2",
+  GREY = "#636363",
+  MEDIUM_GRAY = "#707070",
+  DARK_GREY = "#807870",
+
+  // Browns
+  LIGHT_BROWN = "#69402a",
+  DARK_BROWN = "#632929",
+  OLIVE_BRONZE = "#6e672c",
+
+  // Purples
+  DARK_PURPLE = "#483850",
+  PURPLE = "#6b5a73",
+
+  // Reds
+  LIGHT_RED = "#fca2a2",
   BRIGHT_RED = "#f83018",
-  RED = "#984038",
-  MAROON = "#632929",
-  GREEN = "#306850",
-  BLUE = "#006090",
+  DEEP_RED = "#984038",
+  DARK_RED = "#c03028",
+  DUSTY_ROSE = "#906060",
+
+  // Greens
+  SOFT_GREEN = "#306850",
+  MUTED_GREEN = "#588040",
+
+  // Blues
+  LIGHT_BLUE = "#006090",
+
+  // Yellows and Oranges
   LIGHT_YELLOW = "#ded6b5",
   YELLOW = "#ebd773",
   DARK_YELLOW = "#a0a060",
+  MUTED_GOLD = "b8a038",
   ORANGE = "#c07800",
   LIGHT_ORANGE = "#ffbd73",
+  PEACH_SAND = "#f7b18b",
+}
+
+export enum TypeEffectivenessColor {
+  NO_EFFECT = "#929292", // Grey (0x)
+
+  VERY_RESISTED = "#FF5500", // Deep Orange (0.125x)
+  RESISTED = "#FF7400", // Bright Orange (0.25x)
+  NOT_VERY_EFFECTIVE = "#FE8E00", // Warm Orange (0.5x)
+
+  SUPER_EFFECTIVE = "#4AA500", // Deep Green (2x)
+  VERY_SUPER_EFFECTIVE = "#4BB400", // Brighter Green (4x)
+  MAX_SUPER_EFFECTIVE = "#52C200", // Most vibrant Green (8x)
+
+  DEFENSE_NO_EFFECT = "#B1B100", // Mustard Yellow (0x)
+  DEFENSE_VERY_RESISTED = "#2DB4FF", // Light Blue (0.125x)
+  DEFENSE_RESISTED = "#00A4FF", // Brighter Blue (0.25x)
+  DEFENSE_NOT_VERY_EFFECTIVE = "#0093FF", // Deep Blue (0.5x)
 }

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -9,6 +9,7 @@ export enum CommonColor {
   SOFT_PINK = "#f89890",
   CORAL_PINK = "#F88880",
   BRIGHT_PINK = "#f85888",
+  PURE_RED = "#FF0000",
   WARM_RED = "#e13d3d",
   DEEP_RED = "#e70808",
 
@@ -24,7 +25,8 @@ export enum CommonColor {
   DARK_YELLOW = "#a68e17",
 
   // Greens
-  LIGHT_GREEN = "#78c850",
+  LIGHT_GREEN = "#008000",
+  PURE_GREEN = "#58d858",
 
   // Blues
   LIGHT_BLUE = "#40c8f8",

--- a/src/field/damage-number-handler.ts
+++ b/src/field/damage-number-handler.ts
@@ -9,6 +9,7 @@ import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
 import { DamageNumbersMode } from "#enums/damage-numbers-mode";
 import { GAME_HEIGHT } from "#app/ui-constants";
+import { CommonColor, ShadowColor } from "#enums/color";
 
 type TextAndShadowArr = [string | null, string | null];
 
@@ -46,19 +47,19 @@ export default class DamageNumberHandler {
 
     switch (result) {
       case HitResult.SUPER_EFFECTIVE:
-        [textColor, shadowColor] = ["#f8d030", "#b8a038"];
+        [textColor, shadowColor] = [CommonColor.GOLD_YELLOW, ShadowColor.MUTED_GOLD];
         break;
       case HitResult.NOT_VERY_EFFECTIVE:
-        [textColor, shadowColor] = ["#f08030", "#c03028"];
+        [textColor, shadowColor] = [CommonColor.BRIGHT_ORANGE, ShadowColor.DARK_RED];
         break;
       case HitResult.ONE_HIT_KO:
-        [textColor, shadowColor] = ["#a040a0", "#483850"];
+        [textColor, shadowColor] = [CommonColor.VIBRANT_PURPLE, ShadowColor.DARK_PURPLE];
         break;
       case HitResult.HEAL:
-        [textColor, shadowColor] = ["#78c850", "#588040"];
+        [textColor, shadowColor] = [CommonColor.LIGHT_GREEN, ShadowColor.MUTED_GREEN];
         break;
       default:
-        [textColor, shadowColor] = ["#ffffff", "#636363"];
+        [textColor, shadowColor] = [CommonColor.WHITE, ShadowColor.GREY];
         break;
     }
 

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -20,6 +20,7 @@ import { Biome } from "#enums/biome";
 import { initMysteryEncounters } from "#app/data/mystery-encounters/mystery-encounters";
 import { initVouchers } from "#app/system/init-vouchers";
 import { CANVAS_SCALE, GAME_HEIGHT, GAME_WIDTH, TEMP_SCALE_ADJUSTEMENT } from "./ui-constants";
+import { CommonColor } from "#enums/color";
 import { initAbilities } from "#app/data/init-abilities";
 import { api } from "#app/plugins/api/api";
 import { initMoves } from "#app/data/init-moves";
@@ -414,7 +415,7 @@ export class LoadingScene extends SceneBase {
       text: "0%",
       style: {
         font: "72px emerald",
-        color: "#ffffff",
+        color: CommonColor.WHITE,
       },
     });
     percentText.setOrigin(0.5, 0.5);
@@ -426,7 +427,7 @@ export class LoadingScene extends SceneBase {
       text: "",
       style: {
         font: "48px emerald",
-        color: "#ffffff",
+        color: CommonColor.WHITE,
       },
     });
     assetText.setOrigin(0.5, 0.5);
@@ -450,7 +451,7 @@ export class LoadingScene extends SceneBase {
       text: i18next.t("menu:disclaimerDescription"),
       style: {
         font: "48px emerald",
-        color: "#ffffff",
+        color: CommonColor.WHITE,
         align: "center",
       },
     });

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -439,7 +439,7 @@ export class LoadingScene extends SceneBase {
       text: i18next.t("menu:disclaimer"),
       style: {
         font: "72px emerald",
-        color: "#DA3838",
+        color: CommonColor.WARM_RED,
       },
     });
     disclaimerText.setOrigin(0.5, 0.5);

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -42,7 +42,7 @@ import {
 import { getModifierType } from "#app/utils/modifier-type-utils";
 import { modifierTypes } from "./modifier-types";
 import { ModifierPoolType } from "#enums/modifier-pool-type";
-import { Color, ShadowColor } from "#enums/color";
+import { CommonColor, ShadowColor } from "#enums/color";
 import { FRIENDSHIP_GAIN_FROM_RARE_CANDY } from "#app/data/balance/starters";
 import { applyAbAttrs } from "#app/data/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
@@ -896,10 +896,10 @@ export abstract class LapsingPokemonHeldItemModifier extends PokemonHeldItemModi
     if (this.getPokemon()?.isPlayer()) {
       const battleCountText = addTextObject(27, 0, this.battlesLeft.toString(), TextStyle.PARTY, {
         fontSize: "66px",
-        color: Color.PINK,
+        color: CommonColor.SOFT_PINK,
       });
       battleCountText.setShadow(0, 0);
-      battleCountText.setStroke(ShadowColor.RED, 16);
+      battleCountText.setStroke(ShadowColor.DEEP_RED, 16);
       battleCountText.setOrigin(1, 0);
       container.add(battleCountText);
     }

--- a/src/ui/challenges-select-ui-handler.ts
+++ b/src/ui/challenges-select-ui-handler.ts
@@ -9,7 +9,7 @@ import type { Challenge } from "#app/data/challenge";
 import { getLocalizedSpriteKey } from "#app/utils";
 import { Challenges } from "#enums/challenges";
 import type BBCodeText from "phaser3-rex-plugins/plugins/bbcodetext";
-import { Color, ShadowColor } from "#enums/color";
+import { CommonColor, ShadowColor } from "#enums/color";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
 import { globalScene } from "#app/global-scene";
 import { GAME_HEIGHT, GAME_WIDTH } from "#app/ui-constants";
@@ -205,7 +205,7 @@ export default class GameChallengesUiHandler extends UiHandler {
    * @param text text to set to the BBCode description
    */
   setDescription(text: string): void {
-    this.descriptionText.setText(`[color=${Color.ORANGE}][shadow=${ShadowColor.ORANGE}]${text}`);
+    this.descriptionText.setText(`[color=${CommonColor.SOFT_ORANGE}][shadow=${ShadowColor.ORANGE}]${text}`);
   }
 
   /**

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -42,6 +42,7 @@ import type { PokemonMoveSelectFilter } from "#app/@types/PokemonMoveSelectFilte
 import { PartyFilterAll } from "#app/utils/party-ui-utils";
 import { FilterAllMoves } from "#app/utils/move-utils";
 import { GAME_WIDTH } from "#app/ui-constants";
+import { CommonColor, ShadowColor } from "#enums/color";
 import { type SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { PhaseId } from "#enums/phase-id";
 
@@ -1066,8 +1067,8 @@ export default class PartyUiHandler extends MessageUiHandler {
       const yCoord = -6 - 16 * o;
       const optionText = addBBCodeTextObject(0, yCoord - 16, optionName, TextStyle.WINDOW, { maxLines: 1 });
       if (altText) {
-        optionText.setColor("#40c8f8");
-        optionText.setShadowColor("#006090");
+        optionText.setColor(CommonColor.LIGHT_BLUE);
+        optionText.setShadowColor(ShadowColor.LIGHT_BLUE);
       }
       optionText.setOrigin(0, 0);
 

--- a/src/ui/run-history-ui-handler.ts
+++ b/src/ui/run-history-ui-handler.ts
@@ -16,6 +16,7 @@ import { TrainerVariant } from "#enums/trainer-variant";
 import { RunDisplayMode } from "#enums/run-display-mode";
 import { settings } from "#app/system/settings/settings-manager";
 import { GAME_HEIGHT, GAME_WIDTH } from "#app/ui-constants";
+import { CommonColor } from "#enums/color";
 
 export type RunSelectCallback = (cursor: number) => void;
 
@@ -314,10 +315,10 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
             20,
             `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
             TextStyle.PARTY,
-            { fontSize: "54px", color: "#f8f8f8" },
+            { fontSize: "54px", color: CommonColor.OFF_WHITE },
           );
           enemyLevel.setShadow(0, 0, undefined);
-          enemyLevel.setStroke("#424242", 14);
+          enemyLevel.setStroke(CommonColor.DARK_GREY, 14);
           enemyLevel.setOrigin(1, 0);
           enemyIconContainer.add(enemyIcon);
           enemyIconContainer.add(enemyLevel);
@@ -408,10 +409,10 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
         20,
         `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(pokemon.level, 1000)}`,
         TextStyle.PARTY,
-        { fontSize: "54px", color: "#f8f8f8" },
+        { fontSize: "54px", color: CommonColor.OFF_WHITE },
       );
       text.setShadow(0, 0, undefined);
-      text.setStroke("#424242", 14);
+      text.setStroke(CommonColor.DARK_GREY, 14);
       text.setOrigin(1, 0);
 
       iconContainer.add(icon);

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -23,7 +23,7 @@ import { getLuckString, getLuckTextTint } from "../modifier/modifier-type";
 import RoundRectangle from "phaser3-rex-plugins/plugins/roundrectangle";
 import { getTypeRgb } from "#app/data/type";
 import { ElementalType } from "#enums/elemental-type";
-import { TypeColor, TypeShadow } from "#enums/color";
+import { CommonColor, TypeColor, TypeShadowColor } from "#enums/color";
 import { getNatureStatMultiplier, getNatureName } from "../data/nature";
 import { getVariantTint } from "#app/data/variant";
 import * as Modifier from "../modifier/modifier";
@@ -406,10 +406,10 @@ export default class RunInfoUiHandler extends UiHandler {
       26,
       `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
       enemyLevelStyle,
-      { fontSize: "44px", color: "#f8f8f8" },
+      { fontSize: "44px", color: CommonColor.OFF_WHITE },
     );
     enemyLevel.setShadow(0, 0, undefined);
-    enemyLevel.setStroke("#424242", 14);
+    enemyLevel.setStroke(CommonColor.DARK_GREY, 14);
     enemyLevel.setOrigin(1, 0);
     enemyIconContainer.add(enemyIcon);
     enemyIconContainer.add(enemyLevel);
@@ -436,10 +436,10 @@ export default class RunInfoUiHandler extends UiHandler {
         26,
         `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(enemy.level, 1000)}`,
         bossStatus ? TextStyle.PARTY_RED : TextStyle.PARTY,
-        { fontSize: "44px", color: "#f8f8f8" },
+        { fontSize: "44px", color: CommonColor.OFF_WHITE },
       );
       enemyLevel.setShadow(0, 0, undefined);
-      enemyLevel.setStroke("#424242", 14);
+      enemyLevel.setStroke(CommonColor.DARK_GREY, 14);
       enemyLevel.setOrigin(1, 0);
       enemyIconContainer.add(enemyIcon);
       enemyIconContainer.add(enemyLevel);
@@ -553,7 +553,7 @@ export default class RunInfoUiHandler extends UiHandler {
         { fontSize: "54px" },
       );
       enemyLevel.setShadow(0, 0, undefined);
-      enemyLevel.setStroke("#424242", 14);
+      enemyLevel.setStroke(CommonColor.DARK_GREY, 14);
       enemyLevel.setOrigin(0, 0);
 
       enemyIconContainer.add(enemyIcon);
@@ -702,7 +702,7 @@ export default class RunInfoUiHandler extends UiHandler {
           case Challenges.SINGLE_TYPE:
             const typeRule = ElementalType[this.runInfo.challenges[i].value - 1];
             const typeTextColor = `[color=${TypeColor[typeRule]}]`;
-            const typeShadowColor = `[shadow=${TypeShadow[typeRule]}]`;
+            const typeShadowColor = `[shadow=${TypeShadowColor[typeRule]}]`;
             const typeText =
               typeTextColor + typeShadowColor + i18next.t(`pokemonInfo:Type.${typeRule}`)! + "[/color]" + "[/shadow]";
             rules.push(typeText);
@@ -796,8 +796,8 @@ export default class RunInfoUiHandler extends UiHandler {
       pokemon.stats.forEach((element) => pStats.push(formatFancyLargeNumber(element, 1)));
       for (let i = 0; i < pStats.length; i++) {
         const isMult = getNatureStatMultiplier(pNature, i);
-        pStats[i] = isMult < 1 ? pStats[i] + "[color=#40c8f8]↓[/color]" : pStats[i];
-        pStats[i] = isMult > 1 ? pStats[i] + "[color=#f89890]↑[/color]" : pStats[i];
+        pStats[i] = isMult < 1 ? pStats[i] + `[color=${CommonColor.LIGHT_BLUE}↓[/color]` : pStats[i];
+        pStats[i] = isMult > 1 ? pStats[i] + `[color=${CommonColor.SOFT_PINK}]↑[/color]` : pStats[i];
       }
       const hp = i18next.t("pokemonInfo:Stat.HPshortened") + ": " + pStats[0];
       const atk = i18next.t("pokemonInfo:Stat.ATKshortened") + ": " + pStats[1];

--- a/src/ui/save-slot-select-ui-handler.ts
+++ b/src/ui/save-slot-select-ui-handler.ts
@@ -15,6 +15,7 @@ import { addWindow } from "./ui-theme";
 import { SaveSlotUiMode } from "#enums/save-slot-ui-mode";
 import { RunDisplayMode } from "#enums/run-display-mode";
 import { GAME_HEIGHT, GAME_WIDTH } from "#app/ui-constants";
+import { CommonColor } from "#enums/color";
 
 const SESSION_SLOTS_COUNT = 5;
 const SLOTS_ON_SCREEN = 3;
@@ -400,10 +401,10 @@ class SessionSlot extends Phaser.GameObjects.Container {
         20,
         `${i18next.t("saveSlotSelectUiHandler:lv")}${formatLargeNumber(pokemon.level, 1000)}`,
         TextStyle.PARTY,
-        { fontSize: "54px", color: "#f8f8f8" },
+        { fontSize: "54px", color: CommonColor.OFF_WHITE },
       );
       text.setShadow(0, 0, undefined);
-      text.setStroke("#424242", 14);
+      text.setStroke(CommonColor.DARK_GREY, 14);
       text.setOrigin(1, 0);
 
       iconContainer.add(icon);

--- a/src/ui/text.ts
+++ b/src/ui/text.ts
@@ -8,6 +8,7 @@ import { ModifierTier } from "#enums/modifier-tier";
 import i18next from "#app/plugins/i18n";
 import { settings } from "#app/system/settings/settings-manager";
 import { TextStyle } from "#enums/text-style";
+import { CommonColor, ShadowColor } from "#enums/color";
 
 export interface TextStyleOptions {
   scale: number;
@@ -286,93 +287,93 @@ export function getTextColor(textStyle: TextStyle, shadow?: boolean, uiTheme: Ui
   const isLegacyTheme = uiTheme === UiTheme.LEGACY;
   switch (textStyle) {
     case TextStyle.MESSAGE:
-      return !shadow ? "#f8f8f8" : "#6b5a73";
+      return shadow ? ShadowColor.PURPLE : CommonColor.OFF_WHITE;
     case TextStyle.WINDOW:
     case TextStyle.MOVE_INFO_CONTENT:
     case TextStyle.MOVE_PP_FULL:
     case TextStyle.TOOLTIP_CONTENT:
     case TextStyle.SETTINGS_VALUE:
       if (isLegacyTheme) {
-        return !shadow ? "#484848" : "#d0d0c8";
+        return shadow ? ShadowColor.LIGHT_GREY : CommonColor.GREY;
       }
-      return !shadow ? "#f8f8f8" : "#6b5a73";
+      return shadow ? ShadowColor.PURPLE : CommonColor.OFF_WHITE;
     case TextStyle.MOVE_PP_HALF_FULL:
       if (isLegacyTheme) {
-        return !shadow ? "#a68e17" : "#ebd773";
+        return shadow ? ShadowColor.YELLOW : CommonColor.DARK_YELLOW;
       }
-      return !shadow ? "#ccbe00" : "#6e672c";
+      return shadow ? ShadowColor.OLIVE_BRONZE : CommonColor.DEEP_YELLOW;
     case TextStyle.MOVE_PP_NEAR_EMPTY:
       if (isLegacyTheme) {
-        return !shadow ? "#d64b00" : "#f7b18b";
+        return shadow ? ShadowColor.PEACH_SAND : CommonColor.DEEP_ORANGE;
       }
-      return !shadow ? "#d64b00" : "#69402a";
+      return shadow ? ShadowColor.LIGHT_BROWN : CommonColor.DEEP_ORANGE;
     case TextStyle.MOVE_PP_EMPTY:
       if (isLegacyTheme) {
-        return !shadow ? "#e13d3d" : "#fca2a2";
+        return shadow ? ShadowColor.LIGHT_RED : CommonColor.WARM_RED;
       }
-      return !shadow ? "#e13d3d" : "#632929";
+      return shadow ? ShadowColor.DARK_BROWN : CommonColor.WARM_RED;
     case TextStyle.WINDOW_ALT:
-      return !shadow ? "#484848" : "#d0d0c8";
+      return shadow ? ShadowColor.LIGHT_GREY : CommonColor.GREY;
     case TextStyle.BATTLE_INFO:
       if (isLegacyTheme) {
-        return !shadow ? "#404040" : "#ded6b5";
+        return shadow ? ShadowColor.LIGHT_YELLOW : CommonColor.DARK_GREY;
       }
-      return !shadow ? "#f8f8f8" : "#6b5a73";
+      return shadow ? ShadowColor.PURPLE : CommonColor.OFF_WHITE;
     case TextStyle.PARTY:
-      return !shadow ? "#f8f8f8" : "#707070";
+      return shadow ? ShadowColor.MEDIUM_GRAY : CommonColor.OFF_WHITE;
     case TextStyle.PARTY_RED:
-      return !shadow ? "#f89890" : "#984038";
+      return shadow ? ShadowColor.DEEP_RED : CommonColor.SOFT_PINK;
     case TextStyle.SUMMARY:
-      return !shadow ? "#f8f8f8" : "#636363";
+      return shadow ? ShadowColor.GREY : CommonColor.OFF_WHITE;
     case TextStyle.SUMMARY_ALT:
       if (isLegacyTheme) {
-        return !shadow ? "#f8f8f8" : "#636363";
+        return shadow ? ShadowColor.GREY : CommonColor.OFF_WHITE;
       }
-      return !shadow ? "#484848" : "#d0d0c8";
+      return shadow ? ShadowColor.LIGHT_GREY : CommonColor.GREY;
     case TextStyle.SUMMARY_RED:
     case TextStyle.TOOLTIP_TITLE:
-      return !shadow ? "#e70808" : "#ffbd73";
+      return shadow ? ShadowColor.LIGHT_ORANGE : CommonColor.DEEP_RED;
     case TextStyle.SUMMARY_BLUE:
-      return !shadow ? "#40c8f8" : "#006090";
+      return shadow ? ShadowColor.LIGHT_BLUE : CommonColor.LIGHT_BLUE;
     case TextStyle.SUMMARY_PINK:
-      return !shadow ? "#f89890" : "#984038";
+      return shadow ? ShadowColor.DEEP_RED : CommonColor.SOFT_PINK;
     case TextStyle.SUMMARY_GOLD:
     case TextStyle.MONEY:
-      return !shadow ? "#e8e8a8" : "#a0a060"; // Pale Yellow/Gold
+      return shadow ? ShadowColor.DARK_YELLOW : CommonColor.MUTED_YELLOW;
     case TextStyle.MONEY_WINDOW:
       if (isLegacyTheme) {
-        return !shadow ? "#f8b050" : "#c07800"; // Gold
+        return shadow ? ShadowColor.ORANGE : CommonColor.SOFT_ORANGE;
       }
-      return !shadow ? "#e8e8a8" : "#a0a060"; // Pale Yellow/Gold
+      return shadow ? ShadowColor.DARK_YELLOW : CommonColor.MUTED_YELLOW;
     case TextStyle.SETTINGS_LOCKED:
     case TextStyle.SUMMARY_GRAY:
-      return !shadow ? "#a0a0a0" : "#636363";
+      return shadow ? ShadowColor.GREY : CommonColor.LIGHT_GREY;
     case TextStyle.STATS_LABEL:
-      return !shadow ? "#f8b050" : "#c07800";
+      return shadow ? ShadowColor.ORANGE : CommonColor.SOFT_ORANGE;
     case TextStyle.STATS_VALUE:
       if (isLegacyTheme) {
-        return !shadow ? "#484848" : "#d0d0c8";
+        return shadow ? ShadowColor.LIGHT_GREY : CommonColor.GREY;
       }
-      return !shadow ? "#f8f8f8" : "#6b5a73";
+      return shadow ? ShadowColor.PURPLE : CommonColor.OFF_WHITE;
     case TextStyle.SUMMARY_GREEN:
-      return !shadow ? "#78c850" : "#306850";
+      return shadow ? ShadowColor.SOFT_GREEN : CommonColor.LIGHT_GREEN;
     case TextStyle.SETTINGS_LABEL:
     case TextStyle.PERFECT_IV:
     case TextStyle.CHALLENGE_DESCRIPTION:
-      return !shadow ? "#f8b050" : "#c07800";
+      return shadow ? ShadowColor.ORANGE : CommonColor.SOFT_ORANGE;
     case TextStyle.SETTINGS_SELECTED:
-      return !shadow ? "#f88880" : "#f83018";
+      return shadow ? ShadowColor.BRIGHT_RED : CommonColor.CORAL_PINK;
     case TextStyle.SMALLER_WINDOW_ALT:
-      return !shadow ? "#484848" : "#d0d0c8";
+      return shadow ? ShadowColor.LIGHT_GREY : CommonColor.GREY;
     case TextStyle.BGM_BAR:
-      return !shadow ? "#f8f8f8" : "#6b5a73";
+      return shadow ? ShadowColor.PURPLE : CommonColor.OFF_WHITE;
     case TextStyle.ME_OPTION_DEFAULT:
-      return !shadow ? "#f8f8f8" : "#6b5a73"; // White
+      return shadow ? ShadowColor.PURPLE : CommonColor.OFF_WHITE;
     case TextStyle.ME_OPTION_SPECIAL:
       if (isLegacyTheme) {
-        return !shadow ? "#f8b050" : "#c07800"; // Gold
+        return shadow ? ShadowColor.ORANGE : CommonColor.SOFT_ORANGE;
       }
-      return !shadow ? "#78c850" : "#306850"; // Green
+      return shadow ? ShadowColor.SOFT_GREEN : CommonColor.LIGHT_GREEN;
   }
 }
 

--- a/test/ui/type-hints.test.ts
+++ b/test/ui/type-hints.test.ts
@@ -9,6 +9,7 @@ import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { MockText } from "#test/testUtils/mocks/mocksContainer/mockText";
 import i18next from "i18next";
+import { TypeEffectivenessColor } from "#enums/color";
 
 describe("UI - Type Hints", () => {
   let phaserGame: Phaser.Game;
@@ -56,7 +57,7 @@ describe("UI - Type Hints", () => {
         .getAll<Phaser.GameObjects.Text>()
         .find((text) => text.text === i18next.t("move:dragonClaw.name"))! as unknown as MockText;
 
-      expect.soft(dragonClawText.color).toBe("#929292");
+      expect.soft(dragonClawText.color).toBe(TypeEffectivenessColor.NO_EFFECT);
       ui.getHandler().processInput(Button.ACTION);
     });
     await game.phaseInterceptor.to(CommandPhase);


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->
## What are the changes the user will see?
none

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?
- there exists an enum for colors but is not used
- centralizes management of colors into a single file
**- ideally moving forward, we want to use the existing colors and not introduce new ones, unless absolutely necessary**
**- there are other colors that are hardcoded in hexadecimal numbers but I wanted to keep this PR self-contained**

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?
- removed/moved hardcoded colors, and replaced with enum

other notable changes:
- changed `#424242` to `#404040` since they are _very_ similar and `#424242 `is only used once
- changed `#DA3838` to `#e13d3d`, same reason above
- renamed `Color` enum to `CommonColor` for clarity
- renamed `TypeShadow` enum to `TypeShadowColor` for consistency

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos
<details><summary>CommonColor</summary>

<img width="293" alt="Screenshot 2025-02-11 at 4 23 11 AM" src="https://github.com/user-attachments/assets/f33dd34a-9e97-49c7-ac7b-7e26e7da8163" />

</details> 
<details><summary>TypeColor</summary>

<img width="192" alt="Screenshot 2025-02-11 at 4 23 28 AM" src="https://github.com/user-attachments/assets/8490641f-9a7b-4df0-be3c-c31dbe158f89" />

</details> 

<details><summary>TypeShadowColor</summary>

<img width="239" alt="Screenshot 2025-02-11 at 4 23 42 AM" src="https://github.com/user-attachments/assets/9dcc2a6b-6cd0-416c-8d59-fb7488f71a27" />

</details> 

<details><summary>ShadowColor</summary>

<img width="248" alt="Screenshot 2025-02-11 at 4 25 38 AM" src="https://github.com/user-attachments/assets/14e69129-400f-40fd-8b4e-050aa0aa6847" />


</details> 

<details><summary>TypeEffectivenessColor</summary>
<img width="469" alt="Screenshot 2025-02-11 at 4 26 00 AM" src="https://github.com/user-attachments/assets/cd3309b9-6a63-41a3-b10e-45c07b82feec" />
</details> 


<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
run `grep -E -r --exclude=./src/enums/color.ts '#[0-9A-Fa-f]{3,6}\b' ./src` in root directory
<img width="786" alt="Screenshot 2025-02-11 at 4 37 17 AM" src="https://github.com/user-attachments/assets/1fae9688-0b1e-4001-a4a7-d4e8942d4b4f" />
play test
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
