### PR TITLE
[Bug] Fix status effects not being saved

### DIFF
--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -104,7 +104,7 @@ export default class PokemonData {
     if (sourcePokemon) {
       this.moveset = sourcePokemon.moveset;
       if (!forHistory) {
-        this.status = sourcePokemon.getStatusEffect(false, true);
+        this.status = sourcePokemon.status;
         if (this.player) {
           this.summonData = sourcePokemon.summonData;
         }

--- a/test/battle/reload.test.ts
+++ b/test/battle/reload.test.ts
@@ -5,6 +5,7 @@ import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/testUtils/gameManager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { StatusEffect } from "#enums/status-effect";
 
 describe("Reload", () => {
   let phaserGame: Phaser.Game;
@@ -37,7 +38,7 @@ describe("Reload", () => {
     const postReloadRngState = Phaser.Math.RND.state();
 
     expect(preReloadRngState).toBe(postReloadRngState);
-  }, 20000);
+  });
 
   it("should not have RNG inconsistencies after a biome switch", async () => {
     game.override
@@ -62,7 +63,7 @@ describe("Reload", () => {
     const postReloadRngState = Phaser.Math.RND.state();
 
     expect(preReloadRngState).toBe(postReloadRngState);
-  }, 20000);
+  });
 
   it("should not have weather inconsistencies after a biome switch", async () => {
     game.override
@@ -88,7 +89,7 @@ describe("Reload", () => {
     const postReloadWeather = game.scene.arena.weather;
 
     expect(postReloadWeather).toStrictEqual(preReloadWeather);
-  }, 20000);
+  });
 
   it("should not have RNG inconsistencies at a Daily run wild Pokemon fight", async () => {
     await game.dailyMode.startBattle();
@@ -100,7 +101,7 @@ describe("Reload", () => {
     const postReloadRngState = Phaser.Math.RND.state();
 
     expect(preReloadRngState).toBe(postReloadRngState);
-  }, 20000);
+  });
 
   it("should not have RNG inconsistencies at a Daily run double battle", async () => {
     game.override.battleType("double");
@@ -113,7 +114,7 @@ describe("Reload", () => {
     const postReloadRngState = Phaser.Math.RND.state();
 
     expect(preReloadRngState).toBe(postReloadRngState);
-  }, 20000);
+  });
 
   it("should not have RNG inconsistencies at a Daily run Gym Leader fight", async () => {
     game.override.battleType("single").startingWave(40);
@@ -126,7 +127,7 @@ describe("Reload", () => {
     const postReloadRngState = Phaser.Math.RND.state();
 
     expect(preReloadRngState).toBe(postReloadRngState);
-  }, 20000);
+  });
 
   it("should not have RNG inconsistencies at a Daily run regular trainer fight", async () => {
     game.override.battleType("single").startingWave(45);
@@ -139,7 +140,7 @@ describe("Reload", () => {
     const postReloadRngState = Phaser.Math.RND.state();
 
     expect(preReloadRngState).toBe(postReloadRngState);
-  }, 20000);
+  });
 
   it("should not have RNG inconsistencies at a Daily run wave 50 Boss fight", async () => {
     game.override.battleType("single").startingWave(50);
@@ -152,5 +153,24 @@ describe("Reload", () => {
     const postReloadRngState = Phaser.Math.RND.state();
 
     expect(preReloadRngState).toBe(postReloadRngState);
-  }, 20000);
+  });
+
+  it("should save status effects properly", async () => {
+    game.override.battleType("single").enemySpecies(Species.MAREANIE).enemyMoveset(MoveId.TOXIC);
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    game.move.use(MoveId.SPLASH);
+    await game.toNextTurn();
+    game.move.use(MoveId.SPLASH);
+    await game.doKillOpponents();
+    await game.toNextWave();
+
+    expect(game.field.getPlayerPokemon().getStatusEffect(true)).toBe(StatusEffect.TOXIC);
+
+    await game.reload.reloadSession();
+
+    const newPokemon = game.field.getPlayerPokemon();
+    expect(newPokemon.getStatusEffect(true)).toBe(StatusEffect.TOXIC);
+    expect(newPokemon.status?.toxicTurnCount).toBe(2);
+  });
 });


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

Status effects are preserved properly when reloading a session.

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

Bug introduced by #462.

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

1. Fixed typo in `pokemon-data.ts`.
2. Added a test to `reload.test.ts`. The test file is also moved from `test/rng` to `test/battle` since it now tests for more than RNG.

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

Save and reload a session when a party member has a status condition.

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?