### PR TITLE
[Bug] Fix calculation of move base power

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -757,6 +757,10 @@ export abstract class Move implements Localizable {
 
     applyAbAttrs(AbAttrFlag.MOVE_TYPE_CHANGE, source, true, this, target, undefined, typeChangeMovePowerMultiplier);
 
+    applyMoveAttrs(VariablePowerAttr, source, target, this, power);
+
+    applyAbAttrs(AbAttrFlag.VARIABLE_MOVE_POWER, source, simulated, this, target, power);
+
     const sourceTeraType = source.getTeraType();
     if (
       sourceTeraType !== ElementalType.UNKNOWN
@@ -768,8 +772,6 @@ export abstract class Move implements Localizable {
     ) {
       power.value = 60;
     }
-
-    applyAbAttrs(AbAttrFlag.VARIABLE_MOVE_POWER, source, simulated, this, target, power);
 
     if (source.getAlly()) {
       applyAbAttrs(AbAttrFlag.ALLY_MOVE_CATEGORY_POWER_BOOST, source.getAlly(), simulated, this, target, power);
@@ -802,8 +804,6 @@ export abstract class Move implements Localizable {
     if (typeBoost) {
       power.value *= typeBoost.boostValue;
     }
-
-    applyMoveAttrs(VariablePowerAttr, source, target, this, power);
 
     if (!this.hasAttr(TypelessAttr)) {
       globalScene.arena.applyTags([...WeakenMoveTypeArenaTagTypes], simulated, this.type, power);

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -1,47 +1,51 @@
-import { BattlerIndex } from "#enums/battler-index";
+import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import { FOG_ACCURACY_MULTIPLIER } from "#app/constants";
+import type { AllyMoveCategoryPowerBoostAbAttr } from "#app/data/abilities/ab-attrs/ally-move-category-power-boost-ab-attr";
+import type { FieldMoveTypePowerBoostAbAttr } from "#app/data/abilities/ab-attrs/field-move-type-power-boost-ab-attr";
+import type { MoveTypeChangeAbAttr } from "#app/data/abilities/ab-attrs/move-type-change-ab-attr";
+import type { UserFieldMoveTypePowerBoostAbAttr } from "#app/data/abilities/ab-attrs/user-field-move-type-power-boost-ab-attr";
+import type { VariableMovePowerAbAttr } from "#app/data/abilities/ab-attrs/variable-move-power-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import { type TypeBoostTag } from "#app/data/battler-tags/type-boost-tag";
+import { allMoves } from "#app/data/data-lists";
+import type { ChargingAttackMove } from "#app/data/moves/charging-attack-move";
+import type { ChargingSelfStatusMove } from "#app/data/moves/charging-self-status-move";
+import { GMaxPowerAttr } from "#app/data/moves/move-attrs/gmax-power-attr";
+import { IncrementMovePriorityAttr } from "#app/data/moves/move-attrs/increment-move-priority-attr";
+import type { MoveAttr } from "#app/data/moves/move-attrs/move-attr";
+import { MultiHitAttr } from "#app/data/moves/move-attrs/multi-hit-attr";
+import { OneHitKOAccuracyAttr } from "#app/data/moves/move-attrs/one-hit-ko-accuracy-attr";
+import { SacrificialAttr } from "#app/data/moves/move-attrs/sacrificial-attr";
+import { StatStageChangeAttr } from "#app/data/moves/move-attrs/stat-stage-change-attr";
+import { TypelessAttr } from "#app/data/moves/move-attrs/typeless-attr";
+import { UseHigherAttackingStatAttr } from "#app/data/moves/move-attrs/use-higher-attacking-stat-attr";
+import { VariableAccuracyAttr } from "#app/data/moves/move-attrs/variable-accuracy-attr";
+import { VariablePowerAttr } from "#app/data/moves/move-attrs/variable-power-attr";
+import { VariableTargetAttr } from "#app/data/moves/move-attrs/variable-target-attr";
+import { MoveCondition } from "#app/data/moves/move-conditions/move-condition";
 import { type Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import type { Localizable } from "#app/interfaces/locales";
 import { AttackTypeBoosterModifier } from "#app/modifier/modifier";
 import type { AbstractConstructor, Constructor, nil } from "#app/utils";
 import { BooleanHolder, NumberHolder } from "#app/utils";
-import { Abilities } from "#enums/abilities";
-import { ArenaTagType } from "#enums/arena-tag-type";
 import { WeakenMoveTypeArenaTagTypes } from "#app/utils/arena-tag-type-utils";
+import { applyMoveAttrs } from "#app/utils/move-utils";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { Abilities } from "#enums/abilities";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveCategory } from "#enums/move-category";
 import { MoveFlags } from "#enums/move-flags";
-import { MoveTarget } from "#enums/move-target";
 import { MoveId } from "#enums/move-id";
-import { ElementalType } from "#enums/elemental-type";
+import { MoveTarget } from "#enums/move-target";
+import type { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
 import { WeatherType } from "#enums/weather-type";
 import i18next from "i18next";
-import { type FieldMoveTypePowerBoostAbAttr } from "#app/data/abilities/ab-attrs/field-move-type-power-boost-ab-attr";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { type TypeBoostTag } from "#app/data/battler-tags/type-boost-tag";
-import { IncrementMovePriorityAttr } from "#app/data/moves/move-attrs/increment-move-priority-attr";
-import type { MoveAttr } from "#app/data/moves/move-attrs/move-attr";
-import { MultiHitAttr } from "#app/data/moves/move-attrs/multi-hit-attr";
-import { OneHitKOAccuracyAttr } from "#app/data/moves/move-attrs/one-hit-ko-accuracy-attr";
-import { SacrificialAttr } from "#app/data/moves/move-attrs/sacrificial-attr";
-import { TypelessAttr } from "#app/data/moves/move-attrs/typeless-attr";
-import { VariableAccuracyAttr } from "#app/data/moves/move-attrs/variable-accuracy-attr";
-import { VariablePowerAttr } from "#app/data/moves/move-attrs/variable-power-attr";
-import { VariableTargetAttr } from "#app/data/moves/move-attrs/variable-target-attr";
-import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
-import { MoveCondition } from "#app/data/moves/move-conditions/move-condition";
-import { Stat } from "#enums/stat";
-import { allMoves } from "#app/data/data-lists";
-import { UseHigherAttackingStatAttr } from "#app/data/moves/move-attrs/use-higher-attacking-stat-attr";
-import { GMaxPowerAttr } from "#app/data/moves/move-attrs/gmax-power-attr";
-import type { Species } from "#enums/species";
-import { StatStageChangeAttr } from "#app/data/moves/move-attrs/stat-stage-change-attr";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
-import { applyMoveAttrs } from "#app/utils/move-utils";
-import type { ChargingAttackMove } from "#app/data/moves/charging-attack-move";
-import type { ChargingSelfStatusMove } from "#app/data/moves/charging-self-status-move";
-import { FOG_ACCURACY_MULTIPLIER } from "#app/constants";
 
 export abstract class Move implements Localizable {
   public id: MoveId;
@@ -755,11 +759,19 @@ export abstract class Move implements Localizable {
     const power = new NumberHolder(this.power);
     const typeChangeMovePowerMultiplier = new NumberHolder(1);
 
-    applyAbAttrs(AbAttrFlag.MOVE_TYPE_CHANGE, source, true, this, target, undefined, typeChangeMovePowerMultiplier);
+    applyAbAttrs<MoveTypeChangeAbAttr>(
+      AbAttrFlag.MOVE_TYPE_CHANGE,
+      source,
+      true,
+      this,
+      target,
+      undefined,
+      typeChangeMovePowerMultiplier,
+    );
 
     applyMoveAttrs(VariablePowerAttr, source, target, this, power);
 
-    applyAbAttrs(AbAttrFlag.VARIABLE_MOVE_POWER, source, simulated, this, target, power);
+    applyAbAttrs<VariableMovePowerAbAttr>(AbAttrFlag.VARIABLE_MOVE_POWER, source, simulated, this, target, power);
 
     const sourceTeraType = source.getTeraType();
     if (
@@ -774,7 +786,14 @@ export abstract class Move implements Localizable {
     }
 
     if (source.getAlly()) {
-      applyAbAttrs(AbAttrFlag.ALLY_MOVE_CATEGORY_POWER_BOOST, source.getAlly(), simulated, this, target, power);
+      applyAbAttrs<AllyMoveCategoryPowerBoostAbAttr>(
+        AbAttrFlag.ALLY_MOVE_CATEGORY_POWER_BOOST,
+        source.getAlly(),
+        simulated,
+        this,
+        target,
+        power,
+      );
     }
 
     const fieldAuras = new Set(
@@ -782,7 +801,7 @@ export abstract class Move implements Localizable {
         .getField(true)
         .map(
           (p) =>
-            p.getAbilityAttrs(AbAttrFlag.FIELD_MOVE_TYPE_POWER_BOOST).filter((attr) => {
+            p.getAbilityAttrs<FieldMoveTypePowerBoostAbAttr>(AbAttrFlag.FIELD_MOVE_TYPE_POWER_BOOST).filter((attr) => {
               const condition = attr.getCondition();
               return !condition || condition(p);
             }) as FieldMoveTypePowerBoostAbAttr[],
@@ -795,7 +814,14 @@ export abstract class Move implements Localizable {
 
     const alliedField: Pokemon[] = source.getField();
     alliedField.forEach((p) =>
-      applyAbAttrs(AbAttrFlag.USER_FIELD_MOVE_TYPE_POWER_BOOST, p, simulated, this, target, power),
+      applyAbAttrs<UserFieldMoveTypePowerBoostAbAttr>(
+        AbAttrFlag.USER_FIELD_MOVE_TYPE_POWER_BOOST,
+        p,
+        simulated,
+        this,
+        target,
+        power,
+      ),
     );
 
     power.value *= typeChangeMovePowerMultiplier.value;

--- a/test/battle/damage-calculation.test.ts
+++ b/test/battle/damage-calculation.test.ts
@@ -1,6 +1,8 @@
 import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -112,5 +114,71 @@ describe("Battle Mechanics - Damage Calculation", () => {
     } else {
       expect(charizard.hp).toBe(charizard.getMaxHp() / 2);
     }
+  });
+});
+
+describe("Base Power Calculation", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(Species.SNORLAX)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .disableCrits();
+  });
+
+  it("calculates move modifiers before ability modifiers", async () => {
+    game.override.ability(Abilities.AERILATE);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const crushGrip = allMoves.get(MoveId.CRUSH_GRIP);
+    vi.spyOn(crushGrip, "calculateBattlePower");
+
+    game.move.use(MoveId.CRUSH_GRIP);
+    await game.toNextTurn();
+
+    expect(crushGrip.calculateBattlePower).toHaveLastReturnedWith(144);
+  });
+
+  it("calculates Tera power boost after Technician boost", async () => {
+    game.override.ability(Abilities.TECHNICIAN).startingHeldItems([{ name: "TERA_SHARD", type: ElementalType.NORMAL }]);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const tackle = allMoves.get(MoveId.TACKLE);
+    vi.spyOn(tackle, "calculateBattlePower");
+
+    game.move.use(MoveId.TACKLE);
+    await game.toNextTurn();
+
+    expect(tackle.calculateBattlePower).toHaveLastReturnedWith(60);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.heal(1000);
+
+    const wrap = allMoves.get(MoveId.WRAP);
+    vi.spyOn(wrap, "calculateBattlePower");
+
+    game.move.use(MoveId.WRAP);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    await game.move.forceHit();
+    await game.toNextTurn();
+
+    expect(wrap.calculateBattlePower).toHaveLastReturnedWith(60);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Moves with variable base power like Crush Grip will calculate their base power correctly when the user is Terastallized.
The base power boost from Technician will now apply before the boost from Terastallization.

## Why am I making these changes?
Move base power calculation is incorrect.
> Additionally, moves of the Tera Type that have a [base power](https://bulbapedia.bulbagarden.net/wiki/Base_power) below 60 are increased to 60 base power; this is checked for after [Technician](https://bulbapedia.bulbagarden.net/wiki/Technician_(Ability))'s boost [[3]](https://bulbapedia.bulbagarden.net/wiki/Terastal_phenomenon#cite_note-3).

Also fixes #862 

## What are the changes from a developer perspective?
Moved application of `VariablePowerAttr` and `VariableMovePowerAbAttr` to before Terastallization base power boost.
Some tests added for base power calculation.

## How to test the changes?
`npm run test damage-calculation`

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?