### PR TITLE
[Move] Fully Implement Conversion 2

### DIFF
--- a/src/@types/TurnMove.ts
+++ b/src/@types/TurnMove.ts
@@ -1,11 +1,13 @@
 import type { Move } from "#app/data/move";
 import type { BattlerIndex } from "#enums/battler-index";
+import type { ElementalType } from "#enums/elemental-type";
 import type { MoveResult } from "#enums/move-result";
 
 export interface TurnMove {
   move: Move;
   targets?: BattlerIndex[];
   result: MoveResult;
+  type: ElementalType;
   virtual?: boolean;
   turn?: number;
 }

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -706,7 +706,11 @@ export class InterruptedTag extends BattlerTag {
     super.onAdd(pokemon);
 
     pokemon.getMoveQueue().shift();
-    pokemon.pushMoveHistory({ move: SelfStatusMove.none(), result: MoveResult.OTHER });
+    pokemon.pushMoveHistory({
+      move: SelfStatusMove.none(),
+      result: MoveResult.OTHER,
+      type: ElementalType.UNKNOWN,
+    });
   }
 
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {

--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -853,8 +853,7 @@ export function initMoves() {
     ),
     new StatusMove(MoveId.CONVERSION_2, ElementalType.NORMAL, -1, 30, -1, 0, 2)
       .attr(ResistLastMoveTypeAttr)
-      .ignoresSubstitute()
-      .partial(), // Checks the move's original typing and not if its type is changed through some other means
+      .ignoresSubstitute(),
     new AttackMove(MoveId.AEROBLAST, ElementalType.FLYING, MoveCategory.SPECIAL, 100, 95, 5, -1, 0, 2)
       .windMove()
       .attr(HighCritAttr),

--- a/src/data/move-attrs/delayed-attack-attr.ts
+++ b/src/data/move-attrs/delayed-attack-attr.ts
@@ -47,7 +47,12 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
           .replace("{TARGET}", getPokemonNameWithAffix(target))
           .replace("{USER}", getPokemonNameWithAffix(user)),
       );
-      user.pushMoveHistory({ move, targets: [target.getBattlerIndex()], result: MoveResult.OTHER });
+      user.pushMoveHistory({
+        move,
+        targets: [target.getBattlerIndex()],
+        result: MoveResult.OTHER,
+        type: user.getMoveType(move),
+      });
       // Add a Delayed Attack tag to the arena if it doesn't already exist
       globalScene.arena.addTag(ArenaTagType.DELAYED_ATTACK, user.id);
       // Queue an attack on the added (or existing) tag

--- a/src/data/move-attrs/resist-last-move-type-attr.ts
+++ b/src/data/move-attrs/resist-last-move-type-attr.ts
@@ -3,7 +3,7 @@ import type { Pokemon } from "#app/field/pokemon";
 import type { GameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { toReadableString, NumberHolder } from "#app/utils";
+import { NumberHolder } from "#app/utils";
 import i18next from "i18next";
 import { applyChallenges } from "#app/utils/challenge-utils";
 import { ChallengeType } from "#enums/challenge-type";
@@ -38,7 +38,7 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
     globalScene.queueMessage(
       i18next.t("battle:transformedIntoType", {
         pokemonName: getPokemonNameWithAffix(user),
-        type: toReadableString(ElementalType[type]),
+        type: i18next.t(`pokemonInfo:Type.${ElementalType[type]}`),
       }),
     );
     user.updateInfo();

--- a/src/data/move-attrs/resist-last-move-type-attr.ts
+++ b/src/data/move-attrs/resist-last-move-type-attr.ts
@@ -17,9 +17,6 @@ import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
  * Fails if the user already has ALL types that resist the target's last used move.
  * Fails if the opponent has not used a move yet
  * Fails if the type is unknown or stellar
- *
- * TODO:
- * If a move has its type changed (e.g. {@linkcode MoveId.HIDDEN_POWER}), it will check the new type.
  */
 export class ResistLastMoveTypeAttr extends MoveEffectAttr {
   constructor() {
@@ -32,17 +29,10 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
       return false;
     }
 
-    const moveData = targetMove.move;
-    if (!moveData || [ElementalType.STELLAR, ElementalType.UNKNOWN].includes(moveData.type)) {
-      return false;
-    }
+    const moveType = targetMove.type;
     const userTypes = user.getTypes();
-    const validTypes = this.getTypeResistances(globalScene.gameMode, moveData.type).filter(
-      (t) => !userTypes.includes(t),
-    ); // valid types are ones that are not already the user's types
-    if (!validTypes.length) {
-      return false;
-    }
+    const validTypes = this.getTypeResistances(globalScene.gameMode, moveType).filter((t) => !userTypes.includes(t));
+
     const type = validTypes[user.randSeedInt(validTypes.length)];
     user.summonData.types = [type];
     globalScene.queueMessage(
@@ -75,10 +65,26 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
     return typeResistances;
   }
 
+  /**
+   * This move fails if:
+   * - The target hasn't moved yet
+   * - The target's last move was either typeless or Stellar-type
+   * - The user is already of all types that resist the target's last move
+   */
   override getCondition(): MoveConditionFunc {
-    return (_user, target, _move) => {
-      const moveHistory = target.getLastXMoves();
-      return moveHistory.length !== 0;
+    return (user, target, _move) => {
+      const [targetMove] = target.getLastXMoves();
+      if (!targetMove) {
+        return false;
+      }
+
+      const { move: moveData, type: moveType } = targetMove;
+      if (!moveData || [ElementalType.STELLAR, ElementalType.UNKNOWN].includes(moveType)) {
+        return false;
+      }
+      const userTypes = user.getTypes();
+      const validTypes = this.getTypeResistances(globalScene.gameMode, moveType).filter((t) => !userTypes.includes(t)); // valid types are ones that are not already the user's types
+      return validTypes.length > 0;
     };
   }
 }

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -85,6 +85,7 @@ export class MoveChargePhase extends HitCheckPhase {
         move: this.move.getMove(),
         targets: this.targets,
         result: MoveResult.OTHER,
+        type: user.getMoveType(move),
       });
     }
     this.end();

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -180,6 +180,7 @@ export class MoveEffectPhase extends HitCheckPhase {
       move: this.move.getMove(),
       targets: this.adjustedTargets ?? this.targets,
       result: MoveResult.PENDING,
+      type: user.getMoveType(move),
       virtual: this.move.virtual,
     };
 
@@ -355,6 +356,7 @@ export class MoveEffectPhase extends HitCheckPhase {
         move: this.move.getMove(),
         targets: this.targets,
         result: MoveResult.SUCCESS,
+        type: user.getMoveType(this.move.getMove()),
         virtual: this.move.virtual,
       });
 

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -377,6 +377,7 @@ export class MovePhase extends BattlePhase {
         move: this.move.getMove(),
         targets: this.targets,
         result: MoveResult.FAIL,
+        type: this.pokemon.getMoveType(this.move.getMove()),
         virtual: this.move.virtual,
       });
 
@@ -420,6 +421,7 @@ export class MovePhase extends BattlePhase {
         move: this.move.getMove(),
         targets: this.targets,
         result: MoveResult.FAIL,
+        type: this.pokemon.getMoveType(this.move.getMove()),
         virtual: this.move.virtual,
       });
 
@@ -576,7 +578,11 @@ export class MovePhase extends BattlePhase {
         frenzyMissFunc(this.pokemon, this.move.getMove());
       }
 
-      this.pokemon.pushMoveHistory({ move: SelfStatusMove.none(), result: MoveResult.FAIL });
+      this.pokemon.pushMoveHistory({
+        move: SelfStatusMove.none(),
+        result: MoveResult.FAIL,
+        type: ElementalType.UNKNOWN,
+      });
 
       this.pokemon.lapseTags(BattlerTagLapseType.MOVE_EFFECT);
       this.pokemon.lapseTags(BattlerTagLapseType.AFTER_MOVE);

--- a/test/moves/conversion_2.test.ts
+++ b/test/moves/conversion_2.test.ts
@@ -1,0 +1,158 @@
+import { Abilities } from "#enums/abilities";
+import { BattlerIndex } from "#enums/battler-index";
+import { ElementalType } from "#enums/elemental-type";
+import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
+import { Species } from "#enums/species";
+import { TerrainType } from "#enums/terrain-type";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Moves - Conversion 2", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should change the user's type to a type that resists the target's most recent move", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.SPLASH);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    const playerTypes = player.getTypes();
+    expect(playerTypes).toHaveLength(1);
+    // player's type should resist Normal
+    expect(playerTypes[0]).toBeOneOf([ElementalType.ROCK, ElementalType.STEEL, ElementalType.GHOST]);
+  });
+
+  it("should change the user's type based on the called move if the target last used Nature Power", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.scene.arena.trySetTerrain(TerrainType.MISTY, false, true);
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.NATURE_POWER);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    const playerTypes = player.getTypes();
+    expect(playerTypes).toHaveLength(1);
+    // player's type should resist Fairy (Nature Power in Misty Terrain => Moonblast)
+    expect(playerTypes[0]).toBeOneOf([ElementalType.STEEL, ElementalType.POISON, ElementalType.FIRE]);
+  });
+
+  it("should change the user's type to resist Fairy if the target's last move was affected by Pixilate", async () => {
+    game.override.enemyAbility(Abilities.PIXILATE);
+
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.TACKLE);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    const playerTypes = player.getTypes();
+    expect(playerTypes).toHaveLength(1);
+    // player's type should resist Fairy
+    expect(playerTypes[0]).toBeOneOf([ElementalType.STEEL, ElementalType.POISON, ElementalType.FIRE]);
+  });
+
+  it("should change the user's type according to the target move's changed type, if applicable", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.REVELATION_DANCE);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    const playerTypes = player.getTypes();
+    expect(playerTypes).toHaveLength(1);
+    // player's type should resist Water (not including Water type)
+    expect(playerTypes[0]).toBeOneOf([ElementalType.GRASS, ElementalType.DRAGON]);
+  });
+
+  it("should fail if the target's last move was typeless", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    vi.spyOn(enemy, "getMoveType").mockReturnValue(ElementalType.UNKNOWN);
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.TACKLE);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(player.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
+    expect(player.isOfType(ElementalType.WATER)).toBeTruthy();
+  });
+
+  it("should fail if the target's last move was Stellar-type", async () => {
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    vi.spyOn(enemy, "getMoveType").mockReturnValue(ElementalType.STELLAR);
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.TACKLE);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(player.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
+    expect(player.isOfType(ElementalType.WATER)).toBeTruthy();
+  });
+
+  it("should fail if the user is already of all types that resist the target's last move", async () => {
+    await game.classicMode.startBattle([Species.OBSTAGOON]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.SHADOW_SNEAK);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    // Ghost is resisted only by Dark and Normal. Obstagoon is of both types.
+    expect(player.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
+    expect(player.getTypes()).toEqual([ElementalType.DARK, ElementalType.NORMAL]);
+  });
+});

--- a/test/moves/conversion_2.test.ts
+++ b/test/moves/conversion_2.test.ts
@@ -1,5 +1,6 @@
 import { Abilities } from "#enums/abilities";
 import { BattlerIndex } from "#enums/battler-index";
+import { Challenges } from "#enums/challenges";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
@@ -71,24 +72,51 @@ describe("Moves - Conversion 2", () => {
     expect(playerTypes[0]).toBeOneOf([ElementalType.STEEL, ElementalType.POISON, ElementalType.FIRE]);
   });
 
-  it("should change the user's type to resist Fairy if the target's last move was affected by Pixilate", async () => {
-    game.override.enemyAbility(Abilities.PIXILATE);
+  it.each([
+    {
+      moveType: "Fairy",
+      ability: Abilities.PIXILATE,
+      abilityName: "Pixilate",
+      resistingTypes: [ElementalType.STEEL, ElementalType.POISON, ElementalType.FIRE],
+    },
+    {
+      moveType: "Electric",
+      ability: Abilities.GALVANIZE,
+      abilityName: "Galvanize",
+      resistingTypes: [ElementalType.GRASS, ElementalType.ELECTRIC, ElementalType.DRAGON, ElementalType.GROUND],
+    },
+    {
+      moveType: "Flying",
+      ability: Abilities.AERILATE,
+      abilityName: "Aerilate",
+      resistingTypes: [ElementalType.ROCK, ElementalType.STEEL, ElementalType.ELECTRIC],
+    },
+    {
+      moveType: "Ice",
+      ability: Abilities.REFRIGERATE,
+      abilityName: "Refrigerate",
+      resistingTypes: [ElementalType.STEEL, ElementalType.FIRE, ElementalType.ICE],
+    },
+  ])(
+    "should change the user's type to resist $moveType if the target's last move was affected by $abilityName",
+    async ({ ability, resistingTypes }) => {
+      game.override.enemyAbility(ability);
 
-    await game.classicMode.startBattle([Species.FEEBAS]);
+      await game.classicMode.startBattle([Species.FEEBAS]);
 
-    const player = game.field.getPlayerPokemon();
+      const player = game.field.getPlayerPokemon();
 
-    game.move.use(MoveId.CONVERSION_2);
-    await game.move.forceEnemyMove(MoveId.TACKLE);
-    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+      game.move.use(MoveId.CONVERSION_2);
+      await game.move.forceEnemyMove(MoveId.TACKLE);
+      await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 
-    await game.phaseInterceptor.to("BerryPhase", false);
+      await game.phaseInterceptor.to("BerryPhase", false);
 
-    const playerTypes = player.getTypes();
-    expect(playerTypes).toHaveLength(1);
-    // player's type should resist Fairy
-    expect(playerTypes[0]).toBeOneOf([ElementalType.STEEL, ElementalType.POISON, ElementalType.FIRE]);
-  });
+      const playerTypes = player.getTypes();
+      expect(playerTypes).toHaveLength(1);
+      expect(playerTypes[0]).toBeOneOf(resistingTypes);
+    },
+  );
 
   it("should change the user's type according to the target move's changed type, if applicable", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
@@ -154,5 +182,22 @@ describe("Moves - Conversion 2", () => {
     // Ghost is resisted only by Dark and Normal. Obstagoon is of both types.
     expect(player.getLastXMoves()[0].result).toBe(MoveResult.FAIL);
     expect(player.getTypes()).toEqual([ElementalType.DARK, ElementalType.NORMAL]);
+  });
+
+  it("should account for Inverse Challenge when determining a resisting type", async () => {
+    game.challengeMode.addChallenge(Challenges.INVERSE_BATTLE, 1, 1);
+
+    await game.challengeMode.startBattle([Species.FEEBAS]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.DRAGON_CLAW);
+    await game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+
+    await game.phaseInterceptor.to("BerryPhase", false);
+
+    expect(player.getTypes()).toHaveLength(1);
+    expect(player.isOfType(ElementalType.DRAGON)).toBeTruthy();
   });
 });

--- a/test/moves/disable.test.ts
+++ b/test/moves/disable.test.ts
@@ -6,6 +6,7 @@ import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { TurnMove } from "#app/@types/TurnMove";
+import { ElementalType } from "#enums/elemental-type";
 
 describe("Moves - Disable", () => {
   let phaserGame: Phaser.Game;
@@ -59,6 +60,7 @@ describe("Moves - Disable", () => {
     expect(playerMon.getMoveHistory()[0]).toMatchObject<TurnMove>({
       move: expect.objectContaining({ id: MoveId.DISABLE }),
       result: MoveResult.FAIL,
+      type: ElementalType.NORMAL,
     });
     expect(enemyMon.isMoveRestricted(MoveId.SPLASH)).toBe(false);
   }, 20000);
@@ -115,6 +117,7 @@ describe("Moves - Disable", () => {
     expect(enemyHistory[0]).toMatchObject<TurnMove>({
       move: expect.objectContaining({ id: MoveId.SPLASH }),
       result: MoveResult.SUCCESS,
+      type: ElementalType.NORMAL,
     });
     expect(enemyHistory[1].result).toBe(MoveResult.FAIL);
   }, 20000);

--- a/test/moves/instruct.test.ts
+++ b/test/moves/instruct.test.ts
@@ -7,6 +7,7 @@ import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { ElementalType } from "#enums/elemental-type";
 
 describe("Moves - Instruct", () => {
   let phaserGame: Phaser.Game;
@@ -218,6 +219,7 @@ describe("Moves - Instruct", () => {
         move: expect.objectContaining({ id: MoveId.SONIC_BOOM }),
         targets: [BattlerIndex.PLAYER],
         result: MoveResult.SUCCESS,
+        type: ElementalType.NORMAL,
         virtual: false,
       },
     ];

--- a/test/moves/spit_up.test.ts
+++ b/test/moves/spit_up.test.ts
@@ -2,7 +2,6 @@ import { Stat } from "#enums/stat";
 import { type StockpilingTag } from "#app/data/battler-tags";
 import { allMoves } from "#app/data/all-moves";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import type { TurnMove } from "#app/@types/TurnMove";
 import { MoveResult } from "#enums/move-result";
 import { GameManager } from "#test/testUtils/gameManager";
 import { Abilities } from "#enums/abilities";
@@ -125,11 +124,7 @@ describe("Moves - Spit Up", () => {
     game.move.select(MoveId.SPIT_UP);
     await game.phaseInterceptor.to(TurnInitPhase);
 
-    expect(pokemon.getMoveHistory().at(-1)).toMatchObject<TurnMove>({
-      move: expect.objectContaining({ id: MoveId.SPIT_UP }),
-      result: MoveResult.FAIL,
-    });
-
+    expect(pokemon.getLastXMoves()?.[0]?.result).toBe(MoveResult.FAIL);
     expect(spitUp.calculateBattlePower).not.toHaveBeenCalled();
   });
 
@@ -151,10 +146,7 @@ describe("Moves - Spit Up", () => {
 
       await game.phaseInterceptor.to(TurnInitPhase);
 
-      expect(pokemon.getMoveHistory().at(-1)).toMatchObject<TurnMove>({
-        move: expect.objectContaining({ id: MoveId.SPIT_UP }),
-        result: MoveResult.SUCCESS,
-      });
+      expect(pokemon.getLastXMoves()?.[0]?.result).toBe(MoveResult.SUCCESS);
 
       expect(spitUp.calculateBattlePower).toHaveBeenCalledOnce();
 
@@ -182,10 +174,7 @@ describe("Moves - Spit Up", () => {
       game.move.select(MoveId.SPIT_UP);
       await game.phaseInterceptor.to(TurnInitPhase);
 
-      expect(pokemon.getMoveHistory().at(-1)).toMatchObject<TurnMove>({
-        move: expect.objectContaining({ id: MoveId.SPIT_UP }),
-        result: MoveResult.SUCCESS,
-      });
+      expect(pokemon.getLastXMoves()?.[0]?.result).toBe(MoveResult.SUCCESS);
 
       expect(spitUp.calculateBattlePower).toHaveBeenCalledOnce();
 

--- a/test/moves/stockpile.test.ts
+++ b/test/moves/stockpile.test.ts
@@ -1,6 +1,5 @@
 import { Stat } from "#enums/stat";
 import { type StockpilingTag } from "#app/data/battler-tags";
-import type { TurnMove } from "#app/@types/TurnMove";
 import { MoveResult } from "#enums/move-result";
 import { CommandPhase } from "#app/phases/command-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
@@ -74,10 +73,7 @@ describe("Moves - Stockpile", () => {
           expect(user.getStatStage(Stat.SPDEF)).toBe(3);
           expect(stockpilingTag).toBeDefined();
           expect(stockpilingTag.stockpiledCount).toBe(3);
-          expect(user.getMoveHistory().at(-1)).toMatchObject<TurnMove>({
-            result: MoveResult.FAIL,
-            move: expect.objectContaining({ id: MoveId.STOCKPILE }),
-          });
+          expect(user.getLastXMoves()?.[0]?.result).toBe(MoveResult.FAIL);
         }
       }
     });

--- a/test/moves/swallow.test.ts
+++ b/test/moves/swallow.test.ts
@@ -1,7 +1,6 @@
 import { Stat } from "#enums/stat";
 import { type StockpilingTag } from "#app/data/battler-tags";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import type { TurnMove } from "#app/@types/TurnMove";
 import { MoveResult } from "#enums/move-result";
 import { MovePhase } from "#app/phases/move-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
@@ -135,10 +134,7 @@ describe("Moves - Swallow", () => {
     game.move.select(MoveId.SWALLOW);
     await game.phaseInterceptor.to(TurnInitPhase);
 
-    expect(pokemon.getMoveHistory().at(-1)).toMatchObject<TurnMove>({
-      move: expect.objectContaining({ id: MoveId.SWALLOW }),
-      result: MoveResult.FAIL,
-    });
+    expect(pokemon.getLastXMoves()?.[0]?.result).toBe(MoveResult.FAIL);
   });
 
   describe("restores stat stage boosts granted by stacks", () => {
@@ -159,10 +155,7 @@ describe("Moves - Swallow", () => {
 
       await game.phaseInterceptor.to(TurnInitPhase);
 
-      expect(pokemon.getMoveHistory().at(-1)).toMatchObject<TurnMove>({
-        move: expect.objectContaining({ id: MoveId.SWALLOW }),
-        result: MoveResult.SUCCESS,
-      });
+      expect(pokemon.getLastXMoves()?.[0]?.result).toBe(MoveResult.SUCCESS);
 
       expect(pokemon.getStatStage(Stat.DEF)).toBe(0);
       expect(pokemon.getStatStage(Stat.SPDEF)).toBe(0);
@@ -189,10 +182,7 @@ describe("Moves - Swallow", () => {
 
       await game.phaseInterceptor.to(TurnInitPhase);
 
-      expect(pokemon.getMoveHistory().at(-1)).toMatchObject<TurnMove>({
-        move: expect.objectContaining({ id: MoveId.SWALLOW }),
-        result: MoveResult.SUCCESS,
-      });
+      expect(pokemon.getLastXMoves()?.[0]?.result).toBe(MoveResult.SUCCESS);
 
       expect(pokemon.getStatStage(Stat.DEF)).toBe(1);
       expect(pokemon.getStatStage(Stat.SPDEF)).toBe(-2);


### PR DESCRIPTION
## What are the changes the user will see?

Conversion 2 now accounts for moves' types at their time of use.

## Why am I making these changes?

Shareholder value 📈 

## What are the changes from a developer perspective?

- A Pokemon's move history now logs the type of each move when they are used
- Conversion 2 now uses the type from the last move history entry instead of the move's base type.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

`npm run test conversion_2`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [?] Have I provided screenshots/videos of the changes (if applicable)?
  - [?] Have I made sure that any UI change works for both UI themes (default and legacy)?