### PR TITLE
[Beta][P2] Breaking a shield against a g-max depletes the entire segment now

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4953,18 +4953,19 @@ export class EnemyPokemon extends Pokemon {
             }
 
             damage = toDmgValue(this.hp - hpThreshold + segmentSize * segmentsBypassed);
-            /**
-             * The actual place that the dynamax damage taken factor is applied is in Pokemon.damage
-             * so here we divide by the dynamax damage taken factor and then it will be the proper value
-             * when it is multiplied there
-             */
-            damage = this.isMax(false) ? toDmgValue(damage / DYNAMAX_DAMAGE_TAKEN_FACTOR) : damage;
             clearedBossSegmentIndex = s - segmentsBypassed;
           }
           break;
         }
       }
     }
+
+    /**
+     * The actual place that the dynamax damage taken factor is applied is in Pokemon.damage
+     * so here we divide by the dynamax damage taken factor and then it will be the proper value
+     * when it is multiplied there
+     */
+    damage = this.isMax(false) ? toDmgValue(damage / DYNAMAX_DAMAGE_TAKEN_FACTOR) : damage;
 
     if (globalScene.currentBattle.isClassicFinalBoss) {
       if (!this.formIndex && this.bossSegmentIndex < 1) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4928,6 +4928,12 @@ export class EnemyPokemon extends Pokemon {
 
     let clearedBossSegmentIndex = this.isBoss() ? this.bossSegmentIndex + 1 : 0;
 
+    /**
+     * Modify the damage with the {@linkcode DYNAMAX_DAMAGE_TAKEN_FACTOR} for the checks
+     * involving whether or not HP bars should break
+     */
+    damage = this.isMax(false) ? toDmgValue(damage * DYNAMAX_DAMAGE_TAKEN_FACTOR) : damage;
+
     if (this.isBoss() && !ignoreSegments) {
       const segmentSize = this.getMaxHp() / this.bossSegments;
       for (let s = this.bossSegmentIndex; s > 0; s--) {
@@ -4947,6 +4953,12 @@ export class EnemyPokemon extends Pokemon {
             }
 
             damage = toDmgValue(this.hp - hpThreshold + segmentSize * segmentsBypassed);
+            /**
+             * The actual place that the dynamax damage taken factor is applied is in Pokemon.damage
+             * so here we divide by the dynamax damage taken factor and then it will be the proper value
+             * when it is multiplied there
+             */
+            damage = this.isMax(false) ? toDmgValue(damage / DYNAMAX_DAMAGE_TAKEN_FACTOR) : damage;
             clearedBossSegmentIndex = s - segmentsBypassed;
           }
           break;


### PR DESCRIPTION
## What are the changes the user will see?

Breaking a shield against a G-Max boss will now deplete the entire segment instead of only 2/3 of it

## Why am I making these changes?

Bug documented in #680

## What are the changes from a developer perspective?

* Modified `damage` in `EnemyPokemon.damage` before and after the check for hp bar segments breaking

## Screenshots/Videos

Before:
![image](https://github.com/user-attachments/assets/6267ee85-9001-4ae1-bbba-c4bdc67a482b)

After:
![image](https://github.com/user-attachments/assets/53a9f230-42b2-47fd-ae76-31430a819a0c)


## How to test the changes?

```ts
const overrides = {
  ENEMY_HEALTH_SEGMENTS_OVERRIDE: 4,
  STARTING_WAVE_OVERRIDE:130,
  STARTING_LEVEL_OVERRIDE:130,
  ENEMY_SPECIES_OVERRIDE:Species.SNORLAX,
  ENEMY_FORM_OVERRIDES:{[Species.SNORLAX]: 1 }
}
```

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->