### PR TITLE
[Test] The sprite test will now output useful error messages on fail

### DIFF
--- a/test/sprites/pokemonSprite.test.ts
+++ b/test/sprites/pokemonSprite.test.ts
@@ -98,7 +98,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check female variant files", () => {
@@ -107,7 +107,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check back female variant files", () => {
@@ -116,7 +116,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("check back male variant files", () => {
@@ -127,7 +127,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors", errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   // check over every file if it's correctly set in the masterlist
@@ -138,7 +138,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant back female and check if present in masterlist", () => {
@@ -147,7 +147,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant back male and check if present in masterlist", () => {
@@ -157,7 +157,7 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 
   it("look over every file in variant root and check if present in masterlist", () => {
@@ -166,6 +166,6 @@ describe("check if every variant's sprite are correctly set", () => {
     if (errors.length) {
       console.log("errors for ", dirPath, errors);
     }
-    expect(errors.length).toBe(0);
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The sprite check test didn't give helpful error messages when something was wrong, now it will.

## What are the changes from a developer perspective?
Changed the `expect()`s to go from checking the length of the error message array to checking that it equals an empty array, which makes it output the error message array to the console if it's not empty.

## How to test the changes?
`npm run test pokemonSprite` after breaking something

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test`)
  - [x] Have I created new automated tests (`npm run create-test`) or updated existing tests related to the PR's changes?