### PR TITLE
[Misc] `getPokemonSpecies()` no longer accepts `undefined`

### DIFF
--- a/src/utils/pokemon-species-utils.ts
+++ b/src/utils/pokemon-species-utils.ts
@@ -12,10 +12,7 @@ import { globalScene } from "#app/global-scene";
  * @param species The species to fetch
  * @returns The associated {@linkcode PokemonSpecies} object
  */
-export function getPokemonSpecies(species: Species | Species[] | undefined): PokemonSpecies {
-  if (!species) {
-    throw new Error("`species` must not be undefined in `getPokemonSpecies()`");
-  }
+export function getPokemonSpecies(species: Species | Species[]): PokemonSpecies {
   // If a special pool (named trainers) is used here it CAN happen that they have a array as species (which means choose one of those two). So we catch that with this code block
   if (Array.isArray(species)) {
     // Pick a random species from the list

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -119,7 +119,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.UNCOMMON_BREED, defaultParty);
 
       const config = game.scene.currentBattle.mysteryEncounter!.enemyPartyConfigs[0];
-      const speciesToSpawn = config.pokemonConfigs?.[0].species.speciesId;
+      const speciesToSpawn = config.pokemonConfigs?.[0].species.speciesId!;
 
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
@@ -148,7 +148,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.UNCOMMON_BREED, defaultParty);
 
       const config = game.scene.currentBattle.mysteryEncounter!.enemyPartyConfigs[0];
-      const speciesToSpawn = config.pokemonConfigs?.[0].species.speciesId;
+      const speciesToSpawn = config.pokemonConfigs?.[0].species.speciesId!;
 
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
This was something that should have been changed a while ago but was forgotten about.

## What are the changes from a developer perspective?
`undefined` is no longer valid to be passed in to `getPokemonSpecies()` (previously it would let you do this and then throw an error afterwards anyway).

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?