### PR TITLE
[Docs] Add color hexcodes to tsdocs of enum values, fix some hexcodes

### DIFF
--- a/src/data/exp.ts
+++ b/src/data/exp.ts
@@ -104,7 +104,7 @@ export function getLevelRelExp(level: number, growthRate: GrowthRate): number {
 export function getGrowthRateColor(growthRate: GrowthRate, shadow?: boolean) {
   switch (growthRate) {
     case GrowthRate.ERRATIC:
-      return shadow ? ShadowColor.DUSTY_ROSE : CommonColor.SOFT_PINK;
+      return shadow ? ShadowColor.DUSTY_ROSE : CommonColor.BRIGHT_PINK;
     case GrowthRate.FAST:
       return shadow ? ShadowColor.MUTED_GOLD : CommonColor.GOLD_YELLOW;
     case GrowthRate.MEDIUM_FAST:

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -1,7 +1,7 @@
 import { TypeEffectivenessColor } from "#enums/color";
 import { ElementalType } from "#enums/elemental-type";
 
-export type TypeDamageMultiplier = 0 | 0.125 | 0.25 | 0.5 | 1 | 2 | 4 | 8;
+export type TypeDamageMultiplier = 0 | 0.125 | 0.25 | 0.5 | 1 | 2 | 4 | 8 | 16;
 
 export function getTypeDamageMultiplier(attackType: ElementalType, defType: ElementalType): TypeDamageMultiplier {
   if (attackType === ElementalType.UNKNOWN || defType === ElementalType.UNKNOWN) {
@@ -272,28 +272,17 @@ export function getTypeDamageMultiplier(attackType: ElementalType, defType: Elem
  * Retrieve the color corresponding to a specific damage multiplier
  * @returns A color or undefined if the default color should be used
  */
-export function getTypeDamageMultiplierColor(
-  multiplier: TypeDamageMultiplier,
-  side: "defense" | "offense",
-): string | undefined {
+export function getTypeDamageMultiplierColor(multiplier: TypeDamageMultiplier): string | undefined {
   const effectivenessMap: Record<TypeDamageMultiplier, string | undefined> = {
-    0: side === "offense" ? TypeEffectivenessColor.NO_EFFECT : TypeEffectivenessColor.DEFENSE_NO_EFFECT,
-    0.125: side === "offense" ? TypeEffectivenessColor.VERY_RESISTED : TypeEffectivenessColor.DEFENSE_VERY_RESISTED,
-    0.25: side === "offense" ? TypeEffectivenessColor.RESISTED : TypeEffectivenessColor.DEFENSE_RESISTED,
-    0.5:
-      side === "offense"
-        ? TypeEffectivenessColor.NOT_VERY_EFFECTIVE
-        : TypeEffectivenessColor.DEFENSE_NOT_VERY_EFFECTIVE,
+    0: TypeEffectivenessColor.NO_EFFECT,
+    0.125: TypeEffectivenessColor.VERY_RESISTED,
+    0.25: TypeEffectivenessColor.RESISTED,
+    0.5: TypeEffectivenessColor.NOT_VERY_EFFECTIVE,
     1: undefined,
-    2: side === "offense" ? TypeEffectivenessColor.SUPER_EFFECTIVE : TypeEffectivenessColor.DEFENSE_SUPER_EFFECTIVE,
-    4:
-      side === "offense"
-        ? TypeEffectivenessColor.VERY_SUPER_EFFECTIVE
-        : TypeEffectivenessColor.DEFENSE_VERY_SUPER_EFFECTIVE,
-    8:
-      side === "offense"
-        ? TypeEffectivenessColor.MAX_SUPER_EFFECTIVE
-        : TypeEffectivenessColor.DEFENSE_MAX_SUPER_EFFECTIVE,
+    2: TypeEffectivenessColor.SUPER_EFFECTIVE,
+    4: TypeEffectivenessColor.DOUBLE_SUPER_EFFECTIVE,
+    8: TypeEffectivenessColor.QUAD_SUPER_EFFECTIVE,
+    16: TypeEffectivenessColor.MAX_SUPER_EFFECTIVE,
   };
 
   return effectivenessMap[multiplier];

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -285,14 +285,21 @@ export function getTypeDamageMultiplierColor(
         ? TypeEffectivenessColor.NOT_VERY_EFFECTIVE
         : TypeEffectivenessColor.DEFENSE_NOT_VERY_EFFECTIVE,
     1: undefined,
-    2: TypeEffectivenessColor.SUPER_EFFECTIVE,
-    4: TypeEffectivenessColor.VERY_SUPER_EFFECTIVE,
-    8: TypeEffectivenessColor.MAX_SUPER_EFFECTIVE,
+    2: side === "offense" ? TypeEffectivenessColor.SUPER_EFFECTIVE : TypeEffectivenessColor.DEFENSE_SUPER_EFFECTIVE,
+    4:
+      side === "offense"
+        ? TypeEffectivenessColor.VERY_SUPER_EFFECTIVE
+        : TypeEffectivenessColor.DEFENSE_VERY_SUPER_EFFECTIVE,
+    8:
+      side === "offense"
+        ? TypeEffectivenessColor.MAX_SUPER_EFFECTIVE
+        : TypeEffectivenessColor.DEFENSE_MAX_SUPER_EFFECTIVE,
   };
 
   return effectivenessMap[multiplier];
 }
 
+/** @todo Normalize all RGB/Hexcode colors to the same system */
 export function getTypeRgb(type: ElementalType): [number, number, number] {
   switch (type) {
     case ElementalType.NORMAL:

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -210,6 +210,8 @@ export enum TypeEffectivenessColor {
   /** #929292 */
   NO_EFFECT = "#929292", // Grey (0x)
 
+  /** #ff3500 */
+  MAX_RESISTED = "#ff3500", // Mostly Red (0.0625x) - not possible?
   /** #ff5500 */
   VERY_RESISTED = "#ff5500", // Deep Orange (0.125x)
   /** #ff7400 */
@@ -220,23 +222,9 @@ export enum TypeEffectivenessColor {
   /** #4aa500 */
   SUPER_EFFECTIVE = "#4aa500", // Deep Green (2x)
   /** #4bb400 */
-  VERY_SUPER_EFFECTIVE = "#4bb400", // Brighter Green (4x)
+  DOUBLE_SUPER_EFFECTIVE = "#4bb400", // Green (4x)
   /** #52c200 */
-  MAX_SUPER_EFFECTIVE = "#52c200", // Most vibrant Green (8x)
-
-  /** #b1b100 */
-  DEFENSE_NO_EFFECT = "#b1b100", // Mustard Yellow (0x)
-  /** #2db4ff */
-  DEFENSE_VERY_RESISTED = "#2db4ff", // Light Blue (0.125x)
-  /** #00a4ff */
-  DEFENSE_RESISTED = "#00a4ff", // Brighter Blue (0.25x)
-  /** #0093ff */
-  DEFENSE_NOT_VERY_EFFECTIVE = "#0093ff", // Deep Blue (0.5x)
-
-  /** #fe8e00 - Currently equivalent to `NOT_VERY_EFFECTIVE` */
-  DEFENSE_SUPER_EFFECTIVE = "#fe8e00", // Warm Orange (2x)
-  /** #ff7400 - Currently equivalent to `RESISTED` */
-  DEFENSE_VERY_SUPER_EFFECTIVE = "#ff7400", // Bright Orange (4x)
-  /** #ff5500 - Currently equivalent to `VERY_RESISTED` */
-  DEFENSE_MAX_SUPER_EFFECTIVE = "#ff5500", // Deep Orange (8x)
+  QUAD_SUPER_EFFECTIVE = "#52c200", // Bright Green (8x)
+  /** #61e000 */
+  MAX_SUPER_EFFECTIVE = "#61e000", // Vibrant Green (16x)
 }

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -45,9 +45,9 @@ export enum CommonColor {
 
   // Greens
   /** #008000 */
-  LIGHT_GREEN = "#008000",
+  PURE_GREEN = "#008000",
   /** #58d858 */
-  PURE_GREEN = "#58d858",
+  LIGHT_GREEN = "#58d858",
 
   // Blues
   /** #40c8f8 */

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -232,4 +232,11 @@ export enum TypeEffectivenessColor {
   DEFENSE_RESISTED = "#00a4ff", // Brighter Blue (0.25x)
   /** #0093ff */
   DEFENSE_NOT_VERY_EFFECTIVE = "#0093ff", // Deep Blue (0.5x)
+
+  /** #FE8E00 - Currently equivalent to `NOT_VERY_EFFECTIVE` */
+  DEFENSE_SUPER_EFFECTIVE = "#FE8E00", // Warm Orange (2x)
+  /** #FF7400 - Currently equivalent to `RESISTED` */
+  DEFENSE_VERY_SUPER_EFFECTIVE = "#FF7400", // Orange (4x)
+  /** #FF5500 - Currently equivalent to `VERY_RESISTED` */
+  DEFENSE_MAX_SUPER_EFFECTIVE = "#FF5500", // Deep Orange (8x)
 }

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -1,137 +1,235 @@
 export enum CommonColor {
+  /** #ffffff */
   WHITE = "#ffffff",
+  /** #f8f8f8 */
   OFF_WHITE = "#f8f8f8",
+  /** #a0a0a0 */
   LIGHT_GREY = "#a0a0a0",
+  /** #484848 */
   GREY = "#484848",
+  /** #404040 */
   DARK_GREY = "#404040",
 
   // Reds & Pinks
+  /** #f89890 */
   SOFT_PINK = "#f89890",
+  /** #f88880 */
   CORAL_PINK = "#f88880",
+  /** #f85888 */
   BRIGHT_PINK = "#f85888",
+  /** #ff0000 */
   PURE_RED = "#ff0000",
+  /** #e13d3d */
   WARM_RED = "#e13d3d",
+  /** #e70808 */
   DEEP_RED = "#e70808",
 
+  /** #a040a0 */
   VIBRANT_PURPLE = "#a040a0",
 
   // Oranges & Yellows
+  /** #f8b050 */
   SOFT_ORANGE = "#f8b050",
+  /** #f08030 */
   BRIGHT_ORANGE = "#f08030",
+  /** #d64b00 */
   DEEP_ORANGE = "#d64b00",
+  /** #f8d030 */
   GOLD_YELLOW = "#f8d030",
+  /** #e8e8a8 */
   MUTED_YELLOW = "#e8e8a8",
+  /** #ccbe00 */
   DEEP_YELLOW = "#ccbe00",
+  /** #a68e17 */
   DARK_YELLOW = "#a68e17",
 
   // Greens
+  /** #008000 */
   LIGHT_GREEN = "#008000",
+  /** #58d858 */
   PURE_GREEN = "#58d858",
 
   // Blues
+  /** #40c8f8 */
   LIGHT_BLUE = "#40c8f8",
+  /** #6890f0 */
   SOFT_BLUE = "#6890f0",
 
+  /** #3890f8 */
   GREAT = "#3890f8",
+  /** #f8d038 */
   ULTRA = "#f8d038",
+  /** #e020c0 */
   MASTER = "#e020c0",
+  /** #e64a18 */
   LUXURY = "#e64a18",
 }
 
 export enum TypeColor {
+  /** #ada594 */
   NORMAL = "#ada594",
+  /** #a55239 */
   FIGHTING = "#a55239",
+  /** #9cadf7 */
   FLYING = "#9cadf7",
+  /** #9141cb */
   POISON = "#9141cb",
+  /** #ae7a3b */
   GROUND = "#ae7a3b",
+  /** #bda55a */
   ROCK = "#bda55a",
+  /** #adbd21 */
   BUG = "#adbd21",
+  /** #6363b5 */
   GHOST = "#6363b5",
+  /** #81a6be */
   STEEL = "#81a6be",
+  /** #f75231 */
   FIRE = "#f75231",
+  /** #399cff */
   WATER = "#399cff",
+  /** #7bce52 */
   GRASS = "#7bce52",
+  /** #ffc631 */
   ELECTRIC = "#ffc631",
+  /** #ef4179 */
   PSYCHIC = "#ef4179",
+  /** #5acee7 */
   ICE = "#5acee7",
+  /** #7b63e7 */
   DRAGON = "#7b63e7",
+  /** #735a4a */
   DARK = "#735a4a",
+  /** #ef70ef */
   FAIRY = "#ef70ef",
 }
 
 export enum TypeShadowColor {
+  /** #574f4a */
   NORMAL = "#574f4a",
+  /** #4e637c */
   FIGHTING = "#4e637c",
+  /** #4e637c */
   FLYING = "#4e637c",
+  /** #352166 */
   POISON = "#352166",
+  /** #572d1e */
   GROUND = "#572d1e",
+  /** #5f442d */
   ROCK = "#5f442d",
+  /** #5f5010 */
   BUG = "#5f5010",
+  /** #323d5b */
   GHOST = "#323d5b",
+  /** #415c5f */
   STEEL = "#415c5f",
+  /** #7c1818 */
   FIRE = "#7c1818",
+  /** #1c4e80 */
   WATER = "#1c4e80",
+  /** #4f6729 */
   GRASS = "#4f6729",
+  /** #804618 */
   ELECTRIC = "#804618",
+  /** #782155 */
   PSYCHIC = "#782155",
+  /** #2d5c74 */
   ICE = "#2d5c74",
+  /** #313874 */
   DRAGON = "#313874",
+  /** #392725 */
   DARK = "#392725",
+  /** #663878 */
   FAIRY = "#663878",
 }
 
 export enum ShadowColor {
+  /** #d0d0c8 */
   LIGHT_GREY = "#d0d0c8",
+  /** #636363 */
   GREY = "#636363",
+  /** #707070 */
   MEDIUM_GRAY = "#707070",
+  /** #807870 */
   DARK_GREY = "#807870",
 
   // Browns
+  /** #69402a */
   LIGHT_BROWN = "#69402a",
+  /** #632929 */
   DARK_BROWN = "#632929",
+  /** #6e672c */
   OLIVE_BRONZE = "#6e672c",
 
   // Purples
+  /** #483850 */
   DARK_PURPLE = "#483850",
+  /** #6b5a73 */
   PURPLE = "#6b5a73",
 
   // Reds
+  /** #fca2a2 */
   LIGHT_RED = "#fca2a2",
+  /** #f83018 */
   BRIGHT_RED = "#f83018",
+  /** #984038 */
   DEEP_RED = "#984038",
+  /** #c03028 */
   DARK_RED = "#c03028",
+  /** #906060 */
   DUSTY_ROSE = "#906060",
 
   // Greens
+  /** #306850 */
   SOFT_GREEN = "#306850",
+  /** #588040 */
   MUTED_GREEN = "#588040",
 
   // Blues
+  /** #006090 */
   LIGHT_BLUE = "#006090",
 
   // Yellows and Oranges
+  /** #ded6b5 */
   LIGHT_YELLOW = "#ded6b5",
+  /** #ebd773 */
   YELLOW = "#ebd773",
+  /** #a0a060 */
   DARK_YELLOW = "#a0a060",
+  /** #b8a038 */
   MUTED_GOLD = "#b8a038",
+  /** #c07800 */
   ORANGE = "#c07800",
+  /** #ffbd73 */
   LIGHT_ORANGE = "#ffbd73",
+  /** #f7b18b */
   PEACH_SAND = "#f7b18b",
 }
 
 export enum TypeEffectivenessColor {
+  /** #929292 */
   NO_EFFECT = "#929292", // Grey (0x)
 
+  /** #ff5500 */
   VERY_RESISTED = "#ff5500", // Deep Orange (0.125x)
+  /** #ff7400 */
   RESISTED = "#ff7400", // Bright Orange (0.25x)
+  /** #fe8e00 */
   NOT_VERY_EFFECTIVE = "#fe8e00", // Warm Orange (0.5x)
 
+  /** #4aa500 */
   SUPER_EFFECTIVE = "#4aa500", // Deep Green (2x)
+  /** #4bb400 */
   VERY_SUPER_EFFECTIVE = "#4bb400", // Brighter Green (4x)
+  /** #52c200 */
   MAX_SUPER_EFFECTIVE = "#52c200", // Most vibrant Green (8x)
 
+  /** #b1b100 */
   DEFENSE_NO_EFFECT = "#b1b100", // Mustard Yellow (0x)
+  /** #2db4ff */
   DEFENSE_VERY_RESISTED = "#2db4ff", // Light Blue (0.125x)
+  /** #00a4ff */
   DEFENSE_RESISTED = "#00a4ff", // Brighter Blue (0.25x)
+  /** #0093ff */
   DEFENSE_NOT_VERY_EFFECTIVE = "#0093ff", // Deep Blue (0.5x)
 }

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -233,10 +233,10 @@ export enum TypeEffectivenessColor {
   /** #0093ff */
   DEFENSE_NOT_VERY_EFFECTIVE = "#0093ff", // Deep Blue (0.5x)
 
-  /** #FE8E00 - Currently equivalent to `NOT_VERY_EFFECTIVE` */
-  DEFENSE_SUPER_EFFECTIVE = "#FE8E00", // Warm Orange (2x)
-  /** #FF7400 - Currently equivalent to `RESISTED` */
-  DEFENSE_VERY_SUPER_EFFECTIVE = "#FF7400", // Orange (4x)
-  /** #FF5500 - Currently equivalent to `VERY_RESISTED` */
-  DEFENSE_MAX_SUPER_EFFECTIVE = "#FF5500", // Deep Orange (8x)
+  /** #fe8e00 - Currently equivalent to `NOT_VERY_EFFECTIVE` */
+  DEFENSE_SUPER_EFFECTIVE = "#fe8e00", // Warm Orange (2x)
+  /** #ff7400 - Currently equivalent to `RESISTED` */
+  DEFENSE_VERY_SUPER_EFFECTIVE = "#ff7400", // Bright Orange (4x)
+  /** #ff5500 - Currently equivalent to `VERY_RESISTED` */
+  DEFENSE_MAX_SUPER_EFFECTIVE = "#ff5500", // Deep Orange (8x)
 }

--- a/src/enums/color.ts
+++ b/src/enums/color.ts
@@ -46,8 +46,8 @@ export enum CommonColor {
   // Greens
   /** #008000 */
   PURE_GREEN = "#008000",
-  /** #58d858 */
-  LIGHT_GREEN = "#58d858",
+  /** #78c850 */
+  LIGHT_GREEN = "#78c850",
 
   // Blues
   /** #40c8f8 */

--- a/src/ui/fight-ui-handler.ts
+++ b/src/ui/fight-ui-handler.ts
@@ -343,7 +343,7 @@ export default class FightUiHandler extends UiHandler implements InfoToggle {
     const moveColors = opponents
       .map((opponent) => opponent.getMoveEffectiveness(pokemon, pokemonMove.getMove(), AbilityApplyMode.REVEALED))
       .sort((a, b) => b - a)
-      .map((effectiveness) => getTypeDamageMultiplierColor(effectiveness ?? 0, "offense"));
+      .map((effectiveness) => getTypeDamageMultiplierColor(effectiveness ?? 0));
 
     return moveColors[0];
   }

--- a/src/ui/run-info-ui-handler.ts
+++ b/src/ui/run-info-ui-handler.ts
@@ -796,7 +796,7 @@ export default class RunInfoUiHandler extends UiHandler {
       pokemon.stats.forEach((element) => pStats.push(formatFancyLargeNumber(element, 1)));
       for (let i = 0; i < pStats.length; i++) {
         const isMult = getNatureStatMultiplier(pNature, i);
-        pStats[i] = isMult < 1 ? pStats[i] + `[color=${CommonColor.LIGHT_BLUE}↓[/color]` : pStats[i];
+        pStats[i] = isMult < 1 ? pStats[i] + `[color=${CommonColor.LIGHT_BLUE}]↓[/color]` : pStats[i];
         pStats[i] = isMult > 1 ? pStats[i] + `[color=${CommonColor.SOFT_PINK}]↑[/color]` : pStats[i];
       }
       const hp = i18next.t("pokemonInfo:Stat.HPshortened") + ": " + pStats[0];


### PR DESCRIPTION
## What are the changes the user will see?
Fixed a couple of colors.

## Why am I making these changes?
Ease of looking up what color corresponds to what hexcode.

## What are the changes from a developer perspective?
Added the hexcode for each enum value to its tsdoc.
Swapped `CommonColor.PURE_GREEN` and `CommonColor.LIGHT_GREEN` values so they are no longer reversed and fixed the Light Green hexcode.
Added missing `TypeEffectivenessColor` enum values.
Fixed non-shadow color for `GrowthRate.ERRATIC` in `src/data/exp.ts`.

## Screenshots/Videos
<details><summary>CommonColor enum</summary>
<p>

![image](https://github.com/user-attachments/assets/0c3d1a56-e3e2-4504-9796-694c105e992a)

</p>
</details>
<details><summary>TypeColor enum</summary>
<p>

![image](https://github.com/user-attachments/assets/db9f2db9-b008-47bf-bce9-2e344386a991)

</p>
</details> 
<details><summary>TypeShadowColor enum</summary>
<p>

![image](https://github.com/user-attachments/assets/e9c0abfd-0d5e-4666-b9a2-fd9194c4a216)

</p>
</details> 
<details><summary>ShadowColor enum</summary>
<p>

![image](https://github.com/user-attachments/assets/98d4f424-019e-4b8b-ba45-da3b3d8c2ba1)

</p>
</details> 
<details><summary>TypeEffectivenessColor enum</summary>
<p>

![image](https://github.com/user-attachments/assets/3eaa0fc9-0ff6-4b6d-aa82-292c04264b9d)

</p>
</details>

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?