### PR TITLE
[Beta][Bug] Fix typo in generateBossBiomeTier

### DIFF
--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -220,9 +220,9 @@ export class Arena {
     } else if (tierValue >= 6) {
       return BiomePoolTier.BOSS_RARE;
     } else if (tierValue >= 1) {
-      return BiomePoolTier.SUPER_RARE;
+      return BiomePoolTier.BOSS_SUPER_RARE;
     } else {
-      return BiomePoolTier.ULTRA_RARE;
+      return BiomePoolTier.BOSS_ULTRA_RARE;
     }
   }
 


### PR DESCRIPTION
## What are the changes the user will see?

Boss Super Rare and Boss Ultra Rare Pokemon can spawn again

## Why am I making these changes?

Typo in #659 caught by flaky `classic_final_boss.test`

## What are the changes from a developer perspective?

Fixed typo `SUPER_RARE` -> `BOSS_SUPER_RARE` and `ULTRA_RARE` -> `BOSS_ULTRA_RARE`

## Screenshots/Videos

n/a

## How to test the changes?

`npm run test`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (default and legacy)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
