### PR TITLE
[P2] Perish song KOs g-max Pokemon now

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1870,7 +1870,7 @@ export class PerishSongTag extends BattlerTag {
         }),
       );
     } else {
-      pokemon.damageAndUpdate(pokemon.hp, HitResult.ONE_HIT_KO, false, true, true);
+      pokemon.damageAndUpdate(2 * pokemon.hp, HitResult.ONE_HIT_KO, false, true, true);
     }
 
     return ret;

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1870,6 +1870,7 @@ export class PerishSongTag extends BattlerTag {
         }),
       );
     } else {
+      // The 2 here is just a number big enough to overcome the G-Max damage reduction
       pokemon.damageAndUpdate(2 * pokemon.hp, HitResult.ONE_HIT_KO, false, true, true);
     }
 

--- a/test/battle/gmax_damage_calculation.test.ts
+++ b/test/battle/gmax_damage_calculation.test.ts
@@ -117,5 +117,8 @@ describe("Battle Mechanics - Damage Calculation", () => {
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("VictoryPhase");
+
+    expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+    expect(game.scene.getEnemyParty()[0].isFainted()).toBe(true);
   });
 });

--- a/test/battle/gmax_damage_calculation.test.ts
+++ b/test/battle/gmax_damage_calculation.test.ts
@@ -104,4 +104,18 @@ describe("Battle Mechanics - Damage Calculation", () => {
       (((1 / 16) * 2) / 3) * enemyPokemon.getMaxHp(),
     );
   });
+
+  it("Perish Song should still KO G-Max Pokemon", async () => {
+    game.override.moveset([MoveId.PERISH_SONG, MoveId.SPLASH]);
+    await game.classicMode.startBattle([Species.MAGIKARP, Species.MAGIKARP]);
+
+    game.move.select(MoveId.PERISH_SONG);
+    await game.toNextTurn();
+    game.move.select(MoveId.SPLASH);
+    await game.toNextTurn();
+    game.move.select(MoveId.SPLASH);
+    await game.toNextTurn();
+    game.move.select(MoveId.SPLASH);
+    await game.phaseInterceptor.to("VictoryPhase");
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Perish Song now KOs G-Max Pokemon instead of doing 2/3 of their HP as damage

## Why am I making these changes?

Edge case pointed out in #680

## What are the changes from a developer perspective?

* Added a `2` in the `damageAndUpdate` of the perish song battler tag so the damage is enough to overcome the g-max damage reduction

## Screenshots/Videos

n/a

## How to test the changes?

```ts
const overrides = {
  ENEMY_SPECIES_OVERRIDE:Species.LAPRAS,
  ENEMY_FORM_OVERRIDES:{[Species.LAPRAS]: 1},
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH],
  MOVESET_OVERRIDE: [MoveId.PERISH_SONG],
}
```

`npm run test gmax_damage_calculation`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Has the translation team been contacted for proofreading/translation?
