### PR TITLE
[Move] Add `edgeCase` to moves with "unselectable" conditions

### DIFF
--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -1553,7 +1553,7 @@ export function initMoves() {
       .ignoresProtect()
       .attr(AddArenaTagAttr, ArenaTagType.GRAVITY, ArenaTagRelativeSide.ALL, { turnCount: 5 })
       .target(MoveTarget.BOTH_SIDES)
-      .partial(), // does not prevent Bounce, Fly, etc. from being selected; only causes the moves to fail.
+      .edgeCase(), // does not prevent Bounce, Fly, etc. from being selected; only causes the moves to fail.
     new StatusMove(MoveId.MIRACLE_EYE, ElementalType.PSYCHIC, -1, 40, -1, 0, 4)
       .attr(ExposedMoveAttr, BattlerTagType.IGNORE_DARK)
       .ignoresSubstitute(),
@@ -3702,7 +3702,7 @@ export function initMoves() {
     new AttackMove(MoveId.G_MAX_GRAVITAS, ElementalType.PSYCHIC, MoveCategory.SPECIAL, 80, -1, 3, -1, 0, 8)
       .gMaxMove(Species.ORBEETLE)
       .attr(AddArenaTagAttr, ArenaTagType.GRAVITY, ArenaTagRelativeSide.ALL, { turnCount: 5 })
-      .partial(), // does not prevent Bounce, Fly, etc. from being selected; only causes the moves to fail.
+      .edgeCase(), // does not prevent Bounce, Fly, etc. from being selected; only causes the moves to fail.
     new AttackMove(MoveId.G_MAX_VOLCALITH, ElementalType.ROCK, MoveCategory.PHYSICAL, 80, -1, 3, -1, 0, 8)
       .gMaxMove(Species.COALOSSAL)
       .attr(AddArenaTagAttr, ArenaTagType.G_MAX_VOLCALITH),

--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -3957,7 +3957,8 @@ export function initMoves() {
       .condition((user, _target, move) => {
         const turnMove = user.getLastXMoves(1);
         return !turnMove.length || turnMove[0].move.id !== move.id || turnMove[0].result !== MoveResult.SUCCESS;
-      }), // TODO Add Instruct/Encore interaction
+      }) // TODO Add Instruct/Encore interaction
+      .edgeCase(), // should be unselectable the turn after its used
     new AttackMove(MoveId.COMEUPPANCE, ElementalType.DARK, MoveCategory.PHYSICAL, -1, 100, 10, -1, 0, 9)
       .attr(CounterDamageAttr, (moveId) => allMoves[moveId].isAttackMove(), 1.5)
       .redirectCounter()
@@ -3981,12 +3982,12 @@ export function initMoves() {
     new AttackMove(MoveId.MAGICAL_TORQUE, ElementalType.FAIRY, MoveCategory.PHYSICAL, 100, 100, 10, 30, 0, 9)
       .attr(ConfuseAttr)
       .makesContact(false),
-    new AttackMove(MoveId.BLOOD_MOON, ElementalType.NORMAL, MoveCategory.SPECIAL, 140, 100, 5, -1, 0, 9).condition(
-      (user, _target, move) => {
+    new AttackMove(MoveId.BLOOD_MOON, ElementalType.NORMAL, MoveCategory.SPECIAL, 140, 100, 5, -1, 0, 9)
+      .condition((user, _target, move) => {
         const turnMove = user.getLastXMoves(1);
         return !turnMove.length || turnMove[0].move.id !== move.id || turnMove[0].result !== MoveResult.SUCCESS;
-      },
-    ), // TODO Add Instruct/Encore interaction
+      }) // TODO Add Instruct/Encore interaction
+      .edgeCase(), // should be unselectable the turn after it's used
     new AttackMove(MoveId.MATCHA_GOTCHA, ElementalType.GRASS, MoveCategory.SPECIAL, 80, 90, 15, 20, 0, 9)
       .attr(HitHealAttr)
       .attr(HealStatusEffectAttr, true, StatusEffect.FREEZE)

--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -1552,7 +1552,8 @@ export function initMoves() {
     new StatusMove(MoveId.GRAVITY, ElementalType.PSYCHIC, -1, 5, -1, 0, 4)
       .ignoresProtect()
       .attr(AddArenaTagAttr, ArenaTagType.GRAVITY, ArenaTagRelativeSide.ALL, { turnCount: 5 })
-      .target(MoveTarget.BOTH_SIDES),
+      .target(MoveTarget.BOTH_SIDES)
+      .partial(), // does not prevent Bounce, Fly, etc. from being selected; only causes the moves to fail.
     new StatusMove(MoveId.MIRACLE_EYE, ElementalType.PSYCHIC, -1, 40, -1, 0, 4)
       .attr(ExposedMoveAttr, BattlerTagType.IGNORE_DARK)
       .ignoresSubstitute(),
@@ -3700,7 +3701,8 @@ export function initMoves() {
       .attr(AttackReducePpMoveAttr, 2),
     new AttackMove(MoveId.G_MAX_GRAVITAS, ElementalType.PSYCHIC, MoveCategory.SPECIAL, 80, -1, 3, -1, 0, 8)
       .gMaxMove(Species.ORBEETLE)
-      .attr(AddArenaTagAttr, ArenaTagType.GRAVITY, ArenaTagRelativeSide.ALL, { turnCount: 5 }),
+      .attr(AddArenaTagAttr, ArenaTagType.GRAVITY, ArenaTagRelativeSide.ALL, { turnCount: 5 })
+      .partial(), // does not prevent Bounce, Fly, etc. from being selected; only causes the moves to fail.
     new AttackMove(MoveId.G_MAX_VOLCALITH, ElementalType.ROCK, MoveCategory.PHYSICAL, 80, -1, 3, -1, 0, 8)
       .gMaxMove(Species.COALOSSAL)
       .attr(AddArenaTagAttr, ArenaTagType.G_MAX_VOLCALITH),


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

The current implementation for Gravity doesn't restrict move selection as it does in mainline, according to [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Gravity_(move)):

> Intense gravity also prevents Pokémon from using the moves [Bounce](https://bulbapedia.bulbagarden.net/wiki/Bounce_(move)), [Fly](https://bulbapedia.bulbagarden.net/wiki/Fly_(move)), [Flying Press](https://bulbapedia.bulbagarden.net/wiki/Flying_Press_(move)), [High Jump Kick](https://bulbapedia.bulbagarden.net/wiki/High_Jump_Kick_(move)), [Jump Kick](https://bulbapedia.bulbagarden.net/wiki/Jump_Kick_(move)), [Magnet Rise](https://bulbapedia.bulbagarden.net/wiki/Magnet_Rise_(move)), [Sky Drop](https://bulbapedia.bulbagarden.net/wiki/Sky_Drop_(move)), [Splash](https://bulbapedia.bulbagarden.net/wiki/Splash_(move)) and [Telekinesis](https://bulbapedia.bulbagarden.net/wiki/Telekinesis_(move)). If a Pokémon is in the semi-invulnerable turn of Fly or Bounce when Gravity is used, that move is canceled immediately. If a Pokémon has no other usable moves besides the moves blocked by Gravity, it will use [Struggle](https://bulbapedia.bulbagarden.net/wiki/Struggle_(move)).

Similarly, Gigaton Hammer and Blood Moon should not be selectable the turn after they are used. Stuff Cheeks is already marked with an `edgeCase` for similar reasons.

## What are the changes from a developer perspective?

Added `.edgeCase()` to the following moves' initializations with comments:
- Gravity
- G-max Gravitas
- Gigaton Hammer
- Blood Moon

## Screenshots/Videos

## How to test the changes?

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [?] Have I provided screenshots/videos of the changes (if applicable)?
  - [?] Have I made sure that any UI change works for both UI themes (default and legacy)?