### PR TITLE
[Misc] Update interface usage in phase constructors

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1,37 +1,81 @@
+// -- start tsdoc imports --
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { type PokemonHealPhaseOptions } from "#app/phases/pokemon-heal-phase";
+// -- end tsdoc imports --
+
+import type { ModifierPredicate } from "#app/@types/ModifierPredicate";
+import type { PokemonSpeciesFilter } from "#app/@types/PokemonSpeciesFilter";
+import type { AnySettingKey, SettingsUpdateEventArgs } from "#app/@types/Settings";
+import { Animation } from "#app/animations";
 import type { FixedBattleConfig } from "#app/battle";
 import Battle from "#app/battle";
+import {
+  IV_MAX,
+  IV_MIN,
+  ME_ANTI_VARIANCE_WEIGHT_MODIFIER,
+  ME_AVERAGE_ENCOUNTERS_PER_RUN_TARGET,
+  ME_BASE_SPAWN_WEIGHT,
+  ME_MAX_SPAWN_WEIGHT,
+  PRSFX_SOUND_ADJUSTMENT_RATIO,
+} from "#app/constants";
+import { applyAbAttrs } from "#app/data/apply-ab-attrs";
 import { biomeDepths, getBiomeName } from "#app/data/balance/biomes";
 import { pokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
 import { FRIENDSHIP_GAIN_FROM_BATTLE } from "#app/data/balance/starters";
+import { allTrainerConfigs } from "#app/data/balance/trainer-configs/all-trainer-configs";
 import { MoveChargeAnim } from "#app/data/battle-anims/move-charge-anim";
 import type { DestinyBondTag, GrudgeTag } from "#app/data/battler-tags";
+import { bgmLoopPoint } from "#app/data/bgm-loop-point";
 import { allAbilities, allMoves, allSpecies } from "#app/data/data-lists";
 import { classicFinalBossDialogue } from "#app/data/dialogue";
+import { initCommonAnims } from "#app/data/init-common-anims";
+import { initMoveAnim } from "#app/data/init-move-anim";
 import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
 import { MysteryEncounterSaveData } from "#app/data/mystery-encounters/mystery-encounter-save-data";
 import { allMysteryEncounters, mysteryEncountersByBiome } from "#app/data/mystery-encounters/mystery-encounters";
-import type { SpeciesFormChange } from "#app/data/pokemon-forms";
-import { pokemonFormChanges } from "#app/data/pokemon-forms";
+import { pokemonFormChanges, type SpeciesFormChange } from "#app/data/pokemon-forms";
 import type PokemonSpecies from "#app/data/pokemon-species";
+import { populateAnims } from "#app/data/populate-anims";
+import { SpeciesFormChangeManualTrigger } from "#app/data/species-form-change-triggers/species-form-change-manual-trigger";
+import { SpeciesFormChangeTimeOfDayTrigger } from "#app/data/species-form-change-triggers/species-form-change-time-of-day-trigger";
+import type { SpeciesFormChangeTrigger } from "#app/data/species-form-change-triggers/species-form-change-trigger";
+import { resetStarterColors, starterColors } from "#app/data/starter-colors";
 import { getTypeRgb } from "#app/data/type";
-import type { Variant } from "#app/data/variant";
-import { variantData } from "#app/data/variant";
+import { type Variant, variantData } from "#app/data/variant";
+import { eventBus } from "#app/event-bus";
 import { NewArenaEvent } from "#app/events/battle-scene";
 import { Arena, ArenaBase } from "#app/field/arena";
 import DamageNumberHandler from "#app/field/damage-number-handler";
-import type { Pokemon } from "#app/field/pokemon";
-import { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
+import { EnemyPokemon, PlayerPokemon, type Pokemon } from "#app/field/pokemon";
 import type { PokemonMove } from "#app/field/pokemon-move";
 import PokemonSpriteSparkleHandler from "#app/field/pokemon-sprite-sparkle-handler";
 import Trainer from "#app/field/trainer";
-import type { GameMode } from "#app/game-mode";
-import { getGameMode } from "#app/game-mode";
+import { type GameMode, getGameMode } from "#app/game-mode";
 import { initGlobalScene } from "#app/global-scene";
 import { InputsController } from "#app/inputs-controller";
 import type HeldModifierConfig from "#app/interfaces/held-modifier-config";
 import type { Localizable } from "#app/interfaces/locales";
 import { LoadingScene } from "#app/loading-scene";
 import { CallSourceLogger } from "#app/loggers";
+import {
+  ConsumableModifier,
+  ConsumablePokemonModifier,
+  DoubleBattleChanceBoosterModifier,
+  ExpBalanceModifier,
+  ExpShareModifier,
+  HealingBoosterModifier,
+  type Modifier,
+  ModifierBar,
+  MultipleParticipantExpBonusModifier,
+  type PersistentModifier,
+  PokemonExpBoosterModifier,
+  type PokemonFormChangeItemModifier,
+  type PokemonHeldItemModifier,
+  PokemonHpRestoreModifier,
+  PokemonIncrementingStatModifier,
+  RememberMoveModifier,
+  type TurnHeldItemTransferModifier,
+} from "#app/modifier/modifier";
 import {
   getDefaultModifierTypeForTier,
   getEnemyModifierTypesForWave,
@@ -40,6 +84,7 @@ import {
   getPartyLuckValue,
   PokemonHeldItemModifierType,
 } from "#app/modifier/modifier-type";
+import { modifierTypes } from "#app/modifier/modifier-types";
 import Overrides from "#app/overrides";
 import { type Phase } from "#app/phase";
 import { BattleEndPhase } from "#app/phases/battle-end-phase";
@@ -57,7 +102,7 @@ import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { NewBiomeEncounterPhase } from "#app/phases/new-biome-encounter-phase";
 import { NextEncounterPhase } from "#app/phases/next-encounter-phase";
 import { PokemonAnimPhase } from "#app/phases/pokemon-anim-phase";
-import { PokemonHealPhase, type PokemonHealPhaseOptions } from "#app/phases/pokemon-heal-phase";
+import { PokemonHealPhase } from "#app/phases/pokemon-heal-phase";
 import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
 import { ReturnPhase } from "#app/phases/return-phase";
 import { SelectBiomePhase } from "#app/phases/select-biome-phase";
@@ -73,14 +118,13 @@ import FieldSpritePipeline from "#app/pipelines/field-sprite";
 import InvertPostFX from "#app/pipelines/invert";
 import SpritePipeline from "#app/pipelines/sprite";
 import { SceneBase } from "#app/scene-base";
-import type { Achv } from "#app/system/achv";
-import { achvs } from "#app/system/achv";
+import { type Achv, achvs } from "#app/system/achv";
 import { GameData } from "#app/system/game-data";
 import { initGameSpeed } from "#app/system/game-speed";
 import type PokemonData from "#app/system/pokemon-data";
+import { settings } from "#app/system/settings/settings-manager";
 import type TrainerData from "#app/system/trainer-data";
-import type { Voucher } from "#app/system/voucher";
-import { vouchers } from "#app/system/voucher";
+import { type Voucher, vouchers } from "#app/system/voucher";
 import { TimedEventManager } from "#app/timed-event-manager";
 import { CANVAS_SCALE, GAME_HEIGHT, GAME_WIDTH } from "#app/ui-constants";
 import { UiInputs } from "#app/ui-inputs";
@@ -108,6 +152,11 @@ import {
   randSeedInt,
   shiftCharCodes,
 } from "#app/utils";
+import { loadCommonAnimAssets } from "#app/utils/anim-utils";
+import { getModifierPoolForType } from "#app/utils/modifier-pool-utils";
+import { getModifierType } from "#app/utils/modifier-type-utils";
+import { loadMoveAnimAssets } from "#app/utils/move-anim-utils";
+import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AchvCategory } from "#enums/achv-category";
 import { BattleType } from "#enums/battle-type";
@@ -139,55 +188,6 @@ import i18next from "i18next";
 import Phaser from "phaser";
 import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import type UIPlugin from "phaser3-rex-plugins/templates/ui/ui-plugin";
-import type { ModifierPredicate } from "./@types/ModifierPredicate";
-import type { PokemonSpeciesFilter } from "./@types/PokemonSpeciesFilter";
-import type { AnySettingKey, SettingsUpdateEventArgs } from "./@types/Settings";
-import { Animation } from "./animations";
-import {
-  IV_MAX,
-  IV_MIN,
-  ME_ANTI_VARIANCE_WEIGHT_MODIFIER,
-  ME_AVERAGE_ENCOUNTERS_PER_RUN_TARGET,
-  ME_BASE_SPAWN_WEIGHT,
-  ME_MAX_SPAWN_WEIGHT,
-  PRSFX_SOUND_ADJUSTMENT_RATIO,
-} from "./constants";
-import { applyAbAttrs } from "./data/apply-ab-attrs";
-import { allTrainerConfigs } from "./data/balance/trainer-configs/all-trainer-configs";
-import { bgmLoopPoint } from "./data/bgm-loop-point";
-import { initCommonAnims } from "./data/init-common-anims";
-import { initMoveAnim } from "./data/init-move-anim";
-import { populateAnims } from "./data/populate-anims";
-import { SpeciesFormChangeManualTrigger } from "./data/species-form-change-triggers/species-form-change-manual-trigger";
-import { SpeciesFormChangeTimeOfDayTrigger } from "./data/species-form-change-triggers/species-form-change-time-of-day-trigger";
-import type { SpeciesFormChangeTrigger } from "./data/species-form-change-triggers/species-form-change-trigger";
-import { resetStarterColors, starterColors } from "./data/starter-colors";
-import { eventBus } from "./event-bus";
-import type { Modifier, TurnHeldItemTransferModifier } from "./modifier/modifier";
-import {
-  ConsumableModifier,
-  ConsumablePokemonModifier,
-  DoubleBattleChanceBoosterModifier,
-  ExpBalanceModifier,
-  ExpShareModifier,
-  HealingBoosterModifier,
-  ModifierBar,
-  MultipleParticipantExpBonusModifier,
-  type PersistentModifier,
-  PokemonExpBoosterModifier,
-  type PokemonFormChangeItemModifier,
-  type PokemonHeldItemModifier,
-  PokemonHpRestoreModifier,
-  PokemonIncrementingStatModifier,
-  RememberMoveModifier,
-} from "./modifier/modifier";
-import { modifierTypes } from "./modifier/modifier-types";
-import { settings } from "./system/settings/settings-manager";
-import { loadCommonAnimAssets } from "./utils/anim-utils";
-import { getModifierPoolForType } from "./utils/modifier-pool-utils";
-import { getModifierType } from "./utils/modifier-type-utils";
-import { loadMoveAnimAssets } from "./utils/move-anim-utils";
-import { getPokemonSpecies } from "./utils/pokemon-species-utils";
 
 //#region Types
 
@@ -3668,13 +3668,13 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Queues a new {@linkcode PokemonHealPhase} for the given {@linkcode BattlerIndex}.
-   * @param eager Whether to add the {@linkcode PokemonHealPhase} to the front of the phase queue or defer it
-   * @param battlerIndex The {@linkcode BattlerIndex} to heal
-   * @param hp The amount of HP to heal
-   * @param options Optional {@linkcode PokemonHealPhaseOptions}
+   * @param eager - Whether to add the {@linkcode PokemonHealPhase} to the front of the phase queue or defer it
+   * @param battlerIndex - The {@linkcode BattlerIndex} of the pokemon to heal
+   * @param hpHealed - The amount of HP to heal
+   * @param params_2 - The various {@linkcode PokemonHealPhaseOptions | optional parameters} of `PokemonHealPhase`
    */
-  queuePokemonHeal(eager: boolean, battlerIndex: BattlerIndex, hp: number, options?: PokemonHealPhaseOptions) {
-    const pokemonHealPhase = new PokemonHealPhase(battlerIndex, hp, options);
+  queuePokemonHeal(eager: boolean, ...params: ConstructorParameters<typeof PokemonHealPhase>) {
+    const pokemonHealPhase = new PokemonHealPhase(...params);
 
     if (eager) {
       this.unshiftPhase(pokemonHealPhase);

--- a/src/phases/pokemon-heal-phase.ts
+++ b/src/phases/pokemon-heal-phase.ts
@@ -25,6 +25,17 @@ export interface PokemonHealPhaseOptions {
   fullRestorePP?: boolean;
 }
 
+/**
+ * @param battlerIndex - The {@linkcode BattlerIndex} of the pokemon to heal
+ * @param hpHealed - The amount of HP to heal
+ * @param message - (Optional) Alternate message to be displayed during the heal phase.
+ * @param showFullHpMessage - If `true`, displays a message if the pokemon is already at full HP. Default `true`
+ * @param skipAnim - If `true`, skips animations. Default `false`
+ * @param revive - If `true`, will revive a fainted pokemon. Default `false`
+ * @param healStatus - If `true`, will clear a pokemon's status effect. Default `false`
+ * @param preventFullHeal - If `true`, will not allow healing beyond 1 less than the pokemon's max HP. Default `false`
+ * @param fullRestorePP - If `true`, will restore the pokemon's moves to full PP. Default `false`
+ */
 export class PokemonHealPhase extends CommonAnimPhase {
   override readonly id = PhaseId.POKEMON_HEAL;
 

--- a/src/phases/pokemon-heal-phase.ts
+++ b/src/phases/pokemon-heal-phase.ts
@@ -1,19 +1,19 @@
-import type { BattlerIndex } from "#enums/battler-index";
-import { CommonAnim } from "#enums/common-anim";
 import type { HealBlockTag } from "#app/data/battler-tags";
 import { getStatusEffectHealText } from "#app/data/status-effect";
 import { type DamageResult } from "#app/field/pokemon";
-import { HitResult } from "#enums/hit-result";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { HealingBoosterModifier } from "#app/modifier/modifier";
+import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { NumberHolder } from "#app/utils";
+import { AchvCategory } from "#enums/achv-category";
+import type { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import { CommonAnim } from "#enums/common-anim";
+import { HitResult } from "#enums/hit-result";
+import { PhaseId } from "#enums/phase-id";
 import { StatusEffect } from "#enums/status-effect";
 import i18next from "i18next";
-import { CommonAnimPhase } from "./common-anim-phase";
-import { AchvCategory } from "#enums/achv-category";
-import { PhaseId } from "#enums/phase-id";
 
 export interface PokemonHealPhaseOptions {
   message?: string;
@@ -37,17 +37,29 @@ export class PokemonHealPhase extends CommonAnimPhase {
   private readonly preventFullHeal: boolean;
   private readonly fullRestorePP: boolean;
 
-  constructor(battlerIndex: BattlerIndex, hpHealed: number, options?: PokemonHealPhaseOptions) {
+  constructor(
+    battlerIndex: BattlerIndex,
+    hpHealed: number,
+    {
+      message,
+      showFullHpMessage = true,
+      skipAnim = false,
+      revive = false,
+      healStatus = false,
+      preventFullHeal = false,
+      fullRestorePP = false,
+    }: PokemonHealPhaseOptions = {},
+  ) {
     super(battlerIndex, undefined, CommonAnim.HEALTH_UP);
 
     this.hpHealed = hpHealed;
-    this.message = options?.message;
-    this.showFullHpMessage = options?.showFullHpMessage ?? true;
-    this.skipAnim = options?.skipAnim ?? false;
-    this.revive = options?.revive ?? false;
-    this.healStatus = options?.healStatus ?? false;
-    this.preventFullHeal = options?.preventFullHeal ?? false;
-    this.fullRestorePP = options?.fullRestorePP ?? false;
+    this.message = message;
+    this.showFullHpMessage = showFullHpMessage;
+    this.skipAnim = skipAnim;
+    this.revive = revive;
+    this.healStatus = healStatus;
+    this.preventFullHeal = preventFullHeal;
+    this.fullRestorePP = fullRestorePP;
   }
 
   public override start(): void {

--- a/src/phases/select-modifier-phase.ts
+++ b/src/phases/select-modifier-phase.ts
@@ -2,11 +2,10 @@ import { globalScene } from "#app/global-scene";
 import {
   ExtraModifierModifier,
   HealShopCostModifier,
-  type PokemonHeldItemModifier,
   TempExtraModifierModifier,
   type Modifier,
+  type PokemonHeldItemModifier,
 } from "#app/modifier/modifier";
-import type { ModifierTier } from "#enums/modifier-tier";
 import {
   getPlayerModifierTypeOptions,
   getPlayerShopModifierTypeOptionsForWave,
@@ -21,19 +20,20 @@ import {
   type ModifierType,
   type ModifierTypeOption,
 } from "#app/modifier/modifier-type";
-import { ModifierPoolType } from "#enums/modifier-pool-type";
 import Overrides from "#app/overrides";
+import { BattlePhase } from "#app/phases/abstract-battle-phase";
 import type { ConfirmModeConfig } from "#app/ui/interfaces/confirm-menu-config";
 import type ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
 import { SHOP_OPTIONS_ROW_LIMIT } from "#app/ui/modifier-select-ui-handler";
+import { NumberHolder } from "#app/utils";
+import { FilterItemMaxStacks } from "#app/utils/item-utils";
+import { ModifierPoolType } from "#enums/modifier-pool-type";
+import type { ModifierTier } from "#enums/modifier-tier";
 import { PartyOption } from "#enums/party-option";
 import { PartyUiMode } from "#enums/party-ui-mode";
-import { UiMode } from "#enums/ui-mode";
-import { NumberHolder } from "#app/utils";
-import i18next from "i18next";
-import { BattlePhase } from "./abstract-battle-phase";
-import { FilterItemMaxStacks } from "#app/utils/item-utils";
 import { PhaseId } from "#enums/phase-id";
+import { UiMode } from "#enums/ui-mode";
+import i18next from "i18next";
 
 //#region Types
 
@@ -56,13 +56,18 @@ export class SelectModifierPhase extends BattlePhase {
 
   private typeOptions: ModifierTypeOption[];
 
-  constructor(options?: SelectModifierPhaseOptions) {
+  constructor({
+    rerollCount = 0,
+    modifierTiers,
+    customModifierSettings,
+    isCopy = false,
+  }: SelectModifierPhaseOptions = {}) {
     super();
 
-    this.rerollCount = options?.rerollCount ?? 0;
-    this.modifierTiers = options?.modifierTiers;
-    this.customModifierSettings = options?.customModifierSettings;
-    this.isCopy = options?.isCopy ?? false;
+    this.rerollCount = rerollCount;
+    this.modifierTiers = modifierTiers;
+    this.customModifierSettings = customModifierSettings;
+    this.isCopy = isCopy;
   }
 
   public override start(): void {

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -1,20 +1,20 @@
-import type { BattlerIndex } from "#enums/battler-index";
 import { applyAbAttrs } from "#app/data/apply-ab-attrs";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { ResetNegativeStatStageModifier } from "#app/modifier/modifier";
-import { handleTutorial } from "#app/tutorial";
-import { Tutorial } from "#enums/tutorial";
-import { BooleanHolder, NumberHolder } from "#app/utils";
-import { getStatKey, getStatStageChangeDescriptionKey, Stat, type BattleStat } from "#enums/stat";
-import i18next from "i18next";
+import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
 import { settings } from "#app/system/settings/settings-manager";
-import { PokemonPhase } from "./abstract-pokemon-phase";
+import { handleTutorial } from "#app/tutorial";
 import { CANVAS_SCALE } from "#app/ui-constants";
-import { ArenaTagType } from "#enums/arena-tag-type";
+import { BooleanHolder, NumberHolder } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import type { BattlerIndex } from "#enums/battler-index";
 import { PhaseId } from "#enums/phase-id";
+import { getStatKey, getStatStageChangeDescriptionKey, Stat, type BattleStat } from "#enums/stat";
+import { Tutorial } from "#enums/tutorial";
+import i18next from "i18next";
 
 //#region Types
 
@@ -41,26 +41,32 @@ export class StatStageChangePhase extends PokemonPhase {
   protected readonly canBeCopied: boolean;
   protected readonly bypassReflect: boolean;
   protected readonly onChange?: StatStageChangeCallback;
-  private readonly options?: SSCPhaseOptions;
+  private readonly options: SSCPhaseOptions;
 
   constructor(
     battlerIndex: BattlerIndex,
     source: Pokemon | null,
     stats: BattleStat[],
     stages: number,
-    options?: SSCPhaseOptions,
+    {
+      showMessage = true,
+      ignoreAbilities = false,
+      canBeCopied = true,
+      bypassReflect = false,
+      onChange,
+    }: SSCPhaseOptions = {},
   ) {
     super(battlerIndex);
 
     this.source = source;
     this.stats = stats;
     this.stages = stages;
-    this.showMessage = options?.showMessage ?? true;
-    this.ignoreAbilities = options?.ignoreAbilities ?? false;
-    this.canBeCopied = options?.canBeCopied ?? true;
-    this.bypassReflect = options?.bypassReflect ?? false;
-    this.onChange = options?.onChange;
-    this.options = options;
+    this.showMessage = showMessage;
+    this.ignoreAbilities = ignoreAbilities;
+    this.canBeCopied = canBeCopied;
+    this.bypassReflect = bypassReflect;
+    this.onChange = onChange;
+    this.options = { showMessage, ignoreAbilities, canBeCopied, bypassReflect, onChange };
   }
 
   public override start(): void {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
I've learned a better way of using interfaces since my initial phases refactor PR, so I'm implementing it now.

## What are the changes from a developer perspective?
Just a style change in `pokemon-heal-phase.ts`, `select-modifier-phase.ts`, and `stat-stage-change-phase.ts`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?