### PR TITLE
[Misc] Further cleanup of `PokemonSpecies.getSpeciesForLevel()`

### DIFF
--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -4,7 +4,7 @@ import { PartyMemberStrength } from "#enums/party-member-strength";
 import { Species } from "#enums/species";
 import i18next from "i18next";
 import type { GameMode } from "#app/game-mode";
-import { randSeedInt, randSeedGauss } from "#app/utils";
+import { randSeedGauss, randSeedItem } from "#app/utils";
 import type { GrowthRate } from "#enums/growth-rates";
 import type { EvolutionLevel } from "#app/data/balance/pokemon-evolutions";
 import { pokemonEvolutions, pokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
@@ -168,66 +168,41 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
 
     const evolutions = pokemonEvolutions[this.speciesId];
 
-    const evolutionPool: Map<number, Species> = new Map();
-    const totalWeight = 0;
-    let noEvolutionChance = 1;
+    const evolutionPool: Species[] = [];
 
     for (const ev of evolutions) {
       if (ev.level > level) {
         continue;
       }
 
-      let evolutionChance: number = 0;
-
       const evolutionSpecies = getPokemonSpecies(ev.speciesId);
       const isRegionalEvolution = !this.isRegional() && evolutionSpecies.isRegional();
 
       if (!forTrainer && isRegionalEvolution) {
-        evolutionChance = 0;
-      } else {
-        if ((ev.altLevel !== 0 && level > ev.altLevel) || level > ev.level) {
-          evolutionChance = 1;
-          noEvolutionChance = 0;
-        }
+        continue;
       }
-
-      if (evolutionChance === 1) {
-        evolutionPool.set(evolutionChance, ev.speciesId);
+      if (((ev.altLevel !== 0 && level > ev.altLevel) || level > ev.level) && !evolutionPool.includes(ev.speciesId)) {
+        evolutionPool.push(ev.speciesId);
       }
     }
 
-    if (noEvolutionChance === 1) {
+    if (evolutionPool.length === 0) {
       return this.speciesId;
     }
 
-    const randValue = evolutionPool.size === 1 ? 0 : randSeedInt(totalWeight);
+    const evolution = getPokemonSpecies(randSeedItem(evolutionPool));
 
-    for (const weight of evolutionPool.keys()) {
-      if (randValue < weight) {
-        return getPokemonSpecies(evolutionPool.get(weight)).getSpeciesForLevel(
-          level,
-          true,
-          forTrainer,
-          strength,
-          currentWave,
-        );
-      }
-    }
-
-    return this.speciesId;
+    return evolution.getSpeciesForLevel(level, true, forTrainer, strength, currentWave);
   }
 
   getEvolutionLevels(): EvolutionLevel[] {
     const evolutionLevels: EvolutionLevel[] = [];
-
-    //console.log(Species[this.speciesId], pokemonEvolutions[this.speciesId])
 
     if (pokemonEvolutions.hasOwnProperty(this.speciesId)) {
       for (const e of pokemonEvolutions[this.speciesId]) {
         const speciesId = e.speciesId;
         const level = e.level;
         evolutionLevels.push([speciesId, level]);
-        //console.log(Species[speciesId], getPokemonSpecies(speciesId), getPokemonSpecies(speciesId).getEvolutionLevels());
         const nextEvolutionLevels = getPokemonSpecies(speciesId).getEvolutionLevels();
         for (const npl of nextEvolutionLevels) {
           evolutionLevels.push(npl);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Code cleanup.

## What are the changes from a developer perspective?
- Now-redundant variables `evolutionChance` and `noEvolutionChance` removed from `PokemonSpecies.getSpeciesForLevel()`.
- The array of possible evolutions will now properly be chosen from again.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?