### PR TITLE
[P2] Fix Poltergeist's pre-move message triggering during enemy move evaluation

### DIFF
--- a/src/data/move-attrs/attacked-by-item-attr.ts
+++ b/src/data/move-attrs/attacked-by-item-attr.ts
@@ -26,6 +26,6 @@ export class AttackedByItemAttr extends PreMoveMessageAttr {
   /** Causes failure if the target isn't holding a transferable item */
   override getCondition(): MoveConditionFunc {
     return (_user: Pokemon, target: Pokemon, _move: Move) =>
-      target.getHeldItems().filter((i) => i.isTransferable).length > 0;
+      target.getHeldItems().some((i) => i.isTransferable);
   }
 }

--- a/src/data/move-attrs/attacked-by-item-attr.ts
+++ b/src/data/move-attrs/attacked-by-item-attr.ts
@@ -1,30 +1,31 @@
 import type { Pokemon } from "#app/field/pokemon";
-import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import i18next from "i18next";
 import type { Move } from "#app/data/move";
-import { MoveAttr } from "#app/data/move-attrs/move-attr";
 import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import { PreMoveMessageAttr } from "./pre-move-message-attr";
 
 /**
  * Attribute to cause the move to fail if the target is not holding an item.
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Poltergeist_(move) | Poltergeist}.
- * @extends MoveAttr
+ * @extends PreMoveMessageAttr
  */
-export class AttackedByItemAttr extends MoveAttr {
-  override getCondition(): MoveConditionFunc {
-    return (_user: Pokemon, target: Pokemon, _move: Move) => {
+export class AttackedByItemAttr extends PreMoveMessageAttr {
+  constructor() {
+    super((_user, target, _move) => {
       const heldItems = target.getHeldItems().filter((i) => i.isTransferable);
-      if (heldItems.length === 0) {
-        return false;
-      }
-
       const itemName = heldItems[0]?.type?.name ?? "item";
-      globalScene.queueMessage(
-        i18next.t("moveTriggers:attackedByItem", { pokemonName: getPokemonNameWithAffix(target), itemName: itemName }),
-      );
 
-      return true;
-    };
+      return i18next.t("moveTriggers:attackedByItem", {
+        pokemonName: getPokemonNameWithAffix(target),
+        itemName,
+      });
+    });
+  }
+
+  /** Causes failure if the target isn't holding a transferable item */
+  override getCondition(): MoveConditionFunc {
+    return (_user: Pokemon, target: Pokemon, _move: Move) =>
+      target.getHeldItems().filter((i) => i.isTransferable).length > 0;
   }
 }

--- a/src/data/move-attrs/attacked-by-item-attr.ts
+++ b/src/data/move-attrs/attacked-by-item-attr.ts
@@ -14,6 +14,7 @@ export class AttackedByItemAttr extends PreMoveMessageAttr {
   constructor() {
     super((_user, target, _move) => {
       const heldItems = target.getHeldItems().filter((i) => i.isTransferable);
+      // "item" should be localizable here but under normal circumstances this fallback should never show
       const itemName = heldItems[0]?.type?.name ?? "item";
 
       return i18next.t("moveTriggers:attackedByItem", {
@@ -25,7 +26,6 @@ export class AttackedByItemAttr extends PreMoveMessageAttr {
 
   /** Causes failure if the target isn't holding a transferable item */
   override getCondition(): MoveConditionFunc {
-    return (_user: Pokemon, target: Pokemon, _move: Move) =>
-      target.getHeldItems().some((i) => i.isTransferable);
+    return (_user: Pokemon, target: Pokemon, _move: Move) => target.getHeldItems().some((i) => i.isTransferable);
   }
 }

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -368,6 +368,7 @@ export class MovePhase extends BattlePhase {
      */
     if (success) {
       applyAbAttrs(AbAttrFlag.POKEMON_TYPE_CHANGE, this.pokemon, false, this.move.getMove());
+      this.showPreMoveMessages();
       globalScene.unshiftPhase(new MoveEffectPhase(this.pokemon.getBattlerIndex(), this.targets, this.move));
     } else {
       if ([MoveId.ROAR, MoveId.WHIRLWIND, MoveId.TRICK_OR_TREAT, MoveId.FORESTS_CURSE].includes(this.move.moveId)) {
@@ -620,10 +621,17 @@ export class MovePhase extends BattlePhase {
       }),
       500,
     );
-    applyMoveAttrs(PreMoveMessageAttr, this.pokemon, this.pokemon.getOpponents()[0], this.move.getMove());
   }
 
   public showFailedText(failedText?: string): void {
     globalScene.queueMessage(failedText ?? i18next.t("battle:attackFailed"));
+  }
+
+  /**
+   * Displays the move's pre-execution messages, if applicable.
+   * Ex. Chilly Reception's "<Pokemon> is preparing to tell a chillingly bad joke!"
+   */
+  public showPreMoveMessages(): void {
+    applyMoveAttrs(PreMoveMessageAttr, this.pokemon, this.pokemon.getOpponents()[0], this.move.getMove());
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?

Poltergeist's message ("[Pokemon] is about to be attacked by its [item]!") no longer shows out of turn during the enemy move selection process.

## Why am I making these changes?

fixes #692 

## What are the changes from a developer perspective?

- `AttackedByItemAttr` now extends `PreMoveMessageAttr`
- Messages from `PreMoveMessageAttr` no longer play if the move fails to execute. **NOTE**: this diverges from Chilly Reception's message logic where the move is meant to play its message regardless of it failing, but for the sake of reusability I think this is the better approach to accommodate for both moves

## Screenshots/Videos

https://github.com/user-attachments/assets/da35bd6b-5215-4065-91db-5ae7069a27a9

## How to test the changes?

Using overrides:
1. Give enemies Poltergeist
2. Give your starting pokemon any transferrable held item
3. When the enemy selects Poltergeist, the pre-move message should only play during the move's execution

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (dark and light)?