### PR TITLE
[Balance] Multi-hit moves now use gen 5+ behavior

### DIFF
--- a/src/data/move-attrs/multi-hit-attr.ts
+++ b/src/data/move-attrs/multi-hit-attr.ts
@@ -1,12 +1,12 @@
-import { MultiHitType } from "#enums/multi-hit-type";
-import type { Pokemon } from "#app/field/pokemon";
-import { NumberHolder } from "#app/utils";
 import { applyAbAttrs } from "#app/data/apply-ab-attrs";
 import { type Move } from "#app/data/move";
-import { applyMoveAttrs } from "#app/utils/move-utils";
 import { ChangeMultiHitTypeAttr } from "#app/data/move-attrs/change-multi-hit-type-attr";
 import { MoveAttr } from "#app/data/move-attrs/move-attr";
+import type { Pokemon } from "#app/field/pokemon";
+import { NumberHolder } from "#app/utils";
+import { applyMoveAttrs } from "#app/utils/move-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { MultiHitType } from "#enums/multi-hit-type";
 
 /**
  * Attribute used for attack moves that hit multiple times per use, e.g. Bullet Seed.
@@ -65,14 +65,14 @@ export class MultiHitAttr extends MoveAttr {
   getHitCount(user: Pokemon, _target: Pokemon): number {
     switch (this.multiHitType) {
       case MultiHitType._2_TO_5: {
-        const rand = user.randSeedInt(16);
+        const rand = user.randSeedInt(20);
         const hitValue = new NumberHolder(rand);
         applyAbAttrs(AbAttrFlag.MAX_MULTI_HIT, user, false, hitValue);
-        if (hitValue.value >= 10) {
+        if (hitValue.value >= 13) {
           return 2;
-        } else if (hitValue.value >= 4) {
+        } else if (hitValue.value >= 6) {
           return 3;
-        } else if (hitValue.value >= 2) {
+        } else if (hitValue.value >= 3) {
           return 4;
         } else {
           return 5;

--- a/src/data/move-attrs/multi-hit-attr.ts
+++ b/src/data/move-attrs/multi-hit-attr.ts
@@ -65,6 +65,16 @@ export class MultiHitAttr extends MoveAttr {
   getHitCount(user: Pokemon, _target: Pokemon): number {
     switch (this.multiHitType) {
       case MultiHitType._2_TO_5: {
+        /**
+         * ```
+         * | Hits | RNG rolls | Chance | %  |
+         * |------|-----------|--------|----|
+         * | 2    | 13-19     | 7/20   | 35 |
+         * | 3    | 6-12      | 7/20   | 35 |
+         * | 4    | 3-5       | 3/20   | 15 |
+         * | 5    | 0-2       | 3/20   | 15 |
+         * ```
+         */
         const rand = user.randSeedInt(20);
         const hitValue = new NumberHolder(rand);
         applyAbAttrs(AbAttrFlag.MAX_MULTI_HIT, user, false, hitValue);


### PR DESCRIPTION
## What are the changes the user will see?
Changed behavior of multi-hit moves so that the odds are 35/35/15/15 for 2/3/4/5 hits (gen 5+) instead of 37.5/37.5/12.5/12.5 for 2/3/4/5 hits (gens 1-4).
cf https://bulbapedia.bulbagarden.net/wiki/Multistrike_move#Variable_number_of_strikes

## Why am I making these changes?
Multi-hit moves don't need to be that bad.

## What are the changes from a developer perspective?
The game now rolls a d20 and assigns the number of hits as follows:

| Hits | RNG rolls | Chance | %  |
|------|-----------|--------|----|
| 2    | 13-19     | 7/20   | 35 |
| 3    | 6-12      | 7/20   | 35 |
| 4    | 3-5       | 3/20   | 15 |
| 5    | 0-2       | 3/20   | 15 |

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?