### PR TITLE
[P2] Sand Spit and Seed Sower activate even on KO

### DIFF
--- a/src/data/init-abilities.ts
+++ b/src/data/init-abilities.ts
@@ -1168,7 +1168,7 @@ export function initAbilities() {
       .attr(MoveFlagPowerBoostAbAttr, MoveFlags.SOUND_MOVE, 1.3)
       .attr(ReceivedMoveDamageMultiplierAbAttr, (_target, _user, move) => move.hasFlag(MoveFlags.SOUND_MOVE), 0.5)
       .ignorable(),
-    new Ability(Abilities.SAND_SPIT, 8).attr(
+    new Ability(Abilities.SAND_SPIT, 8).bypassFaint().attr(
       PostDefendWeatherChangeAbAttr,
       WeatherType.SANDSTORM,
       (_target, _user, move) => move.category !== MoveCategory.STATUS,
@@ -1282,7 +1282,7 @@ export function initAbilities() {
     new Ability(Abilities.LINGERING_AROMA, 9)
       .attr(PostDefendAbilityGiveAbAttr, Abilities.LINGERING_AROMA)
       .bypassFaint(),
-    new Ability(Abilities.SEED_SOWER, 9).attr(PostDefendTerrainChangeAbAttr, TerrainType.GRASSY),
+    new Ability(Abilities.SEED_SOWER, 9).bypassFaint().attr(PostDefendTerrainChangeAbAttr, TerrainType.GRASSY),
     new Ability(Abilities.THERMAL_EXCHANGE, 9)
       .attr(
         PostDefendStatStageChangeAbAttr,

--- a/test/abilities/sand_spit.test.ts
+++ b/test/abilities/sand_spit.test.ts
@@ -55,6 +55,6 @@ describe("Abilities - Sand Spit", () => {
     game.move.select(MoveId.GROWL);
     await game.toNextTurn();
 
-    expect(game.scene.arena.weather?.weatherType).not.toBe(WeatherType.SANDSTORM);
+    expect(game.scene.arena.weather).toBeUndefined();
   });
 });

--- a/test/abilities/sand_spit.test.ts
+++ b/test/abilities/sand_spit.test.ts
@@ -22,34 +22,39 @@ describe("Abilities - Sand Spit", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleType("single");
-    game.override.disableCrits();
-
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-
-    game.override.starterSpecies(Species.SILICOBRA);
-    game.override.ability(Abilities.SAND_SPIT);
-    game.override.moveset([MoveId.SPLASH, MoveId.COIL]);
+    game.override
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.SILICOBRA)
+      .enemyAbility(Abilities.SAND_SPIT)
+      .enemyMoveset([MoveId.SPLASH])
+      .moveset([MoveId.TACKLE, MoveId.WATERFALL, MoveId.SURF, MoveId.GROWL]);
   });
 
   it("should trigger when hit with damaging move", async () => {
-    game.override.enemyMoveset([MoveId.TACKLE]);
-    await game.startBattle();
+    await game.classicMode.startBattle([Species.FEEBAS]);
 
-    game.move.select(MoveId.SPLASH);
+    game.move.select(MoveId.TACKLE);
     await game.toNextTurn();
 
     expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SANDSTORM);
-  }, 20000);
+  });
+
+  it("should trigger when KO'd", async () => {
+    game.override.startingLevel(1000).enemyLevel(1);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    game.move.select(MoveId.WATERFALL);
+    await game.phaseInterceptor.to("FaintPhase");
+
+    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SANDSTORM);
+  });
 
   it("should not trigger when targetted with status moves", async () => {
-    game.override.enemyMoveset([MoveId.GROWL]);
-    await game.startBattle();
-
-    game.move.select(MoveId.COIL);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    game.move.select(MoveId.GROWL);
     await game.toNextTurn();
 
     expect(game.scene.arena.weather?.weatherType).not.toBe(WeatherType.SANDSTORM);
-  }, 20000);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Sand Spit and Seed Sower will now activate their effects even if the user is KO'd

## Why am I making these changes?

Fixes #542

## What are the changes from a developer perspective?

* Added the `bypassFaint()` function to sand spit and seed sower
* Updated tests for sand spit

## Screenshots/Videos

n/a

## How to test the changes?

`npm run test sand_spit`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
