### PR TITLE
[Bug] Fix wild Pokemon not picking a random evolution species

### DIFF
--- a/src/data/balance/pokemon-evolutions.ts
+++ b/src/data/balance/pokemon-evolutions.ts
@@ -30,11 +30,17 @@ export class SpeciesFormEvolution {
   public level: number;
   public item: EvolutionItem | null;
   public condition: SpeciesEvolutionCondition | null;
-  /** A numerical level for Pokemon that don't evolve with level
-   * Is 0 if it is a level evolution
-   */
-  public altLevel: number;
+  public enemyEvolveLevel: number;
 
+  /**
+   * @param speciesId The ID of the species that the Pokemon will evolve into.
+   * @param preFormKey The form key that a Pokemon must have before being eligible for this evolution.
+   * @param evoFormKey The form key for the form that the Pokemon will evolve into.
+   * @param level The minimum level that a Pokemon must have for this evolution.
+   * @param item If applicable, the evolution item that the Pokemon must use for this evolution.
+   * @param condition If applicable, an extra condition that the Pokemon must satisfy for this evolution.
+   * @param enemyEvolveLevel The level at which enemy spawns will undergo this evolution. Default: Equal to `level`.
+   */
   constructor(
     speciesId: Species,
     preFormKey: string | null,
@@ -42,7 +48,7 @@ export class SpeciesFormEvolution {
     level: number,
     item: EvolutionItem | null,
     condition: SpeciesEvolutionCondition | null,
-    altLevel: number = 0,
+    enemyEvolveLevel: number = level,
   ) {
     this.speciesId = speciesId;
     this.preFormKey = preFormKey;
@@ -50,7 +56,7 @@ export class SpeciesFormEvolution {
     this.level = level;
     this.item = item || EvolutionItem.NONE;
     this.condition = condition;
-    this.altLevel = altLevel;
+    this.enemyEvolveLevel = enemyEvolveLevel;
   }
 }
 
@@ -60,9 +66,9 @@ export class SpeciesEvolution extends SpeciesFormEvolution {
     level: number,
     item: EvolutionItem | null,
     condition: SpeciesEvolutionCondition | null,
-    altLevel: number = 0,
+    enemyEvolveLevel: number = level,
   ) {
-    super(speciesId, null, null, level, item, condition, altLevel);
+    super(speciesId, null, null, level, item, condition, enemyEvolveLevel);
   }
 }
 

--- a/src/data/daily-run.ts
+++ b/src/data/daily-run.ts
@@ -1,4 +1,3 @@
-import { PartyMemberStrength } from "#enums/party-member-strength";
 import type { Species } from "#enums/species";
 import { globalScene } from "#app/global-scene";
 import { PlayerPokemon } from "#app/field/pokemon";
@@ -54,9 +53,7 @@ export function getDailyRunStarters(seed: string): Starter[] {
           .map((s) => parseInt(s) as Species)
           .filter((s) => speciesStarterCosts[s] === cost);
         const randPkmSpecies = getPokemonSpecies(randSeedItem(costSpecies));
-        const starterSpecies = getPokemonSpecies(
-          randPkmSpecies.getTrainerSpeciesForLevel(startingLevel, true, PartyMemberStrength.STRONGER),
-        );
+        const starterSpecies = getPokemonSpecies(randPkmSpecies.getTrainerSpeciesForLevel(startingLevel, true));
         starters.push(getDailyRunStarter(starterSpecies, startingLevel));
       }
     },

--- a/src/data/daily-run.ts
+++ b/src/data/daily-run.ts
@@ -53,7 +53,7 @@ export function getDailyRunStarters(seed: string): Starter[] {
           .map((s) => parseInt(s) as Species)
           .filter((s) => speciesStarterCosts[s] === cost);
         const randPkmSpecies = getPokemonSpecies(randSeedItem(costSpecies));
-        const starterSpecies = getPokemonSpecies(randPkmSpecies.getTrainerSpeciesForLevel(startingLevel));
+        const starterSpecies = getPokemonSpecies(randPkmSpecies.getEnemySpeciesForLevel(startingLevel, true));
         starters.push(getDailyRunStarter(starterSpecies, startingLevel));
       }
     },

--- a/src/data/daily-run.ts
+++ b/src/data/daily-run.ts
@@ -53,7 +53,7 @@ export function getDailyRunStarters(seed: string): Starter[] {
           .map((s) => parseInt(s) as Species)
           .filter((s) => speciesStarterCosts[s] === cost);
         const randPkmSpecies = getPokemonSpecies(randSeedItem(costSpecies));
-        const starterSpecies = getPokemonSpecies(randPkmSpecies.getTrainerSpeciesForLevel(startingLevel, true));
+        const starterSpecies = getPokemonSpecies(randPkmSpecies.getTrainerSpeciesForLevel(startingLevel));
         starters.push(getDailyRunStarter(starterSpecies, startingLevel));
       }
     },

--- a/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
+++ b/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
@@ -72,7 +72,6 @@ export const BerriesAboundEncounter: MysteryEncounter = MysteryEncounterBuilder.
       level,
       0,
       getPartyLuckValue(globalScene.getPlayerParty()),
-      true,
     );
     const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
     encounter.setDialogueToken("enemyPokemon", getPokemonNameWithAffix(bossPokemon));

--- a/src/data/mystery-encounters/encounters/fight-or-flight-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fight-or-flight-encounter.ts
@@ -68,7 +68,6 @@ export const FightOrFlightEncounter: MysteryEncounter = MysteryEncounterBuilder.
       level,
       0,
       getPartyLuckValue(globalScene.getPlayerParty()),
-      true,
     );
     const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
     encounter.setDialogueToken("enemyPokemon", bossPokemon.getNameToRender());

--- a/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
+++ b/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
@@ -284,7 +284,7 @@ async function summonSafariPokemon() {
     () => {
       enemySpecies = getSafariSpeciesSpawn();
       const level = globalScene.currentBattle.getLevelForWave();
-      enemySpecies = getPokemonSpecies(enemySpecies.getWildSpeciesForLevel(level, true, false, globalScene.gameMode));
+      enemySpecies = getPokemonSpecies(enemySpecies.getWildSpeciesForLevel(level, true));
       pokemon = globalScene.addEnemyPokemon(enemySpecies, level, TrainerSlot.NONE, false);
 
       // Roll shiny twice

--- a/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
+++ b/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
@@ -278,13 +278,12 @@ async function summonSafariPokemon() {
 
   // Generate pokemon using safariPokemonRemaining so they are always the same pokemon no matter how many turns are taken
   // Safari pokemon roll twice on shiny and HA chances, but are otherwise normal
-  let enemySpecies;
-  let pokemon;
+  let enemySpecies: PokemonSpecies;
+  let pokemon: EnemyPokemon;
   globalScene.executeWithSeedOffset(
     () => {
-      enemySpecies = getSafariSpeciesSpawn();
       const level = globalScene.currentBattle.getLevelForWave();
-      enemySpecies = getPokemonSpecies(enemySpecies.getSpeciesForLevel(level));
+      enemySpecies = getPokemonSpecies(getSafariSpeciesSpawn().getEnemySpeciesForLevel(level));
       pokemon = globalScene.addEnemyPokemon(enemySpecies, level, TrainerSlot.NONE, false);
 
       // Roll shiny twice
@@ -313,6 +312,7 @@ async function summonSafariPokemon() {
     },
     globalScene.currentBattle.waveIndex * 1000 * encounter.misc.safariPokemonRemaining,
   );
+  pokemon = pokemon!; // Tell the compiler it's defined
 
   globalScene.gameData.setPokemonSeen(pokemon, true);
   await pokemon.loadAssets();

--- a/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
+++ b/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
@@ -284,7 +284,7 @@ async function summonSafariPokemon() {
     () => {
       enemySpecies = getSafariSpeciesSpawn();
       const level = globalScene.currentBattle.getLevelForWave();
-      enemySpecies = getPokemonSpecies(enemySpecies.getWildSpeciesForLevel(level));
+      enemySpecies = getPokemonSpecies(enemySpecies.getSpeciesForLevel(level));
       pokemon = globalScene.addEnemyPokemon(enemySpecies, level, TrainerSlot.NONE, false);
 
       // Roll shiny twice

--- a/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
+++ b/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
@@ -284,7 +284,7 @@ async function summonSafariPokemon() {
     () => {
       enemySpecies = getSafariSpeciesSpawn();
       const level = globalScene.currentBattle.getLevelForWave();
-      enemySpecies = getPokemonSpecies(enemySpecies.getWildSpeciesForLevel(level, true));
+      enemySpecies = getPokemonSpecies(enemySpecies.getWildSpeciesForLevel(level));
       pokemon = globalScene.addEnemyPokemon(enemySpecies, level, TrainerSlot.NONE, false);
 
       // Roll shiny twice

--- a/src/data/mystery-encounters/encounters/teleporting-hijinks-encounter.ts
+++ b/src/data/mystery-encounters/encounters/teleporting-hijinks-encounter.ts
@@ -151,7 +151,6 @@ export const TeleportingHijinksEncounter: MysteryEncounter = MysteryEncounterBui
         level,
         0,
         getPartyLuckValue(globalScene.getPlayerParty()),
-        true,
       );
       const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
       encounter.setDialogueToken("enemyPokemon", getPokemonNameWithAffix(bossPokemon));
@@ -195,7 +194,6 @@ async function doBiomeTransitionDialogueAndBattleInit() {
     level,
     0,
     getPartyLuckValue(globalScene.getPlayerParty()),
-    true,
   );
   const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
   encounter.setDialogueToken("enemyPokemon", getPokemonNameWithAffix(bossPokemon));

--- a/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
+++ b/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
@@ -71,7 +71,6 @@ export const UncommonBreedEncounter: MysteryEncounter = MysteryEncounterBuilder.
       level,
       0,
       getPartyLuckValue(globalScene.getPlayerParty()),
-      true,
     );
     const pokemon = new EnemyPokemon(species, level, TrainerSlot.NONE, true);
 

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -926,7 +926,7 @@ export function getGoldenBugNetSpecies(level: number): PokemonSpecies {
     w += speciesWeightPair[1];
     if (roll < w) {
       const initialSpecies = getPokemonSpecies(speciesWeightPair[0]);
-      return getPokemonSpecies(initialSpecies.getSpeciesForLevel(level, true));
+      return getPokemonSpecies(initialSpecies.getSpeciesForLevel(level));
     }
   }
 

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -926,7 +926,7 @@ export function getGoldenBugNetSpecies(level: number): PokemonSpecies {
     w += speciesWeightPair[1];
     if (roll < w) {
       const initialSpecies = getPokemonSpecies(speciesWeightPair[0]);
-      return getPokemonSpecies(initialSpecies.getSpeciesForLevel(level));
+      return getPokemonSpecies(initialSpecies.getEnemySpeciesForLevel(level));
     }
   }
 

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -173,7 +173,8 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     const eligibleEvolutions: Species[] = [];
 
     for (const ev of evolutions) {
-      if (ev.level > level) {
+      // TODO: Should enemy Pokemon have a random chance of evolving if they are close to the level threshold?
+      if (ev.enemyEvolveLevel > level) {
         continue;
       }
 
@@ -182,9 +183,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
 
       // Random non-trainer spawns are not eligible for regional evolutions (e.g. Alolan Raichu)
       if (forTrainer || !isRegionalEvolution) {
-        if (level > ev.enemyEvolveLevel) {
-          eligibleEvolutions.push(ev.speciesId);
-        }
+        eligibleEvolutions.push(ev.speciesId);
       }
     }
 
@@ -221,7 +220,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     return prevolutionLevels;
   }
 
-  // This could definitely be written better and more accurate to the getSpeciesForLevel logic, but it is only for generating movesets for evolved Pokemon
+  // TODO: This could definitely be written better and more accurate to the getSpeciesForLevel logic, but it is only for generating movesets for evolved Pokemon
   getSimulatedEvolutionChain(
     currentLevel: number,
     forTrainer: boolean = false,
@@ -241,9 +240,9 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
           prevolutionLevels[l][0],
           Math.min(
             Math.max(
-              evolution?.level! + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * 0.5 * 5) - 1,
+              evolution?.enemyEvolveLevel! + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * 0.5 * 5) - 1,
               2,
-              evolution?.level!,
+              evolution?.enemyEvolveLevel!,
             ),
             currentLevel - 1,
           ),
@@ -259,7 +258,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
           Math.max(
             lastPrevolutionLevel + Math.round(randSeedGauss(0.5, 1 + levelDiff * 0.2) * 0.5 * 5),
             lastPrevolutionLevel + 1,
-            evolution?.level!,
+            evolution?.enemyEvolveLevel!,
           ),
           currentLevel,
         ),

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -200,7 +200,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     return prevolutionLevels;
   }
 
-  // TODO: This could definitely be written better and more accurate to the getSpeciesForLevel logic, but it is only for generating movesets for evolved Pokemon
+  // TODO: This could definitely be written better and more accurate to the getEnemySpeciesForLevel logic, but it is only for generating movesets for evolved Pokemon
   getSimulatedEvolutionChain(
     currentLevel: number,
     forTrainer: boolean = false,

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -128,35 +128,32 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
    * Calculates the correct evolution stage for a wild enemy Pokemon based on its level,
    * applying pre-evolutions and evolutions as necessary.
    * @param level The level of the Pokemon.
-   * @param allowEvolving Whether or not to allow further evolution.
    * @returns The {@linkcode Species | species ID} of the desired evolution stage.
    */
-  getWildSpeciesForLevel(level: number, allowEvolving: boolean): Species {
-    return this.getSpeciesForLevel(level, allowEvolving, false);
+  getWildSpeciesForLevel(level: number): Species {
+    return this.getSpeciesForLevel(level, false);
   }
 
   /**
    * Calculates the correct evolution stage for an enemy trainer's Pokemon based on its level,
    * applying pre-evolutions and evolutions as necessary.
    * @param level The level of the Pokemon.
-   * @param allowEvolving Whether or not to allow further evolution. Default: `false`.
    * @returns The {@linkcode Species | species ID} of the desired evolution stage.
    */
-  getTrainerSpeciesForLevel(level: number, allowEvolving: boolean = false): Species {
-    return this.getSpeciesForLevel(level, allowEvolving, true);
+  getTrainerSpeciesForLevel(level: number): Species {
+    return this.getSpeciesForLevel(level, true);
   }
 
   /**
    * Calculates the correct evolution stage for an enemy Pokemon based on its level,
    * applying pre-evolutions and evolutions as necessary.
    * @param level The level of the Pokemon.
-   * @param allowEvolving Whether or not to allow further evolution. Default: `false`.
    * @param forTrainer Whether or not this Pokemon belongs to an enemy trainer. Default: `false`.
    * @returns The {@linkcode Species | species ID} of the desired evolution stage.
    */
-  getSpeciesForLevel(level: number, allowEvolving: boolean = false, forTrainer: boolean = false): Species {
+  getSpeciesForLevel(level: number, forTrainer: boolean = false): Species {
+    // Apply pre-evolutions
     const prevolutionLevels = this.getPrevolutionLevels();
-
     if (prevolutionLevels.length) {
       for (let pl = prevolutionLevels.length - 1; pl >= 0; pl--) {
         const prevolutionLevel = prevolutionLevels[pl];
@@ -166,10 +163,12 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
       }
     }
 
-    if (!allowEvolving || !pokemonEvolutions.hasOwnProperty(this.speciesId)) {
+    // If the species cannot evolve, we are done
+    if (!pokemonEvolutions.hasOwnProperty(this.speciesId)) {
       return this.speciesId;
     }
 
+    // Apply evolutions
     const evolutions = pokemonEvolutions[this.speciesId];
     const eligibleEvolutions: Species[] = [];
 
@@ -191,7 +190,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
 
     if (eligibleEvolutions.length > 0) {
       const randSpecies = randSeedItem(eligibleEvolutions);
-      return getPokemonSpecies(randSpecies).getSpeciesForLevel(level, true, forTrainer);
+      return getPokemonSpecies(randSpecies).getSpeciesForLevel(level, forTrainer);
     } else {
       return this.speciesId;
     }

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -125,33 +125,13 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
   }
 
   /**
-   * Calculates the correct evolution stage for a wild enemy Pokemon based on its level,
-   * applying pre-evolutions and evolutions as necessary.
+   * Calculates the correct evolution stage for an enemy Pokemon, applying pre-evolutions
+   * and evolutions as necessary based on the Pokemon's level.
    * @param level The level of the Pokemon.
+   * @param forTrainer Whether or not this Pokemon belongs to an enemy trainer (as opposed to being a wild Pokemon). Default: `false`.
    * @returns The {@linkcode Species | species ID} of the desired evolution stage.
    */
-  getWildSpeciesForLevel(level: number): Species {
-    return this.getSpeciesForLevel(level, false);
-  }
-
-  /**
-   * Calculates the correct evolution stage for an enemy trainer's Pokemon based on its level,
-   * applying pre-evolutions and evolutions as necessary.
-   * @param level The level of the Pokemon.
-   * @returns The {@linkcode Species | species ID} of the desired evolution stage.
-   */
-  getTrainerSpeciesForLevel(level: number): Species {
-    return this.getSpeciesForLevel(level, true);
-  }
-
-  /**
-   * Calculates the correct evolution stage for an enemy Pokemon based on its level,
-   * applying pre-evolutions and evolutions as necessary.
-   * @param level The level of the Pokemon.
-   * @param forTrainer Whether or not this Pokemon belongs to an enemy trainer. Default: `false`.
-   * @returns The {@linkcode Species | species ID} of the desired evolution stage.
-   */
-  getSpeciesForLevel(level: number, forTrainer: boolean = false): Species {
+  getEnemySpeciesForLevel(level: number, forTrainer: boolean = false): Species {
     // Apply pre-evolutions
     const prevolutionLevels = this.getPrevolutionLevels();
     if (prevolutionLevels.length) {
@@ -189,7 +169,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
 
     if (eligibleEvolutions.length > 0) {
       const randSpecies = randSeedItem(eligibleEvolutions);
-      return getPokemonSpecies(randSpecies).getSpeciesForLevel(level, forTrainer);
+      return getPokemonSpecies(randSpecies).getEnemySpeciesForLevel(level, forTrainer);
     } else {
       return this.speciesId;
     }

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -1,10 +1,8 @@
 import type { Localizable } from "#app/interfaces/locales";
 import type { Abilities } from "#enums/abilities";
-import { PartyMemberStrength } from "#enums/party-member-strength";
 import { Species } from "#enums/species";
 import i18next from "i18next";
-import type { GameMode } from "#app/game-mode";
-import { randSeedInt, randSeedGauss } from "#app/utils";
+import { randSeedGauss, randSeedItem } from "#app/utils";
 import type { GrowthRate } from "#enums/growth-rates";
 import type { EvolutionLevel } from "#app/data/balance/pokemon-evolutions";
 import { pokemonEvolutions, pokemonPrevolutions } from "#app/data/balance/pokemon-evolutions";
@@ -126,31 +124,37 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     this.name = i18next.t(`pokemon:${Species[this.speciesId].toLowerCase()}`);
   }
 
-  getWildSpeciesForLevel(level: number, allowEvolving: boolean, isBoss: boolean, gameMode: GameMode): Species {
-    return this.getSpeciesForLevel(
-      level,
-      allowEvolving,
-      false,
-      (isBoss ? PartyMemberStrength.WEAKER : PartyMemberStrength.AVERAGE) + (gameMode?.isEndless ? 1 : 0),
-    );
+  /**
+   * Calculates the correct evolution stage for a wild enemy Pokemon based on its level,
+   * applying pre-evolutions and evolutions as necessary.
+   * @param level The level of the Pokemon.
+   * @param allowEvolving Whether or not to allow further evolution.
+   * @returns The {@linkcode Species | species ID} of the desired evolution stage.
+   */
+  getWildSpeciesForLevel(level: number, allowEvolving: boolean): Species {
+    return this.getSpeciesForLevel(level, allowEvolving, false);
   }
 
-  getTrainerSpeciesForLevel(
-    level: number,
-    allowEvolving: boolean = false,
-    strength: PartyMemberStrength,
-    currentWave: number = 0,
-  ): Species {
-    return this.getSpeciesForLevel(level, allowEvolving, true, strength, currentWave);
+  /**
+   * Calculates the correct evolution stage for an enemy trainer's Pokemon based on its level,
+   * applying pre-evolutions and evolutions as necessary.
+   * @param level The level of the Pokemon.
+   * @param allowEvolving Whether or not to allow further evolution. Default: `false`.
+   * @returns The {@linkcode Species | species ID} of the desired evolution stage.
+   */
+  getTrainerSpeciesForLevel(level: number, allowEvolving: boolean = false): Species {
+    return this.getSpeciesForLevel(level, allowEvolving, true);
   }
 
-  getSpeciesForLevel(
-    level: number,
-    allowEvolving: boolean = false,
-    forTrainer: boolean = false,
-    strength: PartyMemberStrength = PartyMemberStrength.WEAKER,
-    currentWave: number = 0,
-  ): Species {
+  /**
+   * Calculates the correct evolution stage for an enemy Pokemon based on its level,
+   * applying pre-evolutions and evolutions as necessary.
+   * @param level The level of the Pokemon.
+   * @param allowEvolving Whether or not to allow further evolution. Default: `false`.
+   * @param forTrainer Whether or not this Pokemon belongs to an enemy trainer. Default: `false`.
+   * @returns The {@linkcode Species | species ID} of the desired evolution stage.
+   */
+  getSpeciesForLevel(level: number, allowEvolving: boolean = false, forTrainer: boolean = false): Species {
     const prevolutionLevels = this.getPrevolutionLevels();
 
     if (prevolutionLevels.length) {
@@ -167,75 +171,30 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     }
 
     const evolutions = pokemonEvolutions[this.speciesId];
-
-    const evolutionPool: Map<number, Species> = new Map();
-    const totalWeight = 0;
-    let noEvolutionChance = 1;
+    const eligibleEvolutions: Species[] = [];
 
     for (const ev of evolutions) {
       if (ev.level > level) {
         continue;
       }
 
-      let evolutionChance: number = 0;
-
       const evolutionSpecies = getPokemonSpecies(ev.speciesId);
       const isRegionalEvolution = !this.isRegional() && evolutionSpecies.isRegional();
 
-      if (!forTrainer && isRegionalEvolution) {
-        evolutionChance = 0;
-      } else {
-        if ((ev.altLevel !== 0 && level > ev.altLevel) || level > ev.level) {
-          evolutionChance = 1;
-          noEvolutionChance = 0;
+      // Random non-trainer spawns are not eligible for regional evolutions (e.g. Alolan Raichu)
+      if (forTrainer || !isRegionalEvolution) {
+        if (level > ev.enemyEvolveLevel) {
+          eligibleEvolutions.push(ev.speciesId);
         }
-      }
-
-      if (evolutionChance === 1) {
-        evolutionPool.set(evolutionChance, ev.speciesId);
       }
     }
 
-    if (noEvolutionChance === 1) {
+    if (eligibleEvolutions.length > 0) {
+      const randSpecies = randSeedItem(eligibleEvolutions);
+      return getPokemonSpecies(randSpecies).getSpeciesForLevel(level, true, forTrainer);
+    } else {
       return this.speciesId;
     }
-
-    const randValue = evolutionPool.size === 1 ? 0 : randSeedInt(totalWeight);
-
-    for (const weight of evolutionPool.keys()) {
-      if (randValue < weight) {
-        return getPokemonSpecies(evolutionPool.get(weight)).getSpeciesForLevel(
-          level,
-          true,
-          forTrainer,
-          strength,
-          currentWave,
-        );
-      }
-    }
-
-    return this.speciesId;
-  }
-
-  getEvolutionLevels(): EvolutionLevel[] {
-    const evolutionLevels: EvolutionLevel[] = [];
-
-    //console.log(Species[this.speciesId], pokemonEvolutions[this.speciesId])
-
-    if (pokemonEvolutions.hasOwnProperty(this.speciesId)) {
-      for (const e of pokemonEvolutions[this.speciesId]) {
-        const speciesId = e.speciesId;
-        const level = e.level;
-        evolutionLevels.push([speciesId, level]);
-        //console.log(Species[speciesId], getPokemonSpecies(speciesId), getPokemonSpecies(speciesId).getEvolutionLevels());
-        const nextEvolutionLevels = getPokemonSpecies(speciesId).getEvolutionLevels();
-        for (const npl of nextEvolutionLevels) {
-          evolutionLevels.push(npl);
-        }
-      }
-    }
-
-    return evolutionLevels;
   }
 
   getPrevolutionLevels(): EvolutionLevel[] {
@@ -250,7 +209,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
           && prevolutionLevels.every((pe) => pe[0] !== parseInt(p))
         ) {
           const speciesId = parseInt(p) as Species;
-          const level = e.level;
+          const level = e.enemyEvolveLevel;
           prevolutionLevels.push([speciesId, level]);
           const subPrevolutionLevels = getPokemonSpecies(speciesId).getPrevolutionLevels();
           for (const spl of subPrevolutionLevels) {

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -174,7 +174,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
 
     for (const ev of evolutions) {
       // TODO: Should enemy Pokemon have a random chance of evolving if they are close to the level threshold?
-      if (ev.enemyEvolveLevel > level) {
+      if (level < ev.enemyEvolveLevel) {
         continue;
       }
 

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1604,7 +1604,7 @@ export function getRandomPartyMemberFunc(
   return (level: number, _strength: PartyMemberStrength) => {
     let species = randSeedItem(speciesPool);
     if (!ignoreEvolution) {
-      species = getPokemonSpecies(species).getTrainerSpeciesForLevel(level, true);
+      species = getPokemonSpecies(species).getTrainerSpeciesForLevel(level);
     }
     return globalScene.addEnemyPokemon(
       getPokemonSpecies(species),
@@ -1632,7 +1632,7 @@ export function getSpeciesFilterRandomPartyMemberFunc(
   return (level: number, _strength: PartyMemberStrength) => {
     const waveIndex = globalScene.currentBattle.waveIndex;
     const species = getPokemonSpecies(
-      globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getTrainerSpeciesForLevel(level, true),
+      globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getTrainerSpeciesForLevel(level),
     );
 
     return globalScene.addEnemyPokemon(species, level, trainerSlot, undefined, false, undefined, postProcess);

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1601,7 +1601,7 @@ export function getRandomPartyMemberFunc(
   ignoreEvolution: boolean = false,
   postProcess?: (enemyPokemon: EnemyPokemon) => void,
 ): PartyMemberFunc {
-  return (level: number, _strength: PartyMemberStrength) => {
+  return (level: number) => {
     let species = randSeedItem(speciesPool);
     if (!ignoreEvolution) {
       species = getPokemonSpecies(species).getEnemySpeciesForLevel(level, true);
@@ -1629,7 +1629,7 @@ export function getSpeciesFilterRandomPartyMemberFunc(
     return (allowLegendaries || notLegendary) && !species.isTrainerForbidden() && originalSpeciesFilter(species);
   };
 
-  return (level: number, _strength: PartyMemberStrength) => {
+  return (level: number) => {
     const waveIndex = globalScene.currentBattle.waveIndex;
     const species = getPokemonSpecies(
       globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getEnemySpeciesForLevel(level, true),

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1604,7 +1604,7 @@ export function getRandomPartyMemberFunc(
   return (level: number, _strength: PartyMemberStrength) => {
     let species = randSeedItem(speciesPool);
     if (!ignoreEvolution) {
-      species = getPokemonSpecies(species).getTrainerSpeciesForLevel(level);
+      species = getPokemonSpecies(species).getEnemySpeciesForLevel(level, true);
     }
     return globalScene.addEnemyPokemon(
       getPokemonSpecies(species),
@@ -1632,7 +1632,7 @@ export function getSpeciesFilterRandomPartyMemberFunc(
   return (level: number, _strength: PartyMemberStrength) => {
     const waveIndex = globalScene.currentBattle.waveIndex;
     const species = getPokemonSpecies(
-      globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getTrainerSpeciesForLevel(level),
+      globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getEnemySpeciesForLevel(level, true),
     );
 
     return globalScene.addEnemyPokemon(species, level, trainerSlot, undefined, false, undefined, postProcess);

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1600,16 +1600,11 @@ export function getRandomPartyMemberFunc(
   trainerSlot: TrainerSlot = TrainerSlot.TRAINER,
   ignoreEvolution: boolean = false,
   postProcess?: (enemyPokemon: EnemyPokemon) => void,
-) {
-  return (level: number, strength: PartyMemberStrength) => {
+): PartyMemberFunc {
+  return (level: number, _strength: PartyMemberStrength) => {
     let species = randSeedItem(speciesPool);
     if (!ignoreEvolution) {
-      species = getPokemonSpecies(species).getTrainerSpeciesForLevel(
-        level,
-        true,
-        strength,
-        globalScene.currentBattle.waveIndex,
-      );
+      species = getPokemonSpecies(species).getTrainerSpeciesForLevel(level, true);
     }
     return globalScene.addEnemyPokemon(
       getPokemonSpecies(species),
@@ -1634,12 +1629,10 @@ export function getSpeciesFilterRandomPartyMemberFunc(
     return (allowLegendaries || notLegendary) && !species.isTrainerForbidden() && originalSpeciesFilter(species);
   };
 
-  return (level: number, strength: PartyMemberStrength) => {
+  return (level: number, _strength: PartyMemberStrength) => {
     const waveIndex = globalScene.currentBattle.waveIndex;
     const species = getPokemonSpecies(
-      globalScene
-        .randomSpecies(waveIndex, level, false, speciesFilter)
-        .getTrainerSpeciesForLevel(level, true, strength, waveIndex),
+      globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getTrainerSpeciesForLevel(level, true),
     );
 
     return globalScene.addEnemyPokemon(species, level, trainerSlot, undefined, false, undefined, postProcess);

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -202,7 +202,7 @@ export class Arena {
       return this.randomSpecies(waveIndex, level, (attempt || 0) + 1);
     }
 
-    const newSpeciesId = ret.getWildSpeciesForLevel(level, true);
+    const newSpeciesId = ret.getWildSpeciesForLevel(level);
     if (newSpeciesId !== ret.speciesId) {
       console.log("Replaced", Species[ret.speciesId], "with", Species[newSpeciesId]);
       ret = getPokemonSpecies(newSpeciesId);

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -134,16 +134,9 @@ export class Arena {
    * @param luckValue - The player's luck value
    * - If the spawned Pokemon is a boss then the RNG ceiling is decreased by half the luck value
    * - If the spawned Pokemon is not a boss then the RNG ceiling is decreased by twice the luck value
-   * @param isBoss - Whether or not to force a boss
    * @returns a Pokemon species
    */
-  randomSpecies(
-    waveIndex: number,
-    level: number,
-    attempt?: number,
-    luckValue?: number,
-    isBoss?: boolean,
-  ): PokemonSpecies {
+  randomSpecies(waveIndex: number, level: number, attempt?: number, luckValue?: number): PokemonSpecies {
     const overrideSpecies = globalScene.gameMode.getOverrideSpecies(waveIndex);
     if (overrideSpecies) {
       return overrideSpecies;
@@ -209,7 +202,7 @@ export class Arena {
       return this.randomSpecies(waveIndex, level, (attempt || 0) + 1);
     }
 
-    const newSpeciesId = ret.getWildSpeciesForLevel(level, true, isBoss ?? isBossSpecies, globalScene.gameMode);
+    const newSpeciesId = ret.getWildSpeciesForLevel(level, true);
     if (newSpeciesId !== ret.speciesId) {
       console.log("Replaced", Species[ret.speciesId], "with", Species[newSpeciesId]);
       ret = getPokemonSpecies(newSpeciesId);

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -202,7 +202,7 @@ export class Arena {
       return this.randomSpecies(waveIndex, level, (attempt || 0) + 1);
     }
 
-    const newSpeciesId = ret.getWildSpeciesForLevel(level);
+    const newSpeciesId = ret.getEnemySpeciesForLevel(level);
     if (newSpeciesId !== ret.speciesId) {
       console.log("Replaced", Species[ret.speciesId], "with", Species[newSpeciesId]);
       ret = getPokemonSpecies(newSpeciesId);

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -413,21 +413,12 @@ export default class Trainer extends Phaser.GameObjects.Container {
         let species = useNewSpeciesPool
           ? getPokemonSpecies(newSpeciesPool[Math.floor(randSeedInt(newSpeciesPool.length))])
           : template.isSameSpecies(index) && index > offset
-            ? getPokemonSpecies(
-                battle.enemyParty[offset].species.getTrainerSpeciesForLevel(
-                  level,
-                  false,
-                  template.getStrength(offset),
-                  globalScene.currentBattle.waveIndex,
-                ),
-              )
+            ? getPokemonSpecies(battle.enemyParty[offset].species.getTrainerSpeciesForLevel(level, false))
             : this.genNewPartyMemberSpecies(level, strength);
 
         // If the species is from newSpeciesPool, we need to adjust it based on the level and strength
         if (newSpeciesPool) {
-          species = getPokemonSpecies(
-            species.getSpeciesForLevel(level, true, true, strength, globalScene.currentBattle.waveIndex),
-          );
+          species = getPokemonSpecies(species.getSpeciesForLevel(level, true, true));
         }
 
         ret = globalScene.addEnemyPokemon(
@@ -476,9 +467,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
       baseSpecies = globalScene.randomSpecies(battle.waveIndex, level, false, this.config.speciesFilter);
     }
 
-    let ret = getPokemonSpecies(
-      baseSpecies.getTrainerSpeciesForLevel(level, true, strength, globalScene.currentBattle.waveIndex),
-    );
+    let ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level, true));
     let retry = false;
 
     console.log(ret.getName());
@@ -500,9 +489,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
       console.log("Attempting reroll of species evolution to fit specialty type...");
       let evoAttempt = 0;
       while (retry && evoAttempt++ < 10) {
-        ret = getPokemonSpecies(
-          baseSpecies.getTrainerSpeciesForLevel(level, true, strength, globalScene.currentBattle.waveIndex),
-        );
+        ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level, true));
         console.log(ret.name);
         if (this.config.specialtyTypes.find((t) => ret.isOfType(t))) {
           retry = false;

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -418,7 +418,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
         // If the species is from newSpeciesPool, we need to adjust it based on the level and strength
         if (useNewSpeciesPool) {
-          species = getPokemonSpecies(species.getSpeciesForLevel(level, true));
+          species = getPokemonSpecies(species.getEnemySpeciesForLevel(level, true));
         }
 
         ret = globalScene.addEnemyPokemon(
@@ -467,7 +467,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
       baseSpecies = globalScene.randomSpecies(battle.waveIndex, level, false, this.config.speciesFilter);
     }
 
-    let ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level));
+    let ret = getPokemonSpecies(baseSpecies.getEnemySpeciesForLevel(level, true));
     let retry = false;
 
     console.log(ret.getName());
@@ -489,7 +489,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
       console.log("Attempting reroll of species evolution to fit specialty type...");
       let evoAttempt = 0;
       while (retry && evoAttempt++ < 10) {
-        ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level));
+        ret = getPokemonSpecies(baseSpecies.getEnemySpeciesForLevel(level, true));
         console.log(ret.name);
         if (this.config.specialtyTypes.find((t) => ret.isOfType(t))) {
           retry = false;

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -413,12 +413,12 @@ export default class Trainer extends Phaser.GameObjects.Container {
         let species = useNewSpeciesPool
           ? getPokemonSpecies(newSpeciesPool[Math.floor(randSeedInt(newSpeciesPool.length))])
           : template.isSameSpecies(index) && index > offset
-            ? getPokemonSpecies(battle.enemyParty[offset].species.getTrainerSpeciesForLevel(level, false))
+            ? battle.enemyParty[offset].species
             : this.genNewPartyMemberSpecies(level, strength);
 
         // If the species is from newSpeciesPool, we need to adjust it based on the level and strength
-        if (newSpeciesPool) {
-          species = getPokemonSpecies(species.getSpeciesForLevel(level, true, true));
+        if (useNewSpeciesPool) {
+          species = getPokemonSpecies(species.getSpeciesForLevel(level, true));
         }
 
         ret = globalScene.addEnemyPokemon(
@@ -467,7 +467,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
       baseSpecies = globalScene.randomSpecies(battle.waveIndex, level, false, this.config.speciesFilter);
     }
 
-    let ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level, true));
+    let ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level));
     let retry = false;
 
     console.log(ret.getName());
@@ -489,7 +489,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
       console.log("Attempting reroll of species evolution to fit specialty type...");
       let evoAttempt = 0;
       while (retry && evoAttempt++ < 10) {
-        ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level, true));
+        ret = getPokemonSpecies(baseSpecies.getTrainerSpeciesForLevel(level));
         console.log(ret.name);
         if (this.config.specialtyTypes.find((t) => ret.isOfType(t))) {
           retry = false;

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -343,15 +343,11 @@ export default class Trainer extends Phaser.GameObjects.Container {
           }
         }
 
-        // Create an empty species pool (which will be set to one of the species pools based on the index)
+        // Create an empty species pool (which will be set to one of the species pools based on the index, if applicable)
         let newSpeciesPool: Species[] = [];
-        let useNewSpeciesPool = false;
 
         // If we are in a double battle of named trainers, we need to use alternate species pools (generate half the party from each trainer)
         if (this.config.trainerTypeDouble && this.isDouble() && !this.config.doubleOnly) {
-          // Use the new species pool for this party generation
-          useNewSpeciesPool = true;
-
           // Get the species pool for the partner trainer and the current trainer
           const speciesPoolPartner = signatureSpecies[TrainerType[this.config.trainerTypeDouble]];
           const speciesPool = signatureSpecies[TrainerType[this.config.trainerType]];
@@ -402,23 +398,19 @@ export default class Trainer extends Phaser.GameObjects.Container {
               newSpeciesPool = speciesPoolPartnerFiltered;
             }
           }
-          // Fallback for when the species pool is empty
-          if (newSpeciesPool.length === 0) {
-            // If all pokemon from this pool are already in the party, generate a random species
-            useNewSpeciesPool = false;
-          }
         }
 
-        // If useNewSpeciesPool is true, we need to generate a new species from the new species pool, otherwise we generate a random species
-        let species = useNewSpeciesPool
-          ? getPokemonSpecies(newSpeciesPool[Math.floor(randSeedInt(newSpeciesPool.length))])
-          : template.isSameSpecies(index) && index > offset
-            ? battle.enemyParty[offset].species
-            : this.genNewPartyMemberSpecies(level, strength);
-
-        // If the species is from newSpeciesPool, we need to adjust it based on the level and strength
-        if (useNewSpeciesPool) {
-          species = getPokemonSpecies(species.getEnemySpeciesForLevel(level, true));
+        let species: PokemonSpecies;
+        if (newSpeciesPool.length > 0) {
+          // If the new species pool is non-empty, select a species from it and set it to its correct evolution stage.
+          const rawSpecies = getPokemonSpecies(randSeedItem(newSpeciesPool));
+          species = getPokemonSpecies(rawSpecies.getEnemySpeciesForLevel(level, true));
+        } else if (template.isSameSpecies(index) && index > offset) {
+          // If the template calls for using the same species as the previous Pokemon, then copy the species.
+          species = battle.enemyParty[offset].species;
+        } else {
+          // If none of the above applies, pick a random species from the trainer's regular pool.
+          species = this.genNewPartyMemberSpecies(level, strength);
         }
 
         ret = globalScene.addEnemyPokemon(

--- a/test/pokemon/evolution.test.ts
+++ b/test/pokemon/evolution.test.ts
@@ -188,7 +188,7 @@ describe("Evolution", () => {
     const trials = 8; // For all 8 Eeveelutions
     for (let i = 0; i < trials; i++) {
       rngSweepProgress = (2 * i + 1) / (2 * trials);
-      actualEvolutions.add(getPokemonSpecies(Species.EEVEE).getWildSpeciesForLevel(100));
+      actualEvolutions.add(getPokemonSpecies(Species.EEVEE).getEnemySpeciesForLevel(100));
     }
     expect(actualEvolutions.size).toBe(trials);
   });

--- a/test/pokemon/evolution.test.ts
+++ b/test/pokemon/evolution.test.ts
@@ -188,7 +188,7 @@ describe("Evolution", () => {
     const trials = 8; // For all 8 Eeveelutions
     for (let i = 0; i < trials; i++) {
       rngSweepProgress = (2 * i + 1) / (2 * trials);
-      actualEvolutions.add(getPokemonSpecies(Species.EEVEE).getWildSpeciesForLevel(100, true));
+      actualEvolutions.add(getPokemonSpecies(Species.EEVEE).getWildSpeciesForLevel(100));
     }
     expect(actualEvolutions.size).toBe(trials);
   });

--- a/test/pokemon/evolution.test.ts
+++ b/test/pokemon/evolution.test.ts
@@ -7,6 +7,8 @@ import { GameManager } from "#test/testUtils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { Gender } from "#enums/gender";
+import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
+import { BiomePoolTier } from "#enums/biome-pool-tier";
 
 describe("Evolution", () => {
   let phaserGame: Phaser.Game;
@@ -173,5 +175,50 @@ describe("Evolution", () => {
       const fourForm = playerPokemon.getEvolution()!;
       expect(fourForm.evoFormKey).toBe(null); // meanwhile, according to the pokemon-forms, the evoFormKey for a 4 family maushold is null
     }
+  });
+
+  it("wild Pokemon with multiple possible evolutions should pick a random evolution", async () => {
+    let rngSweepProgress = 0; // Will simulate full range of RNG rolls by steadily increasing from 0 to 1
+
+    vi.spyOn(Phaser.Math.RND, "realInRange").mockImplementation((min: number, max: number) => {
+      return rngSweepProgress * (max - min) + min;
+    });
+
+    const actualEvolutions = new Set<Species>();
+    const trials = 8; // For all 8 Eeveelutions
+    for (let i = 0; i < trials; i++) {
+      rngSweepProgress = (2 * i + 1) / (2 * trials);
+      actualEvolutions.add(getPokemonSpecies(Species.EEVEE).getWildSpeciesForLevel(100, true));
+    }
+    expect(actualEvolutions.size).toBe(trials);
+  });
+
+  it("wild Pokemon should not already be evolved at level 1", async () => {
+    for (const evoArray of Object.values(pokemonEvolutions)) {
+      for (const evo of evoArray) {
+        expect(evo.enemyEvolveLevel).toBeGreaterThan(1);
+      }
+    }
+  });
+
+  it("wild Pokemon should be pre-evolved if they are at a sufficiently low level", async () => {
+    game.override.enemySpecies(0); // Disable the enemy species override
+    await game.classicMode.startBattle([Species.FEEBAS]);
+
+    game.move.use(MoveId.SPLASH);
+    await game.doKillOpponents();
+
+    // Mock the next wave's Pokemon pool
+    vi.spyOn(game.scene.arena as any, "pokemonPool", "get").mockReturnValue({
+      [BiomePoolTier.COMMON]: [Species.SLOWKING],
+      [BiomePoolTier.UNCOMMON]: [],
+      [BiomePoolTier.RARE]: [],
+      [BiomePoolTier.SUPER_RARE]: [],
+      [BiomePoolTier.ULTRA_RARE]: [],
+    });
+
+    await game.toNextWave();
+
+    expect(game.field.getEnemyPokemon().species.speciesId).toBe(Species.SLOWPOKE);
   });
 });


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

1. If an enemy Pokemon spawn has multiple possible evolutions, it now properly selects a random one.
2. For certain species, if there is a possible pre-evolution and the Pokemon is a low enough level, it now properly selects the pre-evolution.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

Fixing a bug introduced by #749.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->
1. The related functions have been consolidated into one function `getEnemySpeciesForLevel`.
2. This function now picks a random evolution using `randSeedInt()`. The previous `totalWeight` system, which #749 had temporarily broken, is now completely removed.
3. Renamed `altLevel` to `enemyEvolveLevel`. Its default value is now equal to the evolution's regular level instead of 0.
4. Updated `getPrevolutionLevels()` to use `enemyEvolveLevel` (discovered by Temp). (TODO: `getPrevolutionLevels()` is also called by `getSimulatedEvolutionChain()`, which is sometimes used in moveset generation. Hopefully this change does not break moveset generation.)
5. Also deleted the unused function `getEvolutionLevels()` and the unused params `allowEvolving`, `strength`, and `currentWave`.
6. Added some tests.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details><summary>Before the changes: All Eevees evolve into Glaceon</summary>
<p>

![20250228 Before Fix Eeveelutions](https://github.com/user-attachments/assets/5b3adbec-9e32-46da-b0d2-9f86e23acb5a)

</p>
</details> 
<details><summary>After the changes: On the same seed, Eevees evolve into multiple different evolutions</summary>
<p>

![20250228 After Fix Eeveelutions](https://github.com/user-attachments/assets/dbdfaec7-a0dc-4895-bd6d-302696b052d1)

</p>
</details> 

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Edit this line to spawn only Eevee:
https://github.com/Despair-Games/poketernity/blob/5849f8873c6287c48dc94c2e784e6a06e7456f4f/src/field/arena.ts#L175

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR? (#765, #761)
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?