### PR TITLE
[Refactor] Add `ArenaTag.i18nSideKey` to consolidate player side checks

### DIFF
--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1400,15 +1400,9 @@ export class TypeImmuneDamageOverTimeTag extends ArenaTag {
   }
 
   override onAdd(_arena: Arena) {
-    let localeKey = "arenaTag:TypeImmuneDamageOverTimeOnAdd";
-    if (this.side === ArenaTagSide.PLAYER) {
-      localeKey = localeKey.concat("Player");
-    } else {
-      localeKey = localeKey.concat("Enemy");
-    }
-    localeKey = localeKey.concat(ElementalType[this.immuneType]);
-
-    globalScene.queueMessage(i18next.t(localeKey));
+    globalScene.queueMessage(
+      i18next.t(`arenaTag:TypeImmuneDamageOverTimeOnAdd${this.i18nSideKey}${ElementalType[this.immuneType]}`),
+    );
   }
 
   override lapse(arena: Arena): boolean {

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1,34 +1,34 @@
-import { globalScene } from "#app/global-scene";
-import type { Arena } from "#app/field/arena";
-import { ElementalType } from "#enums/elemental-type";
-import { BooleanHolder, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils";
+import { applyAbAttrs } from "#app/data/apply-ab-attrs";
 import { allMoves } from "#app/data/data-lists";
-import { MoveTarget } from "#enums/move-target";
-import { MoveCategory } from "#enums/move-category";
-import { getPokemonNameWithAffix } from "#app/messages";
+import type { Arena } from "#app/field/arena";
 import type { Pokemon } from "#app/field/pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
-import { HitResult } from "#enums/hit-result";
-import { StatusEffect } from "#enums/status-effect";
-import type { BattlerIndex } from "#enums/battler-index";
-import { applyAbAttrs } from "#app/data/apply-ab-attrs";
-import { Stat } from "#enums/stat";
-import { CommonBattleAnim } from "./battle-anims/common-battle-anim";
-import { CommonAnim } from "#enums/common-anim";
-import i18next from "i18next";
-import { Abilities } from "#enums/abilities";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { MoveId } from "#enums/move-id";
+import { globalScene } from "#app/global-scene";
+import { getPokemonNameWithAffix } from "#app/messages";
+import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
-import { CommonAnimPhase } from "#app/phases/common-anim-phase";
-import { MoveFlags } from "#enums/move-flags";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import { type SkyDropTag } from "./battler-tags";
+import { BooleanHolder, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { Abilities } from "#enums/abilities";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import type { BattlerIndex } from "#enums/battler-index";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { CommonAnim } from "#enums/common-anim";
+import { ElementalType } from "#enums/elemental-type";
+import { HitResult } from "#enums/hit-result";
+import { MoveCategory } from "#enums/move-category";
+import { MoveFlags } from "#enums/move-flags";
+import { MoveId } from "#enums/move-id";
+import { MoveTarget } from "#enums/move-target";
 import { PhaseId } from "#enums/phase-id";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+import i18next from "i18next";
+import { CommonBattleAnim } from "./battle-anims/common-battle-anim";
+import { type SkyDropTag } from "./battler-tags";
 
 export abstract class ArenaTag {
   constructor(
@@ -39,32 +39,36 @@ export abstract class ArenaTag {
     public side: ArenaTagSide = ArenaTagSide.BOTH,
   ) {}
 
-  apply(_arena: Arena, _simulated: boolean, ..._args: unknown[]): boolean {
+  public get i18nSideKey(): string {
+    if (this.side === ArenaTagSide.PLAYER) {
+      return "Player";
+    } else if (this.side === ArenaTagSide.ENEMY) {
+      return "Enemy";
+    }
+    return "";
+  }
+
+  public apply(_arena: Arena, _simulated: boolean, ..._args: unknown[]): boolean {
     return true;
   }
 
-  onAdd(_arena: Arena, _quiet: boolean = false): void {}
+  public onAdd(_arena: Arena, _quiet: boolean = false): void {}
 
-  onRemove(_arena: Arena, quiet: boolean = false): void {
+  public onRemove(_arena: Arena, quiet: boolean = false): void {
     if (!quiet) {
       globalScene.queueMessage(
-        i18next.t(
-          `arenaTag:arenaOnRemove${
-            this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-          }`,
-          { moveName: this.getMoveName() },
-        ),
+        i18next.t(`arenaTag:arenaOnRemove${this.i18nSideKey}`, { moveName: this.getMoveName() }),
       );
     }
   }
 
-  onOverlap(_arena: Arena): void {}
+  public onOverlap(_arena: Arena): void {}
 
-  lapse(_arena: Arena): boolean {
+  public lapse(_arena: Arena): boolean {
     return this.turnCount < 1 || !!--this.turnCount;
   }
 
-  getMoveName(): string | null {
+  public getMoveName(): string | null {
     return this.sourceMoveId ? allMoves[this.sourceMoveId].name : null;
   }
 
@@ -73,7 +77,7 @@ export abstract class ArenaTag {
    * This is meant to be inherited from by any arena tag with custom attributes
    * @param source - The {@linkcode ArenaTag} source to load from
    */
-  loadTag(source: ArenaTag | any): void {
+  public loadTag(source: ArenaTag | any): void {
     this.turnCount = source.turnCount;
     this.sourceMoveId = source.sourceMoveId;
     this.sourceId = source.sourceId;
@@ -229,13 +233,7 @@ class ReflectTag extends WeakenMoveScreenTag {
 
   override onAdd(_arena: Arena, quiet: boolean = false): void {
     if (!quiet) {
-      globalScene.queueMessage(
-        i18next.t(
-          `arenaTag:reflectOnAdd${
-            this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-          }`,
-        ),
-      );
+      globalScene.queueMessage(i18next.t(`arenaTag:reflectOnAdd${this.i18nSideKey}`));
     }
   }
 }
@@ -251,13 +249,7 @@ class LightScreenTag extends WeakenMoveScreenTag {
 
   override onAdd(_arena: Arena, quiet: boolean = false): void {
     if (!quiet) {
-      globalScene.queueMessage(
-        i18next.t(
-          `arenaTag:lightScreenOnAdd${
-            this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-          }`,
-        ),
-      );
+      globalScene.queueMessage(i18next.t(`arenaTag:lightScreenOnAdd${this.i18nSideKey}`));
     }
   }
 }
@@ -276,13 +268,7 @@ class AuroraVeilTag extends WeakenMoveScreenTag {
 
   override onAdd(_arena: Arena, quiet: boolean = false): void {
     if (!quiet) {
-      globalScene.queueMessage(
-        i18next.t(
-          `arenaTag:auroraVeilOnAdd${
-            this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-          }`,
-        ),
-      );
+      globalScene.queueMessage(i18next.t(`arenaTag:auroraVeilOnAdd${this.i18nSideKey}`));
     }
   }
 }
@@ -315,12 +301,7 @@ export abstract class ConditionalProtectTag extends ArenaTag {
 
   override onAdd(_arena: Arena): void {
     globalScene.queueMessage(
-      i18next.t(
-        `arenaTag:conditionalProtectOnAdd${
-          this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-        }`,
-        { moveName: super.getMoveName() },
-      ),
+      i18next.t(`arenaTag:conditionalProtectOnAdd${this.i18nSideKey}`, { moveName: super.getMoveName() }),
     );
   }
 
@@ -515,7 +496,7 @@ export class NoCritTag extends ArenaTag {
   /** Queues a message upon adding this effect to the field */
   override onAdd(_arena: Arena): void {
     globalScene.queueMessage(
-      i18next.t(`arenaTag:noCritOnAdd${this.side === ArenaTagSide.PLAYER ? "Player" : "Enemy"}`, {
+      i18next.t(`arenaTag:noCritOnAdd${this.i18nSideKey}`, {
         moveName: this.getMoveName(),
       }),
     );
@@ -1042,25 +1023,17 @@ class StickyWebTag extends EntryHazardTag {
     super(ArenaTagType.STICKY_WEB, MoveId.STICKY_WEB, sourceId, side, 1);
   }
 
+  /** @todo Should `quiet` ever be `true`? */
   override onAdd(arena: Arena, quiet: boolean = false): void {
     super.onAdd(arena);
     const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
     if (!quiet && source) {
-      if (this.side === ArenaTagSide.PLAYER) {
-        globalScene.queueMessage(
-          i18next.t("arenaTag:stickyWebOnAddPlayerSide", {
-            moveName: this.getMoveName(),
-            opponentDesc: source.getOpponentDescriptor(),
-          }),
-        );
-      } else {
-        globalScene.queueMessage(
-          i18next.t("arenaTag:stickyWebOnAddEnemySide", {
-            moveName: this.getMoveName(),
-            opponentDesc: source.getOpponentDescriptor(),
-          }),
-        );
-      }
+      globalScene.queueMessage(
+        i18next.t(`arenaTag:stickyWebOnAdd${this.i18nSideKey}Side`, {
+          moveName: this.getMoveName(),
+          opponentDesc: source.getOpponentDescriptor(),
+        }),
+      );
     }
   }
 
@@ -1167,13 +1140,7 @@ class TailwindTag extends ArenaTag {
 
   override onAdd(_arena: Arena, quiet: boolean = false): void {
     if (!quiet) {
-      globalScene.queueMessage(
-        i18next.t(
-          `arenaTag:tailwindOnAdd${
-            this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-          }`,
-        ),
-      );
+      globalScene.queueMessage(i18next.t(`arenaTag:tailwindOnAdd${this.i18nSideKey}`));
     }
 
     const source = globalScene.getPokemonById(this.sourceId!); //TODO: this bang is questionable!
@@ -1200,13 +1167,7 @@ class TailwindTag extends ArenaTag {
 
   override onRemove(_arena: Arena, quiet: boolean = false): void {
     if (!quiet) {
-      globalScene.queueMessage(
-        i18next.t(
-          `arenaTag:tailwindOnRemove${
-            this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-          }`,
-        ),
-      );
+      globalScene.queueMessage(i18next.t(`arenaTag:tailwindOnRemove${this.i18nSideKey}`));
     }
   }
 }
@@ -1235,23 +1196,11 @@ class SafeguardTag extends ArenaTag {
   }
 
   override onAdd(_arena: Arena): void {
-    globalScene.queueMessage(
-      i18next.t(
-        `arenaTag:safeguardOnAdd${
-          this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-        }`,
-      ),
-    );
+    globalScene.queueMessage(i18next.t(`arenaTag:safeguardOnAdd${this.i18nSideKey}`));
   }
 
   override onRemove(_arena: Arena): void {
-    globalScene.queueMessage(
-      i18next.t(
-        `arenaTag:safeguardOnRemove${
-          this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-        }`,
-      ),
-    );
+    globalScene.queueMessage(i18next.t(`arenaTag:safeguardOnRemove${this.i18nSideKey}`));
   }
 }
 
@@ -1338,13 +1287,7 @@ class FireGrassPledgeTag extends ArenaTag {
 
   override onAdd(_arena: Arena): void {
     // "A sea of fire enveloped your/the opposing team!"
-    globalScene.queueMessage(
-      i18next.t(
-        `arenaTag:fireGrassPledgeOnAdd${
-          this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-        }`,
-      ),
-    );
+    globalScene.queueMessage(i18next.t(`arenaTag:fireGrassPledgeOnAdd${this.i18nSideKey}`));
   }
 
   override lapse(arena: Arena): boolean {
@@ -1389,13 +1332,7 @@ class WaterFirePledgeTag extends ArenaTag {
 
   override onAdd(_arena: Arena): void {
     // "A rainbow appeared in the sky on your/the opposing team's side!"
-    globalScene.queueMessage(
-      i18next.t(
-        `arenaTag:waterFirePledgeOnAdd${
-          this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-        }`,
-      ),
-    );
+    globalScene.queueMessage(i18next.t(`arenaTag:waterFirePledgeOnAdd${this.i18nSideKey}`));
   }
 
   /**
@@ -1425,13 +1362,7 @@ class GrassWaterPledgeTag extends ArenaTag {
 
   override onAdd(_arena: Arena): void {
     // "A swamp enveloped your/the opposing team!"
-    globalScene.queueMessage(
-      i18next.t(
-        `arenaTag:grassWaterPledgeOnAdd${
-          this.side === ArenaTagSide.PLAYER ? "Player" : this.side === ArenaTagSide.ENEMY ? "Enemy" : ""
-        }`,
-      ),
-    );
+    globalScene.queueMessage(i18next.t(`arenaTag:grassWaterPledgeOnAdd${this.i18nSideKey}`));
   }
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To remove the need to recreate the same chained ternary over and over again.

## What are the changes from a developer perspective?
Added `ArenaTag.i18nSideKey` which handles the `side === player ? "Player" : side === enemy ? "Enemy" : ""` check, and replaced all existing instances of the chained ternary with `this.i18nSideKey`.

## Screenshots/Videos
<details><summary>Light Screen</summary>
<p>

![image](https://github.com/user-attachments/assets/4b2961bc-e5cf-4494-b870-d59038e114c4)

![image](https://github.com/user-attachments/assets/72df389f-35bd-401a-b5c8-2e542588cf2e)

</p>
</details> 

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Have I provided screenshots/videos of the changes (if applicable)?