### PR TITLE
[P3] Sky Drop and Present no longer display critical hit message when they don't do damage

### DIFF
--- a/src/field/damage-number-handler.ts
+++ b/src/field/damage-number-handler.ts
@@ -67,7 +67,8 @@ export default class DamageNumberHandler {
       damageNumber.setColor(textColor);
     }
     if (shadowColor) {
-      if (critical) {
+      // Only moves that deal damage should display critical animation
+      if (critical && result !== HitResult.HEAL && amount > 0) {
         damageNumber.setShadowOffset(0, 0);
         damageNumber.setStroke(shadowColor, 12);
       } else {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -524,7 +524,7 @@ export class MoveEffectPhase extends HitCheckPhase {
       }
     }
 
-    if (isCritical) {
+    if (isCritical && dmg > 0) {
       globalScene.queueMessage(i18next.t("battle:hitResultCriticalHit"));
     }
 

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -521,26 +521,26 @@ export class MoveEffectPhase extends HitCheckPhase {
         if (user.isPlayer() && !target.isPlayer()) {
           globalScene.applyModifiers(DamageMoneyRewardModifier, true, user, new NumberHolder(damage));
         }
-      }
-    }
 
-    if (isCritical && dmg > 0) {
-      globalScene.queueMessage(i18next.t("battle:hitResultCriticalHit"));
-    }
+        if (isCritical) {
+          globalScene.queueMessage(i18next.t("battle:hitResultCriticalHit"));
+        }
 
-    // `.isFainted()` is here in case a multi hit move ends early
-    // we still want to queue the appropriate message
-    if (user.turnData.hitsLeft === 1 || target.isFainted()) {
-      switch (result) {
-        case HitResult.SUPER_EFFECTIVE:
-          globalScene.queueMessage(i18next.t("battle:hitResultSuperEffective"));
-          break;
-        case HitResult.NOT_VERY_EFFECTIVE:
-          globalScene.queueMessage(i18next.t("battle:hitResultNotVeryEffective"));
-          break;
-        case HitResult.ONE_HIT_KO:
-          globalScene.queueMessage(i18next.t("battle:hitResultOneHitKO"));
-          break;
+        // `.isFainted()` is here in case a multi hit move ends early
+        // we still want to queue the appropriate message
+        if (user.turnData.hitsLeft === 1 || target.isFainted()) {
+          switch (result) {
+            case HitResult.SUPER_EFFECTIVE:
+              globalScene.queueMessage(i18next.t("battle:hitResultSuperEffective"));
+              break;
+            case HitResult.NOT_VERY_EFFECTIVE:
+              globalScene.queueMessage(i18next.t("battle:hitResultNotVeryEffective"));
+              break;
+            case HitResult.ONE_HIT_KO:
+              globalScene.queueMessage(i18next.t("battle:hitResultOneHitKO"));
+              break;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## What are the changes the user will see?

* Sky drop will no longer display a critical hit message when it fails
* Sky drop will no longer display effectiveness message when it fails
* Present will no longer display a critical hit message when it heals

## Why am I making these changes?

Fixes #700

## What are the changes from a developer perspective?
* Added an extra `result !== HitResult.HEAL && amount > 0` check in `DamageNumberHandler.add`
* ~~Added an extra `dmg > 0` check in `move-effect-phase.applyMove`~~
* Moved critical hit and effectiveness damage display


## Screenshots/Videos

n/a

## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.FOCUS_ENERGY, MoveId.SKY_DROP, MoveId.PRESENT],
  ABILITY_OVERRIDE: Abilities.SUPER_LUCK,
  ENEMY_MOVESET_OVERRIDE: [MoveId.SPLASH],
  STARTING_LEVEL_OVERRIDE:1000,
  STARTING_WAVE_OVERRIDE:11
}
```

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->