### PR TITLE
[P1] Fix consecutive-use moves infinitely queueing failing moves

### DIFF
--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1114,6 +1114,11 @@ export abstract class MoveLockTag extends BattlerTag {
     super(tagType, BattlerTagLapseType.AFTER_MOVE, turnCount, sourceMoveId);
   }
 
+  override onRemove(pokemon: Pokemon): void {
+    const moveHistory = pokemon.getMoveHistory();
+    moveHistory.splice(0, moveHistory.length);
+  }
+
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.CUSTOM) {
       return this.handleCustomLapse(pokemon);
@@ -1226,6 +1231,8 @@ export class FrenzyTag extends MoveLockTag {
   }
 
   override onRemove(pokemon: Pokemon): void {
+    super.onRemove(pokemon);
+
     if (this.turnCount <= 0) {
       // Only add CONFUSED tag if a disruption occurs on the final confusion-inducing turn of FRENZY
       pokemon.addTag(BattlerTagType.CONFUSED, pokemon.randSeedIntRange(2, 4));

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -47,7 +47,7 @@ import {
 } from "#app/utils/battler-tag-type-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { PhaseId } from "#enums/phase-id";
-import type { BattlerIndex } from "#enums/battler-index";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveTarget } from "#enums/move-target";
 
 export class BattlerTag {
@@ -1108,7 +1108,7 @@ export class NightmareTag extends BattlerTag {
  * @extends BattlerTag
  */
 export abstract class MoveLockTag extends BattlerTag {
-  protected lastTargets: BattlerIndex[];
+  protected lastTargets?: BattlerIndex[];
 
   constructor(tagType: BattlerTagType, turnCount: number, sourceMoveId: MoveId) {
     super(tagType, BattlerTagLapseType.AFTER_MOVE, turnCount, sourceMoveId);
@@ -1130,7 +1130,10 @@ export abstract class MoveLockTag extends BattlerTag {
    * @returns `true` if the tag is to be retained after lapsing
    */
   protected handleAfterMoveLapse(pokemon: Pokemon): boolean {
-    const { move: lastMove, targets: lastTargets, result: lastMoveResult } = pokemon.getLastXMoves()?.[0];
+    if (!pokemon.getLastXMoves()?.[0]) {
+      return false;
+    }
+    const { move: lastMove, targets: lastTargets, result: lastMoveResult } = pokemon.getLastXMoves()[0];
 
     // If this pokemon somehow used another move (e.g. via Dancer), don't advance this tag
     if (![this.sourceMoveId, MoveId.NONE].includes(lastMove.id)) {
@@ -1139,7 +1142,6 @@ export abstract class MoveLockTag extends BattlerTag {
 
     const ret =
       super.lapse(pokemon, BattlerTagLapseType.AFTER_MOVE)
-      && !!lastTargets
       && lastTargets.length > 0
       && lastMoveResult === MoveResult.SUCCESS;
 
@@ -1179,9 +1181,14 @@ export abstract class MoveLockTag extends BattlerTag {
    * @returns the target(s), by {@linkcode BattlerIndex}, for the next usage of this tag's move
    */
   protected getNextTargets(pokemon: Pokemon, move: Move): BattlerIndex[] {
-    if ((move.moveTarget = MoveTarget.RANDOM_NEAR_ENEMY)) {
+    if (move.moveTarget === MoveTarget.RANDOM_NEAR_ENEMY) {
       return getMoveTargets(pokemon, move.id).targets;
     } else {
+      // Failsafe if `this.lastTargets` has somehow not been set
+      if (!this.lastTargets?.length) {
+        this.lastTargets = pokemon.isPlayer() ? [BattlerIndex.ENEMY] : [BattlerIndex.PLAYER];
+      }
+
       // Note: this assumes the locked move is single-target
       const lastTarget = globalScene.getFieldPokemonByBattlerIndex(this.lastTargets[0]);
       const adjacentIndex = this.lastTargets[0] + (this.lastTargets[0] % 2 === 0 ? 1 : -1);

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1115,8 +1115,8 @@ export abstract class MoveLockTag extends BattlerTag {
   }
 
   override onRemove(pokemon: Pokemon): void {
-    const moveHistory = pokemon.getMoveHistory();
-    moveHistory.splice(0, moveHistory.length);
+    const moveQueue = pokemon.getMoveQueue();
+    moveQueue.splice(0, moveQueue.length);
   }
 
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -1108,11 +1108,28 @@ export class NightmareTag extends BattlerTag {
  * @extends BattlerTag
  */
 export abstract class MoveLockTag extends BattlerTag {
+  protected lastTargets: BattlerIndex[];
+
   constructor(tagType: BattlerTagType, turnCount: number, sourceMoveId: MoveId) {
     super(tagType, BattlerTagLapseType.AFTER_MOVE, turnCount, sourceMoveId);
   }
 
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
+    if (lapseType === BattlerTagLapseType.CUSTOM) {
+      return this.handleCustomLapse(pokemon);
+    } else {
+      return this.handleAfterMoveLapse(pokemon);
+    }
+  }
+
+  /**
+   * Queues the tag's source move on all turns except this tag's last turn
+   * if the tag holder's last move was successful. The queued move initially
+   * has no targets; the move targeting is instead resolved by this tag's custom lapse.
+   * @param pokemon the {@linkcode Pokemon} with this tag
+   * @returns `true` if the tag is to be retained after lapsing
+   */
+  protected handleAfterMoveLapse(pokemon: Pokemon): boolean {
     const { move: lastMove, targets: lastTargets, result: lastMoveResult } = pokemon.getLastXMoves()?.[0];
 
     // If this pokemon somehow used another move (e.g. via Dancer), don't advance this tag
@@ -1121,34 +1138,71 @@ export abstract class MoveLockTag extends BattlerTag {
     }
 
     const ret =
-      super.lapse(pokemon, lapseType)
+      super.lapse(pokemon, BattlerTagLapseType.AFTER_MOVE)
       && !!lastTargets
       && lastTargets.length > 0
       && lastMoveResult === MoveResult.SUCCESS;
 
     if (ret) {
-      const nextTargets = this.getNextTargets(pokemon, lastMove, lastTargets);
       const move = allMoves[this.sourceMoveId];
-      pokemon.getMoveQueue().push({ move, targets: nextTargets, ignorePP: true, type: pokemon.getMoveType(move) });
+      this.lastTargets = lastTargets;
+      pokemon.getMoveQueue().push({ move, targets: [], ignorePP: true, type: pokemon.getMoveType(move) });
     }
 
     return ret;
   }
 
   /**
+   * Determines the next queued move's target during command selection
+   * @param pokemon the {@linkcode Pokemon} with this tag
+   */
+  protected handleCustomLapse(pokemon: Pokemon): boolean {
+    const queuedMove = pokemon.getMoveQueue()[0];
+
+    /**
+     * If the pokemon somehow doesn't have a queued move, abort
+     * target adjustment and remove this tag. This is just a failsafe;
+     * under normal circumstances, this should never happen.
+     */
+    if (!queuedMove) {
+      return false;
+    }
+
+    queuedMove.targets = this.getNextTargets(pokemon, queuedMove.move);
+    return true;
+  }
+
+  /**
    * Obtains the target(s) for move actions queued by this tag
    * @param pokemon the {@linkcode Pokemon} with this tag
    * @param move the {@linkcode Move} queued by this tag
-   * @param lastTargets the target(s), by {@linkcode BattlerIndex}, attacked by
-   * the source Pokemon's last use of the move.
    * @returns the target(s), by {@linkcode BattlerIndex}, for the next usage of this tag's move
    */
-  protected getNextTargets(pokemon: Pokemon, move: Move, lastTargets: BattlerIndex[]): BattlerIndex[] {
+  protected getNextTargets(pokemon: Pokemon, move: Move): BattlerIndex[] {
     if ((move.moveTarget = MoveTarget.RANDOM_NEAR_ENEMY)) {
       return getMoveTargets(pokemon, move.id).targets;
     } else {
-      return lastTargets;
+      // Note: this assumes the locked move is single-target
+      const lastTarget = globalScene.getFieldPokemonByBattlerIndex(this.lastTargets[0]);
+      const adjacentIndex = this.lastTargets[0] + (this.lastTargets[0] % 2 === 0 ? 1 : -1);
+      const adjacentTarget = globalScene.getFieldPokemonByBattlerIndex(adjacentIndex);
+
+      if (
+        !lastTarget?.isActive(true)
+        && globalScene.currentBattle.double
+        && adjacentTarget?.isActive(true)
+        && adjacentTarget !== pokemon
+      ) {
+        return [adjacentIndex];
+      } else {
+        return this.lastTargets;
+      }
     }
+  }
+
+  override loadTag(source: BattlerTag | any): void {
+    super.loadTag(source);
+    this.lastTargets = source.lastTargets;
   }
 }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -140,6 +140,7 @@ import {
 import { WeakenMoveScreenArenaTagTypes } from "#app/utils/arena-tag-type-utils";
 import {
   CritBoostBattlerTagTypes,
+  MoveLockTagTypes,
   SemiInvulnerableBattlerTagTypes,
   TrappedBattlerTagTypes,
 } from "#app/utils/battler-tag-type-utils";
@@ -4565,6 +4566,7 @@ export class EnemyPokemon extends Pokemon {
           (moveIndex > -1 && this.getMoveset()[moveIndex]!.isUsable(this, queuedMove.ignorePP))
           || queuedMove.virtual
         ) {
+          MoveLockTagTypes.forEach((tagType) => this.lapseTag(tagType));
           return queuedMove;
         } else {
           this.getMoveQueue().shift();

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -11,7 +11,7 @@ import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { FieldPhase } from "#app/phases/abstract-field-phase";
 import { isNullOrUndefined } from "#app/utils";
-import { TrappedBattlerTagTypes } from "#app/utils/battler-tag-type-utils";
+import { MoveLockTagTypes, TrappedBattlerTagTypes } from "#app/utils/battler-tag-type-utils";
 import { isFieldTargeted } from "#app/utils/move-utils";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -96,12 +96,10 @@ export class CommandPhase extends FieldPhase {
       && moveQueue[0]
       && moveQueue[0].move.id !== MoveId.NONE
       && !moveQueue[0].virtual
-      && (!pokemon.getMoveset().find((m) => m.moveId === moveQueue[0].move.id)
-        || !pokemon
-          .getMoveset()
-          [
-            pokemon.getMoveset().findIndex((m) => m.moveId === moveQueue[0].move.id)
-          ].isUsable(pokemon, moveQueue[0].ignorePP))
+      && !pokemon
+        .getMoveset()
+        .find((m) => m.moveId === moveQueue[0].move.id)
+        ?.isUsable(pokemon, moveQueue[0].ignorePP)
     ) {
       moveQueue.shift();
     }
@@ -116,6 +114,7 @@ export class CommandPhase extends FieldPhase {
           (moveIndex > -1 && pokemon.getMoveset()[moveIndex].isUsable(pokemon, queuedMove.ignorePP))
           || queuedMove.virtual
         ) {
+          MoveLockTagTypes.forEach((tagType) => pokemon.lapseTag(tagType));
           this.handleCommand(BattleCommand.FIGHT, moveIndex, queuedMove.ignorePP, queuedMove);
         } else {
           ui.setMode(UiMode.COMMAND, this.fieldIndex);

--- a/test/moves/thrash.test.ts
+++ b/test/moves/thrash.test.ts
@@ -132,4 +132,27 @@ describe("Moves - Thrash", () => {
     expect(player.getTag(BattlerTagType.FRENZY)).toBeUndefined();
     expect(player.getTag(BattlerTagType.CONFUSED)).toBeDefined();
   });
+
+  it("should continue execution between waves", async () => {
+    game.override.enemyLevel(1);
+
+    await game.classicMode.startBattle([Species.MAGIKARP]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.THRASH);
+    await game.toNextWave();
+
+    expect(player.getTag(BattlerTagType.FRENZY)).toBeDefined();
+    expect(player.getMoveQueue()[0]).toMatchObject({
+      move: expect.objectContaining({ id: MoveId.THRASH }),
+      targets: [BattlerIndex.ENEMY],
+      ignorePP: true,
+    });
+
+    const nextEnemy = game.field.getEnemyPokemon();
+
+    await game.phaseInterceptor.to("FaintPhase", false);
+    expect(nextEnemy.isFainted()).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Frenzy moves (e.g. Outrage) should no longer infinitely fail after eligible targets are cleared from the field.

## Why am I making these changes?

fixes #768 

## What are the changes from a developer perspective?

- `MoveLockTag` no longer resolves follow-up moves' targeting immediately after using the associated move. Instead, follow-up moves' targeting is resolved at the start of the next turn, during forced move selection.
- Added a new test to `thrash.test.ts` to verify continued execution between waves

## Screenshots/Videos

https://github.com/user-attachments/assets/33c3bfb0-b933-49a4-90ee-75c1a806b287


## How to test the changes?

`npm run test thrash` - 1 new test

<details><summary>Overrides for manual testing</summary>
<p>

```
BATTLE_TYPE_OVERRIDE: "single",
STARTING_LEVEL_OVERRIDE: 50,
MOVESET_OVERRIDE: [MoveId.OUTRAGE, MoveId.SPLASH],
ENEMY_MOVESET_OVERRIDE: MoveId.SPLASH
```

You can also change the battle type to `"double"` to verify target redirection.

</p>
</details>

## Checklist

- [x] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?

#### If there are no locale changes:
- [x] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->