### PR TITLE
[Refactor][Bug] Add `canSetWeather` utility + Fix Chilly Reception

### DIFF
--- a/src/data/ab-attrs/post-biome-change-weather-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-biome-change-weather-change-ab-attr.ts
@@ -13,7 +13,7 @@ export class PostBiomeChangeWeatherChangeAbAttr extends PostBiomeChangeAbAttr {
   }
 
   override apply(_pokemon: Pokemon, simulated: boolean): boolean {
-    if (!globalScene.arena.weather?.isImmutable()) {
+    if (!globalScene.arena.weather?.isPrimal()) {
       return simulated
         ? !globalScene.arena.hasWeather(this.weatherType)
         : globalScene.arena.trySetWeather(this.weatherType, true);

--- a/src/data/ab-attrs/post-defend-weather-change-ab-attr.ts
+++ b/src/data/ab-attrs/post-defend-weather-change-ab-attr.ts
@@ -20,7 +20,7 @@ export class PostDefendWeatherChangeAbAttr extends PostDefendAbAttr {
     if (this.condition && !this.condition(pokemon, attacker, move)) {
       return false;
     }
-    if (!globalScene.arena.weather?.isImmutable()) {
+    if (globalScene.arena.canSetWeather(this.weatherType)) {
       if (simulated) {
         return !globalScene.arena.hasWeather(this.weatherType);
       }

--- a/src/data/ab-attrs/suppress-weather-effect-ab-attr.ts
+++ b/src/data/ab-attrs/suppress-weather-effect-ab-attr.ts
@@ -5,17 +5,17 @@ import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { PreWeatherEffectAbAttr } from "./pre-weather-effect-ab-attr";
 
 export class SuppressWeatherEffectAbAttr extends PreWeatherEffectAbAttr {
-  public readonly affectsImmutable: boolean;
+  public readonly affectsPrimal: boolean;
 
-  constructor(affectsImmutable: boolean = false) {
+  constructor(affectsPrimal: boolean = false) {
     super();
     this._flags.add(AbAttrFlag.SUPPRESS_WEATHER_EFFECT);
 
-    this.affectsImmutable = affectsImmutable;
+    this.affectsPrimal = affectsPrimal;
   }
 
   override apply(_pokemon: Pokemon, _simulated: boolean, weather: Weather, cancelled: BooleanHolder): boolean {
-    if (this.affectsImmutable || weather.isImmutable()) {
+    if (this.affectsPrimal || weather.isPrimal()) {
       cancelled.value = true;
       return true;
     }

--- a/src/data/move-attrs/weather-change-attr.ts
+++ b/src/data/move-attrs/weather-change-attr.ts
@@ -23,8 +23,6 @@ export class WeatherChangeAttr extends MoveEffectAttr {
   }
 
   override getCondition(): MoveConditionFunc {
-    return (_user, _target, _move) =>
-      !globalScene.arena.weather
-      || (globalScene.arena.weather.weatherType !== this.weatherType && !globalScene.arena.weather.isImmutable());
+    return (_user, _target, _move) => globalScene.arena.canSetWeather(this.weatherType);
   }
 }

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -58,8 +58,7 @@ export class Weather {
    * @returns true for sandstorm or hail, false otherwise
    */
   isDamaging(): boolean {
-    const DAMAGING_WEATHER = Object.freeze([WeatherType.SANDSTORM, WeatherType.HAIL]);
-    return DAMAGING_WEATHER.includes(this.weatherType);
+    return [WeatherType.SANDSTORM, WeatherType.HAIL].includes(this.weatherType);
   }
 
   /**

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -27,7 +27,7 @@ export class Weather {
 
   constructor(weatherType: WeatherType, turnsLeft?: number) {
     this.weatherType = weatherType;
-    this.turnsLeft = !this.isImmutable() ? turnsLeft || 0 : 0;
+    this.turnsLeft = !this.isPrimal() ? turnsLeft || 0 : 0;
   }
 
   /**
@@ -35,7 +35,7 @@ export class Weather {
    * @returns false if turnsLeft is set to 0. True otherwise
    */
   lapse(): boolean {
-    if (this.isImmutable()) {
+    if (this.isPrimal()) {
       return true;
     }
     if (this.turnsLeft) {
@@ -49,7 +49,7 @@ export class Weather {
    * Checks if the weather is immutable (heavy rain, harsh sun, or strong winds)
    * @returns true if {@linkcode WeatherType} is immutable, false otherwise
    */
-  isImmutable(): boolean {
+  isPrimal(): boolean {
     return PRIMAL_WEATHER.includes(this.weatherType);
   }
 
@@ -149,7 +149,7 @@ export class Weather {
           ? pokemon.getPassiveAbility().getAttrs<SuppressWeatherEffectAbAttr>(AbAttrFlag.SUPPRESS_WEATHER_EFFECT)[0]
           : null;
       }
-      if (suppressWeatherEffectAbAttr && (!this.isImmutable() || suppressWeatherEffectAbAttr.affectsImmutable)) {
+      if (suppressWeatherEffectAbAttr && (!this.isPrimal() || suppressWeatherEffectAbAttr.affectsPrimal)) {
         return true;
       }
     }

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -12,6 +12,11 @@ import { WeatherType } from "#enums/weather-type";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 /**
+ * Weather types that are associated with the primal forms of the Generation III cover legendaries and cannot be overwritten by weaker weather types
+ */
+export const PRIMAL_WEATHER = Object.freeze([WeatherType.HARSH_SUN, WeatherType.HEAVY_RAIN, WeatherType.STRONG_WINDS]);
+
+/**
  * Class representing Weather effects
  * @var weatherType - The {@linkcode WeatherType} that is being represented
  * @var turnsLeft - How many turns the weather still has left (0 if immutable)
@@ -45,14 +50,7 @@ export class Weather {
    * @returns true if {@linkcode WeatherType} is immutable, false otherwise
    */
   isImmutable(): boolean {
-    switch (this.weatherType) {
-      case WeatherType.HEAVY_RAIN:
-      case WeatherType.HARSH_SUN:
-      case WeatherType.STRONG_WINDS:
-        return true;
-    }
-
-    return false;
+    return PRIMAL_WEATHER.includes(this.weatherType);
   }
 
   /**
@@ -60,13 +58,8 @@ export class Weather {
    * @returns true for sandstorm or hail, false otherwise
    */
   isDamaging(): boolean {
-    switch (this.weatherType) {
-      case WeatherType.SANDSTORM:
-      case WeatherType.HAIL:
-        return true;
-    }
-
-    return false;
+    const DAMAGING_WEATHER = Object.freeze([WeatherType.SANDSTORM, WeatherType.HAIL]);
+    return DAMAGING_WEATHER.includes(this.weatherType);
   }
 
   /**

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -25,9 +25,9 @@ export class Weather {
   public weatherType: WeatherType;
   public turnsLeft: number;
 
-  constructor(weatherType: WeatherType, turnsLeft?: number) {
+  constructor(weatherType: WeatherType, turnsLeft: number = 0) {
     this.weatherType = weatherType;
-    this.turnsLeft = !this.isPrimal() ? turnsLeft || 0 : 0;
+    this.turnsLeft = !this.isPrimal() ? turnsLeft : 0;
   }
 
   /**

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -2,10 +2,10 @@ import { globalScene } from "#app/global-scene";
 import type { BiomeTierTrainerPools, PokemonPools } from "#app/data/balance/biomes";
 import { biomePokemonPools, biomeTrainerPools } from "#app/data/balance/biomes";
 import { BiomePoolTier } from "#enums/biome-pool-tier";
-import { type AbstractConstructor, isNullOrUndefined, randSeedInt } from "#app/utils";
+import { type AbstractConstructor, randSeedInt } from "#app/utils";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
-import { getWeatherClearMessage, getWeatherStartMessage, Weather } from "#app/data/weather";
+import { getWeatherClearMessage, getWeatherStartMessage, PRIMAL_WEATHER, Weather } from "#app/data/weather";
 import { CommonAnim } from "#enums/common-anim";
 import type { ElementalType } from "#enums/elemental-type";
 import type { Move } from "#app/data/move";
@@ -405,11 +405,8 @@ export class Arena {
       if (weather === this.weather.weatherType) {
         return false;
       }
-      if (this.weather.isImmutable()) {
-        if ([WeatherType.NONE, ...primalWeathers].includes(weather)) {
-          return true;
-        }
-        return false;
+      if (this.weather.isImmutable() && [WeatherType.NONE, ...PRIMAL_WEATHER].includes(weather)) {
+        return true;
       }
     } else if (weather === WeatherType.NONE) {
       return false;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -397,31 +397,21 @@ export class Arena {
 
   /**
    * Helper function that checks if it is possible to set a new weather given current weather conditions
-   * @param newWeather the weather that the game is attempting to set
+   * @param weather - The weather that the game is attempting to set
    * @returns `true` if the weather can be set given current conditions | `false` if not
    */
-  canSetWeather(newWeather: WeatherType): boolean {
+  public canSetWeather(weather: WeatherType): boolean {
     if (this.weather) {
-      // Checks if the new weather is identical to the current weather
-      if (newWeather === this.weather.weatherType) {
+      if (weather === this.weather.weatherType) {
         return false;
       }
-      // Checks if the current weather is immutable
       if (this.weather.isImmutable()) {
-        // Only other immutable weather types can overwrite immutable weather
-        if (
-          newWeather === WeatherType.HARSH_SUN
-          || newWeather === WeatherType.HEAVY_RAIN
-          || newWeather === WeatherType.STRONG_WINDS
-          || newWeather === WeatherType.NONE
-        ) {
+        if ([WeatherType.NONE, ...primalWeathers].includes(weather)) {
           return true;
-        } else {
-          return false;
         }
+        return false;
       }
-      // Checks if there is no current weather and the game is attempting to set the weather to none
-    } else if (isNullOrUndefined(this.weather) && newWeather === WeatherType.NONE) {
+    } else if (weather === WeatherType.NONE) {
       return false;
     }
     return true;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -441,7 +441,7 @@ export class Arena {
 
     const oldWeatherType = this.weather?.weatherType || WeatherType.NONE;
 
-    this.weather = weather ? new Weather(weather, hasPokemonSource ? 5 : 0) : null;
+    this.weather = weather !== WeatherType.NONE ? new Weather(weather, hasPokemonSource ? 5 : 0) : null;
 
     if (this.weather) {
       this.eventTarget.dispatchEvent(

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import type { BiomeTierTrainerPools, PokemonPools } from "#app/data/balance/biomes";
 import { biomePokemonPools, biomeTrainerPools } from "#app/data/balance/biomes";
 import { BiomePoolTier } from "#enums/biome-pool-tier";
-import { type AbstractConstructor, randSeedInt } from "#app/utils";
+import { type AbstractConstructor, isNullOrUndefined, randSeedInt } from "#app/utils";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
 import { getWeatherClearMessage, getWeatherStartMessage, Weather } from "#app/data/weather";
@@ -420,6 +420,9 @@ export class Arena {
           return false;
         }
       }
+      // Checks if there is no current weather and the game is attempting to set the weather to none
+    } else if (isNullOrUndefined(this.weather) && newWeather === WeatherType.NONE) {
+      return false;
     }
     return true;
   }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -405,7 +405,7 @@ export class Arena {
       if (weather === this.weather.weatherType) {
         return false;
       }
-      if (this.weather.isImmutable() && [WeatherType.NONE, ...PRIMAL_WEATHER].includes(weather)) {
+      if (this.weather.isPrimal() && [WeatherType.NONE, ...PRIMAL_WEATHER].includes(weather)) {
         return true;
       }
     } else if (weather === WeatherType.NONE) {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -413,6 +413,7 @@ export class Arena {
           newWeather === WeatherType.HARSH_SUN
           || newWeather === WeatherType.HEAVY_RAIN
           || newWeather === WeatherType.STRONG_WINDS
+          || newWeather === WeatherType.NONE
         ) {
           return true;
         } else {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -396,6 +396,34 @@ export class Arena {
   }
 
   /**
+   * Helper function that checks if it is possible to set a new weather given current weather conditions
+   * @param newWeather the weather that the game is attempting to set
+   * @returns `true` if the weather can be set given current conditions | `false` if not
+   */
+  canSetWeather(newWeather: WeatherType): boolean {
+    if (this.weather) {
+      // Checks if the new weather is identical to the current weather
+      if (newWeather === this.weather.weatherType) {
+        return false;
+      }
+      // Checks if the current weather is immutable
+      if (this.weather.isImmutable()) {
+        // Only other immutable weather types can overwrite immutable weather
+        if (
+          newWeather === WeatherType.HARSH_SUN
+          || newWeather === WeatherType.HEAVY_RAIN
+          || newWeather === WeatherType.STRONG_WINDS
+        ) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
    * Attempts to set a new weather to the battle
    * @param weather {@linkcode WeatherType} new {@linkcode WeatherType} to set
    * @param hasPokemonSource boolean if the new weather is from a pokemon
@@ -406,7 +434,7 @@ export class Arena {
       return this.trySetWeatherOverride(Overrides.WEATHER_OVERRIDE);
     }
 
-    if (this.weather?.weatherType === (weather || undefined)) {
+    if (!this.canSetWeather(weather)) {
       return false;
     }
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -397,18 +397,18 @@ export class Arena {
 
   /**
    * Helper function that checks if it is possible to set a new weather given current weather conditions
-   * @param weather - The weather that the game is attempting to set
+   * @param newWeather - The weather that the game is attempting to set
    * @returns `true` if the weather can be set given current conditions | `false` if not
    */
-  public canSetWeather(weather: WeatherType): boolean {
+  public canSetWeather(newWeather: WeatherType): boolean {
     if (this.weather) {
-      if (weather === this.weather.weatherType) {
+      if (newWeather === this.weather.weatherType) {
         return false;
       }
-      if (this.weather.isPrimal() && [WeatherType.NONE, ...PRIMAL_WEATHER].includes(weather)) {
-        return true;
+      if (this.weather.isPrimal() && ![WeatherType.NONE, ...PRIMAL_WEATHER].includes(newWeather)) {
+        return false;
       }
-    } else if (weather === WeatherType.NONE) {
+    } else if (newWeather === WeatherType.NONE) {
       return false;
     }
     return true;
@@ -416,29 +416,29 @@ export class Arena {
 
   /**
    * Attempts to set a new weather to the battle
-   * @param weather {@linkcode WeatherType} new {@linkcode WeatherType} to set
+   * @param newWeather {@linkcode WeatherType} new {@linkcode WeatherType} to set
    * @param hasPokemonSource boolean if the new weather is from a pokemon
    * @returns true if new weather set, false if no weather provided or attempting to set the same weather as currently in use
    */
-  trySetWeather(weather: WeatherType, hasPokemonSource: boolean): boolean {
+  trySetWeather(newWeather: WeatherType, hasPokemonSource: boolean): boolean {
     if (Overrides.WEATHER_OVERRIDE) {
       return this.trySetWeatherOverride(Overrides.WEATHER_OVERRIDE);
     }
 
-    if (!this.canSetWeather(weather)) {
+    if (!this.canSetWeather(newWeather)) {
       return false;
     }
 
     const oldWeatherType = this.weather?.weatherType || WeatherType.NONE;
 
-    this.weather = weather !== WeatherType.NONE ? new Weather(weather, hasPokemonSource ? 5 : 0) : null;
+    this.weather = newWeather !== WeatherType.NONE ? new Weather(newWeather, hasPokemonSource ? 5 : 0) : null;
 
     if (this.weather) {
       this.eventTarget.dispatchEvent(
         new WeatherChangedEvent(oldWeatherType, this.weather.weatherType, this.weather.turnsLeft),
       );
-      globalScene.unshiftPhase(new CommonAnimPhase(undefined, undefined, CommonAnim.SUNNY + (weather - 1)));
-      globalScene.queueMessage(getWeatherStartMessage(weather) ?? "");
+      globalScene.unshiftPhase(new CommonAnimPhase(undefined, undefined, CommonAnim.SUNNY + (newWeather - 1)));
+      globalScene.queueMessage(getWeatherStartMessage(newWeather) ?? "");
     } else {
       globalScene.queueMessage(getWeatherClearMessage(oldWeatherType) ?? "");
     }
@@ -448,9 +448,9 @@ export class Arena {
       .filter((p) => p.isOnField())
       .map((pokemon) => {
         pokemon.findAndRemoveTags(
-          (t) => "weatherTypes" in t && !(t.weatherTypes as WeatherType[]).find((t) => t === weather),
+          (t) => "weatherTypes" in t && !(t.weatherTypes as WeatherType[]).find((t) => t === newWeather),
         );
-        applyAbAttrs(AbAttrFlag.POST_WEATHER_CHANGE, pokemon, false, weather);
+        applyAbAttrs(AbAttrFlag.POST_WEATHER_CHANGE, pokemon, false, newWeather);
       });
 
     return true;

--- a/test/arena/primal_weather.test.ts
+++ b/test/arena/primal_weather.test.ts
@@ -1,0 +1,46 @@
+import { Abilities } from "#enums/abilities";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { WeatherType } from "#enums/weather-type";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Primal Weather", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .ability(Abilities.BALL_FETCH)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemySpecies(Species.MAGIKARP)
+      .enemyMoveset(MoveId.SPLASH);
+  });
+
+  it.each([
+    { weatherName: "Harsh Sun", ability: Abilities.DESOLATE_LAND, weatherType: WeatherType.HARSH_SUN },
+    { weatherName: "Heavy Rain", ability: Abilities.PRIMORDIAL_SEA, weatherType: WeatherType.HEAVY_RAIN },
+    { weatherName: "Strong Winds", ability: Abilities.DELTA_STREAM, weatherType: WeatherType.STRONG_WINDS },
+  ])("$weatherName can't be overwritten by non-primal weather", async ({ ability, weatherType }) => {
+    game.override.ability(ability);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    game.move.use(MoveId.SANDSTORM);
+    await game.toEndOfTurn();
+
+    expect(game.scene.arena.hasWeather(weatherType)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

Fixes #710 

## Why am I making these changes?

The game would benefit from a `canSetWeather` function

## What are the changes from a developer perspective?

Created a `canSetWeather` function that will check if a new weather can. be set on the field before overwriting the current weather in `trySetWeather`
Changed `isImmutable()` to `isPrimal()` because primal weather can be overwritten by other primal weather, so it is not 'immutable' and `isPrimal()` clarifies the weather hierarchy better. 
Created a 'PRIMAL_WEATHER' constant that is used for reference in `canSetWeather()` and `isPrimal()` 
Cleaned up `isDamaging()` to match `isPrimal()` 

## How to test the changes?

Chilly Reception should no longer overwrite the 'immutable' weathers like Strong Winds/Harsh Sun/Heavy Rain

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)