### PR TITLE
[P3] Fix map and gender select menu configurations

### DIFF
--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -1,7 +1,7 @@
 import { biomeLinks, getBiomeName } from "#app/data/balance/biomes";
 import { globalScene } from "#app/global-scene";
 import { MapModifier, MoneyInterestModifier } from "#app/modifier/modifier";
-import type { OptionSelectItem } from "#app/ui/interfaces/option-select-config";
+import type { OptionSelectItem, OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
 import { UiMode } from "#enums/ui-mode";
 import { randSeedInt } from "#app/utils";
 import { Biome } from "#enums/biome";
@@ -71,11 +71,14 @@ export class SelectBiomePhase extends BattlePhase {
           return ret;
         });
 
-        ui.setMode(UiMode.OPTION_SELECT, {
+        const optionSelectConfig: OptionSelectModeConfig = {
           options: biomeSelectItems,
-          delay: 1000,
+          blockCancelButton: true,
+          inputDelay: 1000,
           yOffset: 48,
-        });
+        };
+
+        ui.setMode(UiMode.OPTION_SELECT, optionSelectConfig);
       } else {
         setNextBiome(biomes[randSeedInt(biomes.length)]);
       }

--- a/src/phases/select-gender-phase.ts
+++ b/src/phases/select-gender-phase.ts
@@ -34,6 +34,7 @@ export class SelectGenderPhase extends Phase {
           },
         },
       ],
+      inputDelay: 1000,
       blockCancelButton: true,
       yOffset: 48,
     };

--- a/src/phases/select-gender-phase.ts
+++ b/src/phases/select-gender-phase.ts
@@ -5,6 +5,7 @@ import { UiMode } from "#enums/ui-mode";
 import { PlayerGender } from "#enums/player-gender";
 import i18next from "i18next";
 import { PhaseId } from "#enums/phase-id";
+import type { OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
 
 export class SelectGenderPhase extends Phase {
   override readonly id = PhaseId.SELECT_GENDER;
@@ -14,29 +15,31 @@ export class SelectGenderPhase extends Phase {
 
     const { gameData, ui } = globalScene;
 
+    const menuOptionsConfig: OptionSelectModeConfig = {
+      options: [
+        {
+          label: i18next.t("settings:boy"),
+          handler: () => {
+            settings.update("display", "playerGender", PlayerGender.MALE);
+            gameData.saveSystem().then(() => this.end());
+            return true;
+          },
+        },
+        {
+          label: i18next.t("settings:girl"),
+          handler: () => {
+            settings.update("display", "playerGender", PlayerGender.FEMALE);
+            gameData.saveSystem().then(() => this.end());
+            return true;
+          },
+        },
+      ],
+      blockCancelButton: true,
+      yOffset: 48,
+    };
+
     ui.showText(i18next.t("menu:boyOrGirl"), null, () => {
-      ui.setMode(UiMode.OPTION_SELECT, {
-        options: [
-          {
-            label: i18next.t("settings:boy"),
-            handler: () => {
-              settings.update("display", "playerGender", PlayerGender.MALE);
-              gameData.saveSystem().then(() => this.end());
-              return true;
-            },
-          },
-          {
-            label: i18next.t("settings:girl"),
-            handler: () => {
-              settings.update("display", "playerGender", PlayerGender.FEMALE);
-              gameData.saveSystem().then(() => this.end());
-              return true;
-            },
-          },
-        ],
-        noCancel: true,
-        yOffset: 48,
-      });
+      ui.setMode(UiMode.OPTION_SELECT, menuOptionsConfig);
     });
   }
 

--- a/src/ui/login-form-ui-handler.ts
+++ b/src/ui/login-form-ui-handler.ts
@@ -7,7 +7,7 @@ import i18next from "i18next";
 import { addTextObject } from "./text";
 import { TextStyle } from "#enums/text-style";
 import { addWindow } from "./ui-theme";
-import type { OptionSelectItem } from "#app/ui/interfaces/option-select-config";
+import type { OptionSelectItem, OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
 import { api } from "#app/plugins/api/api";
 import { globalScene } from "#app/global-scene";
 import JSZip from "jszip";
@@ -230,12 +230,13 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
             },
           });
         }
-        globalScene.ui.setOverlayMode(UiMode.OPTION_SELECT, {
+        const optionSelectConfig: OptionSelectModeConfig = {
           options: options,
-          delay: 1000,
+          inputDelay: 1000,
           xOffset: GAME_WIDTH,
           yOffset: GAME_HEIGHT - this.usernameInfoImage.displayHeight - 16 * dataKeys.length - 22,
-        });
+        };
+        globalScene.ui.setOverlayMode(UiMode.OPTION_SELECT, optionSelectConfig);
       } else {
         if (dataKeys.length > 2) {
           return onFail(this.ERR_TOO_MANY_SAVES);

--- a/src/ui/login-form-ui-handler.ts
+++ b/src/ui/login-form-ui-handler.ts
@@ -232,7 +232,6 @@ export default class LoginFormUiHandler extends FormModalUiHandler {
         }
         const optionSelectConfig: OptionSelectModeConfig = {
           options: options,
-          inputDelay: 1000,
           xOffset: GAME_WIDTH,
           yOffset: GAME_HEIGHT - this.usernameInfoImage.displayHeight - 16 * dataKeys.length - 22,
         };

--- a/src/ui/menu-ui-handler.ts
+++ b/src/ui/menu-ui-handler.ts
@@ -488,7 +488,6 @@ export default class MenuUiHandler extends OptionSelectUiHandler {
           });
           globalScene.ui.setOverlayMode(UiMode.OPTION_SELECT, {
             options: options,
-            delay: 0,
             yOffset: this.menuMessageBox.displayHeight + 1,
           });
           return true;

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -40,7 +40,11 @@ import { Tutorial } from "#enums/tutorial";
 import { handleTutorial } from "#app/tutorial";
 import { DropDown, DropDownLabel, DropDownOption } from "#app/ui/drop-down";
 import { FilterBar } from "#app/ui/filter-bar";
-import type { OptionSelectIconConfig, OptionSelectItem } from "#app/ui/interfaces/option-select-config";
+import type {
+  OptionSelectIconConfig,
+  OptionSelectItem,
+  OptionSelectModeConfig,
+} from "#app/ui/interfaces/option-select-config";
 import MessageUiHandler from "#app/ui/message-ui-handler";
 import MoveInfoOverlay from "#app/ui/move-info-overlay";
 import PokemonIconAnimHandler from "#app/ui/pokemon-icon-anim-handler";
@@ -1601,87 +1605,94 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
               },
             },
           );
+
+          // Manage Moves options
           if (this.speciesStarterMoves.length > 1) {
-            // this lets you change the pokemon moves
+            const getMoveOptions = (
+              moves: MoveId[],
+              selectHandler: (moveId: MoveId, index: number, currentMoveId?: MoveId, currentIndex?: number) => boolean,
+              cancelHandler: () => boolean,
+              currentMoveId?: MoveId,
+              currentIndex?: number,
+            ): OptionSelectModeConfig => {
+              const options: OptionSelectItem[] = moves.map((moveId: MoveId, index: number): OptionSelectItem => {
+                return {
+                  label: allMoves[moveId].name,
+                  handler: () => selectHandler(moveId, index, currentMoveId, currentIndex),
+                  onHover: () => {
+                    this.moveInfoOverlay.show(allMoves[moveId]);
+                  },
+                };
+              });
+              options.push({
+                label: i18next.t("menu:cancel"),
+                handler: cancelHandler,
+                onHover: () => {
+                  this.moveInfoOverlay.clear();
+                },
+              });
+
+              return {
+                options: options,
+                maxOptions: 8,
+                yOffset: 29,
+              };
+            };
+
+            const onSelectedMoveToSwapWith = (moveId: MoveId, index: number): boolean => {
+              this.blockInput = true;
+              ui.setMode(UiMode.STARTER_SELECT).then(() => {
+                ui.showText(
+                  `${i18next.t("starterSelectUiHandler:selectMoveSwapWith")} ${allMoves[moveId].name}.`,
+                  null,
+                  () => {
+                    const possibleMoves = this.speciesStarterMoves.filter((sm: MoveId) => sm !== moveId);
+                    this.moveInfoOverlay.show(allMoves[possibleMoves[0]]);
+                    const movesOptions = getMoveOptions(
+                      possibleMoves,
+                      onSelectedMoveToSwapTo,
+                      onCancelMoveToSwapTo,
+                      moveId,
+                      index,
+                    );
+                    ui.setModeWithoutClear(UiMode.OPTION_SELECT, movesOptions);
+                    this.blockInput = false;
+                  },
+                );
+              });
+              return true;
+            };
+
+            const onCancelMoveToSwapWith = () => {
+              this.moveInfoOverlay.clear();
+              this.clearText();
+              ui.setMode(UiMode.STARTER_SELECT);
+              return true;
+            };
+
+            const onSelectedMoveToSwapTo = (
+              moveId: MoveId,
+              _i: number,
+              baseMoveId: MoveId,
+              baseMoveIndex: number,
+            ): boolean => {
+              this.switchMoveHandler(baseMoveIndex, moveId, baseMoveId);
+              showSwapOptions(this.starterMoveset!); // TODO: is this bang correct?
+              return true;
+            };
+
+            const onCancelMoveToSwapTo = () => {
+              showSwapOptions(this.starterMoveset!); // TODO: is this bang correct?
+              return true;
+            };
+
             const showSwapOptions = (moveset: StarterMoveset) => {
               this.blockInput = true;
-
               ui.setMode(UiMode.STARTER_SELECT).then(() => {
                 ui.showText(i18next.t("starterSelectUiHandler:selectMoveSwapOut"), null, () => {
                   this.moveInfoOverlay.show(allMoves[moveset[0]]);
-
-                  ui.setModeWithoutClear(UiMode.OPTION_SELECT, {
-                    options: moveset
-                      .map((m: MoveId, i: number) => {
-                        const option: OptionSelectItem = {
-                          label: allMoves[m].name,
-                          handler: () => {
-                            this.blockInput = true;
-                            ui.setMode(UiMode.STARTER_SELECT).then(() => {
-                              ui.showText(
-                                `${i18next.t("starterSelectUiHandler:selectMoveSwapWith")} ${allMoves[m].name}.`,
-                                null,
-                                () => {
-                                  const possibleMoves = this.speciesStarterMoves.filter((sm: MoveId) => sm !== m);
-                                  this.moveInfoOverlay.show(allMoves[possibleMoves[0]]);
-
-                                  ui.setModeWithoutClear(UiMode.OPTION_SELECT, {
-                                    options: possibleMoves
-                                      .map((sm) => {
-                                        // make an option for each available starter move
-                                        const option = {
-                                          label: allMoves[sm].name,
-                                          handler: () => {
-                                            this.switchMoveHandler(i, sm, m);
-                                            showSwapOptions(this.starterMoveset!); // TODO: is this bang correct?
-                                            return true;
-                                          },
-                                          onHover: () => {
-                                            this.moveInfoOverlay.show(allMoves[sm]);
-                                          },
-                                        };
-                                        return option;
-                                      })
-                                      .concat({
-                                        label: i18next.t("menu:cancel"),
-                                        handler: () => {
-                                          showSwapOptions(this.starterMoveset!); // TODO: is this bang correct?
-                                          return true;
-                                        },
-                                        onHover: () => {
-                                          this.moveInfoOverlay.clear();
-                                        },
-                                      }),
-                                    maxOptions: 8,
-                                    yOffset: 29,
-                                  });
-                                  this.blockInput = false;
-                                },
-                              );
-                            });
-                            return true;
-                          },
-                          onHover: () => {
-                            this.moveInfoOverlay.show(allMoves[m]);
-                          },
-                        };
-                        return option;
-                      })
-                      .concat({
-                        label: i18next.t("menu:cancel"),
-                        handler: () => {
-                          this.moveInfoOverlay.clear();
-                          this.clearText();
-                          ui.setMode(UiMode.STARTER_SELECT);
-                          return true;
-                        },
-                        onHover: () => {
-                          this.moveInfoOverlay.clear();
-                        },
-                      }),
-                    maxOptions: 8,
-                    yOffset: 29,
-                  });
+                  const movesOptions = getMoveOptions(moveset, onSelectedMoveToSwapWith, onCancelMoveToSwapWith);
+                  ui.setModeWithoutClear(UiMode.OPTION_SELECT, movesOptions);
                   this.blockInput = false;
                 });
               });


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

- Can no longer exit out of the gender menu without making a selection (it would select "girl" by default in that case)
- Adds a 1 second input delay before being able to validate the choice
- Biome selection menu also has a 1 second input deal and prevents cancelled
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

It shouldn't be possible to press cancel to exit those menus, since there is no "cancel" options. The input delay is here to prevent accidental selection cause by mashing.
In #238 I renamed a few fields in the mode's configuration and since the type wasn't being enforced everywhere some configs didn't get properly updated as a result (`delay` was renamed to `inputDelay` and `noCancel` to `blockCancelButton`)

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience<
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

- use `blockCancelButton` instead of the previous name `noCancel` in Select Gender Phase
- add `blockCancelButton` in SelectBiomePhase and changed `delay` to `inputDelay`
- went over the remaining option select configs to make sure they didn't present the same issue. 
- Took the opportunity to somewhat reduce the nesting in the starter select "Manage Moves" option. Behavior should still be the same though (does not fix an existing bug where reordering moves does not work for some Pokemon).

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

<details><summary>Details</summary>

Gender Select input delay

https://github.com/user-attachments/assets/d0ea531d-9aeb-4c37-8b8e-cd3feb14c9cd

Map input delay

https://github.com/user-attachments/assets/b29eb435-247b-467c-bbf0-67f4b43d2008

Starter Select move selection still working

https://github.com/user-attachments/assets/c4444f02-c9d8-465d-8724-61e912a366a7

</details> 

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

Gender selection
- Open the game in a private window to have a fresh file and get offered the gender choice
- During the choice, try to cancel with X / whatever button you're usually using to cancel

Map:
```
  STARTING_LEVEL_OVERRIDE: 50,
  STARTING_WAVE_OVERRIDE: 10,
  STARTING_BIOME_OVERRIDE: Biome.PLAINS,
  STARTING_HELD_ITEMS_OVERRIDE: [ {name: "DYNAMAX_BAND"}, {name: "MAP"}],
```

Starter Select:
Play around with the "Manage Move" menus, behavior should be as before (better to be done on a save file with at least some unlocks)

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?
