### PR TITLE
[P1][Beta] Fix egg summary not getting egg hatch data

### DIFF
--- a/src/phases/egg-lapse-phase.ts
+++ b/src/phases/egg-lapse-phase.ts
@@ -115,6 +115,7 @@ export class EggLapsePhase extends Phase {
       return this.end();
     }
     globalScene.gameData.eggs.splice(eggIndex, 1);
+    this.generatePokemon(egg);
   }
 
   /**


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

Egg summary no longer crashes
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

Broken in #775 
<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

put back the call to `generatePokemon` in EggLapsePhase that shouldn't have been deleted
<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

Before:
![image](https://github.com/user-attachments/assets/383b5af4-fd40-4803-bfff-992de99514cb)


After:
![image](https://github.com/user-attachments/assets/f9447757-b437-4181-a08e-56d1daab4c98)

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
```
  EGG_FREE_GACHA_PULLS_OVERRIDE: true,
  EGG_IMMEDIATE_HATCH_OVERRIDE: true,
```
- pull at least 2 eggs
- clear a wave
- say 'yes' to skipping to the egg summary
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [X] Otherwise: **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?
