### PR TITLE
[P3] Fix settings giving a warning due to unset player gender

### DIFF
--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -136,18 +136,9 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
       this.optionsContainer.add(this.settingLabels[i]);
       this.optionValueLabels.push(
         uiItem.options.map((option) => {
-          const valueLabel = addTextObject(
-            0,
-            0,
-            option.label,
-            option.value === settingsManager[this.category][uiItem.key]
-              ? TextStyle.SETTINGS_SELECTED
-              : TextStyle.SETTINGS_VALUE,
-          );
+          const valueLabel = addTextObject(0, 0, option.label, TextStyle.SETTINGS_VALUE);
           valueLabel.setOrigin(0, 0);
-
           this.optionsContainer.add(valueLabel);
-
           return valueLabel;
         }),
       );

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -169,26 +169,8 @@ export default class AbstractSettingsUiHandler extends MessageUiHandler {
       }
     });
 
-    this.optionCursors = this.uiItems.map((uiItem) => {
-      const value = settingsManager[this.category][uiItem.key];
-      let index = 0;
-
-      if (value !== undefined) {
-        index = uiItem.options.findIndex((o) => {
-          return o.value === value;
-        });
-      }
-
-      if (index < 0) {
-        console.warn(
-          `Could not find index for ${uiItem.key}.`,
-          `\nExpected value: ${settingsManager[this.category][uiItem.key]}`,
-          `\nAvailable values:`,
-          uiItem.options,
-        );
-      }
-      return Math.max(index, 0);
-    });
+    // Treat all settings as having the first options selected. These get properly updated in show()
+    this.optionCursors = new Array(this.uiItems.length).fill(0);
 
     this.scrollBar = new ScrollBar(
       this.optionsBg.width - 9,


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

No more warning in console (and tests) when running the game with no set player gender
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

When launching the game for the first time the PlayerGender's default value is UNSET, so that the game knows to offer the option to the player.
However since all ui handlers are initialized at launch, the settings ui handler attempts to draw everything at that point, and since the UNSET value is not one that is offered to players it throws a warning in the console
This warning shouldn't happen in this situation

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

- Remove the code outputting the warning from `setup` and set the `optionsCursors` to a default value.
The code's purpose is to highlight all the currently selected settings, but the same code is being run when the settings are opened, in `show`, so it does not need to be done in setup.
- Remove the code that highlights the currently selected option from `setup`, since it is handled in `show` as well

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

before:
warning shown when running tests (from PR 672's branch, because currently warnings do not get logged during tests)
![413628069-b12ed769-7f26-4fe7-a2c2-4ba8aedc090b](https://github.com/user-attachments/assets/31e23356-3472-4912-8f64-a2042065071f)
warning shown in console
![image](https://github.com/user-attachments/assets/735803a9-502c-4bfe-b76b-10ebcfade142)

after:
The correct options are still highlighted, but no more warnings
![image](https://github.com/user-attachments/assets/ad9e9630-6f5c-4eb7-9e05-e43d5544fa32)
![image](https://github.com/user-attachments/assets/70ac95b1-2093-477b-93d6-c168ed881b7a)
 
<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

- Run the game, check that the correct settings are highlighted
- Run the game in a private window to have an unset gender
- No warning should be shown in the console,

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
