### PR TITLE
[P2] HA Giratina no longer loses HA when going from origin->altered

### DIFF
--- a/src/data/init-species.ts
+++ b/src/data/init-species.ts
@@ -16460,7 +16460,7 @@ export function initSpecies() {
         650,
         Abilities.LEVITATE,
         Abilities.NONE,
-        Abilities.NONE,
+        Abilities.LEVITATE,
         680,
         150,
         120,


### PR DESCRIPTION
## What are the changes the user will see?

A HA Giratina that goes from altered->origin and then origin->altered will keep its HA

## Why am I making these changes?

https://github.com/Despair-Games/poketernity/issues/589

## What are the changes from a developer perspective?

Changed Origin Giratina's HA to LEVITATE instead of NONE

## Screenshots/Videos

n/a

## How to test the changes?

```ts
const overrides = {
  STARTER_SPECIES_OVERRIDE: Species.GIRATINA,
  STARTING_LEVEL_OVERRIDE:1000,
  STARTING_WAVE_OVERRIDE: 196,
  ITEM_REWARD_OVERRIDE: [{name:"FORM_CHANGE_ITEM"}, {name: "RARE_FORM_CHANGE_ITEM"}],
}
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
