### PR TITLE
[P2] Fog can be suppressed

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -120,5 +120,5 @@ export const IV_MAX = 31;
  */
 export const DYNAMAX_DAMAGE_TAKEN_FACTOR = 2 / 3;
 
-// Custom implementation. Mainline is 0.6
-export const FOG_ACCURACY_MODIFIER = 0.9;
+/** Custom implementation. Mainline is 0.6. */
+export const FOG_ACCURACY_MULTIPLIER = 0.9;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -119,3 +119,6 @@ export const IV_MAX = 31;
  * Tweak this value if necessary for balancing purposes
  */
 export const DYNAMAX_DAMAGE_TAKEN_FACTOR = 2 / 3;
+
+// Custom implementation. Mainline is 0.6
+export const FOG_ACCURACY_MODIFIER = 0.9;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -41,6 +41,7 @@ import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { applyMoveAttrs } from "#app/utils/move-utils";
 import type { ChargingAttackMove } from "#app/data/moves/charging-attack-move";
 import type { ChargingSelfStatusMove } from "#app/data/moves/charging-self-status-move";
+import { FOG_ACCURACY_MODIFIER } from "#app/constants";
 
 export abstract class Move implements Localizable {
   public id: MoveId;
@@ -728,12 +729,8 @@ export abstract class Move implements Localizable {
     const isOhko = this.hasAttr(OneHitKOAccuracyAttr);
 
     // TODO: wide lens was calculated here
-    if (globalScene.arena.hasWeather(WeatherType.FOG)) {
-      /**
-       *  The 0.9 multiplier is Game-specific implementation, Bulbapedia uses 3/5
-       *  See Fog {@link https://bulbapedia.bulbagarden.net/wiki/Fog}
-       */
-      moveAccuracy.value = Math.floor(moveAccuracy.value * 0.9);
+    if (globalScene.arena.hasWeather(WeatherType.FOG) && !globalScene.arena.weather?.isEffectSuppressed()) {
+      moveAccuracy.value = Math.floor(moveAccuracy.value * FOG_ACCURACY_MODIFIER);
     }
 
     if (!isOhko && globalScene.arena.getTag(ArenaTagType.GRAVITY)) {

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -41,7 +41,7 @@ import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { applyMoveAttrs } from "#app/utils/move-utils";
 import type { ChargingAttackMove } from "#app/data/moves/charging-attack-move";
 import type { ChargingSelfStatusMove } from "#app/data/moves/charging-self-status-move";
-import { FOG_ACCURACY_MODIFIER } from "#app/constants";
+import { FOG_ACCURACY_MULTIPLIER } from "#app/constants";
 
 export abstract class Move implements Localizable {
   public id: MoveId;
@@ -730,7 +730,7 @@ export abstract class Move implements Localizable {
 
     // TODO: wide lens was calculated here
     if (globalScene.arena.hasWeather(WeatherType.FOG) && !globalScene.arena.weather?.isEffectSuppressed()) {
-      moveAccuracy.value = Math.floor(moveAccuracy.value * FOG_ACCURACY_MODIFIER);
+      moveAccuracy.value = Math.floor(moveAccuracy.value * FOG_ACCURACY_MULTIPLIER);
     }
 
     if (!isOhko && globalScene.arena.getTag(ArenaTagType.GRAVITY)) {

--- a/test/arena/weather_fog.test.ts
+++ b/test/arena/weather_fog.test.ts
@@ -7,7 +7,7 @@ import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { FOG_ACCURACY_MODIFIER } from "#app/constants";
+import { FOG_ACCURACY_MULTIPLIER } from "#app/constants";
 
 describe("Weather - Fog", () => {
   let phaserGame: Phaser.Game;
@@ -43,7 +43,7 @@ describe("Weather - Fog", () => {
     game.move.select(MoveId.TACKLE);
     await game.phaseInterceptor.to(MoveEffectPhase);
 
-    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100 * FOG_ACCURACY_MODIFIER);
+    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100 * FOG_ACCURACY_MULTIPLIER);
   });
 
   it("move accuracy is unaffected if fog is suppressed", async () => {

--- a/test/arena/weather_fog.test.ts
+++ b/test/arena/weather_fog.test.ts
@@ -7,6 +7,7 @@ import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { FOG_ACCURACY_MODIFIER } from "#app/constants";
 
 describe("Weather - Fog", () => {
   let phaserGame: Phaser.Game;
@@ -24,23 +25,36 @@ describe("Weather - Fog", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.weather(WeatherType.FOG).battleType("single");
-    game.override.moveset([MoveId.TACKLE]);
-    game.override.ability(Abilities.BALL_FETCH);
-    game.override.enemyAbility(Abilities.BALL_FETCH);
-    game.override.enemySpecies(Species.MAGIKARP);
-    game.override.enemyMoveset([MoveId.SPLASH]);
+    game.override
+      .weather(WeatherType.FOG)
+      .battleType("single")
+      .enemySpecies(Species.MAGIKARP)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyMoveset([MoveId.SPLASH])
+      .moveset([MoveId.TACKLE]);
   });
 
-  it("move accuracy is multiplied by 90%", async () => {
+  it("move accuracy is changed in fog", async () => {
     const moveToCheck = allMoves[MoveId.TACKLE];
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
-    await game.startBattle([Species.MAGIKARP]);
+    await game.classicMode.startBattle([Species.FEEBAS]);
     game.move.select(MoveId.TACKLE);
     await game.phaseInterceptor.to(MoveEffectPhase);
 
-    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100 * 0.9);
+    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100 * FOG_ACCURACY_MODIFIER);
+  });
+
+  it("move accuracy is unaffected if fog is suppressed", async () => {
+    const moveToCheck = allMoves[MoveId.TACKLE];
+
+    vi.spyOn(moveToCheck, "calculateBattleAccuracy");
+    game.override.ability(Abilities.AIR_LOCK);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+    game.move.select(MoveId.TACKLE);
+    await game.phaseInterceptor.to(MoveEffectPhase);
+
+    expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Fog no longer lowers accuracy if suppressed

## Why am I making these changes?

Fixes #559

## What are the changes from a developer perspective?

* Created a new constant for fog accuracy modifier if we want to tweak it
* Added an extra suppression check for fog
* Updated tests

## Screenshots/Videos

n/a

## How to test the changes?

`npm run test weather_fog`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
