### PR TITLE
[Move][P3] Splash, Celebrate, Hold Hands now display messages

### DIFF
--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -242,6 +242,7 @@ import { WeatherType } from "#enums/weather-type";
 import i18next from "i18next";
 import { RageAttr } from "./move-attrs/rage-attr";
 import { DoubleDamageToMaxAttr } from "./move-attrs/double-damage-to-max-attr";
+import { DisplayMessageAttr } from "./move-attrs/display-message-attr";
 
 export function initMoves() {
   const rawAllMoves = [
@@ -755,7 +756,9 @@ export function initMoves() {
     new AttackMove(MoveId.PSYWAVE, ElementalType.PSYCHIC, MoveCategory.SPECIAL, -1, 100, 15, -1, 0, 1).attr(
       RandomLevelDamageAttr,
     ),
-    new SelfStatusMove(MoveId.SPLASH, ElementalType.NORMAL, -1, 40, -1, 0, 1).condition(failOnGravityCondition),
+    new SelfStatusMove(MoveId.SPLASH, ElementalType.NORMAL, -1, 40, -1, 0, 1)
+      .condition(failOnGravityCondition)
+      .attr(DisplayMessageAttr, i18next.t("moveTriggers:splash")),
     new SelfStatusMove(MoveId.ACID_ARMOR, ElementalType.POISON, -1, 20, -1, 0, 1).attr(
       StatStageChangeAttr,
       [Stat.DEF],
@@ -2568,8 +2571,15 @@ export function initMoves() {
     new AttackMove(MoveId.DAZZLING_GLEAM, ElementalType.FAIRY, MoveCategory.SPECIAL, 80, 100, 10, -1, 0, 6).target(
       MoveTarget.ALL_NEAR_ENEMIES,
     ),
-    new SelfStatusMove(MoveId.CELEBRATE, ElementalType.NORMAL, -1, 40, -1, 0, 6),
+    new SelfStatusMove(MoveId.CELEBRATE, ElementalType.NORMAL, -1, 40, -1, 0, 6).attr(
+      DisplayMessageAttr,
+      i18next.t("moveTriggers:celebrate", { pokemonName: "{USER}" }),
+    ),
     new StatusMove(MoveId.HOLD_HANDS, ElementalType.NORMAL, -1, 40, -1, 0, 6)
+      .attr(
+        DisplayMessageAttr,
+        i18next.t("moveTriggers:holdHands", { pokemonName: "{USER}", targetPokemonName: "{TARGET}" }),
+      )
       .ignoresSubstitute()
       .target(MoveTarget.NEAR_ALLY),
     new StatusMove(MoveId.BABY_DOLL_EYES, ElementalType.FAIRY, 100, 30, -1, 1, 6).attr(

--- a/src/data/move-attrs/display-message-attr.ts
+++ b/src/data/move-attrs/display-message-attr.ts
@@ -1,0 +1,32 @@
+import type { Pokemon } from "#app/field/pokemon";
+import type { Move } from "#app/data/move";
+import { globalScene } from "#app/global-scene";
+import { MoveEffectAttr } from "./move-effect-attr";
+import { getPokemonNameWithAffix } from "#app/messages";
+
+/**
+ * Attribute to display a message
+ * @extends MoveAttr
+ */
+export class DisplayMessageAttr extends MoveEffectAttr {
+  private displayMessage: string;
+
+  constructor(displayMessage: string) {
+    super();
+    this.displayMessage = displayMessage;
+  }
+  /**
+   * Displays the intended message
+   * @param user The user of the move
+   * @param target The target of the move
+   * @param _move n/a
+   * @returns `true`
+   */
+  override applyEffect(user: Pokemon, target: Pokemon | null, _move: Move): boolean {
+    const replacedMessage = this.displayMessage
+      .replace("{USER}", getPokemonNameWithAffix(user))
+      .replace("{TARGET}", getPokemonNameWithAffix(target));
+    globalScene.queueMessage(replacedMessage);
+    return true;
+  }
+}

--- a/src/data/move-attrs/display-message-attr.ts
+++ b/src/data/move-attrs/display-message-attr.ts
@@ -6,7 +6,7 @@ import { getPokemonNameWithAffix } from "#app/messages";
 
 /**
  * Attribute to display a message
- * @extends MoveAttr
+ * @extends MoveEffectAttr 
  */
 export class DisplayMessageAttr extends MoveEffectAttr {
   private displayMessage: string;


### PR DESCRIPTION
## What are the changes the user will see?

Splash, Celebrate, and Hold Hands now display messages

## Why am I making these changes?

Closes #614 

## What are the changes from a developer perspective?

* Created a new `DisplayMessageAttr`

## Screenshots/Videos

Splash: 
![image](https://github.com/user-attachments/assets/d22a50e8-f612-4228-ad51-f61139670d41)

Celebrate:
![image](https://github.com/user-attachments/assets/42713ef8-5af4-45aa-a4c1-18b2fe7a8c2e)

Hold Hands:
![image](https://github.com/user-attachments/assets/4ba4610c-05b7-4b04-9c00-17bf80f1b18a)


## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.SPLASH, MoveId.CELEBRATE, MoveId.HOLD_HANDS],
  BATTLE_TYPE_OVERRIDE: "double"
}
```

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

Are there any localization additions or changes? If so:

- [x] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/Despair-Games/poketernity-locales/pull/29
- [ ] Has the translation team been contacted for proofreading/translation?
