### PR TITLE
[P2] Change sheer force multiplier from 1.33 -> 1.3

### DIFF
--- a/src/data/init-abilities.ts
+++ b/src/data/init-abilities.ts
@@ -628,7 +628,7 @@ export function initAbilities() {
       .attr(PostDefendStealHeldItemAbAttr, (_target, _user, move) => move.hasFlag(MoveFlags.MAKES_CONTACT))
       .condition(getSheerForceHitDisableAbCondition()),
     new Ability(Abilities.SHEER_FORCE, 5)
-      .attr(MovePowerBoostAbAttr, (_user, _target, move) => !!move && move.chance >= 1, 5461 / 4096)
+      .attr(MovePowerBoostAbAttr, (_user, _target, move) => !!move && move.chance >= 1, 1.3)
       .attr(MoveEffectChanceMultiplierAbAttr, 0), // Should disable life orb, eject button, red card, kee/maranga berry if they get implemented
     new Ability(Abilities.CONTRARY, 5).attr(StatStageChangeMultiplierAbAttr, -1).ignorable(),
     new Ability(Abilities.UNNERVE, 5).attr(PreventBerryUseAbAttr),

--- a/test/abilities/sheer_force.test.ts
+++ b/test/abilities/sheer_force.test.ts
@@ -35,7 +35,7 @@ describe("Abilities - Sheer Force", () => {
       .disableCrits();
   });
 
-  const SHEER_FORCE_MULT = 5461 / 4096;
+  const SHEER_FORCE_MULT = 1.3;
 
   it("Sheer Force should boost the power of the move but disable secondary effects", async () => {
     game.override.moveset([MoveId.AIR_SLASH]);

--- a/test/moves/burning_jealousy.test.ts
+++ b/test/moves/burning_jealousy.test.ts
@@ -89,7 +89,7 @@ describe("Moves - Burning Jealousy", () => {
     await game.phaseInterceptor.to("BerryPhase");
 
     expect(allMoves[MoveId.BURNING_JEALOUSY].calculateBattlePower).toHaveReturnedWith(
-      (allMoves[MoveId.BURNING_JEALOUSY].power * 5461) / 4096,
+      allMoves[MoveId.BURNING_JEALOUSY].power * 1.3,
     );
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Sheer Force gives a +30% boost instead of +33%

## Why am I making these changes?

Fixes #122

## What are the changes from a developer perspective?

Changed the incorrect `5461/4096` to the much simpler 1.3 that we already use in lots of places rather than `5325/4096`

## Screenshots/Videos

n/a

## How to test the changes?

`npm run test sheer_force`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
