### PR TITLE
[Misc] Delete stale pokemon objects in `BattleEndPhase`

### DIFF
--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -59,6 +59,12 @@ export class BattleEndPhase extends BattlePhase {
 
     globalScene.clearEnemyHeldItemModifiers();
 
+    try {
+      globalScene.getEnemyParty().forEach((p) => p.destroy());
+    } catch {
+      console.warn("Unable to destroy stale pokemon objects in BattleEndPhase.");
+    }
+
     const lapsingModifiers = globalScene.findModifiers(
       (m) => m.isLapsingPersistentModifier() || m.isLapsingPokemonHeldItemModifier(),
     ) as (LapsingPersistentModifier | LapsingPokemonHeldItemModifier)[];

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -345,4 +345,33 @@ describe("Test Battle Phase", () => {
     );
     await game.phaseInterceptor.to("SwitchPhase");
   });
+
+  it("moves between waves normally", async () => {
+    game.override
+      .battleType("single")
+      .enemySpecies(Species.SUNKERN)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .startingWave(8)
+      .startingLevel(1000)
+      .enemyMoveset(MoveId.SPLASH);
+
+    await game.classicMode.startBattle([Species.ARCEUS]);
+
+    game.move.use(MoveId.FLAMETHROWER);
+    await game.toNextTurn();
+    game.move.use(MoveId.FLAMETHROWER);
+    await game.toNextWave();
+
+    expect(game.scene.currentBattle.waveIndex).toBe(9);
+
+    game.move.use(MoveId.FLAMETHROWER);
+    await game.toNextWave();
+
+    expect(game.scene.currentBattle.waveIndex).toBe(10);
+
+    game.move.use(MoveId.FLAMETHROWER);
+    await game.toNextTurn();
+
+    expect(game.scene.currentBattle.waveIndex).toBe(11);
+  });
 });

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -1,34 +1,147 @@
 import { allSpecies } from "#app/data/data-lists";
-import { Stat } from "#enums/stat";
 import { getGameMode } from "#app/game-mode";
-import { GameModes } from "#enums/game-modes";
-import { BattleEndPhase } from "#app/phases/battle-end-phase";
-import { CommandPhase } from "#app/phases/command-phase";
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
 import { EncounterPhase } from "#app/phases/encounter-phase";
-import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { LoginPhase } from "#app/phases/login-phase";
-import { NextEncounterPhase } from "#app/phases/next-encounter-phase";
-import { SelectGenderPhase } from "#app/phases/select-gender-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
-import { SummonPhase } from "#app/phases/summon-phase";
-import { SwitchPhase } from "#app/phases/switch-phase";
-import { TitlePhase } from "#app/phases/title-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
-import { VictoryPhase } from "#app/phases/victory-phase";
-import { GameManager } from "#test/testUtils/gameManager";
-import { generateStarter } from "#test/testUtils/gameManagerUtils";
-import { UiMode } from "#enums/ui-mode";
+import { settings } from "#app/system/settings/settings-manager";
 import { Abilities } from "#enums/abilities";
+import { Biome } from "#enums/biome";
+import { GameModes } from "#enums/game-modes";
 import { MoveId } from "#enums/move-id";
 import { PlayerGender } from "#enums/player-gender";
 import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
+import { UiMode } from "#enums/ui-mode";
+import { GameManager } from "#test/testUtils/gameManager";
+import { generateStarter } from "#test/testUtils/gameManagerUtils";
+import { EVERYTHING_SAVE_FILE_PATH } from "#test/testUtils/testUtils";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { Biome } from "#enums/biome";
-import { EVERYTHING_SAVE_FILE_PATH } from "#test/testUtils/testUtils";
-import { settings } from "#app/system/settings/settings-manager";
+
+describe("Test Phase Interceptor", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    settings.update("display", "playerGender", PlayerGender.UNSET);
+  });
+
+  it("test phase interceptor with prompt", async () => {
+    await game.phaseInterceptor.run("LoginPhase");
+
+    game.onNextPrompt("SelectGenderPhase", UiMode.OPTION_SELECT, () => {
+      settings.update("display", "playerGender", PlayerGender.FEMALE);
+      game.endPhase();
+    });
+
+    await game.phaseInterceptor.run("SelectGenderPhase");
+
+    await game.phaseInterceptor.run("TitlePhase");
+    await game.waitMode(UiMode.TITLE);
+
+    expect(game.scene.ui?.getMode()).toBe(UiMode.TITLE);
+    expect(settings.display.playerGender).toBe(PlayerGender.FEMALE);
+  });
+
+  it("test phase interceptor with prompt with preparation for a future prompt", async () => {
+    await game.phaseInterceptor.run("LoginPhase");
+
+    game.onNextPrompt("SelectGenderPhase", UiMode.OPTION_SELECT, () => {
+      settings.update("display", "playerGender", PlayerGender.MALE);
+      game.endPhase();
+    });
+
+    game.onNextPrompt("CheckSwitchPhase", UiMode.CONFIRM, () => {
+      game.setMode(UiMode.MESSAGE);
+      game.endPhase();
+    });
+    await game.phaseInterceptor.run("SelectGenderPhase");
+
+    await game.phaseInterceptor.run("TitlePhase");
+    await game.waitMode(UiMode.TITLE);
+
+    expect(game.scene.ui?.getMode()).toBe(UiMode.TITLE);
+    expect(settings.display.playerGender).toBe(PlayerGender.MALE);
+  });
+
+  it("newGame one-liner", async () => {
+    await game.classicMode.startBattle();
+    expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
+    expect(game.scene.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+  });
+
+  it("wrong phase", async () => {
+    await game.phaseInterceptor.run("LoginPhase");
+    await game.phaseInterceptor.run("LoginPhase").catch((e) => {
+      expect(e).toBe("Wrong phase: this is SelectGenderPhase and not LoginPhase");
+    });
+  });
+
+  it("wrong phase but skip", async () => {
+    await game.phaseInterceptor.run("LoginPhase");
+    await game.phaseInterceptor.run("LoginPhase", () => game.isCurrentPhase("SelectGenderPhase"));
+  });
+
+  it("good run", async () => {
+    await game.phaseInterceptor.run("LoginPhase");
+    game.onNextPrompt(
+      "SelectGenderPhase",
+      UiMode.OPTION_SELECT,
+      () => {
+        settings.update("display", "playerGender", PlayerGender.MALE);
+        game.endPhase();
+      },
+      () => game.isCurrentPhase("TitlePhase"),
+    );
+    await game.phaseInterceptor.run("SelectGenderPhase", () => game.isCurrentPhase("TitlePhase"));
+    await game.phaseInterceptor.run("TitlePhase");
+  });
+
+  it("good run from select gender to title", async () => {
+    await game.phaseInterceptor.run("LoginPhase");
+    game.onNextPrompt(
+      "SelectGenderPhase",
+      UiMode.OPTION_SELECT,
+      () => {
+        settings.update("display", "playerGender", PlayerGender.MALE);
+        game.endPhase();
+      },
+      () => game.isCurrentPhase("TitlePhase"),
+    );
+    await game.phaseInterceptor.to("TitlePhase");
+  });
+
+  it("good run to SummonPhase phase", async () => {
+    await game.phaseInterceptor.run("LoginPhase");
+    game.onNextPrompt(
+      "SelectGenderPhase",
+      UiMode.OPTION_SELECT,
+      () => {
+        settings.update("display", "playerGender", PlayerGender.MALE);
+        game.endPhase();
+      },
+      () => game.isCurrentPhase("TitlePhase"),
+    );
+    game.onNextPrompt("TitlePhase", UiMode.TITLE, () => {
+      game.scene.gameMode = getGameMode(GameModes.CLASSIC);
+      const starters = generateStarter(game.scene);
+      const selectStarterPhase = new SelectStarterPhase();
+      game.scene.pushPhase(new EncounterPhase(false));
+      selectStarterPhase.initBattle(starters);
+    });
+    await game.phaseInterceptor.to("SummonPhase");
+  });
+});
 
 describe("Test Battle Phase", () => {
   let phaserGame: Phaser.Game;
@@ -46,52 +159,7 @@ describe("Test Battle Phase", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    settings.update("display", "playerGender", PlayerGender.UNSET); // just for these tests!
   });
-
-  it("test phase interceptor with prompt", async () => {
-    await game.phaseInterceptor.run(LoginPhase);
-
-    game.onNextPrompt("SelectGenderPhase", UiMode.OPTION_SELECT, () => {
-      settings.update("display", "playerGender", PlayerGender.FEMALE);
-      game.endPhase();
-    });
-
-    await game.phaseInterceptor.run(SelectGenderPhase);
-
-    await game.phaseInterceptor.run(TitlePhase);
-    await game.waitMode(UiMode.TITLE);
-
-    expect(game.scene.ui?.getMode()).toBe(UiMode.TITLE);
-    expect(settings.display.playerGender).toBe(PlayerGender.FEMALE);
-  }, 20000);
-
-  it("test phase interceptor with prompt with preparation for a future prompt", async () => {
-    await game.phaseInterceptor.run(LoginPhase);
-
-    game.onNextPrompt("SelectGenderPhase", UiMode.OPTION_SELECT, () => {
-      settings.update("display", "playerGender", PlayerGender.MALE);
-      game.endPhase();
-    });
-
-    game.onNextPrompt("CheckSwitchPhase", UiMode.CONFIRM, () => {
-      game.setMode(UiMode.MESSAGE);
-      game.endPhase();
-    });
-    await game.phaseInterceptor.run(SelectGenderPhase);
-
-    await game.phaseInterceptor.run(TitlePhase);
-    await game.waitMode(UiMode.TITLE);
-
-    expect(game.scene.ui?.getMode()).toBe(UiMode.TITLE);
-    expect(settings.display.playerGender).toBe(PlayerGender.MALE);
-  }, 20000);
-
-  it("newGame one-liner", async () => {
-    await game.startBattle();
-    expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.getCurrentPhase()!.constructor.name).toBe(CommandPhase.name);
-  }, 20000);
 
   it("do attack wave 3 - single battle - regular - OHKO", async () => {
     game.override.starterSpecies(Species.MEWTWO);
@@ -101,10 +169,10 @@ describe("Test Battle Phase", () => {
     game.override.moveset([MoveId.TACKLE]);
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.enemyMoveset([MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(SelectModifierPhase, false);
-  }, 20000);
+    await game.phaseInterceptor.to("SelectModifierPhase", false);
+  });
 
   it("do attack wave 3 - single battle - regular - NO OHKO with opponent using non damage attack", async () => {
     game.override.starterSpecies(Species.MEWTWO);
@@ -115,10 +183,10 @@ describe("Test Battle Phase", () => {
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.enemyMoveset([MoveId.TAIL_WHIP, MoveId.TAIL_WHIP, MoveId.TAIL_WHIP, MoveId.TAIL_WHIP]);
     game.override.battleType("single");
-    await game.startBattle();
+    await game.classicMode.startBattle();
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnInitPhase, false);
-  }, 20000);
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+  });
 
   it("load 100% data file", async () => {
     await game.importData(EVERYTHING_SAVE_FILE_PATH);
@@ -127,14 +195,14 @@ describe("Test Battle Phase", () => {
       return species.caughtAttr !== 0n;
     }).length;
     expect(caughtCount).toBe(Object.keys(allSpecies).length);
-  }, 20000);
+  });
 
   it("start battle with selected team", async () => {
-    await game.startBattle([Species.CHARIZARD, Species.CHANSEY, Species.MEW]);
+    await game.classicMode.startBattle([Species.CHARIZARD, Species.CHANSEY, Species.MEW]);
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(Species.CHARIZARD);
     expect(game.scene.getPlayerParty()[1].species.speciesId).toBe(Species.CHANSEY);
     expect(game.scene.getPlayerParty()[2].species.speciesId).toBe(Species.MEW);
-  }, 20000);
+  });
 
   it("test remove random battle seed int", async () => {
     for (let i = 0; i < 10; i++) {
@@ -143,87 +211,25 @@ describe("Test Battle Phase", () => {
     }
   });
 
-  it("wrong phase", async () => {
-    await game.phaseInterceptor.run(LoginPhase);
-    await game.phaseInterceptor.run(LoginPhase).catch((e) => {
-      expect(e).toBe("Wrong phase: this is SelectGenderPhase and not LoginPhase");
-    });
-  }, 20000);
-
-  it("wrong phase but skip", async () => {
-    await game.phaseInterceptor.run(LoginPhase);
-    await game.phaseInterceptor.run(LoginPhase, () => game.isCurrentPhase(SelectGenderPhase));
-  }, 20000);
-
-  it("good run", async () => {
-    await game.phaseInterceptor.run(LoginPhase);
-    game.onNextPrompt(
-      "SelectGenderPhase",
-      UiMode.OPTION_SELECT,
-      () => {
-        settings.update("display", "playerGender", PlayerGender.MALE);
-        game.endPhase();
-      },
-      () => game.isCurrentPhase(TitlePhase),
-    );
-    await game.phaseInterceptor.run(SelectGenderPhase, () => game.isCurrentPhase(TitlePhase));
-    await game.phaseInterceptor.run(TitlePhase);
-  }, 20000);
-
-  it("good run from select gender to title", async () => {
-    await game.phaseInterceptor.run(LoginPhase);
-    game.onNextPrompt(
-      "SelectGenderPhase",
-      UiMode.OPTION_SELECT,
-      () => {
-        settings.update("display", "playerGender", PlayerGender.MALE);
-        game.endPhase();
-      },
-      () => game.isCurrentPhase(TitlePhase),
-    );
-    await game.phaseInterceptor.runFrom(SelectGenderPhase).to(TitlePhase);
-  }, 20000);
-
-  it("good run to SummonPhase phase", async () => {
-    await game.phaseInterceptor.run(LoginPhase);
-    game.onNextPrompt(
-      "SelectGenderPhase",
-      UiMode.OPTION_SELECT,
-      () => {
-        settings.update("display", "playerGender", PlayerGender.MALE);
-        game.endPhase();
-      },
-      () => game.isCurrentPhase(TitlePhase),
-    );
-    game.onNextPrompt("TitlePhase", UiMode.TITLE, () => {
-      game.scene.gameMode = getGameMode(GameModes.CLASSIC);
-      const starters = generateStarter(game.scene);
-      const selectStarterPhase = new SelectStarterPhase();
-      game.scene.pushPhase(new EncounterPhase(false));
-      selectStarterPhase.initBattle(starters);
-    });
-    await game.phaseInterceptor.runFrom(SelectGenderPhase).to(SummonPhase);
-  }, 20000);
-
   it("2vs1", async () => {
     game.override.battleType("single");
     game.override.enemySpecies(Species.MIGHTYENA);
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
-    await game.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
+    await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.getCurrentPhase()!.constructor.name).toBe(CommandPhase.name);
-  }, 20000);
+    expect(game.scene.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+  });
 
   it("1vs1", async () => {
     game.override.battleType("single");
     game.override.enemySpecies(Species.MIGHTYENA);
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
-    await game.startBattle([Species.BLASTOISE]);
+    await game.classicMode.startBattle([Species.BLASTOISE]);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.getCurrentPhase()!.constructor.name).toBe(CommandPhase.name);
-  }, 20000);
+    expect(game.scene.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+  });
 
   it("2vs2", async () => {
     game.override.battleType("double");
@@ -231,10 +237,10 @@ describe("Test Battle Phase", () => {
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
     game.override.startingWave(3);
-    await game.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
+    await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.getCurrentPhase()!.constructor.name).toBe(CommandPhase.name);
-  }, 20000);
+    expect(game.scene.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+  });
 
   it("4vs2", async () => {
     game.override.battleType("double");
@@ -242,10 +248,10 @@ describe("Test Battle Phase", () => {
     game.override.enemyAbility(Abilities.HYDRATION);
     game.override.ability(Abilities.HYDRATION);
     game.override.startingWave(3);
-    await game.startBattle([Species.BLASTOISE, Species.CHARIZARD, Species.DARKRAI, Species.GABITE]);
+    await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD, Species.DARKRAI, Species.GABITE]);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.getCurrentPhase()!.constructor.name).toBe(CommandPhase.name);
-  }, 20000);
+    expect(game.scene.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+  });
 
   it("kill opponent pokemon", async () => {
     const moveToUse = MoveId.SPLASH;
@@ -258,14 +264,14 @@ describe("Test Battle Phase", () => {
     game.override.startingWave(3);
     game.override.moveset([moveToUse]);
     game.override.enemyMoveset([MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE]);
-    await game.startBattle([Species.DARMANITAN, Species.CHARIZARD]);
+    await game.classicMode.startBattle([Species.DARMANITAN, Species.CHARIZARD]);
 
     game.move.select(moveToUse);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     await game.killPokemon(game.scene.currentBattle.enemyParty[0]);
     expect(game.scene.currentBattle.enemyParty[0].isFainted()).toBe(true);
-    await game.phaseInterceptor.to(VictoryPhase, false);
-  }, 200000);
+    await game.phaseInterceptor.to("VictoryPhase", false);
+  });
 
   it("to next turn", async () => {
     const moveToUse = MoveId.SPLASH;
@@ -278,12 +284,12 @@ describe("Test Battle Phase", () => {
     game.override.startingWave(3);
     game.override.moveset([moveToUse]);
     game.override.enemyMoveset([MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE]);
-    await game.startBattle();
+    await game.classicMode.startBattle();
     const turn = game.scene.currentBattle.turn;
     game.move.select(moveToUse);
     await game.toNextTurn();
     expect(game.scene.currentBattle.turn).toBeGreaterThan(turn);
-  }, 20000);
+  });
 
   it("does not set new weather if staying in same biome", async () => {
     const moveToUse = MoveId.SPLASH;
@@ -307,7 +313,7 @@ describe("Test Battle Phase", () => {
     await game.toNextWave();
     expect(game.scene.arena.trySetWeather).not.toHaveBeenCalled();
     expect(game.scene.currentBattle.waveIndex).toBeGreaterThan(waveIndex);
-  }, 20000);
+  });
 
   it("does not force switch if active pokemon faints at same time as enemy mon and is revived in post-battle", async () => {
     const moveToUse = MoveId.TAKE_DOWN;
@@ -321,11 +327,11 @@ describe("Test Battle Phase", () => {
       .enemyMoveset(MoveId.SPLASH)
       .startingHeldItems([{ name: "TEMP_STAT_STAGE_BOOSTER", type: Stat.ACC }]);
 
-    await game.startBattle();
+    await game.classicMode.startBattle();
     game.scene.getPlayerPokemon()!.hp = 1;
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(BattleEndPhase);
+    await game.phaseInterceptor.to("BattleEndPhase");
     game.doRevivePokemon(0); // pretend max revive was picked
     game.doSelectModifier();
 
@@ -335,8 +341,8 @@ describe("Test Battle Phase", () => {
       () => {
         expect.fail("Switch was forced");
       },
-      () => game.isCurrentPhase(NextEncounterPhase),
+      () => game.isCurrentPhase("NextEncounterPhase"),
     );
-    await game.phaseInterceptor.to(SwitchPhase);
-  }, 20000);
+    await game.phaseInterceptor.to("SwitchPhase");
+  });
 });

--- a/test/testUtils/gameManager.ts
+++ b/test/testUtils/gameManager.ts
@@ -1,3 +1,10 @@
+// -- start tsdoc imports --
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { type CommandPhase } from "#app/phases/command-phase";
+import { type TurnEndPhase } from "#app/phases/turn-end-phase";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+// -- end tsdoc imports --
+
 import { updateUserInfo } from "#app/account";
 import { BattlerIndex } from "#enums/battler-index";
 import BattleScene from "#app/battle-scene";
@@ -10,21 +17,13 @@ import { GameModes } from "#enums/game-modes";
 import { ModifierTypeOption } from "#app/modifier/modifier-type";
 import { modifierTypes } from "#app/modifier/modifier-types";
 import overrides from "#app/overrides";
-import { CheckSwitchPhase } from "#app/phases/check-switch-phase";
-import { CommandPhase } from "#app/phases/command-phase";
 import { EncounterPhase } from "#app/phases/encounter-phase";
-import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
+import type { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
 import { FaintPhase } from "#app/phases/faint-phase";
 import { LoginPhase } from "#app/phases/login-phase";
-import { MovePhase } from "#app/phases/move-phase";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
 import { type SelectTargetPhase } from "#app/phases/select-target-phase";
 import { TitlePhase } from "#app/phases/title-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
-import { TurnStartPhase } from "#app/phases/turn-start-phase";
 import type BattleMessageUiHandler from "#app/ui/battle-message-ui-handler";
 import type CommandUiHandler from "#app/ui/command-ui-handler";
 import type ModifierSelectUiHandler from "#app/ui/modifier-select-ui-handler";
@@ -54,6 +53,7 @@ import { FieldHelper } from "#test/testUtils/helpers/fieldHelper";
 import { ReloadHelper } from "#test/testUtils/helpers/reloadHelper";
 import { SettingsHelper } from "#test/testUtils/helpers/settingsHelper";
 import type { InputsHandler } from "#test/testUtils/inputsHandler";
+import type { PhaseInterceptorPhase } from "#test/testUtils/phaseInterceptor";
 import { PhaseInterceptor } from "#test/testUtils/phaseInterceptor";
 import { TextInterceptor } from "#test/testUtils/TextInterceptor";
 import { AES, enc } from "crypto-js";
@@ -231,7 +231,7 @@ export class GameManager {
       this.removeEnemyHeldItems();
     }
 
-    await this.phaseInterceptor.to(EncounterPhase);
+    await this.phaseInterceptor.to("EncounterPhase");
     console.log("===finished run to final boss encounter===");
   }
 
@@ -259,7 +259,7 @@ export class GameManager {
         this.scene.pushPhase(new EncounterPhase(false));
         selectStarterPhase.initBattle(starters);
       },
-      () => this.isCurrentPhase(EncounterPhase),
+      () => this.isCurrentPhase("EncounterPhase"),
     );
 
     this.onNextPrompt(
@@ -269,11 +269,11 @@ export class GameManager {
         const handler = this.scene.ui.getHandler() as BattleMessageUiHandler;
         handler.processInput(Button.ACTION);
       },
-      () => this.isCurrentPhase(MysteryEncounterPhase),
+      () => this.isCurrentPhase("MysteryEncounterPhase"),
       true,
     );
 
-    await this.phaseInterceptor.run(EncounterPhase);
+    await this.phaseInterceptor.run("EncounterPhase");
     if (!isNullOrUndefined(encounterType)) {
       expect(this.scene.currentBattle?.mysteryEncounter?.encounterType).toBe(encounterType);
     }
@@ -297,7 +297,7 @@ export class GameManager {
           this.setMode(UiMode.MESSAGE);
           this.endPhase();
         },
-        () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase),
+        () => this.isCurrentPhase("CommandPhase") || this.isCurrentPhase("TurnInitPhase"),
       );
 
       this.onNextPrompt(
@@ -307,11 +307,11 @@ export class GameManager {
           this.setMode(UiMode.MESSAGE);
           this.endPhase();
         },
-        () => this.isCurrentPhase(CommandPhase) || this.isCurrentPhase(TurnInitPhase),
+        () => this.isCurrentPhase("CommandPhase") || this.isCurrentPhase("TurnInitPhase"),
       );
     }
 
-    await this.phaseInterceptor.to(CommandPhase);
+    await this.phaseInterceptor.to("CommandPhase");
     console.log("==================[New Turn]==================");
   }
 
@@ -340,10 +340,10 @@ export class GameManager {
         handler.processInput(Button.ACTION);
       },
       () =>
-        this.isCurrentPhase(CommandPhase)
-        || this.isCurrentPhase(MovePhase)
-        || this.isCurrentPhase(TurnStartPhase)
-        || this.isCurrentPhase(TurnEndPhase),
+        this.isCurrentPhase("CommandPhase")
+        || this.isCurrentPhase("MovePhase")
+        || this.isCurrentPhase("TurnStartPhase")
+        || this.isCurrentPhase("TurnEndPhase"),
     );
   }
 
@@ -365,9 +365,9 @@ export class GameManager {
         handler.processInput(Button.CANCEL);
       },
       () =>
-        this.isCurrentPhase(CommandPhase)
-        || this.isCurrentPhase(NewBattlePhase)
-        || this.isCurrentPhase(CheckSwitchPhase),
+        this.isCurrentPhase("CommandPhase")
+        || this.isCurrentPhase("NewBattlePhase")
+        || this.isCurrentPhase("CheckSwitchPhase"),
       true,
     );
 
@@ -379,9 +379,9 @@ export class GameManager {
         handler.processInput(Button.ACTION);
       },
       () =>
-        this.isCurrentPhase(CommandPhase)
-        || this.isCurrentPhase(NewBattlePhase)
-        || this.isCurrentPhase(CheckSwitchPhase),
+        this.isCurrentPhase("CommandPhase")
+        || this.isCurrentPhase("NewBattlePhase")
+        || this.isCurrentPhase("CheckSwitchPhase"),
     );
   }
 
@@ -396,7 +396,7 @@ export class GameManager {
    */
   async forceEnemyMove(moveId: MoveId, target?: BattlerIndex) {
     // Wait for the next EnemyCommandPhase to start
-    await this.phaseInterceptor.to(EnemyCommandPhase, false);
+    await this.phaseInterceptor.to("EnemyCommandPhase", false);
     const enemy = this.scene.getEnemyField()[(this.scene.getCurrentPhase() as EnemyCommandPhase).getFieldIndex()];
     const legalTargets = getMoveTargets(enemy, moveId);
 
@@ -414,7 +414,7 @@ export class GameManager {
      * This allows this function to be called consecutively to
      * force a move for each enemy in a double battle.
      */
-    await this.phaseInterceptor.to(EnemyCommandPhase);
+    await this.phaseInterceptor.to("EnemyCommandPhase");
   }
 
   forceEnemyToSwitch() {
@@ -430,13 +430,13 @@ export class GameManager {
 
   /** Transition to the first {@linkcode CommandPhase} of the next turn. */
   async toNextTurn() {
-    await this.phaseInterceptor.to(TurnInitPhase);
-    await this.phaseInterceptor.to(CommandPhase);
+    await this.phaseInterceptor.to("TurnInitPhase");
+    await this.phaseInterceptor.to("CommandPhase");
   }
 
   /** Transition to the {@linkcode TurnEndPhase | end of the current turn}. */
   async toEndOfTurn() {
-    await this.phaseInterceptor.to(TurnEndPhase);
+    await this.phaseInterceptor.to("TurnEndPhase");
   }
 
   /** Emulate selecting a modifier (item) and transition to the next upcoming {@linkcode CommandPhase} */
@@ -450,7 +450,7 @@ export class GameManager {
         this.setMode(UiMode.MESSAGE);
         this.endPhase();
       },
-      () => this.isCurrentPhase(TurnInitPhase) || this.isCurrentPhase(CommandPhase),
+      () => this.isCurrentPhase("TurnInitPhase") || this.isCurrentPhase("CommandPhase"),
     );
 
     await this.toNextTurn();
@@ -469,7 +469,7 @@ export class GameManager {
    * @param phaseTarget - The target phase.
    * @returns True if the current phase matches the target phase, otherwise false.
    */
-  isCurrentPhase(phaseTarget) {
+  isCurrentPhase(phaseTarget: PhaseInterceptorPhase) {
     const targetName = typeof phaseTarget === "string" ? phaseTarget : phaseTarget.name;
     return this.scene.getCurrentPhase()?.constructor.name === targetName;
   }
@@ -519,7 +519,7 @@ export class GameManager {
     return new Promise<void>(async (resolve, reject) => {
       pokemon.hp = 0;
       this.scene.pushPhase(new FaintPhase(pokemon.getBattlerIndex(), true));
-      await this.phaseInterceptor.to(FaintPhase).catch((e) => reject(e));
+      await this.phaseInterceptor.to("FaintPhase").catch((e) => reject(e));
       resolve();
     });
   }

--- a/test/testUtils/phaseInterceptor.ts
+++ b/test/testUtils/phaseInterceptor.ts
@@ -189,7 +189,7 @@ type PhaseString =
   | "PostGameOverPhase"
   | "RevivalBlessingPhase";
 
-type PhaseInterceptorPhase = PhaseClass | PhaseString;
+export type PhaseInterceptorPhase = PhaseClass | PhaseString;
 
 export class PhaseInterceptor {
   public scene;


### PR DESCRIPTION
PR text copied from cat's original PR.

## What are the changes the user will see?
The user should ideally see improvements in game performance.

## Why am I making these changes?
It turns out that the game was not destroying enemy Pokémon objects after each battle and left them sitting in scene, meaning that a pile of enemy Pokémon assets were piling up wave after wave. This would often force a refresh. 

## What are the changes from a developer perspective?
After modifiers are cleared from enemy Pokémon, the enemy Pokémon object is destroyed.

## How to test the changes?
Transition between waves and observe whether the game functions normally or not.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?