### PR TITLE
[P2][P3] Starter moveset for Pokemon with forms now updates properly

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2391,6 +2391,13 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.checkIconId(this.starterIcons[index], species, props.female, props.formIndex, props.shiny, props.variant);
   }
 
+  /**
+   * Puts a move at the requested index in the current highlighted Pokemon's moveset.
+   * If the move was already present in the moveset, swap its position with the one in the new spot currently.
+   * @param targetIndex the index to put the move, between 0 and 3
+   * @param newMoveId the {@linkcode MoveId} of the move to add in
+   * @param previousMoveId the {@linkcode MoveId} of the move that was in that spot previously
+   */
   switchMoveHandler(targetIndex: number, newMoveId: MoveId, previousMoveId: MoveId): void {
     if (!this.starterMoveset) {
       console.warn("Trying to update a non existing moveset");
@@ -2431,11 +2438,12 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     if (!this.starterMoveset) {
       return;
     }
-    // Find the index of that Pokemon species in the team, if it is present.
-    const starterIndex = this.starterSpecies.findIndex((species: PokemonSpecies) => species.speciesId === speciesId);
-    if (starterIndex >= 0) {
-      this.starterMovesets[starterIndex] = this.starterMoveset;
-    }
+    // Find the Pokemon of that species in the team, and give them the correct moveset.
+    this.starterSpecies.forEach((species: PokemonSpecies, index: number) => {
+      if (species.speciesId === speciesId) {
+        this.starterMovesets[index] = this.starterMoveset!;
+      }
+    });
   }
 
   updateButtonIcon(iconSetting, gamepadType, iconElement, controlLabel): void {

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -2391,56 +2391,50 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     this.checkIconId(this.starterIcons[index], species, props.female, props.formIndex, props.shiny, props.variant);
   }
 
-  switchMoveHandler(i: number, newMoveId: MoveId, moveId: MoveId) {
+  switchMoveHandler(targetIndex: number, newMoveId: MoveId, previousMoveId: MoveId): void {
+    if (!this.starterMoveset) {
+      console.warn("Trying to update a non existing moveset");
+      return;
+    }
+
     const speciesId = this.lastSpecies.speciesId;
-    const existingMoveIndex = this.starterMoveset?.indexOf(newMoveId)!; // TODO: is this bang correct?
-    this.starterMoveset![i] = newMoveId; // TODO: is this bang correct?
+    const existingMoveIndex = this.starterMoveset.indexOf(newMoveId);
+    this.starterMoveset[targetIndex] = newMoveId;
     if (existingMoveIndex > -1) {
-      this.starterMoveset![existingMoveIndex] = moveId; // TODO: is this bang correct?
+      this.starterMoveset[existingMoveIndex] = previousMoveId;
     }
-    const props: DexAttrProps = globalScene.gameData.getSpeciesDexAttrProps(this.lastSpecies, this.dexAttrCursor);
-    // species has different forms
+    const updatedMoveset = this.starterMoveset.slice(0) as StarterMoveset;
+    const formIndex = globalScene.gameData.getSpeciesDexAttrProps(this.lastSpecies, this.dexAttrCursor).formIndex;
+    const starterData = globalScene.gameData.starterData[speciesId];
+
     if (pokemonFormLevelMoves.hasOwnProperty(speciesId)) {
-      // starterMoveData doesn't have base form moves or is using the single form format
-      if (
-        !globalScene.gameData.starterData[speciesId].moveset
-        || Array.isArray(globalScene.gameData.starterData[speciesId].moveset)
-      ) {
-        globalScene.gameData.starterData[speciesId].moveset = {
-          [props.formIndex]: this.starterMoveset?.slice(0) as StarterMoveset,
-        };
+      // Species has forms with different movesets
+      if (!starterData.moveset || Array.isArray(starterData.moveset)) {
+        starterData.moveset = {};
       }
-      const starterMoveData = globalScene.gameData.starterData[speciesId].moveset;
-
-      // starterMoveData doesn't have active form moves
-      if (!starterMoveData.hasOwnProperty(props.formIndex)) {
-        globalScene.gameData.starterData[speciesId].moveset[props.formIndex] = this.starterMoveset?.slice(
-          0,
-        ) as StarterMoveset;
-      }
-
-      // does the species' starter move data have its form's starter moves and has it been updated
-      if (starterMoveData.hasOwnProperty(props.formIndex)) {
-        // active form move hasn't been updated
-        if (starterMoveData[props.formIndex][existingMoveIndex] !== newMoveId) {
-          globalScene.gameData.starterData[speciesId].moveset[props.formIndex] = this.starterMoveset?.slice(
-            0,
-          ) as StarterMoveset;
-        }
-      }
+      starterData.moveset[formIndex] = updatedMoveset;
     } else {
-      globalScene.gameData.starterData[speciesId].moveset = this.starterMoveset?.slice(0) as StarterMoveset;
+      starterData.moveset = updatedMoveset;
     }
+
     this.setSpeciesDetails(this.lastSpecies, { forSeen: false });
 
-    // switch moves of starter if exists
-    if (this.starterMovesets.length) {
-      Array.from({ length: this.starterSpecies.length }, (_, i) => {
-        const starterSpecies = this.starterSpecies[i];
-        if (starterSpecies.speciesId === speciesId) {
-          this.starterMovesets[i] = this.starterMoveset!; // TODO: is this bang correct?
-        }
-      });
+    // switch moves of selected starter if it exists
+    this.updateSelectedStarterMoveset(speciesId);
+  }
+
+  /**
+   * Update the starter moveset for the given species, if it is part of the selected starters.
+   * @param speciesId the {@linkcode Species} to consider
+   */
+  private updateSelectedStarterMoveset(speciesId: Species): void {
+    if (!this.starterMoveset) {
+      return;
+    }
+    // Find the index of that Pokemon species in the team, if it is present.
+    const starterIndex = this.starterSpecies.findIndex((species: PokemonSpecies) => species.speciesId === speciesId);
+    if (starterIndex >= 0) {
+      this.starterMovesets[starterIndex] = this.starterMoveset;
     }
   }
 

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -3571,6 +3571,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
           return this.starterMoveset?.indexOf(move) === i;
         }) as StarterMoveset;
 
+        if (!isNullOrUndefined(formIndex)) {
+          // If we're switching form and the Pokemon is in the team, we need to update its moveset
+          this.updateSelectedStarterMoveset(species.speciesId);
+        }
+
         const speciesForm = getPokemonSpeciesForm(species.speciesId, formIndex!); // TODO: is the bang correct?
         const formText = capitalizeString(species?.forms[formIndex!]?.formKey, "-", false, false); // TODO: is the bang correct?
 


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

- It is now possible to switch the order of moves in the current moveset of Pokemon with forms
- Switching the form of a starter after having added it to the team will no longer start the run with an empty moveset
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

- Fixes #517 
- Having an empty moveset is not ideal

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

- rewrote `switchMoveHandler` to streamline it. (The original issue was this 
https://github.com/Despair-Games/poketernity/blob/969326c4ba21961d2581b6b839c6d3c84539a4f5/src/ui/starter-select-ui-handler.ts#L2425
checking `starterMoveData[props.formIndex][existingMoveIndex]` instead of `starterMoveData[props.formIndex][i]`)
But that check wasn't really needed anyway, so it's gone now)
- put the code updating the current starters' moveset at the end of `switchMoveHandler` in its own function, and also call it in `setSpecies` when changing the form of a Pokemon, to make sure the moveset gets updated

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

<details><summary>Move swaping</summary>

https://github.com/user-attachments/assets/5950d0f1-526a-4ecf-817e-086b9553ce30

https://github.com/user-attachments/assets/f63f4c56-2265-4c7d-a129-8b7330781286

</details> 

<details><summary>Empty moveset</summary>

https://github.com/user-attachments/assets/eb7d4ae8-6203-46c6-846e-3514b8e1017b

https://github.com/user-attachments/assets/7002249f-ebd7-46d6-a683-5eaeea2d5c67

</details> 

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

<details><summary>Move Swapping</summary>

  - Starter select
  - Go to a mon with form specific movesets like Pikachu, Meowth, Oricorio or Calyrex [Full list of affected mons](<https://github.com/Despair-Games/poketernity/blob/beta/src/data/balance/pokemon-form-level-moves.ts>)
  - Try to swap around the moves in its moveset several time. 
</details>
<details><summary>Empty Moveset</summary>

1. Starter select
2. Go to a mon with form specific movesets and that you can change form for, like Pikachu, Rotom or Paldean Tauros
3. Add the mon to the team
4. While it's in the team, switch it to a different form. The shown moveset should change.
<sub> If it doesn't, either the mon doesn't fit the requirements, or you have legacy data of a time when the species didn't have form specific movesets. To fix it temove the mon from the team, make any change to the moveset, then go back to step 3
5. Do not update the moveset and start the run
6. The Pokemon should have the correct moveset 
</details>

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [X] **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
