### PR TITLE
[Balance] Remove custom Hidden Abilities from all species

### DIFF
--- a/src/data/balance/trainer-configs/evil-boss-trainer-configs.ts
+++ b/src/data/balance/trainer-configs/evil-boss-trainer-configs.ts
@@ -527,7 +527,6 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
       getRandomPartyMemberFunc([Species.GOLISOPOD], TrainerSlot.TRAINER, true, (p) => {
         p.setBoss(true, 2);
         p.generateAndPopulateMoveset();
-        p.abilityIndex = 2; //Anticipation
         p.gender = Gender.MALE;
         p.pokeball = PokeballType.ULTRA_BALL;
       }),

--- a/src/data/init-species.ts
+++ b/src/data/init-species.ts
@@ -9648,7 +9648,7 @@ export function initSpecies() {
       24,
       Abilities.TRUANT,
       Abilities.NONE,
-      Abilities.STALL,
+      Abilities.NONE,
       280,
       60,
       60,
@@ -9662,7 +9662,7 @@ export function initSpecies() {
       GrowthRate.SLOW,
       50,
       false,
-    ), //Custom Hidden
+    ),
     new PokemonSpecies(
       Species.VIGOROTH,
       3,
@@ -9673,7 +9673,7 @@ export function initSpecies() {
       46.5,
       Abilities.VITAL_SPIRIT,
       Abilities.NONE,
-      Abilities.INSOMNIA,
+      Abilities.NONE,
       440,
       80,
       80,
@@ -9687,7 +9687,7 @@ export function initSpecies() {
       GrowthRate.SLOW,
       50,
       false,
-    ), //Custom Hidden
+    ),
     new PokemonSpecies(
       Species.SLAKING,
       3,
@@ -9698,7 +9698,7 @@ export function initSpecies() {
       130.5,
       Abilities.TRUANT,
       Abilities.NONE,
-      Abilities.STALL,
+      Abilities.NONE,
       670,
       150,
       160,
@@ -9712,7 +9712,7 @@ export function initSpecies() {
       GrowthRate.SLOW,
       50,
       false,
-    ), //Custom Hidden
+    ),
     new PokemonSpecies(
       Species.NINCADA,
       3,
@@ -16387,7 +16387,7 @@ export function initSpecies() {
       420,
       Abilities.SLOW_START,
       Abilities.NONE,
-      Abilities.NORMALIZE,
+      Abilities.NONE,
       670,
       110,
       160,
@@ -19047,7 +19047,7 @@ export function initSpecies() {
       9.5,
       Abilities.DEFEATIST,
       Abilities.NONE,
-      Abilities.EMERGENCY_EXIT,
+      Abilities.NONE,
       401,
       55,
       112,
@@ -19061,7 +19061,7 @@ export function initSpecies() {
       GrowthRate.MEDIUM_FAST,
       87.5,
       false,
-    ), //Custom Hidden
+    ),
     new PokemonSpecies(
       Species.ARCHEOPS,
       5,
@@ -19072,7 +19072,7 @@ export function initSpecies() {
       32,
       Abilities.DEFEATIST,
       Abilities.NONE,
-      Abilities.EMERGENCY_EXIT,
+      Abilities.NONE,
       567,
       75,
       140,
@@ -19086,7 +19086,7 @@ export function initSpecies() {
       GrowthRate.MEDIUM_FAST,
       87.5,
       false,
-    ), //Custom Hidden
+    ),
     new PokemonSpecies(
       Species.TRUBBISH,
       5,
@@ -27769,7 +27769,7 @@ export function initSpecies() {
       12,
       Abilities.WIMP_OUT,
       Abilities.NONE,
-      Abilities.RUN_AWAY,
+      Abilities.NONE,
       230,
       25,
       35,
@@ -27783,7 +27783,7 @@ export function initSpecies() {
       GrowthRate.MEDIUM_FAST,
       50,
       false,
-    ), //Custom Hidden
+    ),
     new PokemonSpecies(
       Species.GOLISOPOD,
       7,
@@ -27794,7 +27794,7 @@ export function initSpecies() {
       108,
       Abilities.EMERGENCY_EXIT,
       Abilities.NONE,
-      Abilities.ANTICIPATION,
+      Abilities.NONE,
       530,
       75,
       125,
@@ -27808,7 +27808,7 @@ export function initSpecies() {
       GrowthRate.MEDIUM_FAST,
       50,
       false,
-    ), //Custom Hidden
+    ),
     new PokemonSpecies(
       Species.SANDYGAST,
       7,


### PR DESCRIPTION
## What are the changes the user will see?

Custom abilities have been removed from all Pokemon (except Ferroseed, which has Anticipation for technical reasons). The Pokemon impacted by this change are
- Slakoth / Vigoroth / Slaking (Stall / Insomnia / Stall)
- Regigias (Normalize)
- Archen / Archeops (Emergency Exit)
- Wimpod / Golisopod (Run Away / Anticipation)

## Why am I making these changes?

A few reasons:

1. These Pokemon are balanced in mainline around their signature abilities; having an alternative ability undermines that.
2. Starter Pokemon should be balanced from a clean slate considering how many other features are planned.

## What are the changes from a developer perspective?

Custom hidden abilities in `init-species` have been replaced with `Abilities.NONE`

## Screenshots/Videos

## How to test the changes?

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?