### PR TITLE
[Refactor] Add `applyBattlerTags` function

### DIFF
--- a/src/data/apply-battler-tags.ts
+++ b/src/data/apply-battler-tags.ts
@@ -1,0 +1,24 @@
+import type { BattlerTag } from "#app/data/battler-tags";
+import type { BattlerTagType } from "#enums/battler-tag-type";
+
+/**
+ * Applies all tags of the given tag type(s) until a tag's `apply`
+ * function returns with `true`.
+ * @param tagTypes The type(s) of tags to apply; can be a single {@linkcode BattlerTagType}
+ * or an array.
+ * @param params The parameters for the specified tag class's `apply` function, including
+ * - `pokemon`: the {@linkcode Pokemon} with the tag
+ * - `simulated`: `true` if this apply call should be resolved without changing game state
+ * - any additional arguments specific to the tag class
+ * @returns `true` if a tag applied successfully
+ */
+export function applyBattlerTags<T extends BattlerTag = BattlerTag>(
+  tagTypes: BattlerTagType | readonly BattlerTagType[],
+  ...params: Parameters<T["apply"]>
+): boolean {
+  const [pokemon, simulated, ...args] = params;
+  const tagTypeArr = Array.isArray(tagTypes) ? tagTypes : [tagTypes];
+
+  const tags = pokemon.findTags((tag) => tagTypeArr.includes(tag.tagType));
+  return tags.some((tag) => tag.apply(pokemon, simulated, ...args));
+}

--- a/src/phases/hit-check-phase.ts
+++ b/src/phases/hit-check-phase.ts
@@ -1,4 +1,4 @@
-import { ProtectedTag } from "#app/data/battler-tags";
+import type { ProtectedTag } from "#app/data/battler-tags";
 import { HitsTagAttr } from "#app/data/move-attrs/hits-tag-attr";
 import { OneHitKOAttr } from "#app/data/move-attrs/one-hit-ko-attr";
 import { ToxicAccuracyAttr } from "#app/data/move-attrs/toxic-accuracy-attr";
@@ -8,7 +8,7 @@ import type { PokemonMove } from "#app/field/pokemon-move";
 import { globalScene } from "#app/global-scene";
 import { BooleanHolder } from "#app/utils";
 import { ConditionalProtectArenaTagTypes } from "#app/utils/arena-tag-type-utils";
-import { SemiInvulnerableBattlerTagTypes } from "#app/utils/battler-tag-type-utils";
+import { ProtectionBattlerTagTypes, SemiInvulnerableBattlerTagTypes } from "#app/utils/battler-tag-type-utils";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -18,6 +18,7 @@ import { MoveTarget } from "#enums/move-target";
 import { ElementalType } from "#enums/elemental-type";
 import { PokemonPhase } from "./abstract-pokemon-phase";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { applyBattlerTags } from "#app/data/apply-battler-tags";
 
 //#region Types
 
@@ -121,7 +122,7 @@ export abstract class HitCheckPhase extends PokemonPhase {
     /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */
     const isProtected =
       hasConditionalProtectApplied.value
-      || target.findTags((t) => t instanceof ProtectedTag)[0]?.apply(target, simulated, user, move);
+      || applyBattlerTags<ProtectedTag>(ProtectionBattlerTagTypes, target, false, user, move);
 
     if (isProtected) {
       return [HitCheckResult.PROTECTED, 0];

--- a/src/phases/hit-check-phase.ts
+++ b/src/phases/hit-check-phase.ts
@@ -122,7 +122,7 @@ export abstract class HitCheckPhase extends PokemonPhase {
     /** Is the target protected by Protect, etc. or a relevant conditional protection effect? */
     const isProtected =
       hasConditionalProtectApplied.value
-      || applyBattlerTags<ProtectedTag>(ProtectionBattlerTagTypes, target, false, user, move);
+      || applyBattlerTags<ProtectedTag>(ProtectionBattlerTagTypes, target, simulated, user, move);
 
     if (isProtected) {
       return [HitCheckResult.PROTECTED, 0];

--- a/src/utils/battler-tag-type-utils.ts
+++ b/src/utils/battler-tag-type-utils.ts
@@ -7,6 +7,16 @@ export const SemiInvulnerableBattlerTagTypes = Object.freeze([
   BattlerTagType.HIDDEN,
 ]);
 
+export const ProtectionBattlerTagTypes = Object.freeze([
+  BattlerTagType.PROTECTED,
+  BattlerTagType.BANEFUL_BUNKER,
+  BattlerTagType.SPIKY_SHIELD,
+  BattlerTagType.SILK_TRAP,
+  BattlerTagType.BURNING_BULWARK,
+  BattlerTagType.KINGS_SHIELD,
+  BattlerTagType.OBSTRUCT,
+]);
+
 export const MoveLockTagTypes = Object.freeze([BattlerTagType.FRENZY]);
 
 export const CritBoostBattlerTagTypes = Object.freeze([BattlerTagType.CRIT_BOOST, BattlerTagType.DRAGON_CHEER]);


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

Looking up tags and then calling their `apply` functions directly is cumbersome, and some of my recent PRs (e.g. #699) led to duplicate logic being added around the codebase.

## What are the changes from a developer perspective?

A new helper function has been added to apply tags of given type(s):

```ts
export function applyBattlerTags<T extends BattlerTag = BattlerTag>(
  tagTypes: BattlerTagType | readonly BattlerTagType[],
  ...params: Parameters<T["apply"]>
): boolean;
```

This function matches the current API for applying move and ability attributes and accepts the readonly `BattlerTagType` groupings in `battler-tag-type-utils.ts`. As proof of concept, the logic to apply protection effects during hit check has been changed to use the new function.

## Screenshots/Videos

N/A

## How to test the changes?

`npm run test [protect | baneful_bunker | obstruct]`

## Checklist

- [x] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?
