### PR TITLE
[Checkup] Super Luck documentation and tests

### DIFF
--- a/src/data/ab-attrs/bonus-crit-ab-attr.ts
+++ b/src/data/ab-attrs/bonus-crit-ab-attr.ts
@@ -1,16 +1,23 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { BooleanHolder } from "#app/utils";
+import type { NumberHolder } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbAttr } from "./ab-attr";
 
+/**
+ * Ability attribute that provides bonus critical hit rate stages to the ability holder
+ * It is used by the ability Super Luck, which provides a one stage boost to critical hit rate.
+ */
 export class BonusCritAbAttr extends AbAttr {
-  constructor(showAbility: boolean = true, showAbilityInstant: boolean = false) {
+  private stages: number; // Additional critical hit stages provided by the ability
+
+  constructor(stages: number, showAbility: boolean = true, showAbilityInstant: boolean = false) {
     super(showAbility, showAbilityInstant);
     this._flags.add(AbAttrFlag.BONUS_CRIT);
+    this.stages = stages;
   }
 
-  override apply(_pokemon: Pokemon, _simulated: boolean, bonusCrit: BooleanHolder): boolean {
-    bonusCrit.value = true;
+  override apply(_pokemon: Pokemon, _simulated: boolean, critStage: NumberHolder): boolean {
+    critStage.value += this.stages;
     return true;
   }
 }

--- a/src/data/ab-attrs/bonus-crit-ab-attr.ts
+++ b/src/data/ab-attrs/bonus-crit-ab-attr.ts
@@ -10,7 +10,7 @@ import { AbAttr } from "./ab-attr";
  */
 export class BonusCritAbAttr extends AbAttr {
   /** Additional critical hit stages provided by the ability. */
-  private stages: number; 
+  private readonly stages: number;
 
   constructor(stages: number, showAbility: boolean = true, showAbilityInstant: boolean = false) {
     super(showAbility, showAbilityInstant);

--- a/src/data/ab-attrs/bonus-crit-ab-attr.ts
+++ b/src/data/ab-attrs/bonus-crit-ab-attr.ts
@@ -6,9 +6,11 @@ import { AbAttr } from "./ab-attr";
 /**
  * Ability attribute that provides bonus critical hit rate stages to the ability holder
  * It is used by the ability Super Luck, which provides a one stage boost to critical hit rate.
+ * @extends AbAttr
  */
 export class BonusCritAbAttr extends AbAttr {
-  private stages: number; // Additional critical hit stages provided by the ability
+  /** Additional critical hit stages provided by the ability. */
+  private stages: number; 
 
   constructor(stages: number, showAbility: boolean = true, showAbilityInstant: boolean = false) {
     super(showAbility, showAbilityInstant);

--- a/src/data/init-abilities.ts
+++ b/src/data/init-abilities.ts
@@ -544,7 +544,7 @@ export function initAbilities() {
         i18next.t("abilityTriggers:postSummonMoldBreaker", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       )
       .attr(MoveAbilityBypassAbAttr),
-    new Ability(Abilities.SUPER_LUCK, 4).attr(BonusCritAbAttr),
+    new Ability(Abilities.SUPER_LUCK, 4).attr(BonusCritAbAttr, 1),
     new Ability(Abilities.AFTERMATH, 4).attr(PostFaintContactDamageAbAttr, 4).bypassFaint(),
     new Ability(Abilities.ANTICIPATION, 4)
       .attr(AnticipationAbAttr, (pokemon: Pokemon) =>

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1071,11 +1071,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // TODO: Scope Lens and Leek were applied here
     globalScene.applyModifiers(TempCritBoosterModifier, source.isPlayer(), critStage);
 
-    const bonusCrit = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.BONUS_CRIT, source, simulated, bonusCrit);
-    if (bonusCrit.value) {
-      critStage.value += 1;
-    }
+    // Applies the effects of the ability 'Super Luck' here
+    applyAbAttrs(AbAttrFlag.BONUS_CRIT, source, simulated, critStage);
 
     const critBoostTag = source.getTag(...CritBoostBattlerTagTypes);
     if (critBoostTag) {

--- a/test/abilities/super_luck.test.ts
+++ b/test/abilities/super_luck.test.ts
@@ -1,0 +1,42 @@
+import { allMoves } from "#app/data/all-moves";
+import { Abilities } from "#enums/abilities";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Super Luck", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .moveset([MoveId.TACKLE])
+      .ability(Abilities.SUPER_LUCK)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH);
+  });
+
+  it("should boost the ability holder's critical stage by 1", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const playerPokemon = game.field.getPlayerPokemon();
+
+    expect(playerPokemon.getCritStage(playerPokemon, allMoves[MoveId.TACKLE])).toBe(1);
+  });
+});

--- a/test/abilities/super_luck.test.ts
+++ b/test/abilities/super_luck.test.ts
@@ -23,7 +23,7 @@ describe("Abilities - Super Luck", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([MoveId.TACKLE])
+      .moveset([MoveId.TACKLE, MoveId.RAZOR_LEAF])
       .ability(Abilities.SUPER_LUCK)
       .battleType("single")
       .disableCrits()
@@ -38,5 +38,6 @@ describe("Abilities - Super Luck", () => {
     const playerPokemon = game.field.getPlayerPokemon();
 
     expect(playerPokemon.getCritStage(playerPokemon, allMoves[MoveId.TACKLE])).toBe(1);
+    expect(playerPokemon.getCritStage(playerPokemon, allMoves[MoveId.RAZOR_LEAF])).toBe(2);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

None.

## Why am I making these changes?

An ability checkup a day...

## What are the changes from a developer perspective?

- Documentation and test added for Super Luck
- Super Luck's ability attribute has been revised to take in a number of stages to boost and add that number to the ability holder's critical hit stages instead of changing a booleanholder's boolean to true. This makes the ability attribute `BonusCritAbAttr` much more self-evident in what it exactly does. In addition, this also matches how moves with a higher critical hit rate function in `pokemon.getCritStages`

## How to test the changes?

`npm run test super_luck`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
