### PR TITLE
[Refactor] Use a `Map` instead of an object for `allMoves`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1214,7 +1214,7 @@ export default class BattleScene extends SceneBase {
     if (reloadI18n) {
       const localizable: Localizable[] = [
         ...allSpecies,
-        ...Object.values(allMoves),
+        ...allMoves.values(),
         ...allAbilities,
         ...getEnumValues(ModifierPoolType)
           .map((mpt) => getModifierPoolForType(mpt))

--- a/src/data/ab-attrs/post-damage-force-switch-ab-attr.ts
+++ b/src/data/ab-attrs/post-damage-force-switch-ab-attr.ts
@@ -69,7 +69,7 @@ export class PostDamageForceSwitchAbAttr extends PostDamageAbAttr {
         if (forbiddenDefendingMoves.includes(enemyLastMoveUsed.move.id) || pokemon.getTag(BattlerTagType.SKY_DROP)) {
           return false;
           // Will not activate if the Pokémon's HP falls below half by a move affected by Sheer Force.
-        } else if (allMoves[enemyLastMoveUsed.move.id].chance >= 0 && source.hasAbility(Abilities.SHEER_FORCE)) {
+        } else if (allMoves.get(enemyLastMoveUsed.move.id).chance >= 0 && source.hasAbility(Abilities.SHEER_FORCE)) {
           return false;
           // Activate only after the last hit of multistrike moves
         } else if (source.turnData.hitsLeft > 1) {

--- a/src/data/ab-attrs/redirect-move-ab-attr.ts
+++ b/src/data/ab-attrs/redirect-move-ab-attr.ts
@@ -25,7 +25,7 @@ export class RedirectMoveAbAttr extends AbAttr {
   }
 
   canRedirect(moveId: MoveId): boolean {
-    const move = allMoves[moveId];
+    const move = allMoves.get(moveId);
     return !![MoveTarget.NEAR_OTHER, MoveTarget.OTHER].find((t) => move.moveTarget === t);
   }
 }

--- a/src/data/ab-attrs/redirect-type-move-ab-attr.ts
+++ b/src/data/ab-attrs/redirect-type-move-ab-attr.ts
@@ -12,6 +12,6 @@ export class RedirectTypeMoveAbAttr extends RedirectMoveAbAttr {
   }
 
   override canRedirect(moveId: MoveId): boolean {
-    return super.canRedirect(moveId) && allMoves[moveId].type === this.type;
+    return super.canRedirect(moveId) && allMoves.get(moveId).type === this.type;
   }
 }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -70,7 +70,7 @@ export abstract class ArenaTag {
   }
 
   public getMoveName(): string | null {
-    return this.sourceMoveId ? allMoves[this.sourceMoveId].name : null;
+    return this.sourceMoveId ? allMoves.get(this.sourceMoveId).name : null;
   }
 
   /**
@@ -332,7 +332,7 @@ export abstract class ConditionalProtectTag extends ArenaTag {
     if (
       (this.side === ArenaTagSide.PLAYER) === defender.isPlayer()
       && this.protectConditionFunc(arena, moveId)
-      && (this.ignoresBypass || !allMoves[moveId].checkFlag(MoveFlags.IGNORE_PROTECT, attacker, defender))
+      && (this.ignoresBypass || !allMoves.get(moveId).checkFlag(MoveFlags.IGNORE_PROTECT, attacker, defender))
     ) {
       if (!isProtected.value) {
         isProtected.value = true;
@@ -361,7 +361,7 @@ export abstract class ConditionalProtectTag extends ArenaTag {
  *   This includes moves with modified priorities from abilities (e.g. Prankster)
  */
 const QuickGuardConditionFunc: ProtectConditionFunc = (_arena, moveId) => {
-  const move = allMoves[moveId];
+  const move = allMoves.get(moveId);
   const effectPhase = globalScene.getCurrentPhase();
 
   if (effectPhase?.is<MoveEffectPhase>(PhaseId.MOVE_EFFECT)) {
@@ -391,7 +391,7 @@ class QuickGuardTag extends ConditionalProtectTag {
  * @returns `true` if the incoming move is multi-targeted (even if it's only used against one Pokemon).
  */
 const WideGuardConditionFunc: ProtectConditionFunc = (_arena, moveId): boolean => {
-  const move = allMoves[moveId];
+  const move = allMoves.get(moveId);
 
   switch (move.moveTarget) {
     case MoveTarget.ALL_ENEMIES:
@@ -422,7 +422,7 @@ class WideGuardTag extends ConditionalProtectTag {
  * @returns `true` if the incoming move is not a Status move.
  */
 const MatBlockConditionFunc: ProtectConditionFunc = (_arena, moveId): boolean => {
-  const move = allMoves[moveId];
+  const move = allMoves.get(moveId);
   return move.category !== MoveCategory.STATUS;
 };
 
@@ -458,7 +458,7 @@ class MatBlockTag extends ConditionalProtectTag {
  * Pokemon or sides of the field.
  */
 const CraftyShieldConditionFunc: ProtectConditionFunc = (_arena, moveId) => {
-  const move = allMoves[moveId];
+  const move = allMoves.get(moveId);
   return (
     move.category === MoveCategory.STATUS
     && move.moveTarget !== MoveTarget.ENEMY_SIDE

--- a/src/data/balance/egg-moves.ts
+++ b/src/data/balance/egg-moves.ts
@@ -592,7 +592,7 @@ function parseEggMoves(content: string): void {
 
   lines.forEach((line, _l) => {
     const cols = line.split(",").slice(0, 5);
-    const moveNames = Object.values(allMoves).map((m) => m.name.replace(/ \([A-Z]\)$/, "").toLowerCase());
+    const moveNames = [...allMoves.values()].map((m) => m.name.replace(/ \([A-Z]\)$/, "").toLowerCase());
     const enumSpeciesName = cols[0].toUpperCase().replace(/[ -]/g, "_");
     const species = speciesValues[speciesNames.findIndex((s) => s === enumSpeciesName)];
 

--- a/src/data/battle-anims/move-anim.ts
+++ b/src/data/battle-anims/move-anim.ts
@@ -28,10 +28,10 @@ export class MoveAnim extends BattleAnim {
   }
 
   protected override isHideUser(): boolean {
-    return allMoves[this.moveId].hasFlag(MoveFlags.HIDE_USER);
+    return allMoves.get(this.moveId).hasFlag(MoveFlags.HIDE_USER);
   }
 
   protected override isHideTarget(): boolean {
-    return allMoves[this.moveId].hasFlag(MoveFlags.HIDE_TARGET);
+    return allMoves.get(this.moveId).hasFlag(MoveFlags.HIDE_TARGET);
   }
 }

--- a/src/data/battler-tags.ts
+++ b/src/data/battler-tags.ts
@@ -101,7 +101,7 @@ export class BattlerTag {
   }
 
   getMoveName(): string | null {
-    return this.sourceMoveId ? allMoves[this.sourceMoveId].name : null;
+    return this.sourceMoveId ? allMoves.get(this.sourceMoveId).name : null;
   }
 
   /**
@@ -259,7 +259,7 @@ export class ThroatChoppedTag extends MoveRestrictionBattlerTag {
    * @returns `true` if the move is sound-based, `false` otherwise
    */
   override isMoveRestricted(moveId: MoveId): boolean {
-    return allMoves[moveId].hasFlag(MoveFlags.SOUND_MOVE);
+    return allMoves.get(moveId).hasFlag(MoveFlags.SOUND_MOVE);
   }
 
   /**
@@ -270,7 +270,7 @@ export class ThroatChoppedTag extends MoveRestrictionBattlerTag {
    * @returns the message to display when the player attempts to select the restricted move
    */
   override getSelectionDeniedText(_pokemon: Pokemon, moveId: MoveId): string {
-    return i18next.t("battle:moveCannotBeSelected", { moveName: allMoves[moveId].name });
+    return i18next.t("battle:moveCannotBeSelected", { moveName: allMoves.get(moveId).name });
   }
 
   /**
@@ -327,7 +327,7 @@ export class DisabledTag extends MoveRestrictionBattlerTag {
     globalScene.queueMessage(
       i18next.t("battlerTags:disabledOnAdd", {
         pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-        moveName: allMoves[this.moveId].name,
+        moveName: allMoves.get(this.moveId).name,
       }),
     );
   }
@@ -339,14 +339,14 @@ export class DisabledTag extends MoveRestrictionBattlerTag {
     globalScene.queueMessage(
       i18next.t("battlerTags:disabledLapse", {
         pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-        moveName: allMoves[this.moveId].name,
+        moveName: allMoves.get(this.moveId).name,
       }),
     );
   }
 
   /** @override */
   override getSelectionDeniedText(_pokemon: Pokemon, moveId: MoveId): string {
-    return i18next.t("battle:moveDisabled", { moveName: allMoves[moveId].name });
+    return i18next.t("battle:moveDisabled", { moveName: allMoves.get(moveId).name });
   }
 
   /**
@@ -358,7 +358,7 @@ export class DisabledTag extends MoveRestrictionBattlerTag {
   override getInterruptedText(pokemon: Pokemon, moveId: MoveId): string {
     return i18next.t("battle:disableInterruptedMove", {
       pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-      moveName: allMoves[moveId].name,
+      moveName: allMoves.get(moveId).name,
     });
   }
 
@@ -430,7 +430,7 @@ export class GorillaTacticsTag extends MoveRestrictionBattlerTag {
    */
   override getSelectionDeniedText(pokemon: Pokemon, _moveId: MoveId): string {
     return i18next.t("battle:canOnlyUseMove", {
-      moveName: allMoves[this.moveId].name,
+      moveName: allMoves.get(this.moveId).name,
       pokemonName: getPokemonNameWithAffix(pokemon),
     });
   }
@@ -595,7 +595,7 @@ export class TrappedTag extends BattlerTag {
 
   override canAdd(pokemon: Pokemon): boolean {
     const source = globalScene.getPokemonById(this.sourceId!)!;
-    const move = allMoves[this.sourceMoveId];
+    const move = allMoves.get(this.sourceMoveId);
 
     const isGhost = pokemon.isOfType(ElementalType.GHOST);
     const isTrapped = pokemon.getTag(...TrappedBattlerTagTypes);
@@ -1158,7 +1158,7 @@ export abstract class MoveLockTag extends BattlerTag {
       && lastMoveResult === MoveResult.SUCCESS;
 
     if (ret) {
-      const move = allMoves[this.sourceMoveId];
+      const move = allMoves.get(this.sourceMoveId);
       this.lastTargets = lastTargets;
       pokemon.getMoveQueue().push({ move, targets: [], ignorePP: true, type: pokemon.getMoveType(move) });
     }
@@ -1320,7 +1320,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
   }
 
   override getSelectionDeniedText(_pokemon: Pokemon, moveId: MoveId): string {
-    return i18next.t("battle:moveDisabled", { moveName: allMoves[moveId].name });
+    return i18next.t("battle:moveDisabled", { moveName: allMoves.get(moveId).name });
   }
 
   override getInterruptedText(_pokemon: Pokemon, _moveId: MoveId): string {
@@ -2930,7 +2930,7 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
    * @returns `true` if the move has a TRIAGE_MOVE flag
    */
   override isMoveRestricted(moveId: MoveId): boolean {
-    if (allMoves[moveId].hasFlag(MoveFlags.TRIAGE_MOVE)) {
+    if (allMoves.get(moveId).hasFlag(MoveFlags.TRIAGE_MOVE)) {
       return true;
     }
     return false;
@@ -2945,9 +2945,9 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
    * @returns `true` if the move cannot be used because the target is an ally
    */
   override isMoveTargetRestricted(moveId: MoveId, user: Pokemon, target: Pokemon) {
-    const moveCategory = new NumberHolder(allMoves[moveId].category);
-    applyMoveAttrs(StatusCategoryOnAllyAttr, user, target, allMoves[moveId], moveCategory);
-    if (allMoves[moveId].hasAttr(HealOnAllyAttr) && moveCategory.value === MoveCategory.STATUS) {
+    const moveCategory = new NumberHolder(allMoves.get(moveId).category);
+    applyMoveAttrs(StatusCategoryOnAllyAttr, user, target, allMoves.get(moveId), moveCategory);
+    if (allMoves.get(moveId).hasAttr(HealOnAllyAttr) && moveCategory.value === MoveCategory.STATUS) {
       return true;
     }
     return false;
@@ -2959,8 +2959,8 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
   override getSelectionDeniedText(pokemon: Pokemon, moveId: MoveId): string {
     return i18next.t("battle:moveDisabledHealBlock", {
       pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-      moveName: allMoves[moveId].name,
-      healBlockName: allMoves[MoveId.HEAL_BLOCK].name,
+      moveName: allMoves.get(moveId).name,
+      healBlockName: allMoves.get(MoveId.HEAL_BLOCK).name,
     });
   }
 
@@ -2973,8 +2973,8 @@ export class HealBlockTag extends MoveRestrictionBattlerTag {
   override getInterruptedText(pokemon: Pokemon, moveId: MoveId): string {
     return i18next.t("battle:moveDisabledHealBlock", {
       pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-      moveName: allMoves[moveId].name,
-      healBlockName: allMoves[MoveId.HEAL_BLOCK].name,
+      moveName: allMoves.get(moveId).name,
+      healBlockName: allMoves.get(MoveId.HEAL_BLOCK).name,
     });
   }
 
@@ -3268,7 +3268,7 @@ export class TormentTag extends MoveRestrictionBattlerTag {
     }
     // This checks for locking / momentum moves like Rollout and Hydro Cannon + if the user is under the influence of BattlerTagType.FRENZY
     // Because Uproar's unique behavior is not implemented, it does not check for Uproar. Torment has been marked as partial in moves.ts
-    const moveObj = allMoves[lastMoveTurn.move.id];
+    const moveObj = allMoves.get(lastMoveTurn.move.id);
     const isUnaffected = moveObj.hasAttr(ConsecutiveUseDoublePowerAttr) || user.getTag(BattlerTagType.FRENZY);
     const validLastMoveResult = lastMoveTurn.result === MoveResult.SUCCESS || lastMoveTurn.result === MoveResult.MISS;
     if (
@@ -3315,20 +3315,20 @@ export class TauntTag extends MoveRestrictionBattlerTag {
    * @returns `true` if the move is a status move
    */
   override isMoveRestricted(moveId: MoveId): boolean {
-    return allMoves[moveId].category === MoveCategory.STATUS;
+    return allMoves.get(moveId).category === MoveCategory.STATUS;
   }
 
   override getSelectionDeniedText(pokemon: Pokemon, moveId: MoveId): string {
     return i18next.t("battle:moveDisabledTaunt", {
       pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-      moveName: allMoves[moveId].name,
+      moveName: allMoves.get(moveId).name,
     });
   }
 
   override getInterruptedText(pokemon: Pokemon, moveId: MoveId): string {
     return i18next.t("battle:moveDisabledTaunt", {
       pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-      moveName: allMoves[moveId].name,
+      moveName: allMoves.get(moveId).name,
     });
   }
 }
@@ -3373,7 +3373,7 @@ export class ImprisoningTag extends BattlerTag implements RestrictingBattlerTag 
   public getInterruptedText(pokemon: Pokemon, moveId: MoveId): string {
     return i18next.t("battle:moveDisabledImprison", {
       pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-      moveName: allMoves[moveId].name,
+      moveName: allMoves.get(moveId).name,
     });
   }
 

--- a/src/data/data-lists.ts
+++ b/src/data/data-lists.ts
@@ -3,13 +3,7 @@ import { type Move } from "#app/data/move";
 import { type MoveId } from "#enums/move-id";
 import type { Ability } from "#app/data/ability";
 
-//#region Type
-
-export type AllMoves = {
-  [moveId in MoveId]: Move;
-};
-
 // Initialized as being empty; these will be filled during initialization
 export const allSpecies: PokemonSpecies[] = [];
-export const allMoves: AllMoves = {} as AllMoves;
+export const allMoves = new Map<MoveId, Move>();
 export const allAbilities: Ability[] = [];

--- a/src/data/data-lists.ts
+++ b/src/data/data-lists.ts
@@ -1,9 +1,14 @@
-import type PokemonSpecies from "#app/data/pokemon-species";
+import { type Ability } from "#app/data/ability";
 import { type Move } from "#app/data/move";
+import type PokemonSpecies from "#app/data/pokemon-species";
 import { type MoveId } from "#enums/move-id";
-import type { Ability } from "#app/data/ability";
+
+interface MoveMap<K, V> extends Map<K, V> {
+  get(key: K): V;
+}
 
 // Initialized as being empty; these will be filled during initialization
 export const allSpecies: PokemonSpecies[] = [];
-export const allMoves = new Map<MoveId, Move>();
+// @ts-expect-error - this forcibly overrides `Map`'s `get` function to not type hint a return of `undefined`
+export const allMoves: MoveMap<MoveId, Move> = new Map<MoveId, Move>();
 export const allAbilities: Ability[] = [];

--- a/src/data/init-abilities.ts
+++ b/src/data/init-abilities.ts
@@ -1548,7 +1548,7 @@ function getSheerForceHitDisableAbCondition(): AbAttrCondition {
 
     /**if the last move chance is greater than or equal to cero, and the last attacker's ability is sheer force*/
     const SheerForceAffected =
-      allMoves[lastReceivedAttack.moveId].chance >= 0 && lastAttacker.hasAbility(Abilities.SHEER_FORCE);
+      allMoves.get(lastReceivedAttack.moveId).chance >= 0 && lastAttacker.hasAbility(Abilities.SHEER_FORCE);
 
     return !SheerForceAffected;
   };

--- a/src/data/init-move-anim.ts
+++ b/src/data/init-move-anim.ts
@@ -1,9 +1,9 @@
+import { AnimConfig } from "#app/data/anim-config";
+import { chargeAnims } from "#app/data/charge-anims";
 import { allMoves } from "#app/data/data-lists";
-import { chargeAnims } from "./charge-anims";
-import { moveAnims } from "./move-anims";
-import { AnimConfig } from "./anim-config";
-import { initMoveChargeAnim } from "./init-move-charge-anim";
-import type { Move } from "#app/data/move";
+import { initMoveChargeAnim } from "#app/data/init-move-charge-anim";
+import type { ChargingMove } from "#app/data/move";
+import { moveAnims } from "#app/data/move-anims";
 import { BeakBlastHeaderAttr } from "#app/data/move-attrs/beak-blast-header-attr";
 import { DelayedAttackAttr } from "#app/data/move-attrs/delayed-attack-attr";
 import { globalScene } from "#app/global-scene";
@@ -20,9 +20,10 @@ export function initMoveAnim(move: MoveId): Promise<void> {
       } else {
         const loadedCheckTimer = setInterval(() => {
           if (moveAnims.get(move) !== null) {
-            const chargeAnimSource = allMoves[move].isChargingMove()
-              ? allMoves[move]
-              : (allMoves[move].getAttrs(DelayedAttackAttr)[0] ?? allMoves[move].getAttrs(BeakBlastHeaderAttr)[0]);
+            const chargeAnimSource = allMoves.get(move).isChargingMove()
+              ? (allMoves.get(move) as ChargingMove)
+              : (allMoves.get(move).getAttrs(DelayedAttackAttr)[0]
+                ?? allMoves.get(move).getAttrs(BeakBlastHeaderAttr)[0]);
             if (chargeAnimSource && chargeAnims.get(chargeAnimSource.chargeAnim) === null) {
               return;
             }
@@ -33,9 +34,9 @@ export function initMoveAnim(move: MoveId): Promise<void> {
       }
     } else {
       moveAnims.set(move, null);
-      const defaultMoveAnim = allMoves[move].isAttackMove()
+      const defaultMoveAnim = allMoves.get(move).isAttackMove()
         ? MoveId.TACKLE
-        : (allMoves[move] as Move).isSelfStatusMove() // as Move is necessary for the ts-compiler
+        : allMoves.get(move).isSelfStatusMove()
           ? MoveId.FOCUS_ENERGY
           : MoveId.TAIL_WHIP;
 
@@ -58,9 +59,10 @@ export function initMoveAnim(move: MoveId): Promise<void> {
             } else {
               populateMoveAnim(move, ba);
             }
-            const chargeAnimSource = allMoves[move].isChargingMove()
-              ? allMoves[move]
-              : (allMoves[move].getAttrs(DelayedAttackAttr)[0] ?? allMoves[move].getAttrs(BeakBlastHeaderAttr)[0]);
+            const chargeAnimSource = allMoves.get(move).isChargingMove()
+              ? (allMoves.get(move) as ChargingMove)
+              : (allMoves.get(move).getAttrs(DelayedAttackAttr)[0]
+                ?? allMoves.get(move).getAttrs(BeakBlastHeaderAttr)[0]);
             if (chargeAnimSource) {
               initMoveChargeAnim(chargeAnimSource.chargeAnim).then(() => resolve());
             } else {

--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -3875,7 +3875,7 @@ export function initMoves() {
 
   for (const move of rawAllMoves) {
     // Make sure `allMoves` assigns correct ID to every move
-    allMoves[move.id] = move;
+    allMoves.set(move.id, move);
     addFireMovesThawFrozenTargetAttribute(move);
   }
 }

--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -462,7 +462,7 @@ export function initMoves() {
       .condition(failOnMaxCondition)
       .attr(WeightPowerAttr),
     new AttackMove(MoveId.COUNTER, ElementalType.FIGHTING, MoveCategory.PHYSICAL, -1, 100, 20, -1, -5, 1)
-      .attr(CounterDamageAttr, (moveId) => allMoves[moveId].category === MoveCategory.PHYSICAL, 2)
+      .attr(CounterDamageAttr, (moveId) => allMoves.get(moveId).category === MoveCategory.PHYSICAL, 2)
       .target(MoveTarget.ATTACKER),
     new AttackMove(MoveId.SEISMIC_TOSS, ElementalType.FIGHTING, MoveCategory.PHYSICAL, -1, 100, 20, -1, 0, 1).attr(
       LevelDamageAttr,
@@ -1087,7 +1087,7 @@ export function initMoves() {
       .attr(StatStageChangeAttr, [Stat.DEF], -1)
       .bitingMove(),
     new AttackMove(MoveId.MIRROR_COAT, ElementalType.PSYCHIC, MoveCategory.SPECIAL, -1, 100, 20, -1, -5, 2)
-      .attr(CounterDamageAttr, (moveId) => allMoves[moveId].category === MoveCategory.SPECIAL, 2)
+      .attr(CounterDamageAttr, (moveId) => allMoves.get(moveId).category === MoveCategory.SPECIAL, 2)
       .target(MoveTarget.ATTACKER),
     new StatusMove(MoveId.PSYCH_UP, ElementalType.NORMAL, -1, 10, -1, 0, 2).ignoresSubstitute().attr(CopyStatsAttr),
     new AttackMove(MoveId.EXTREME_SPEED, ElementalType.NORMAL, MoveCategory.PHYSICAL, 80, 100, 5, -1, 2, 2),
@@ -1573,7 +1573,7 @@ export function initMoves() {
       .attr(AcupressureStatStageChangeAttr)
       .target(MoveTarget.USER_OR_NEAR_ALLY),
     new AttackMove(MoveId.METAL_BURST, ElementalType.STEEL, MoveCategory.PHYSICAL, -1, 100, 10, -1, 0, 4)
-      .attr(CounterDamageAttr, (moveId) => allMoves[moveId].isAttackMove(), 1.5)
+      .attr(CounterDamageAttr, (moveId) => allMoves.get(moveId).isAttackMove(), 1.5)
       .redirectCounter()
       .makesContact(false)
       .target(MoveTarget.ATTACKER),
@@ -3760,7 +3760,7 @@ export function initMoves() {
       }) // TODO Add Instruct/Encore interaction
       .edgeCase(), // should be unselectable the turn after its used
     new AttackMove(MoveId.COMEUPPANCE, ElementalType.DARK, MoveCategory.PHYSICAL, -1, 100, 10, -1, 0, 9)
-      .attr(CounterDamageAttr, (moveId) => allMoves[moveId].isAttackMove(), 1.5)
+      .attr(CounterDamageAttr, (moveId) => allMoves.get(moveId).isAttackMove(), 1.5)
       .redirectCounter()
       .target(MoveTarget.ATTACKER),
     new AttackMove(MoveId.AQUA_CUTTER, ElementalType.WATER, MoveCategory.PHYSICAL, 70, 100, 20, -1, 0, 9)

--- a/src/data/move-attrs/metronome-attr.ts
+++ b/src/data/move-attrs/metronome-attr.ts
@@ -25,7 +25,7 @@ export class MetronomeAttr extends CallMoveAttr {
    */
   public getRandomMove(user: Pokemon): MoveId {
     const moveIds = getEnumValues(MoveId).filter(
-      (m) => !this.invalidMoves.includes(m) && !allMoves[m].name.endsWith(" (N)"),
+      (m) => !this.invalidMoves.includes(m) && !allMoves.get(m).name.endsWith(" (N)"),
     );
 
     return moveIds[user.randSeedInt(moveIds.length)];
@@ -41,7 +41,7 @@ export class MetronomeAttr extends CallMoveAttr {
    * @param args Unused
    */
   override apply(user: Pokemon, target: Pokemon, _move: Move, overridden: BooleanHolder): boolean {
-    return super.apply(user, target, allMoves[this.getRandomMove(user)], overridden);
+    return super.apply(user, target, allMoves.get(this.getRandomMove(user)), overridden);
   }
 }
 

--- a/src/data/move-attrs/nature-power-attr.ts
+++ b/src/data/move-attrs/nature-power-attr.ts
@@ -118,6 +118,6 @@ export class NaturePowerAttr extends CallMoveAttr {
         break;
     }
 
-    return super.apply(user, target, allMoves[moveId], overridden);
+    return super.apply(user, target, allMoves.get(moveId), overridden);
   }
 }

--- a/src/data/move-attrs/random-moveset-move-attr.ts
+++ b/src/data/move-attrs/random-moveset-move-attr.ts
@@ -34,7 +34,7 @@ export class RandomMovesetMoveAttr extends CallMoveAttr {
    * @param overridden - {@linkcode BooleanHolder} for if the move is overridden
    */
   override apply(user: Pokemon, target: Pokemon, _move: Move, overridden: BooleanHolder): boolean {
-    return super.apply(user, target, allMoves[this.moveId], overridden);
+    return super.apply(user, target, allMoves.get(this.moveId), overridden);
   }
 
   override getCondition(): MoveConditionFunc {

--- a/src/data/move-attrs/repeat-move-attr.ts
+++ b/src/data/move-attrs/repeat-move-attr.ts
@@ -111,7 +111,7 @@ export class RepeatMoveAttr extends MoveEffectAttr {
       if (
         !movesetMove // called move not in target's moveset (dancer, forgetting the move, etc.)
         || movesetMove.ppUsed === movesetMove.getMovePp() // move out of pp
-        || allMoves[lastMove?.move.id ?? MoveId.NONE].isChargingMove() // called move is a charging/recharging move
+        || allMoves.get(lastMove?.move.id ?? MoveId.NONE).isChargingMove() // called move is a charging/recharging move
         || !moveTargets.length // called move has no targets
         || unrepeatablemoves.includes(lastMove?.move.id ?? MoveId.NONE)
       ) {

--- a/src/data/move-attrs/sketch-attr.ts
+++ b/src/data/move-attrs/sketch-attr.ts
@@ -33,7 +33,7 @@ export class SketchAttr extends MoveEffectAttr {
       return false;
     }
 
-    const sketchedMove = allMoves[targetMove.move.id];
+    const sketchedMove = allMoves.get(targetMove.move.id);
     const sketchIndex = user.getMoveset().findIndex((m) => m.moveId === move.id);
     if (sketchIndex === -1) {
       return false;

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -970,15 +970,15 @@ export type MoveTargetSet = {
 
 export function getMoveTargets(user: Pokemon, moveId: MoveId, replaceTarget?: MoveTarget): MoveTargetSet {
   const variableTarget = new NumberHolder(0);
-  user.getOpponents().forEach((p) => applyMoveAttrs(VariableTargetAttr, user, p, allMoves[moveId], variableTarget));
+  user.getOpponents().forEach((p) => applyMoveAttrs(VariableTargetAttr, user, p, allMoves.get(moveId), variableTarget));
 
   let moveTarget: MoveTarget | undefined;
-  if (allMoves[moveId].hasAttr(VariableTargetAttr)) {
+  if (allMoves.get(moveId).hasAttr(VariableTargetAttr)) {
     moveTarget = variableTarget.value;
   } else if (replaceTarget !== undefined) {
     moveTarget = replaceTarget;
   } else if (moveId) {
-    moveTarget = allMoves[moveId].moveTarget;
+    moveTarget = allMoves.get(moveId).moveTarget;
   } else if (moveId === undefined) {
     moveTarget = MoveTarget.NEAR_ENEMY;
   }

--- a/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
+++ b/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
@@ -733,7 +733,7 @@ function doBugTypeMoveTutor(): Promise<void> {
         },
         onHover: () => {
           moveInfoOverlay.active = true;
-          moveInfoOverlay.show(allMoves[move.moveId]);
+          moveInfoOverlay.show(allMoves.get(move.moveId));
         },
       };
       return option;

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -1230,7 +1230,7 @@ export const pokemonFormChanges: PokemonFormChanges = {
       Species.AEGISLASH,
       "shield",
       "blade",
-      new SpeciesFormChangePreMoveTrigger((m) => allMoves[m].category !== MoveCategory.STATUS),
+      new SpeciesFormChangePreMoveTrigger((m) => allMoves.get(m).category !== MoveCategory.STATUS),
       true,
       [],
       new SpeciesFormChangeCondition((p) => p.hasAbility(Abilities.STANCE_CHANGE)),

--- a/src/field/pokemon-move.ts
+++ b/src/field/pokemon-move.ts
@@ -60,7 +60,7 @@ export class PokemonMove {
   }
 
   getMove(): Move {
-    return allMoves[this.moveId];
+    return allMoves.get(this.moveId);
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2387,20 +2387,19 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         // Other damaging moves 2x weight if 0-1 damaging moves, 0.5x if 2, 0.125x if 3. These weights double if STAB.
         // Status moves remain unchanged on weight, this encourages 1-2
         movePool = baseWeights
-          .filter((m) => !this.moveset.some((mo) => m[0] === mo?.moveId))
+          .filter((m) => !this.moveset.some((mo) => m[0] === mo.moveId))
           .map((m) => {
             let ret: number;
             if (
               this.moveset.some(
-                (mo) =>
-                  mo?.getMove().category !== MoveCategory.STATUS && mo?.getMove().type === allMoves.get(m[0]).type,
+                (mo) => mo.getMove().category !== MoveCategory.STATUS && mo.getMove().type === allMoves.get(m[0]).type,
               )
             ) {
               ret = Math.ceil(Math.sqrt(m[1]));
             } else if (allMoves.get(m[0]).category !== MoveCategory.STATUS) {
               ret = Math.ceil(
                 (m[1]
-                  / Math.max(Math.pow(4, this.moveset.filter((mo) => (mo?.getMove().power ?? 0) > 1).length) / 8, 0.5))
+                  / Math.max(Math.pow(4, this.moveset.filter((mo) => (mo.getMove().power ?? 0) > 1).length) / 8, 0.5))
                   * (this.isOfType(allMoves.get(m[0]).type) ? 2 : 1),
               );
             } else {
@@ -2410,7 +2409,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
           });
       } else {
         // Non-trainer pokemon just use normal weights
-        movePool = baseWeights.filter((m) => !this.moveset.some((mo) => m[0] === mo?.moveId));
+        movePool = baseWeights.filter((m) => !this.moveset.some((mo) => m[0] === mo.moveId));
       }
       const totalWeight = movePool.reduce((v, m) => v + m[1], 0);
       let rand = randSeedInt(totalWeight);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1262,7 +1262,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
       overrideArray.forEach((moveId: MoveId, index: number) => {
         const ppUsed = this.moveset[index]?.ppUsed ?? 0;
-        this.moveset[index] = new PokemonMove(moveId, Math.min(ppUsed, allMoves[moveId].pp));
+        this.moveset[index] = new PokemonMove(moveId, Math.min(ppUsed, allMoves.get(moveId).pp));
       });
     }
 
@@ -2234,10 +2234,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         weight = 50;
       }
       // Assume level 1 moves with 80+ BP are "move reminder" moves and bump their weight
-      if (weight === 1 && allMoves[levelMove[1]].power >= 80) {
+      if (weight === 1 && allMoves.get(levelMove[1]).power >= 80) {
         weight = 40;
       }
-      if (!movePool.some((m) => m[0] === levelMove[1]) && !allMoves[levelMove[1]].name.endsWith(" (N)")) {
+      if (!movePool.some((m) => m[0] === levelMove[1]) && !allMoves.get(levelMove[1]).name.endsWith(" (N)")) {
         movePool.push([levelMove[1], weight]);
       }
     }
@@ -2258,7 +2258,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
             break;
           }
         }
-        if (compatible && !movePool.some((m) => m[0] === moveId) && !allMoves[moveId].name.endsWith(" (N)")) {
+        if (compatible && !movePool.some((m) => m[0] === moveId) && !allMoves.get(moveId).name.endsWith(" (N)")) {
           if (tmPoolTiers[moveId] === ModifierTier.COMMON && this.level >= 15) {
             movePool.push([moveId, 4]);
           } else if (tmPoolTiers[moveId] === ModifierTier.GREAT && this.level >= 30) {
@@ -2273,7 +2273,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       if (this.level >= 60) {
         for (let i = 0; i < 3; i++) {
           const moveId = speciesEggMoves[this.species.getRootSpeciesId()][i];
-          if (!movePool.some((m) => m[0] === moveId) && !allMoves[moveId].name.endsWith(" (N)")) {
+          if (!movePool.some((m) => m[0] === moveId) && !allMoves.get(moveId).name.endsWith(" (N)")) {
             movePool.push([moveId, 40]);
           }
         }
@@ -2282,7 +2282,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         if (
           this.level >= 170
           && !movePool.some((m) => m[0] === moveId)
-          && !allMoves[moveId].name.endsWith(" (N)")
+          && !allMoves.get(moveId).name.endsWith(" (N)")
           && !this.isBoss()
         ) {
           movePool.push([moveId, 30]);
@@ -2292,22 +2292,28 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     // Bosses never get self ko moves
     if (this.isBoss()) {
-      movePool = movePool.filter((m) => !allMoves[m[0]].hasAttr(SacrificialAttr));
+      movePool = movePool.filter((m) => !allMoves.get(m[0]).hasAttr(SacrificialAttr));
     }
     if (this.hasTrainer()) {
       // Trainers never get OHKO moves
-      movePool = movePool.filter((m) => !allMoves[m[0]].hasAttr(OneHitKOAttr));
+      movePool = movePool.filter((m) => !allMoves.get(m[0]).hasAttr(OneHitKOAttr));
       // Half the weight of self KO moves
-      movePool = movePool.map((m) => [m[0], m[1] * (!!allMoves[m[0]].hasAttr(SacrificialAttr) ? 0.5 : 1)]);
+      movePool = movePool.map((m) => [m[0], m[1] * (allMoves.get(m[0]).hasAttr(SacrificialAttr) ? 0.5 : 1)]);
       // Trainers get a weight bump to stat buffing moves
       movePool = movePool.map((m) => [
         m[0],
-        m[1] * (allMoves[m[0]].getAttrs(StatStageChangeAttr).some((a) => a.stages > 1 && a.selfTarget) ? 1.25 : 1),
+        m[1]
+          * (allMoves
+            .get(m[0])
+            .getAttrs(StatStageChangeAttr)
+            .some((a) => a.stages > 1 && a.selfTarget)
+            ? 1.25
+            : 1),
       ]);
       // Trainers get a weight decrease to multiturn moves
       movePool = movePool.map((m) => [
         m[0],
-        m[1] * (!!allMoves[m[0]].isChargingMove() || !!allMoves[m[0]].hasAttr(RechargeAttr) ? 0.7 : 1),
+        m[1] * (allMoves.get(m[0]).isChargingMove() || allMoves.get(m[0]).hasAttr(RechargeAttr) ? 0.7 : 1),
       ]);
     }
 
@@ -2315,15 +2321,15 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // Caps max power at 90 to avoid something like hyper beam ruining the stats.
     // This is a pretty soft weighting factor, although it is scaled with the weight multiplier.
     const maxPower = Math.min(
-      movePool.reduce((v, m) => Math.max(allMoves[m[0]].power, v), 40),
+      movePool.reduce((v, m) => Math.max(allMoves.get(m[0]).power, v), 40),
       90,
     );
     movePool = movePool.map((m) => [
       m[0],
       m[1]
-        * (allMoves[m[0]].category === MoveCategory.STATUS
+        * (allMoves.get(m[0]).category === MoveCategory.STATUS
           ? 1
-          : Math.max(Math.min(allMoves[m[0]].power / maxPower, 1), 0.5)),
+          : Math.max(Math.min(allMoves.get(m[0]).power / maxPower, 1), 0.5)),
     ]);
 
     // Weight damaging moves against the lower stat
@@ -2331,7 +2337,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const spAtk = this.getStat(Stat.SPATK);
     const worseCategory: MoveCategory = atk > spAtk ? MoveCategory.SPECIAL : MoveCategory.PHYSICAL;
     const statRatio = worseCategory === MoveCategory.PHYSICAL ? atk / spAtk : spAtk / atk;
-    movePool = movePool.map((m) => [m[0], m[1] * (allMoves[m[0]].category === worseCategory ? statRatio : 1)]);
+    movePool = movePool.map((m) => [m[0], m[1] * (allMoves.get(m[0]).category === worseCategory ? statRatio : 1)]);
 
     /** The higher this is the more the game weights towards higher level moves. At `0` all moves are equal weight. */
     let weightMultiplier = 0.9;
@@ -2349,7 +2355,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // Trainers and bosses always force a stab move
     if (this.hasTrainer() || this.isBoss()) {
       const stabMovePool = baseWeights.filter(
-        (m) => allMoves[m[0]].category !== MoveCategory.STATUS && this.isOfType(allMoves[m[0]].type),
+        (m) => allMoves.get(m[0]).category !== MoveCategory.STATUS && this.isOfType(allMoves.get(m[0]).type),
       );
 
       if (stabMovePool.length) {
@@ -2363,7 +2369,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     } else {
       // Normal wild pokemon just force a random damaging move
-      const attackMovePool = baseWeights.filter((m) => allMoves[m[0]].category !== MoveCategory.STATUS);
+      const attackMovePool = baseWeights.filter((m) => allMoves.get(m[0]).category !== MoveCategory.STATUS);
       if (attackMovePool.length) {
         const totalWeight = attackMovePool.reduce((v, m) => v + m[1], 0);
         let rand = randSeedInt(totalWeight);
@@ -2386,15 +2392,16 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
             let ret: number;
             if (
               this.moveset.some(
-                (mo) => mo?.getMove().category !== MoveCategory.STATUS && mo?.getMove().type === allMoves[m[0]].type,
+                (mo) =>
+                  mo?.getMove().category !== MoveCategory.STATUS && mo?.getMove().type === allMoves.get(m[0]).type,
               )
             ) {
               ret = Math.ceil(Math.sqrt(m[1]));
-            } else if (allMoves[m[0]].category !== MoveCategory.STATUS) {
+            } else if (allMoves.get(m[0]).category !== MoveCategory.STATUS) {
               ret = Math.ceil(
                 (m[1]
                   / Math.max(Math.pow(4, this.moveset.filter((mo) => (mo?.getMove().power ?? 0) > 1).length) / 8, 0.5))
-                  * (this.isOfType(allMoves[m[0]].type) ? 2 : 1),
+                  * (this.isOfType(allMoves.get(m[0]).type) ? 2 : 1),
               );
             } else {
               ret = m[1];
@@ -4835,7 +4842,7 @@ export class EnemyPokemon extends Pokemon {
       }
     }
     return {
-      move: allMoves[MoveId.STRUGGLE],
+      move: allMoves.get(MoveId.STRUGGLE),
       targets: this.getNextTargets(MoveId.STRUGGLE),
       type: ElementalType.UNKNOWN,
     };
@@ -4861,7 +4868,7 @@ export class EnemyPokemon extends Pokemon {
       return targets.map((p) => p.getBattlerIndex());
     }
 
-    const move = allMoves[moveId];
+    const move = allMoves.get(moveId);
 
     /**
      * Get the move's target benefit score against each potential target.

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1046,7 +1046,7 @@ export class TmModifierType extends PokemonModifierType {
   constructor(moveId: MoveId) {
     super(
       "",
-      `tm_${ElementalType[allMoves[moveId].type].toLowerCase()}`,
+      `tm_${ElementalType[allMoves.get(moveId).type].toLowerCase()}`,
       (_type, args) => new TmModifier(this, (args[0] as PlayerPokemon).id),
       (pokemon: PlayerPokemon) => {
         if (
@@ -1066,7 +1066,7 @@ export class TmModifierType extends PokemonModifierType {
   override get name(): string {
     return i18next.t("modifierType:ModifierType.TmModifierType.name", {
       moveId: leftPad(Object.keys(tmSpecies).indexOf(this.moveId.toString()) + 1, 3),
-      moveName: allMoves[this.moveId].name,
+      moveName: allMoves.get(this.moveId).name,
     });
   }
 
@@ -1075,7 +1075,7 @@ export class TmModifierType extends PokemonModifierType {
       settings.display.enableMoveInfo
         ? "modifierType:ModifierType.TmModifierTypeWithInfo.description"
         : "modifierType:ModifierType.TmModifierType.description",
-      { moveName: allMoves[this.moveId].name },
+      { moveName: allMoves.get(this.moveId).name },
     );
   }
 }
@@ -1364,7 +1364,7 @@ export class TmModifierTypeGenerator extends ModifierTypeGenerator {
       const tierUniqueCompatibleTms = partyMemberCompatibleTms
         .flat()
         .filter((tm) => tmPoolTiers[tm] === tier)
-        .filter((tm) => !allMoves[tm].name.endsWith(" (N)"))
+        .filter((tm) => !allMoves.get(tm).name.endsWith(" (N)"))
         .filter((tm, i, array) => array.indexOf(tm) === i);
       if (!tierUniqueCompatibleTms.length) {
         return null;

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -194,10 +194,10 @@ export class CommandPhase extends FieldPhase {
             command: BattleCommand.FIGHT,
             cursor,
             turnMove: {
-              move: allMoves[moveId],
+              move: allMoves.get(moveId),
               targets: [],
               ignorePP: ignorePp,
-              type: pokemon.getMoveType(allMoves[moveId]),
+              type: pokemon.getMoveType(allMoves.get(moveId)),
             },
             args,
           };

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -161,7 +161,7 @@ export class FaintPhase extends PokemonPhase {
 
     if (this.source && pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
-      applyAbAttrs(AbAttrFlag.POST_FAINT, pokemon, false, this.source, allMoves[lastAttack.moveId]);
+      applyAbAttrs(AbAttrFlag.POST_FAINT, pokemon, false, this.source, allMoves.get(lastAttack.moveId));
     } else {
       //If killed by indirect damage, apply post-faint abilities without providing the source of fatal damage
       applyAbAttrs(AbAttrFlag.POST_FAINT, pokemon, false);
@@ -174,7 +174,7 @@ export class FaintPhase extends PokemonPhase {
       if (defeatSource?.isOnField()) {
         applyAbAttrs(AbAttrFlag.POST_VICTORY, defeatSource, false);
         // TODO: Refactor Fell Stinger
-        const pvmove = allMoves[pokemon.turnData.attacksReceived[0].moveId];
+        const pvmove = allMoves.get(pokemon.turnData.attacksReceived[0].moveId);
         const pvattrs = pvmove.getAttrs(PostVictoryStatStageChangeAttr);
         if (pvattrs.length) {
           for (const pvattr of pvattrs) {

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -51,7 +51,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
       return this.end();
     }
 
-    const move = allMoves[this.moveId];
+    const move = allMoves.get(this.moveId);
     const currentMoveset = pokemon.getMoveset();
 
     // The game first checks if the Pokemon already has the move and ends the phase if it does.

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -462,7 +462,7 @@ export class MovePhase extends BattlePhase {
    * @param success - Whether the move was successful or not.
    */
   protected updateLastMoveId(success: boolean): void {
-    if (!allMoves[this.move.moveId].hasAttr(CopycatAttr)) {
+    if (!allMoves.get(this.move.moveId).hasAttr(CopycatAttr)) {
       if (success) {
         globalScene.currentBattle.lastMove = this.move.getMove();
       }

--- a/src/phases/select-target-phase.ts
+++ b/src/phases/select-target-phase.ts
@@ -30,7 +30,7 @@ export class SelectTargetPhase extends PokemonPhase {
 
       const user = globalScene.getFieldPokemonByBattlerIndex(this.fieldIndex);
       const firstTarget = globalScene.getFieldPokemonByBattlerIndex(targets[0]);
-      const moveObject = allMoves[moveId];
+      const moveObject = allMoves.get(moveId);
 
       // TODO: Resolve bang
       if (user?.isMoveTargetRestricted(moveObject.id, user, firstTarget!)) {
@@ -39,7 +39,7 @@ export class SelectTargetPhase extends PokemonPhase {
           ?.getSelectionDeniedText(user, moveObject.id);
 
         globalScene.queueMessage(
-          errorMessage ?? i18next.t("battle:moveCannotBeSelected", { moveName: allMoves[moveId].name }),
+          errorMessage ?? i18next.t("battle:moveCannotBeSelected", { moveName: allMoves.get(moveId).name }),
           0,
           true,
         );

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1803,7 +1803,7 @@ export class GameData {
         return;
       }
       globalScene.audioManager.playSound("level_up_fanfare");
-      const moveName = allMoves[speciesEggMoves[speciesId][eggMoveIndex]].name;
+      const moveName = allMoves.get(speciesEggMoves[speciesId][eggMoveIndex]).name;
       // TODO: use a proper localized message in this case
       let message = prependSpeciesToMessage ? species.getName() + " " : "";
       message +=

--- a/src/ui/modifier-select-ui-handler.ts
+++ b/src/ui/modifier-select-ui-handler.ts
@@ -530,7 +530,7 @@ export default class ModifierSelectUiHandler extends AwaitableUiHandler {
       type && ui.showText(type.getDescription());
       if (type instanceof TmModifierType) {
         // prepare the move overlay to be shown with the toggle
-        this.moveInfoOverlay.show(allMoves[type.moveId]);
+        this.moveInfoOverlay.show(allMoves.get(type.moveId));
       }
     } else if (cursor === 0) {
       this.cursorObj.setPosition(

--- a/src/ui/party-ui-handler.ts
+++ b/src/ui/party-ui-handler.ts
@@ -547,7 +547,7 @@ export default class PartyUiHandler extends MessageUiHandler {
         if (this.partyUiMode === PartyUiMode.REMEMBER_MOVE_MODIFIER) {
           const option = this.options[this.optionsCursor];
           const pokemon = globalScene.getPlayerParty()[this.cursor];
-          const move = allMoves[pokemon.getLearnableLevelMoves()[option]];
+          const move = allMoves.get(pokemon.getLearnableLevelMoves()[option]);
           if (move) {
             this.moveInfoOverlay.show(move);
           } else {
@@ -785,7 +785,7 @@ export default class PartyUiHandler extends MessageUiHandler {
 
     if (this.partyUiMode === PartyUiMode.REMEMBER_MOVE_MODIFIER && learnableLevelMoves?.length) {
       // show the move overlay with info for the first move
-      this.moveInfoOverlay.show(allMoves[learnableLevelMoves[0]]);
+      this.moveInfoOverlay.show(allMoves.get(learnableLevelMoves[0]));
     }
 
     const itemModifiers =
@@ -825,7 +825,10 @@ export default class PartyUiHandler extends MessageUiHandler {
             const isBatonPassMove =
               this.partyUiMode === PartyUiMode.FAINT_SWITCH
               && moveHistory.length
-              && allMoves[moveHistory[moveHistory.length - 1].move.id].getAttrs(ForceSwitchOutAttr)[0]?.isBatonPass()
+              && allMoves
+                .get(moveHistory[moveHistory.length - 1].move.id)
+                .getAttrs(ForceSwitchOutAttr)[0]
+                ?.isBatonPass()
               && moveHistory[moveHistory.length - 1].result === MoveResult.SUCCESS;
 
             // isBatonPassMove and allowBatonModifierSwitch shouldn't ever be true
@@ -974,7 +977,7 @@ export default class PartyUiHandler extends MessageUiHandler {
         }
       } else if (this.partyUiMode === PartyUiMode.REMEMBER_MOVE_MODIFIER) {
         const move = learnableLevelMoves[option];
-        optionName = allMoves[move].name;
+        optionName = allMoves.get(move).name;
         altText = !pokemon
           .getSpeciesForm()
           .getLevelMoves()

--- a/src/ui/pokemon-hatch-info-container.ts
+++ b/src/ui/pokemon-hatch-info-container.ts
@@ -164,7 +164,7 @@ export default class PokemonHatchInfoContainer extends PokemonInfoContainer {
     const hasEggMoves = species && speciesEggMoves.hasOwnProperty(species.speciesId);
 
     for (let em = 0; em < 4; em++) {
-      const eggMove = hasEggMoves ? allMoves[speciesEggMoves[species.speciesId][em]] : null;
+      const eggMove = hasEggMoves ? allMoves.get(speciesEggMoves[species.speciesId][em]) : null;
       const eggMoveUnlocked = eggMove && globalScene.gameData.starterData[species.speciesId].eggMoves & Math.pow(2, em);
       this.pokemonEggMoveBgs[em].setFrame(
         ElementalType[eggMove ? eggMove.type : ElementalType.UNKNOWN].toString().toLowerCase(),

--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -1617,10 +1617,10 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
             ): OptionSelectModeConfig => {
               const options: OptionSelectItem[] = moves.map((moveId: MoveId, index: number): OptionSelectItem => {
                 return {
-                  label: allMoves[moveId].name,
+                  label: allMoves.get(moveId).name,
                   handler: () => selectHandler(moveId, index, currentMoveId, currentIndex),
                   onHover: () => {
-                    this.moveInfoOverlay.show(allMoves[moveId]);
+                    this.moveInfoOverlay.show(allMoves.get(moveId));
                   },
                 };
               });
@@ -1643,11 +1643,11 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
               this.blockInput = true;
               ui.setMode(UiMode.STARTER_SELECT).then(() => {
                 ui.showText(
-                  `${i18next.t("starterSelectUiHandler:selectMoveSwapWith")} ${allMoves[moveId].name}.`,
+                  `${i18next.t("starterSelectUiHandler:selectMoveSwapWith")} ${allMoves.get(moveId).name}.`,
                   null,
                   () => {
                     const possibleMoves = this.speciesStarterMoves.filter((sm: MoveId) => sm !== moveId);
-                    this.moveInfoOverlay.show(allMoves[possibleMoves[0]]);
+                    this.moveInfoOverlay.show(allMoves.get(possibleMoves[0]));
                     const movesOptions = getMoveOptions(
                       possibleMoves,
                       onSelectedMoveToSwapTo,
@@ -1690,7 +1690,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
               this.blockInput = true;
               ui.setMode(UiMode.STARTER_SELECT).then(() => {
                 ui.showText(i18next.t("starterSelectUiHandler:selectMoveSwapOut"), null, () => {
-                  this.moveInfoOverlay.show(allMoves[moveset[0]]);
+                  this.moveInfoOverlay.show(allMoves.get(moveset[0]));
                   const movesOptions = getMoveOptions(moveset, onSelectedMoveToSwapWith, onCancelMoveToSwapWith);
                   ui.setModeWithoutClear(UiMode.OPTION_SELECT, movesOptions);
                   this.blockInput = false;
@@ -3615,7 +3615,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     }
 
     for (let m = 0; m < 4; m++) {
-      const move = m < this.starterMoveset.length ? allMoves[this.starterMoveset[m]] : null;
+      const move = m < this.starterMoveset.length ? allMoves.get(this.starterMoveset[m]) : null;
       this.pokemonMoveBgs[m].setFrame(ElementalType[move ? move.type : ElementalType.UNKNOWN].toString().toLowerCase());
       this.pokemonMoveLabels[m].setText(move ? move.name : "-");
       this.pokemonMoveContainers[m].setVisible(!!move);
@@ -3624,7 +3624,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
     const hasEggMoves = species && speciesEggMoves.hasOwnProperty(species.speciesId);
 
     for (let em = 0; em < 4; em++) {
-      const eggMove = hasEggMoves ? allMoves[speciesEggMoves[species.speciesId][em]] : null;
+      const eggMove = hasEggMoves ? allMoves.get(speciesEggMoves[species.speciesId][em]) : null;
       const eggMoveUnlocked = eggMove && globalScene.gameData.starterData[species.speciesId].eggMoves & (1 << em);
       this.pokemonEggMoveBgs[em].setFrame(
         ElementalType[eggMove ? eggMove.type : ElementalType.UNKNOWN].toString().toLowerCase(),

--- a/src/utils/move-anim-utils.ts
+++ b/src/utils/move-anim-utils.ts
@@ -1,4 +1,3 @@
-import { AnimConfig } from "#app/data/anim-config";
 import { chargeAnims } from "#app/data/charge-anims";
 import { allMoves } from "#app/data/data-lists";
 import type { ChargingMove } from "#app/data/move";
@@ -10,7 +9,7 @@ import type { MoveId } from "#enums/move-id";
 
 export function loadMoveAnimAssets(moveIds: MoveId[], startLoad?: boolean): Promise<void> {
   return new Promise((resolve) => {
-    const moveAnimations = moveIds.map((m) => moveAnims.get(m) as AnimConfig).flat();
+    const moveAnimations = moveIds.map((m) => moveAnims.get(m)!).flat();
 
     for (const moveId of moveIds) {
       const chargeAnimSource = allMoves.get(moveId).isChargingMove()
@@ -27,7 +26,7 @@ export function loadMoveAnimAssets(moveIds: MoveId[], startLoad?: boolean): Prom
       if (Array.isArray(moveChargeAnims)) {
         moveAnimations.push(moveChargeAnims[0]);
         moveAnimations.push(moveChargeAnims[1]);
-      } else if (moveChargeAnims instanceof AnimConfig) {
+      } else if (moveChargeAnims) {
         moveAnimations.push(moveChargeAnims);
       }
     }

--- a/src/utils/move-anim-utils.ts
+++ b/src/utils/move-anim-utils.ts
@@ -1,7 +1,8 @@
-import { allMoves } from "#app/data/data-lists";
-import { chargeAnims } from "#app/data/charge-anims";
-import { moveAnims } from "#app/data/move-anims";
 import { AnimConfig } from "#app/data/anim-config";
+import { chargeAnims } from "#app/data/charge-anims";
+import { allMoves } from "#app/data/data-lists";
+import type { ChargingMove } from "#app/data/move";
+import { moveAnims } from "#app/data/move-anims";
 import { BeakBlastHeaderAttr } from "#app/data/move-attrs/beak-blast-header-attr";
 import { DelayedAttackAttr } from "#app/data/move-attrs/delayed-attack-attr";
 import { loadAnimAssets } from "#app/utils/anim-utils";
@@ -10,18 +11,27 @@ import type { MoveId } from "#enums/move-id";
 export function loadMoveAnimAssets(moveIds: MoveId[], startLoad?: boolean): Promise<void> {
   return new Promise((resolve) => {
     const moveAnimations = moveIds.map((m) => moveAnims.get(m) as AnimConfig).flat();
+
     for (const moveId of moveIds) {
-      const chargeAnimSource = allMoves[moveId].isChargingMove()
-        ? allMoves[moveId]
-        : (allMoves[moveId].getAttrs(DelayedAttackAttr)[0] ?? allMoves[moveId].getAttrs(BeakBlastHeaderAttr)[0]);
-      if (chargeAnimSource) {
-        const moveChargeAnims = chargeAnims.get(chargeAnimSource.chargeAnim);
-        moveAnimations.push(moveChargeAnims instanceof AnimConfig ? moveChargeAnims : moveChargeAnims![0]); // TODO: is the bang correct?
-        if (Array.isArray(moveChargeAnims)) {
-          moveAnimations.push(moveChargeAnims[1]);
-        }
+      const chargeAnimSource = allMoves.get(moveId).isChargingMove()
+        ? (allMoves.get(moveId) as ChargingMove)
+        : (allMoves.get(moveId).getAttrs(DelayedAttackAttr)[0]
+          ?? allMoves.get(moveId).getAttrs(BeakBlastHeaderAttr)[0]);
+
+      if (!chargeAnimSource) {
+        continue;
+      }
+
+      const moveChargeAnims = chargeAnims.get(chargeAnimSource.chargeAnim);
+
+      if (Array.isArray(moveChargeAnims)) {
+        moveAnimations.push(moveChargeAnims[0]);
+        moveAnimations.push(moveChargeAnims[1]);
+      } else if (moveChargeAnims instanceof AnimConfig) {
+        moveAnimations.push(moveChargeAnims);
       }
     }
+
     loadAnimAssets(moveAnimations, startLoad).then(() => resolve());
   });
 }

--- a/test/abilities/aura_break.test.ts
+++ b/test/abilities/aura_break.test.ts
@@ -32,7 +32,7 @@ describe("Abilities - Aura Break", () => {
   });
 
   it("reverses the effect of Fairy Aura", async () => {
-    const moveToCheck = allMoves[MoveId.MOONBLAST];
+    const moveToCheck = allMoves.get(MoveId.MOONBLAST);
     const basePower = moveToCheck.power;
 
     game.override.ability(Abilities.FAIRY_AURA);
@@ -46,7 +46,7 @@ describe("Abilities - Aura Break", () => {
   });
 
   it("reverses the effect of Dark Aura", async () => {
-    const moveToCheck = allMoves[MoveId.DARK_PULSE];
+    const moveToCheck = allMoves.get(MoveId.DARK_PULSE);
     const basePower = moveToCheck.power;
 
     game.override.ability(Abilities.DARK_AURA);
@@ -60,7 +60,7 @@ describe("Abilities - Aura Break", () => {
   });
 
   it("has no effect if neither Fairy Aura nor Dark Aura are present", async () => {
-    const moveToCheck = allMoves[MoveId.MOONBLAST];
+    const moveToCheck = allMoves.get(MoveId.MOONBLAST);
     const basePower = moveToCheck.power;
 
     game.override.ability(Abilities.BALL_FETCH);

--- a/test/abilities/battery.test.ts
+++ b/test/abilities/battery.test.ts
@@ -34,7 +34,7 @@ describe("Abilities - Battery", () => {
   });
 
   it("raises the power of allies' special moves by 30%", async () => {
-    const moveToCheck = allMoves[MoveId.DAZZLING_GLEAM];
+    const moveToCheck = allMoves.get(MoveId.DAZZLING_GLEAM);
     const basePower = moveToCheck.power;
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
@@ -49,7 +49,7 @@ describe("Abilities - Battery", () => {
   });
 
   it("does not raise the power of allies' non-special moves", async () => {
-    const moveToCheck = allMoves[MoveId.BREAKING_SWIPE];
+    const moveToCheck = allMoves.get(MoveId.BREAKING_SWIPE);
     const basePower = moveToCheck.power;
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
@@ -64,7 +64,7 @@ describe("Abilities - Battery", () => {
   });
 
   it("does not raise the power of the ability owner's special moves", async () => {
-    const moveToCheck = allMoves[MoveId.DAZZLING_GLEAM];
+    const moveToCheck = allMoves.get(MoveId.DAZZLING_GLEAM);
     const basePower = moveToCheck.power;
 
     vi.spyOn(moveToCheck, "calculateBattlePower");

--- a/test/abilities/battle_bond.test.ts
+++ b/test/abilities/battle_bond.test.ts
@@ -59,7 +59,7 @@ describe("Abilities - BATTLE BOND", () => {
   it("should not keep buffing Water Shuriken after Greninja switches to base form", async () => {
     await game.classicMode.startBattle([Species.GRENINJA]);
 
-    const waterShuriken = allMoves[MoveId.WATER_SHURIKEN];
+    const waterShuriken = allMoves.get(MoveId.WATER_SHURIKEN);
     vi.spyOn(waterShuriken, "calculateBattlePower");
 
     let actualMultiHitType: MultiHitType | null = null;

--- a/test/abilities/effect_spore.test.ts
+++ b/test/abilities/effect_spore.test.ts
@@ -131,7 +131,7 @@ describe("Abilities - Effect Spore", () => {
     // Apply the Effect Spore attr while simulating the full range of possible RNG rolls.
     // Unfortunately, actually using Tackle 100 times takes too long, so we only apply the attr.
     for (rngSweepProgress = 0; rngSweepProgress < 100; rngSweepProgress++) {
-      abilityAttr.apply(playerPokemon, false, enemyPokemon, allMoves[MoveId.TACKLE]);
+      abilityAttr.apply(playerPokemon, false, enemyPokemon, allMoves.get(MoveId.TACKLE));
     }
 
     expect(sleepCount).toBe(11);

--- a/test/abilities/fluffy.test.ts
+++ b/test/abilities/fluffy.test.ts
@@ -44,7 +44,7 @@ describe("Abilities - Fluffy", () => {
     await game.toEndOfTurn();
 
     const damageMultiplier = (abilitySpy.mock.lastCall?.[4] as NumberHolder).value;
-    expect(allMoves[MoveId.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+    expect(allMoves.get(MoveId.TACKLE).hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
     expect(damageMultiplier).toBe(0.5);
   });
 
@@ -70,7 +70,7 @@ describe("Abilities - Fluffy", () => {
     await game.toEndOfTurn();
 
     const damageMultiplier = (abilitySpy.mock.lastCall?.[4] as NumberHolder).value;
-    expect(allMoves[MoveId.FIRE_FANG].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+    expect(allMoves.get(MoveId.FIRE_FANG).hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
     expect(damageMultiplier).toBe(1);
   });
 
@@ -84,7 +84,7 @@ describe("Abilities - Fluffy", () => {
     await game.toEndOfTurn();
 
     const damageMultiplier = (abilitySpy.mock.lastCall?.[4] as NumberHolder).value;
-    expect(allMoves[MoveId.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+    expect(allMoves.get(MoveId.TACKLE).hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
     expect(damageMultiplier).toBe(1);
   });
 });

--- a/test/abilities/friend_guard.test.ts
+++ b/test/abilities/friend_guard.test.ts
@@ -49,7 +49,9 @@ describe("Moves - Friend Guard", () => {
     // Get the last return value from `getAttackDamage`
     const turn1Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
     // Making sure the test is controlled; turn 1 damage is equal to base damage (after rounding)
-    expect(turn1Damage).toBe(Math.floor(player1.getBaseDamage(enemy1, allMoves[MoveId.TACKLE], MoveCategory.PHYSICAL)));
+    expect(turn1Damage).toBe(
+      Math.floor(player1.getBaseDamage(enemy1, allMoves.get(MoveId.TACKLE), MoveCategory.PHYSICAL)),
+    );
 
     vi.spyOn(player2, "getAbility").mockReturnValue(allAbilities[Abilities.FRIEND_GUARD]);
 
@@ -63,7 +65,7 @@ describe("Moves - Friend Guard", () => {
     const turn2Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
     // With the ally's Friend Guard, damage should have been reduced from base damage by 25%
     expect(turn2Damage).toBe(
-      Math.floor(player1.getBaseDamage(enemy1, allMoves[MoveId.TACKLE], MoveCategory.PHYSICAL) * 0.75),
+      Math.floor(player1.getBaseDamage(enemy1, allMoves.get(MoveId.TACKLE), MoveCategory.PHYSICAL) * 0.75),
     );
   });
 

--- a/test/abilities/gale_wings.test.ts
+++ b/test/abilities/gale_wings.test.ts
@@ -37,7 +37,7 @@ describe("Abilities - Gale Wings", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
     const playerPokemon = game.scene.getPlayerPokemon();
 
-    const flyingMove = allMoves[MoveId.WING_ATTACK];
+    const flyingMove = allMoves.get(MoveId.WING_ATTACK);
     vi.spyOn(flyingMove, "getPriority");
 
     game.move.select(MoveId.WING_ATTACK);
@@ -52,7 +52,7 @@ describe("Abilities - Gale Wings", () => {
     const playerPokemon = game.scene.getPlayerPokemon()!;
     playerPokemon.hp = 1;
 
-    const flyingMove = allMoves[MoveId.WING_ATTACK];
+    const flyingMove = allMoves.get(MoveId.WING_ATTACK);
     vi.spyOn(flyingMove, "getPriority");
 
     game.move.select(MoveId.WING_ATTACK);
@@ -69,7 +69,7 @@ describe("Abilities - Gale Wings", () => {
     //IVs for Flying-Type Hidden Power
     playerPokemon.ivs = [31, 31, 31, 30, 30, 30];
 
-    const flyingMove = allMoves[MoveId.HIDDEN_POWER];
+    const flyingMove = allMoves.get(MoveId.HIDDEN_POWER);
     vi.spyOn(flyingMove, "getPriority");
 
     game.move.select(MoveId.HIDDEN_POWER);
@@ -85,7 +85,7 @@ describe("Abilities - Gale Wings", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    const flyingMove = allMoves[MoveId.TACKLE];
+    const flyingMove = allMoves.get(MoveId.TACKLE);
     vi.spyOn(flyingMove, "getPriority");
 
     game.move.select(MoveId.TACKLE);

--- a/test/abilities/galvanize.test.ts
+++ b/test/abilities/galvanize.test.ts
@@ -45,7 +45,7 @@ describe("Abilities - Galvanize", () => {
     const enemyPokemon = game.scene.getEnemyPokemon()!;
     vi.spyOn(enemyPokemon, "getMoveEffectiveness");
 
-    const move = allMoves[MoveId.TACKLE];
+    const move = allMoves.get(MoveId.TACKLE);
     vi.spyOn(move, "calculateBattlePower");
 
     game.move.select(MoveId.TACKLE);

--- a/test/abilities/gooey.test.ts
+++ b/test/abilities/gooey.test.ts
@@ -46,7 +46,7 @@ describe("Abilities - Gooey/Tangling Hair", () => {
       game.move.select(MoveId.TACKLE);
       await game.toEndOfTurn();
 
-      expect(allMoves[MoveId.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+      expect(allMoves.get(MoveId.TACKLE).hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
       expect(pokemon.getStatStage(Stat.SPD)).toBe(-1);
     },
   );
@@ -64,7 +64,7 @@ describe("Abilities - Gooey/Tangling Hair", () => {
       game.move.select(MoveId.TACKLE);
       await game.toEndOfTurn();
 
-      expect(allMoves[MoveId.TACKLE].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+      expect(allMoves.get(MoveId.TACKLE).hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
       expect(pokemon.getStatStage(Stat.SPD)).toBe(0);
     },
   );
@@ -82,7 +82,7 @@ describe("Abilities - Gooey/Tangling Hair", () => {
       game.move.select(MoveId.EMBER);
       await game.toEndOfTurn();
 
-      expect(allMoves[MoveId.EMBER].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(false);
+      expect(allMoves.get(MoveId.EMBER).hasFlag(MoveFlags.MAKES_CONTACT)).toBe(false);
       expect(pokemon.getStatStage(Stat.SPD)).toBe(0);
     },
   );
@@ -98,7 +98,7 @@ describe("Abilities - Gooey/Tangling Hair", () => {
     game.move.select(MoveId.DOUBLE_IRON_BASH);
     await game.toEndOfTurn();
 
-    expect(allMoves[MoveId.DOUBLE_IRON_BASH].hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
+    expect(allMoves.get(MoveId.DOUBLE_IRON_BASH).hasFlag(MoveFlags.MAKES_CONTACT)).toBe(true);
     expect(pokemon.getStatStage(Stat.SPD)).toBe(-2);
   });
 });

--- a/test/abilities/hustle.test.ts
+++ b/test/abilities/hustle.test.ts
@@ -83,13 +83,13 @@ describe("Abilities - Hustle", () => {
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     vi.spyOn(pikachu, "getAccuracyMultiplier");
-    vi.spyOn(allMoves[MoveId.FISSURE], "calculateBattleAccuracy");
+    vi.spyOn(allMoves.get(MoveId.FISSURE), "calculateBattleAccuracy");
 
     game.move.select(MoveId.FISSURE);
     await game.phaseInterceptor.to("DamageAnimPhase");
 
     expect(enemyPokemon.turnData.damageTaken).toBe(enemyPokemon.getMaxHp());
     expect(pikachu.getAccuracyMultiplier).toHaveReturnedWith(1);
-    expect(allMoves[MoveId.FISSURE].calculateBattleAccuracy).toHaveReturnedWith(100);
+    expect(allMoves.get(MoveId.FISSURE).calculateBattleAccuracy).toHaveReturnedWith(100);
   });
 });

--- a/test/abilities/infiltrator.test.ts
+++ b/test/abilities/infiltrator.test.ts
@@ -50,13 +50,19 @@ describe("Abilities - Infiltrator", () => {
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
 
-    const preScreenDmg = enemy.getAttackDamage(player, allMoves[moveId], AbilityApplyMode.DEFAULT, false, false).damage;
+    const preScreenDmg = enemy.getAttackDamage(
+      player,
+      allMoves.get(moveId),
+      AbilityApplyMode.DEFAULT,
+      false,
+      false,
+    ).damage;
 
     game.scene.arena.addTag(tagType, enemy.id, 1, MoveId.NONE, ArenaTagSide.ENEMY, true);
 
     const postScreenDmg = enemy.getAttackDamage(
       player,
-      allMoves[moveId],
+      allMoves.get(moveId),
       AbilityApplyMode.DEFAULT,
       false,
       false,

--- a/test/abilities/libero.test.ts
+++ b/test/abilities/libero.test.ts
@@ -69,7 +69,7 @@ describe("Abilities - Libero", () => {
 
     expect(leadPokemon.summonData.abilitiesApplied.filter((a) => a === Abilities.LIBERO)).toHaveLength(1);
     const leadPokemonType = ElementalType[leadPokemon.getTypes()[0]];
-    const moveType = ElementalType[allMoves[MoveId.AGILITY].type];
+    const moveType = ElementalType[allMoves.get(MoveId.AGILITY).type];
     expect(leadPokemonType).not.toBe(moveType);
 
     await game.toNextTurn();
@@ -210,7 +210,7 @@ describe("Abilities - Libero", () => {
     const leadPokemon = game.scene.getPlayerPokemon()!;
     expect(leadPokemon).not.toBe(undefined);
 
-    leadPokemon.summonData.types = [allMoves[MoveId.SPLASH].type];
+    leadPokemon.summonData.types = [allMoves.get(MoveId.SPLASH).type];
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to(TurnEndPhase);
 
@@ -296,6 +296,6 @@ function testPokemonTypeMatchesDefaultMoveType(pokemon: PlayerPokemon, moveId: M
   expect(pokemon.summonData.abilitiesApplied).toContain(Abilities.LIBERO);
   expect(pokemon.getTypes()).toHaveLength(1);
   const pokemonType = ElementalType[pokemon.getTypes()[0]],
-    moveType = ElementalType[allMoves[moveId].type];
+    moveType = ElementalType[allMoves.get(moveId).type];
   expect(pokemonType).toBe(moveType);
 }

--- a/test/abilities/low_hp_type_attack_multiplier.test.ts
+++ b/test/abilities/low_hp_type_attack_multiplier.test.ts
@@ -94,7 +94,7 @@ describe("Abilities - Overgrow/Blaze/Torrent/Swarm", () => {
       await game.phaseInterceptor.to("MoveEndPhase", false);
 
       const statUsed =
-        playerPokemon.getMoveCategory(game.scene.getEnemyPokemon()!, allMoves[moveId]) === MoveCategory.PHYSICAL
+        playerPokemon.getMoveCategory(game.scene.getEnemyPokemon()!, allMoves.get(moveId)) === MoveCategory.PHYSICAL
           ? Stat.ATK
           : Stat.SPATK;
       expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[statUsed]));

--- a/test/abilities/mega_launcher.test.ts
+++ b/test/abilities/mega_launcher.test.ts
@@ -39,7 +39,7 @@ describe("Abilities - Mega Launcher", () => {
     const enemyPokemon = game.scene.getEnemyPokemon()!;
     const enemyHpRecovered = Math.floor(enemyPokemon.hp * 0.75);
     enemyPokemon.hp = 1;
-    const pulseMove = allMoves[MoveId.HEAL_PULSE];
+    const pulseMove = allMoves.get(MoveId.HEAL_PULSE);
     game.move.select(MoveId.HEAL_PULSE);
     await game.toEndOfTurn();
 

--- a/test/abilities/move_flag_immunity.test.ts
+++ b/test/abilities/move_flag_immunity.test.ts
@@ -66,7 +66,7 @@ describe("Ability Attribute - Move Flag Immunity", () => {
 
       const lastEnemyMove = enemyPokemon.getLastXMoves()[0];
       expect(lastEnemyMove.result).toBe(MoveResult.FAIL);
-      expect(allMoves[enemyMove].checkFlag(moveFlag, enemyPokemon, null)).toBe(true);
+      expect(allMoves.get(enemyMove).checkFlag(moveFlag, enemyPokemon, null)).toBe(true);
     },
   );
 });

--- a/test/abilities/move_flag_power_boost.test.ts
+++ b/test/abilities/move_flag_power_boost.test.ts
@@ -88,7 +88,7 @@ describe("Abilities - Move Flag Power Boost Ability Attr", () => {
       game.override.moveset(move).ability(ability);
       await game.classicMode.startBattle([Species.FEEBAS]);
       const playerPokemon = game.scene.getPlayerPokemon()!;
-      const moveUsed = allMoves[move];
+      const moveUsed = allMoves.get(move);
       vi.spyOn(moveUsed, "calculateBattlePower");
 
       game.move.select(move);

--- a/test/abilities/parental_bond.test.ts
+++ b/test/abilities/parental_bond.test.ts
@@ -430,7 +430,7 @@ describe("Abilities - Parental Bond", () => {
   it("should only apply the effects of Secret Power on the final hit", async () => {
     game.override.moveset(MoveId.SECRET_POWER).enemyMoveset(MoveId.MISTY_TERRAIN); // Secret Power lowers Sp Atk in Misty Terrain
 
-    vi.spyOn(allMoves[MoveId.SECRET_POWER], "chance", "get").mockReturnValue(-1);
+    vi.spyOn(allMoves.get(MoveId.SECRET_POWER), "chance", "get").mockReturnValue(-1);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 

--- a/test/abilities/power_spot.test.ts
+++ b/test/abilities/power_spot.test.ts
@@ -34,7 +34,7 @@ describe("Abilities - Power Spot", () => {
   });
 
   it("raises the power of allies' special moves by 30%", async () => {
-    const moveToCheck = allMoves[MoveId.DAZZLING_GLEAM];
+    const moveToCheck = allMoves.get(MoveId.DAZZLING_GLEAM);
     const basePower = moveToCheck.power;
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
@@ -48,7 +48,7 @@ describe("Abilities - Power Spot", () => {
   });
 
   it("raises the power of allies' physical moves by 30%", async () => {
-    const moveToCheck = allMoves[MoveId.BREAKING_SWIPE];
+    const moveToCheck = allMoves.get(MoveId.BREAKING_SWIPE);
     const basePower = moveToCheck.power;
 
     vi.spyOn(moveToCheck, "calculateBattlePower");
@@ -62,7 +62,7 @@ describe("Abilities - Power Spot", () => {
   });
 
   it("does not raise the power of the ability owner's moves", async () => {
-    const moveToCheck = allMoves[MoveId.BREAKING_SWIPE];
+    const moveToCheck = allMoves.get(MoveId.BREAKING_SWIPE);
     const basePower = moveToCheck.power;
 
     vi.spyOn(moveToCheck, "calculateBattlePower");

--- a/test/abilities/protean.test.ts
+++ b/test/abilities/protean.test.ts
@@ -69,7 +69,7 @@ describe("Abilities - Protean", () => {
 
     expect(leadPokemon.summonData.abilitiesApplied.filter((a) => a === Abilities.PROTEAN)).toHaveLength(1);
     const leadPokemonType = ElementalType[leadPokemon.getTypes()[0]];
-    const moveType = ElementalType[allMoves[MoveId.AGILITY].type];
+    const moveType = ElementalType[allMoves.get(MoveId.AGILITY).type];
     expect(leadPokemonType).not.toBe(moveType);
 
     await game.toNextTurn();
@@ -210,7 +210,7 @@ describe("Abilities - Protean", () => {
     const leadPokemon = game.scene.getPlayerPokemon()!;
     expect(leadPokemon).not.toBe(undefined);
 
-    leadPokemon.summonData.types = [allMoves[MoveId.SPLASH].type];
+    leadPokemon.summonData.types = [allMoves.get(MoveId.SPLASH).type];
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to(TurnEndPhase);
 
@@ -296,6 +296,6 @@ function testPokemonTypeMatchesDefaultMoveType(pokemon: PlayerPokemon, moveId: M
   expect(pokemon.summonData.abilitiesApplied).toContain(Abilities.PROTEAN);
   expect(pokemon.getTypes()).toHaveLength(1);
   const pokemonType = ElementalType[pokemon.getTypes()[0]],
-    moveType = ElementalType[allMoves[moveId].type];
+    moveType = ElementalType[allMoves.get(moveId).type];
   expect(pokemonType).toBe(moveType);
 }

--- a/test/abilities/sap_sipper.test.ts
+++ b/test/abilities/sap_sipper.test.ts
@@ -131,9 +131,9 @@ describe("Abilities - Sap Sipper", () => {
   it("activate once against multi-hit grass attacks (metronome)", async () => {
     const moveToUse = MoveId.METRONOME;
 
-    const randomMoveAttr = allMoves[MoveId.METRONOME].findAttr(
-      (attr) => attr instanceof MetronomeAttr,
-    ) as MetronomeAttr;
+    const randomMoveAttr = allMoves
+      .get(MoveId.METRONOME)
+      .findAttr((attr) => attr instanceof MetronomeAttr) as MetronomeAttr;
     vi.spyOn(randomMoveAttr, "getRandomMove").mockReturnValue(MoveId.BULLET_SEED);
 
     game.override.moveset(moveToUse);

--- a/test/abilities/serene_grace.test.ts
+++ b/test/abilities/serene_grace.test.ts
@@ -38,7 +38,7 @@ describe("Abilities - Serene Grace", () => {
   it("Serene Grace should double the secondary effect chance of a move", async () => {
     await game.classicMode.startBattle([Species.SHUCKLE]);
 
-    const airSlashMove = allMoves[MoveId.AIR_SLASH];
+    const airSlashMove = allMoves.get(MoveId.AIR_SLASH);
     const airSlashFlinchAttr = airSlashMove.getAttrs(FlinchAttr)[0];
     vi.spyOn(airSlashFlinchAttr, "getMoveChance");
 

--- a/test/abilities/sheer_force.test.ts
+++ b/test/abilities/sheer_force.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Sheer Force", () => {
     game.override.moveset([MoveId.AIR_SLASH]);
     await game.classicMode.startBattle([Species.SHUCKLE]);
 
-    const airSlashMove = allMoves[MoveId.AIR_SLASH];
+    const airSlashMove = allMoves.get(MoveId.AIR_SLASH);
     vi.spyOn(airSlashMove, "calculateBattlePower");
     const airSlashFlinchAttr = airSlashMove.getAttrs(FlinchAttr)[0];
     vi.spyOn(airSlashFlinchAttr, "getMoveChance");
@@ -60,7 +60,7 @@ describe("Abilities - Sheer Force", () => {
     game.override.moveset([MoveId.BIND]);
     await game.classicMode.startBattle([Species.SHUCKLE]);
 
-    const bindMove = allMoves[MoveId.BIND];
+    const bindMove = allMoves.get(MoveId.BIND);
     vi.spyOn(bindMove, "calculateBattlePower");
 
     game.move.select(MoveId.BIND);
@@ -76,7 +76,7 @@ describe("Abilities - Sheer Force", () => {
     game.override.moveset([MoveId.TACKLE]);
     await game.classicMode.startBattle([Species.PIDGEOT]);
 
-    const tackleMove = allMoves[MoveId.TACKLE];
+    const tackleMove = allMoves.get(MoveId.TACKLE);
     vi.spyOn(tackleMove, "calculateBattlePower");
 
     game.move.select(MoveId.TACKLE);
@@ -96,7 +96,7 @@ describe("Abilities - Sheer Force", () => {
 
     await game.classicMode.startBattle([Species.PIDGEOT]);
     const enemyPokemon = game.scene.getEnemyPokemon();
-    const headbuttMove = allMoves[MoveId.HEADBUTT];
+    const headbuttMove = allMoves.get(MoveId.HEADBUTT);
     vi.spyOn(headbuttMove, "calculateBattlePower");
     const headbuttFlinchAttr = headbuttMove.getAttrs(FlinchAttr)[0];
     vi.spyOn(headbuttFlinchAttr, "getMoveChance");
@@ -132,7 +132,7 @@ describe("Abilities - Sheer Force", () => {
     await game.toNextTurn();
 
     // Check that both Pokemon's Color Change activated
-    const expectedTypes = [allMoves[moveToUse].type];
+    const expectedTypes = [allMoves.get(moveToUse).type];
     expect(pidgeot.getTypes()).toStrictEqual(expectedTypes);
     expect(onix.getTypes()).toStrictEqual(expectedTypes);
   });

--- a/test/abilities/soundproof.test.ts
+++ b/test/abilities/soundproof.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Soundproof", () => {
     game.move.select(MoveId.CLANGOROUS_SOUL);
     await game.toEndOfTurn();
 
-    const soundMove = allMoves[MoveId.CLANGOROUS_SOUL];
+    const soundMove = allMoves.get(MoveId.CLANGOROUS_SOUL);
     const lastMove = playerPokemon.getLastXMoves()[0];
 
     expect(lastMove.result).toBe(MoveResult.SUCCESS);

--- a/test/abilities/steely_spirit.test.ts
+++ b/test/abilities/steely_spirit.test.ts
@@ -11,7 +11,7 @@ describe("Abilities - Steely Spirit", () => {
   let game: GameManager;
   const steelySpiritMultiplier = 1.5;
   const moveToCheck = MoveId.IRON_HEAD;
-  const ironHeadPower = allMoves[moveToCheck].power;
+  const ironHeadPower = allMoves.get(moveToCheck).power;
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -30,7 +30,7 @@ describe("Abilities - Steely Spirit", () => {
     game.override.enemyAbility(Abilities.BALL_FETCH);
     game.override.moveset([MoveId.IRON_HEAD, MoveId.SPLASH]);
     game.override.enemyMoveset(MoveId.SPLASH);
-    vi.spyOn(allMoves[moveToCheck], "calculateBattlePower");
+    vi.spyOn(allMoves.get(moveToCheck), "calculateBattlePower");
   });
 
   it("increases Steel-type moves' power used by the user and its allies by 50%", async () => {
@@ -46,7 +46,7 @@ describe("Abilities - Steely Spirit", () => {
     game.move.select(MoveId.SPLASH, 1);
     await game.phaseInterceptor.to("MoveEffectPhase");
 
-    expect(allMoves[moveToCheck].calculateBattlePower).toHaveReturnedWith(ironHeadPower * steelySpiritMultiplier);
+    expect(allMoves.get(moveToCheck).calculateBattlePower).toHaveReturnedWith(ironHeadPower * steelySpiritMultiplier);
   });
 
   it("stacks if multiple users with this ability are on the field.", async () => {
@@ -63,7 +63,7 @@ describe("Abilities - Steely Spirit", () => {
     game.move.select(moveToCheck, 1, enemyToCheck.getBattlerIndex());
     await game.phaseInterceptor.to("MoveEffectPhase");
 
-    expect(allMoves[moveToCheck].calculateBattlePower).toHaveReturnedWith(
+    expect(allMoves.get(moveToCheck).calculateBattlePower).toHaveReturnedWith(
       ironHeadPower * Math.pow(steelySpiritMultiplier, 2),
     );
   });
@@ -85,13 +85,13 @@ describe("Abilities - Steely Spirit", () => {
     game.move.select(MoveId.SPLASH, 1);
     await game.phaseInterceptor.to("MoveEffectPhase");
 
-    expect(allMoves[moveToCheck].calculateBattlePower).toHaveReturnedWith(ironHeadPower);
+    expect(allMoves.get(moveToCheck).calculateBattlePower).toHaveReturnedWith(ironHeadPower);
   });
 
   it("affects variable-type moves if their resolved type is Steel", async () => {
     game.override.ability(Abilities.STEELY_SPIRIT).moveset([MoveId.REVELATION_DANCE]);
 
-    const revelationDance = allMoves[MoveId.REVELATION_DANCE];
+    const revelationDance = allMoves.get(MoveId.REVELATION_DANCE);
     vi.spyOn(revelationDance, "calculateBattlePower");
 
     await game.classicMode.startBattle([Species.KLINKLANG]);

--- a/test/abilities/sticky_hold.test.ts
+++ b/test/abilities/sticky_hold.test.ts
@@ -43,9 +43,9 @@ describe("Abilities - Sticky Hold", () => {
   )("should prevent the user from losing a held item when hit by the move $name", async ({ moveId: move }) => {
     // Force item removal RNG calls to succeed
     if (move === MoveId.THIEF) {
-      vi.spyOn(allMoves[move].getAttrs(StealHeldItemChanceAttr)[0], "chance", "get").mockReturnValue(1.0);
+      vi.spyOn(allMoves.get(move).getAttrs(StealHeldItemChanceAttr)[0], "chance", "get").mockReturnValue(1.0);
     }
-    vi.spyOn(allMoves[move], "chance", "get").mockReturnValue(-1);
+    vi.spyOn(allMoves.get(move), "chance", "get").mockReturnValue(-1);
 
     await game.classicMode.startBattle([Species.FEEBAS]);
 

--- a/test/abilities/super_luck.test.ts
+++ b/test/abilities/super_luck.test.ts
@@ -37,7 +37,7 @@ describe("Abilities - Super Luck", () => {
 
     const playerPokemon = game.field.getPlayerPokemon();
 
-    expect(playerPokemon.getCritStage(playerPokemon, allMoves[MoveId.TACKLE])).toBe(1);
-    expect(playerPokemon.getCritStage(playerPokemon, allMoves[MoveId.RAZOR_LEAF])).toBe(2);
+    expect(playerPokemon.getCritStage(playerPokemon, allMoves.get(MoveId.TACKLE))).toBe(1);
+    expect(playerPokemon.getCritStage(playerPokemon, allMoves.get(MoveId.RAZOR_LEAF))).toBe(2);
   });
 });

--- a/test/abilities/triage.test.ts
+++ b/test/abilities/triage.test.ts
@@ -44,7 +44,7 @@ describe("Abilities - Triage", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;
-    const moveToUse = allMoves[moveId];
+    const moveToUse = allMoves.get(moveId);
     const originalPriority = moveToUse.priority;
     expect(moveToUse.checkFlag(MoveFlags.TRIAGE_MOVE, playerPokemon, null)).toBe(true);
     expect(moveToUse.getPriority(playerPokemon)).toBe(originalPriority + 3);
@@ -62,7 +62,7 @@ describe("Abilities - Triage", () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     const playerPokemon = game.scene.getPlayerPokemon()!;
-    const moveToUse = allMoves[moveId];
+    const moveToUse = allMoves.get(moveId);
     const originalPriority = moveToUse.priority;
     expect(moveToUse.checkFlag(MoveFlags.TRIAGE_MOVE, playerPokemon, null)).toBe(false);
     expect(moveToUse.getPriority(playerPokemon)).toBe(originalPriority);
@@ -84,7 +84,7 @@ describe("Abilities - Triage", () => {
     await game.toEndOfTurn();
 
     // The Pokemon using Pollen Puff on its ally should be after the enemy Pokemon using Quick Attack
-    expect(allMoves[MoveId.POLLEN_PUFF].checkFlag(MoveFlags.TRIAGE_MOVE, playerPokemon, null)).toBe(false);
+    expect(allMoves.get(MoveId.POLLEN_PUFF).checkFlag(MoveFlags.TRIAGE_MOVE, playerPokemon, null)).toBe(false);
     expect(playerPokemon.turnData.order).toBeGreaterThanOrEqual(2);
   });
 });

--- a/test/abilities/unaware.test.ts
+++ b/test/abilities/unaware.test.ts
@@ -77,7 +77,7 @@ describe("Abilities - Unaware", () => {
   });
 
   it("should not cause the opponent's Stored Power to ignore the opponent's stat stages", async () => {
-    const storedPowerMove = allMoves[MoveId.STORED_POWER];
+    const storedPowerMove = allMoves.get(MoveId.STORED_POWER);
     vi.spyOn(storedPowerMove, "calculateBattlePower");
 
     await game.classicMode.startBattle([Species.FEEBAS]);
@@ -93,7 +93,7 @@ describe("Abilities - Unaware", () => {
   });
 
   it("should not cause the move Punishment to ignore the opponent's stat stages", async () => {
-    const punishmentMove = allMoves[MoveId.PUNISHMENT];
+    const punishmentMove = allMoves.get(MoveId.PUNISHMENT);
     vi.spyOn(punishmentMove, "calculateBattlePower");
 
     game.override.startingLevel(5).enemyLevel(100);
@@ -171,7 +171,7 @@ describe("Abilities - Unaware", () => {
 
   it("should not ignore an opponent's physical damage reduction from a Burn status", async () => {
     // TODO: Is there a more direct way to test for Burn damage reduction?
-    vi.spyOn(allMoves[MoveId.WILL_O_WISP], "accuracy", "get").mockReturnValue(-1);
+    vi.spyOn(allMoves.get(MoveId.WILL_O_WISP), "accuracy", "get").mockReturnValue(-1);
     game.override.startingLevel(1000).enemyLevel(1000);
     await game.classicMode.startBattle([Species.FEEBAS]);
 

--- a/test/abilities/unburden.test.ts
+++ b/test/abilities/unburden.test.ts
@@ -62,7 +62,7 @@ describe("Abilities - Unburden", () => {
         { name: "BERRY", type: BerryType.LUM, count: 1 },
       ]);
     // For the various tests that use Thief, give it a 100% steal rate
-    vi.spyOn(allMoves[MoveId.THIEF], "attrs", "get").mockReturnValue([new StealHeldItemChanceAttr(1.0)]);
+    vi.spyOn(allMoves.get(MoveId.THIEF), "attrs", "get").mockReturnValue([new StealHeldItemChanceAttr(1.0)]);
   });
 
   it("should activate when a berry is eaten", async () => {

--- a/test/abilities/wimp_out.test.ts
+++ b/test/abilities/wimp_out.test.ts
@@ -405,7 +405,7 @@ describe("Abilities - Wimp Out", () => {
   it("triggers status on the wimp out user before a new pokemon is switched in", async () => {
     game.override.enemyMoveset(MoveId.SLUDGE_BOMB).startingLevel(80);
     await game.classicMode.startBattle([Species.WIMPOD, Species.TYRUNT]);
-    vi.spyOn(allMoves[MoveId.SLUDGE_BOMB], "chance", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.SLUDGE_BOMB), "chance", "get").mockReturnValue(100);
 
     game.move.select(MoveId.SPLASH);
     game.doSelectPartyPokemon(1);

--- a/test/abilities/wonder_skin.test.ts
+++ b/test/abilities/wonder_skin.test.ts
@@ -32,7 +32,7 @@ describe("Abilities - Wonder Skin", () => {
   });
 
   it("lowers accuracy of status moves to 50%", async () => {
-    const moveToCheck = allMoves[MoveId.CHARM];
+    const moveToCheck = allMoves.get(MoveId.CHARM);
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
@@ -44,7 +44,7 @@ describe("Abilities - Wonder Skin", () => {
   });
 
   it("does not lower accuracy of non-status moves", async () => {
-    const moveToCheck = allMoves[MoveId.TACKLE];
+    const moveToCheck = allMoves.get(MoveId.TACKLE);
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
@@ -59,7 +59,7 @@ describe("Abilities - Wonder Skin", () => {
 
   bypassAbilities.forEach((ability) => {
     it(`does not affect pokemon with ${allAbilities[ability].name}`, async () => {
-      const moveToCheck = allMoves[MoveId.CHARM];
+      const moveToCheck = allMoves.get(MoveId.CHARM);
 
       game.override.ability(ability);
       vi.spyOn(moveToCheck, "calculateBattleAccuracy");

--- a/test/ai/enemy_command.test.ts
+++ b/test/ai/enemy_command.test.ts
@@ -27,7 +27,7 @@ function getEnemyMoveChoices(pokemon: EnemyPokemon, moveChoices: MoveChoiceSet):
   }
 
   for (const [moveId, count] of Object.entries(moveChoices)) {
-    console.log(`Move: ${allMoves[moveId].name}   Count: ${count} (${(count / NUM_TRIALS) * 100}%)`);
+    console.log(`Move: ${allMoves.get(Number(moveId)).name}   Count: ${count} (${(count / NUM_TRIALS) * 100}%)`);
   }
 }
 

--- a/test/arena/arena_gravity.test.ts
+++ b/test/arena/arena_gravity.test.ts
@@ -38,7 +38,7 @@ describe("Arena - Gravity", () => {
   // Reference: https://bulbapedia.bulbagarden.net/wiki/Gravity_(move)
 
   it("non-OHKO move accuracy is multiplied by 1.67", async () => {
-    const moveToCheck = allMoves[MoveId.TACKLE];
+    const moveToCheck = allMoves.get(MoveId.TACKLE);
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
@@ -59,7 +59,7 @@ describe("Arena - Gravity", () => {
 
   it("OHKO move accuracy is not affected", async () => {
     /** See Fissure {@link https://bulbapedia.bulbagarden.net/wiki/Fissure_(move)} */
-    const moveToCheck = allMoves[MoveId.FISSURE];
+    const moveToCheck = allMoves.get(MoveId.FISSURE);
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 

--- a/test/arena/grassy_terrain.test.ts
+++ b/test/arena/grassy_terrain.test.ts
@@ -38,7 +38,7 @@ describe("Arena - Grassy Terrain", () => {
   it("should halve the damage of Earthquake", async () => {
     await game.classicMode.startBattle([Species.TAUROS]);
 
-    const eq = allMoves[MoveId.EARTHQUAKE];
+    const eq = allMoves.get(MoveId.EARTHQUAKE);
     vi.spyOn(eq, "calculateBattlePower");
 
     game.move.select(MoveId.EARTHQUAKE);
@@ -60,7 +60,7 @@ describe("Arena - Grassy Terrain", () => {
     game.challengeMode.addChallenge(Challenges.INVERSE_BATTLE, 1, 1); // So that Earthquake actually has an effect
     await game.challengeMode.startBattle([Species.FEEBAS]);
 
-    const eq = allMoves[MoveId.EARTHQUAKE];
+    const eq = allMoves.get(MoveId.EARTHQUAKE);
     vi.spyOn(eq, "calculateBattlePower");
 
     game.move.select(MoveId.GRASSY_TERRAIN);

--- a/test/arena/weather_fog.test.ts
+++ b/test/arena/weather_fog.test.ts
@@ -35,7 +35,7 @@ describe("Weather - Fog", () => {
   });
 
   it("move accuracy is changed in fog", async () => {
-    const moveToCheck = allMoves[MoveId.TACKLE];
+    const moveToCheck = allMoves.get(MoveId.TACKLE);
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 
@@ -47,7 +47,7 @@ describe("Weather - Fog", () => {
   });
 
   it("move accuracy is unaffected if fog is suppressed", async () => {
-    const moveToCheck = allMoves[MoveId.TACKLE];
+    const moveToCheck = allMoves.get(MoveId.TACKLE);
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
     game.override.ability(Abilities.AIR_LOCK);

--- a/test/arena/weather_strong_winds.test.ts
+++ b/test/arena/weather_strong_winds.test.ts
@@ -41,7 +41,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.THUNDERBOLT);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.THUNDERBOLT].type, pikachu)).toBe(0.5);
+    expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.THUNDERBOLT).type, pikachu)).toBe(0.5);
   });
 
   it("electric type move is neutral for flying type pokemon", async () => {
@@ -52,7 +52,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.THUNDERBOLT);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.THUNDERBOLT].type, pikachu)).toBe(1);
+    expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.THUNDERBOLT).type, pikachu)).toBe(1);
   });
 
   it("ice type move is neutral for flying type pokemon", async () => {
@@ -63,7 +63,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.ICE_BEAM);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.ICE_BEAM].type, pikachu)).toBe(1);
+    expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.ICE_BEAM).type, pikachu)).toBe(1);
   });
 
   it("rock type move is neutral for flying type pokemon", async () => {
@@ -74,7 +74,7 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.ROCK_SLIDE);
 
     await game.phaseInterceptor.to(TurnStartPhase);
-    expect(enemy.getAttackTypeEffectiveness(allMoves[MoveId.ROCK_SLIDE].type, pikachu)).toBe(1);
+    expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.ROCK_SLIDE).type, pikachu)).toBe(1);
   });
 
   it("weather goes away when last trainer pokemon dies to indirect damage", async () => {

--- a/test/battle/damage_calculation.test.ts
+++ b/test/battle/damage_calculation.test.ts
@@ -45,7 +45,7 @@ describe("Battle Mechanics - Damage Calculation", () => {
 
     // expected base damage = [(2*level/5 + 2) * power * playerATK / enemyDEF / 50] + 2
     //                      = 31.8666...
-    expect(enemyPokemon.getAttackDamage(playerPokemon, allMoves[MoveId.TACKLE]).damage).toBeCloseTo(31);
+    expect(enemyPokemon.getAttackDamage(playerPokemon, allMoves.get(MoveId.TACKLE)).damage).toBeCloseTo(31);
   });
 
   it("Attacks deal 1 damage at minimum", async () => {
@@ -71,7 +71,7 @@ describe("Battle Mechanics - Damage Calculation", () => {
     const magikarp = game.scene.getPlayerPokemon()!;
     const dragonite = game.scene.getEnemyPokemon()!;
 
-    expect(dragonite.getAttackDamage(magikarp, allMoves[MoveId.DRAGON_RAGE]).damage).toBe(40);
+    expect(dragonite.getAttackDamage(magikarp, allMoves.get(MoveId.DRAGON_RAGE)).damage).toBe(40);
   });
 
   it("One-hit KO moves ignore damage multipliers", async () => {
@@ -82,7 +82,7 @@ describe("Battle Mechanics - Damage Calculation", () => {
     const magikarp = game.scene.getPlayerPokemon()!;
     const aggron = game.scene.getEnemyPokemon()!;
 
-    expect(aggron.getAttackDamage(magikarp, allMoves[MoveId.FISSURE]).damage).toBe(aggron.hp);
+    expect(aggron.getAttackDamage(magikarp, allMoves.get(MoveId.FISSURE)).damage).toBe(aggron.hp);
   });
 
   it("When the user fails to use Jump Kick with Wonder Guard ability, the damage should be 1.", async () => {

--- a/test/battlerTags/substitute.test.ts
+++ b/test/battlerTags/substitute.test.ts
@@ -202,7 +202,7 @@ describe("BattlerTag - SubstituteTag", () => {
       vi.spyOn(mockPokemon.scene as BattleScene, "queueMessage").mockReturnValue();
 
       const pokemonMove = {
-        getMove: vi.fn().mockReturnValue(allMoves[MoveId.TACKLE]) as PokemonMove["getMove"],
+        getMove: vi.fn().mockReturnValue(allMoves.get(MoveId.TACKLE)) as PokemonMove["getMove"],
       } as PokemonMove;
 
       const moveEffectPhase = {
@@ -211,7 +211,7 @@ describe("BattlerTag - SubstituteTag", () => {
       } as MoveEffectPhase;
 
       vi.spyOn(mockPokemon.scene as BattleScene, "getCurrentPhase").mockReturnValue(moveEffectPhase);
-      vi.spyOn(allMoves[MoveId.TACKLE], "hitsSubstitute").mockReturnValue(true);
+      vi.spyOn(allMoves.get(MoveId.TACKLE), "hitsSubstitute").mockReturnValue(true);
 
       expect(subject.lapse(mockPokemon, BattlerTagLapseType.HIT)).toBeTruthy();
 

--- a/test/data/all_moves.test.ts
+++ b/test/data/all_moves.test.ts
@@ -54,7 +54,7 @@ describe("All Moves", async () => {
   const moveData: MoveData[] = JSON.parse(file);
 
   it.each(moveData)("$identifier, if implemented, should have correct move data", async (move: MoveData) => {
-    const pktyMove = allMoves[move.id as MoveId] as Move;
+    const pktyMove = allMoves.get(move.id as MoveId) as Move;
     if (pktyMove && !isUnimplemented(pktyMove.name)) {
       expect(
         pktyMove.type,

--- a/test/data/moveset-data.test.ts
+++ b/test/data/moveset-data.test.ts
@@ -15,12 +15,12 @@ describe("Moveset Data", async () => {
         if (G_MAX_FORM_KEYS.includes(formChange.formKey)) {
           // If G-max, check that the form change learns the correct G-Max move
           expect(formChange.movesToLearn.length).toBe(1);
-          const move = allMoves[formChange.movesToLearn[0]];
+          const move = allMoves.get(formChange.movesToLearn[0]);
           expect(move.getAttrs(GMaxPowerAttr)[0].signatureSpecies).toBe(Number(species));
         } else {
           // If not G-max, check that no G-max moves are learned
           for (const moveId of formChange.movesToLearn) {
-            expect(allMoves[moveId].hasAttr(GMaxPowerAttr)).toBe(false);
+            expect(allMoves.get(moveId).hasAttr(GMaxPowerAttr)).toBe(false);
           }
         }
       }
@@ -31,7 +31,7 @@ describe("Moveset Data", async () => {
       for (const moveArray of Object.values(pokemonFormLevelMoves[species])) {
         for (const [level, moveId] of moveArray as [number, MoveId][]) {
           // If it is a G-max move, check that the species being assigned this move is correct
-          const gmaxAttr = allMoves[moveId].getAttrs(GMaxPowerAttr)[0];
+          const gmaxAttr = allMoves.get(moveId).getAttrs(GMaxPowerAttr)[0];
           if (gmaxAttr) {
             expect(gmaxAttr.signatureSpecies).toBe(Number(species));
             expect(level).toBe(FORM_CHANGE_MOVE);

--- a/test/moves/astonish.test.ts
+++ b/test/moves/astonish.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Astonish", () => {
     game.override.startingLevel(100);
     game.override.enemyLevel(100);
 
-    vi.spyOn(allMoves[MoveId.ASTONISH], "chance", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.ASTONISH), "chance", "get").mockReturnValue(100);
   });
 
   test("move effect should cancel the target's move on the turn it applies", async () => {

--- a/test/moves/baton_pass.test.ts
+++ b/test/moves/baton_pass.test.ts
@@ -59,7 +59,7 @@ describe("Moves - Baton Pass", () => {
 
   it("passes stat stage buffs when AI uses it", async () => {
     // arrange
-    game.override.startingWave(5).enemyMoveset(new Array(4).fill([MoveId.NASTY_PLOT]));
+    game.override.startingWave(5).enemyMoveset(MoveId.NASTY_PLOT);
     await game.classicMode.startBattle([Species.RAICHU, Species.SHUCKLE]);
 
     // round 1 - ai buffs

--- a/test/moves/body_press.test.ts
+++ b/test/moves/body_press.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Body Press", () => {
 
   it("should use the user's Defense stat to calculate damage", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const bodyPress = allMoves[MoveId.BODY_PRESS];
+    const bodyPress = allMoves.get(MoveId.BODY_PRESS);
 
     const player = game.field.getPlayerPokemon();
     vi.spyOn(player, "stats", "get").mockReturnValue(Array(6).fill(100));
@@ -55,7 +55,7 @@ describe("Moves - Body Press", () => {
 
   it("should use Defense stat stages during damage calculation", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const bodyPress = allMoves[MoveId.BODY_PRESS];
+    const bodyPress = allMoves.get(MoveId.BODY_PRESS);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
@@ -74,7 +74,7 @@ describe("Moves - Body Press", () => {
 
   it("should only apply Attack stat multipliers from abilities for damage", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const bodyPress = allMoves[MoveId.BODY_PRESS];
+    const bodyPress = allMoves.get(MoveId.BODY_PRESS);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();

--- a/test/moves/brick_break.test.ts
+++ b/test/moves/brick_break.test.ts
@@ -70,7 +70,9 @@ describe("Moves - Brick Break", () => {
 
     const damage = spy.mock.results.at(-1)?.value.damage;
 
-    expect(damage).toBe(toDmgValue(enemy.getBaseDamage(player, allMoves[MoveId.BRICK_BREAK], MoveCategory.PHYSICAL)));
+    expect(damage).toBe(
+      toDmgValue(enemy.getBaseDamage(player, allMoves.get(MoveId.BRICK_BREAK), MoveCategory.PHYSICAL)),
+    );
   });
 
   it("should not remove screens if the move has no effect", async () => {

--- a/test/moves/burning_jealousy.test.ts
+++ b/test/moves/burning_jealousy.test.ts
@@ -82,14 +82,14 @@ describe("Moves - Burning Jealousy", () => {
 
   it("should be boosted by Sheer Force even if opponent didn't raise stat stages", async () => {
     game.override.ability(Abilities.SHEER_FORCE).enemyMoveset(MoveId.SPLASH);
-    vi.spyOn(allMoves[MoveId.BURNING_JEALOUSY], "calculateBattlePower");
+    vi.spyOn(allMoves.get(MoveId.BURNING_JEALOUSY), "calculateBattlePower");
     await game.classicMode.startBattle();
 
     game.move.select(MoveId.BURNING_JEALOUSY);
     await game.toEndOfTurn();
 
-    expect(allMoves[MoveId.BURNING_JEALOUSY].calculateBattlePower).toHaveReturnedWith(
-      allMoves[MoveId.BURNING_JEALOUSY].power * 1.3,
+    expect(allMoves.get(MoveId.BURNING_JEALOUSY).calculateBattlePower).toHaveReturnedWith(
+      allMoves.get(MoveId.BURNING_JEALOUSY).power * 1.3,
     );
   });
 });

--- a/test/moves/ceaseless_edge.test.ts
+++ b/test/moves/ceaseless_edge.test.ts
@@ -36,7 +36,7 @@ describe("Moves - Ceaseless Edge", () => {
     game.override.enemyLevel(100);
     game.override.moveset([MoveId.CEASELESS_EDGE, MoveId.SPLASH, MoveId.ROAR]);
     game.override.enemyMoveset(MoveId.SPLASH);
-    vi.spyOn(allMoves[MoveId.CEASELESS_EDGE], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.CEASELESS_EDGE), "accuracy", "get").mockReturnValue(100);
   });
 
   test("move should hit and apply spikes", async () => {

--- a/test/moves/copycat.test.ts
+++ b/test/moves/copycat.test.ts
@@ -14,7 +14,7 @@ describe("Moves - Copycat", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
-  const randomMoveAttr = allMoves[MoveId.METRONOME].getAttrs(MetronomeAttr)[0];
+  const randomMoveAttr = allMoves.get(MoveId.METRONOME).getAttrs(MetronomeAttr)[0];
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({

--- a/test/moves/destiny_bond.test.ts
+++ b/test/moves/destiny_bond.test.ts
@@ -179,7 +179,7 @@ describe("Moves - Destiny Bond", () => {
 
   it("should not cause a crash if the user is KO'd by Ceaseless Edge", async () => {
     const moveToUse = MoveId.CEASELESS_EDGE;
-    vi.spyOn(allMoves[moveToUse], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(moveToUse), "accuracy", "get").mockReturnValue(100);
 
     game.override.moveset(moveToUse);
     await game.classicMode.startBattle(defaultParty);

--- a/test/moves/diamond_storm.test.ts
+++ b/test/moves/diamond_storm.test.ts
@@ -33,7 +33,7 @@ describe("Moves - Diamond Storm", () => {
 
   it("should only increase defense once even if hitting 2 pokemon", async () => {
     game.override.battleType("double");
-    const diamondStorm = allMoves[MoveId.DIAMOND_STORM];
+    const diamondStorm = allMoves.get(MoveId.DIAMOND_STORM);
     vi.spyOn(diamondStorm, "chance", "get").mockReturnValue(100);
     vi.spyOn(diamondStorm, "accuracy", "get").mockReturnValue(100);
     await game.classicMode.startBattle([Species.FEEBAS]);

--- a/test/moves/dig.test.ts
+++ b/test/moves/dig.test.ts
@@ -97,14 +97,14 @@ describe("Moves - Dig", () => {
     const playerPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    const preDigEarthquakeDmg = playerPokemon.getAttackDamage(enemyPokemon, allMoves[MoveId.EARTHQUAKE]).damage;
+    const preDigEarthquakeDmg = playerPokemon.getAttackDamage(enemyPokemon, allMoves.get(MoveId.EARTHQUAKE)).damage;
 
     game.move.select(MoveId.DIG);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
     await game.phaseInterceptor.to("MoveEffectPhase");
 
-    const postDigEarthquakeDmg = playerPokemon.getAttackDamage(enemyPokemon, allMoves[MoveId.EARTHQUAKE]).damage;
+    const postDigEarthquakeDmg = playerPokemon.getAttackDamage(enemyPokemon, allMoves.get(MoveId.EARTHQUAKE)).damage;
     // these hopefully get avoid rounding errors :shrug:
     expect(postDigEarthquakeDmg).toBeGreaterThanOrEqual(2 * preDigEarthquakeDmg);
     expect(postDigEarthquakeDmg).toBeLessThan(2 * (preDigEarthquakeDmg + 1));

--- a/test/moves/dragon_tail.test.ts
+++ b/test/moves/dragon_tail.test.ts
@@ -33,7 +33,7 @@ describe("Moves - Dragon Tail", () => {
       .startingLevel(5)
       .enemyLevel(5);
 
-    vi.spyOn(allMoves[MoveId.DRAGON_TAIL], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.DRAGON_TAIL), "accuracy", "get").mockReturnValue(100);
   });
 
   it("should cause opponent to flee, and not crash", async () => {

--- a/test/moves/dynamax_cannon.test.ts
+++ b/test/moves/dynamax_cannon.test.ts
@@ -11,7 +11,7 @@ describe("Moves - Dynamax Cannon", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
-  const dynamaxCannon = allMoves[MoveId.DYNAMAX_CANNON];
+  const dynamaxCannon = allMoves.get(MoveId.DYNAMAX_CANNON);
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({

--- a/test/moves/effectiveness.test.ts
+++ b/test/moves/effectiveness.test.ts
@@ -30,7 +30,7 @@ function testMoveEffectiveness(
     overrideHeldItems(target, false);
   }
 
-  expect(target.getMoveEffectiveness(user, allMoves[moveId])).toBe(expected);
+  expect(target.getMoveEffectiveness(user, allMoves.get(moveId))).toBe(expected);
   user.destroy();
   target.destroy();
 }

--- a/test/moves/flail.test.ts
+++ b/test/moves/flail.test.ts
@@ -27,7 +27,7 @@ describe("Moves - Flail", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    flail = allMoves[MoveId.FLAIL];
+    flail = allMoves.get(MoveId.FLAIL);
     game.override
       .moveset(MoveId.FLAIL)
       .battleType("single")

--- a/test/moves/fly.test.ts
+++ b/test/moves/fly.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Fly", () => {
       .enemyAbility(Abilities.BALL_FETCH)
       .enemyMoveset(MoveId.TACKLE);
 
-    vi.spyOn(allMoves[MoveId.FLY], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.FLY), "accuracy", "get").mockReturnValue(100);
   });
 
   it("should make the user semi-invulnerable, then attack over 2 turns", async () => {

--- a/test/moves/foul_play.test.ts
+++ b/test/moves/foul_play.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Foul Play", () => {
 
   it("should use the target's Attack stat to calculate damage", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const foulPlay = allMoves[MoveId.FOUL_PLAY];
+    const foulPlay = allMoves.get(MoveId.FOUL_PLAY);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
@@ -54,7 +54,7 @@ describe("Moves - Foul Play", () => {
 
   it("should use the target's Attack stat stages during damage calculation", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const foulPlay = allMoves[MoveId.FOUL_PLAY];
+    const foulPlay = allMoves.get(MoveId.FOUL_PLAY);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
@@ -73,7 +73,7 @@ describe("Moves - Foul Play", () => {
 
   it("should only apply the user's Attack stat multipliers from abilities for damage", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const foulPlay = allMoves[MoveId.FOUL_PLAY];
+    const foulPlay = allMoves.get(MoveId.FOUL_PLAY);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
@@ -90,7 +90,7 @@ describe("Moves - Foul Play", () => {
 
   it("should apply damage reduction from the user's burn and not the target's", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const foulPlay = allMoves[MoveId.FOUL_PLAY];
+    const foulPlay = allMoves.get(MoveId.FOUL_PLAY);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();

--- a/test/moves/freezy_frost.test.ts
+++ b/test/moves/freezy_frost.test.ts
@@ -33,7 +33,7 @@ describe("Moves - Freezy Frost", () => {
       .moveset([MoveId.FREEZY_FROST, MoveId.HOWL, MoveId.SPLASH])
       .ability(Abilities.BALL_FETCH);
 
-    vi.spyOn(allMoves[MoveId.FREEZY_FROST], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.FREEZY_FROST), "accuracy", "get").mockReturnValue(100);
   });
 
   it("should clear stat changes of user and opponent", async () => {

--- a/test/moves/fusion_flare_bolt.test.ts
+++ b/test/moves/fusion_flare_bolt.test.ts
@@ -31,8 +31,8 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    fusionFlare = allMoves[MoveId.FUSION_FLARE];
-    fusionBolt = allMoves[MoveId.FUSION_BOLT];
+    fusionFlare = allMoves.get(MoveId.FUSION_FLARE);
+    fusionBolt = allMoves.get(MoveId.FUSION_BOLT);
     game.override.moveset([fusionFlare.id, fusionBolt.id]);
     game.override.startingLevel(1);
 

--- a/test/moves/future_sight.test.ts
+++ b/test/moves/future_sight.test.ts
@@ -258,7 +258,7 @@ describe("Moves - Future Sight", () => {
   it.todo("should invoke the move's first phase when called by Metronome", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
 
-    const randomMoveAttr = allMoves[MoveId.METRONOME].getAttrs(MetronomeAttr)[0];
+    const randomMoveAttr = allMoves.get(MoveId.METRONOME).getAttrs(MetronomeAttr)[0];
     vi.spyOn(randomMoveAttr, "getRandomMove").mockReturnValue(MoveId.FUTURE_SIGHT);
 
     const enemy = game.field.getEnemyPokemon();

--- a/test/moves/hard_press.test.ts
+++ b/test/moves/hard_press.test.ts
@@ -11,7 +11,7 @@ describe("Moves - Hard Press", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
-  const moveToCheck = allMoves[MoveId.HARD_PRESS];
+  const moveToCheck = allMoves.get(MoveId.HARD_PRESS);
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({

--- a/test/moves/hyper_beam.test.ts
+++ b/test/moves/hyper_beam.test.ts
@@ -34,7 +34,7 @@ describe("Moves - Hyper Beam", () => {
     game.override.enemyLevel(100);
 
     game.override.moveset([MoveId.HYPER_BEAM, MoveId.TACKLE]);
-    vi.spyOn(allMoves[MoveId.HYPER_BEAM], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.HYPER_BEAM), "accuracy", "get").mockReturnValue(100);
   });
 
   it("should force the user to recharge on the next turn (and only that turn)", async () => {

--- a/test/moves/lash_out.test.ts
+++ b/test/moves/lash_out.test.ts
@@ -37,13 +37,13 @@ describe("Moves - Lash Out", () => {
   });
 
   it("should deal double damage if the user's stat stages were lowered this turn", async () => {
-    vi.spyOn(allMoves[MoveId.LASH_OUT], "calculateBattlePower");
+    vi.spyOn(allMoves.get(MoveId.LASH_OUT), "calculateBattlePower");
     await game.classicMode.startBattle();
 
     game.move.select(MoveId.LASH_OUT);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
 
-    expect(allMoves[MoveId.LASH_OUT].calculateBattlePower).toHaveReturnedWith(150);
+    expect(allMoves.get(MoveId.LASH_OUT).calculateBattlePower).toHaveReturnedWith(150);
   });
 });

--- a/test/moves/metronome.test.ts
+++ b/test/moves/metronome.test.ts
@@ -16,7 +16,7 @@ describe("Moves - Metronome", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
-  const randomMoveAttr = allMoves[MoveId.METRONOME].getAttrs(MetronomeAttr)[0];
+  const randomMoveAttr = allMoves.get(MoveId.METRONOME).getAttrs(MetronomeAttr)[0];
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({
@@ -72,7 +72,7 @@ describe("Moves - Metronome", () => {
     await game.classicMode.startBattle();
     const player = game.scene.getPlayerPokemon()!;
     vi.spyOn(randomMoveAttr, "getRandomMove").mockReturnValue(MoveId.HYPER_BEAM);
-    vi.spyOn(allMoves[MoveId.HYPER_BEAM], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.HYPER_BEAM), "accuracy", "get").mockReturnValue(100);
 
     game.move.select(MoveId.METRONOME);
     await game.toNextTurn();
@@ -128,7 +128,7 @@ describe("Moves - Metronome", () => {
       rngSweepProgress = (2 * i + 1) / (2 * trials);
 
       const moveId = randomMoveAttr.getRandomMove(user);
-      expect(allMoves[moveId].hasFlag(MoveFlags.G_MAX_MOVE)).toBe(false);
+      expect(allMoves.get(moveId).hasFlag(MoveFlags.G_MAX_MOVE)).toBe(false);
     }
   });
 });

--- a/test/moves/moongeist_beam.test.ts
+++ b/test/moves/moongeist_beam.test.ts
@@ -49,7 +49,7 @@ describe("Moves - Moongeist Beam", () => {
   // Also covers Photon Geyser and Sunsteel Strike
   it("should not ignore enemy abilities when called by another move, such as metronome", async () => {
     await game.classicMode.startBattle([Species.MILOTIC]);
-    vi.spyOn(allMoves[MoveId.METRONOME].getAttrs(MetronomeAttr)[0], "getRandomMove").mockReturnValue(
+    vi.spyOn(allMoves.get(MoveId.METRONOME).getAttrs(MetronomeAttr)[0], "getRandomMove").mockReturnValue(
       MoveId.MOONGEIST_BEAM,
     );
 

--- a/test/moves/ohko.test.ts
+++ b/test/moves/ohko.test.ts
@@ -90,7 +90,7 @@ describe("Moves - One Hit KO Moves", () => {
   it("OHKO moves accuracy goes up by 1% for each level the user is above the target", async () => {
     game.override.startingLevel(142).enemySpecies(Species.ARCEUS).ability(Abilities.BALL_FETCH);
     await game.classicMode.startBattle([Species.ALAKAZAM]);
-    const moveToCheck = allMoves[MoveId.GUILLOTINE];
+    const moveToCheck = allMoves.get(MoveId.GUILLOTINE);
 
     vi.spyOn(moveToCheck, "calculateBattleAccuracy");
 

--- a/test/moves/photon_geyser.test.ts
+++ b/test/moves/photon_geyser.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Moves - Photon Geyser", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const photonGeyserAttr = allMoves[MoveId.PHOTON_GEYSER].getAttrs(UseHigherAttackingStatAttr)[0];
+  const photonGeyserAttr = allMoves.get(MoveId.PHOTON_GEYSER).getAttrs(UseHigherAttackingStatAttr)[0];
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({

--- a/test/moves/pledge_moves.test.ts
+++ b/test/moves/pledge_moves.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Pledge Moves", () => {
   it("Fire Pledge - should be an 80-power Fire-type attack outside of combination", async () => {
     await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
 
-    const firePledge = allMoves[MoveId.FIRE_PLEDGE];
+    const firePledge = allMoves.get(MoveId.FIRE_PLEDGE);
     vi.spyOn(firePledge, "calculateBattlePower");
 
     const playerPokemon = game.scene.getPlayerField();
@@ -62,7 +62,7 @@ describe("Moves - Pledge Moves", () => {
   it("Fire Pledge - should not combine with an ally using Fire Pledge", async () => {
     await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
 
-    const firePledge = allMoves[MoveId.FIRE_PLEDGE];
+    const firePledge = allMoves.get(MoveId.FIRE_PLEDGE);
     vi.spyOn(firePledge, "calculateBattlePower");
 
     const playerPokemon = game.scene.getPlayerField();
@@ -108,7 +108,7 @@ describe("Moves - Pledge Moves", () => {
   it("Grass Pledge - should combine with Fire Pledge to form a 150-power Fire-type attack that creates a 'sea of fire'", async () => {
     await game.classicMode.startBattle([Species.CHARIZARD, Species.BLASTOISE]);
 
-    const grassPledge = allMoves[MoveId.GRASS_PLEDGE];
+    const grassPledge = allMoves.get(MoveId.GRASS_PLEDGE);
     vi.spyOn(grassPledge, "calculateBattlePower");
 
     const playerPokemon = game.scene.getPlayerField();
@@ -167,7 +167,7 @@ describe("Moves - Pledge Moves", () => {
 
     await game.classicMode.startBattle([Species.BLASTOISE, Species.VENUSAUR]);
 
-    const firePledge = allMoves[MoveId.FIRE_PLEDGE];
+    const firePledge = allMoves.get(MoveId.FIRE_PLEDGE);
     vi.spyOn(firePledge, "calculateBattlePower");
 
     const playerPokemon = game.scene.getPlayerField();
@@ -205,7 +205,7 @@ describe("Moves - Pledge Moves", () => {
   it("Water Pledge - should combine with Grass Pledge to form a 150-power Grass-type attack that creates a 'swamp'", async () => {
     await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
 
-    const waterPledge = allMoves[MoveId.WATER_PLEDGE];
+    const waterPledge = allMoves.get(MoveId.WATER_PLEDGE);
     vi.spyOn(waterPledge, "calculateBattlePower");
 
     const playerPokemon = game.scene.getPlayerField();
@@ -257,7 +257,7 @@ describe("Moves - Pledge Moves", () => {
 
     await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
 
-    const ironHeadFlinchAttr = allMoves[MoveId.IRON_HEAD].getAttrs(FlinchAttr)[0];
+    const ironHeadFlinchAttr = allMoves.get(MoveId.IRON_HEAD).getAttrs(FlinchAttr)[0];
     vi.spyOn(ironHeadFlinchAttr, "getMoveChance");
 
     game.move.select(MoveId.WATER_PLEDGE, 0, BattlerIndex.ENEMY);

--- a/test/moves/present.test.ts
+++ b/test/moves/present.test.ts
@@ -37,7 +37,7 @@ describe("Moves - Present", () => {
     { descriptor: "first hit", hitsLeft: 2, totalOutcomes: 100, expectedHeals: 20 },
     { descriptor: "subsequent hits", hitsLeft: 1, totalOutcomes: 80, expectedHeals: 0 },
   ])("should have correct probabilities on $descriptor", async ({ hitsLeft, totalOutcomes, expectedHeals }) => {
-    const presentAttr = allMoves[MoveId.PRESENT].getAttrs(PresentPowerAttr)[0];
+    const presentAttr = allMoves.get(MoveId.PRESENT).getAttrs(PresentPowerAttr)[0];
 
     await game.classicMode.startBattle([Species.FEEBAS]);
 
@@ -60,7 +60,7 @@ describe("Moves - Present", () => {
       rngSweepProgress = (2 * i + 1) / (2 * totalOutcomes);
 
       const power = new NumberHolder(-1);
-      presentAttr.apply(player, enemy, allMoves[MoveId.PRESENT], power);
+      presentAttr.apply(player, enemy, allMoves.get(MoveId.PRESENT), power);
       switch (power.value) {
         case 40:
           count40power++;

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -55,7 +55,7 @@ describe("Moves - Protect", () => {
 
   test("should prevent secondary effects from the opponent's attack", async () => {
     game.override.enemyMoveset([MoveId.CEASELESS_EDGE]);
-    vi.spyOn(allMoves[MoveId.CEASELESS_EDGE], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.CEASELESS_EDGE), "accuracy", "get").mockReturnValue(100);
 
     await game.classicMode.startBattle([Species.CHARIZARD]);
 

--- a/test/moves/psyshock.test.ts
+++ b/test/moves/psyshock.test.ts
@@ -46,7 +46,7 @@ describe("Moves - Psyshock", () => {
 
   it("should use the user's Sp. Atk stat stages during damage calculation", async () => {
     await game.classicMode.startBattle([Species.FEEBAS]);
-    const psyshock = allMoves[MoveId.PSYSHOCK];
+    const psyshock = allMoves.get(MoveId.PSYSHOCK);
 
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();

--- a/test/moves/retaliate.test.ts
+++ b/test/moves/retaliate.test.ts
@@ -9,7 +9,7 @@ describe("Moves - Retaliate", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
-  const retaliate = allMoves[MoveId.RETALIATE];
+  const retaliate = allMoves.get(MoveId.RETALIATE);
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({

--- a/test/moves/rollout.test.ts
+++ b/test/moves/rollout.test.ts
@@ -36,7 +36,7 @@ describe("Moves - Rollout", () => {
 
   it("should double it's dmg on sequential uses but reset after 5", async () => {
     game.override.moveset([MoveId.ROLLOUT]);
-    vi.spyOn(allMoves[MoveId.ROLLOUT], "accuracy", "get").mockReturnValue(100); //always hit
+    vi.spyOn(allMoves.get(MoveId.ROLLOUT), "accuracy", "get").mockReturnValue(100); //always hit
 
     const variance = 5;
     const turns = 6;

--- a/test/moves/round.test.ts
+++ b/test/moves/round.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Round", () => {
   it("should cue other instances of Round together in Speed order", async () => {
     await game.classicMode.startBattle([Species.BLISSEY, Species.FEEBAS]);
 
-    const round = allMoves[MoveId.ROUND];
+    const round = allMoves.get(MoveId.ROUND);
     const spy = vi.spyOn(round, "calculateBattlePower");
 
     game.move.select(MoveId.ROUND, 0, BattlerIndex.ENEMY);

--- a/test/moves/scale_shot.test.ts
+++ b/test/moves/scale_shot.test.ts
@@ -62,7 +62,7 @@ describe("Moves - Scale Shot", () => {
   });
 
   it("unaffected by sheer force", async () => {
-    const moveToCheck = allMoves[MoveId.SCALE_SHOT];
+    const moveToCheck = allMoves.get(MoveId.SCALE_SHOT);
     const basePower = moveToCheck.power;
 
     game.override.enemySpecies(Species.WOBBUFFET);

--- a/test/moves/secret_power.test.ts
+++ b/test/moves/secret_power.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Secret Power", () => {
 
   it("Secret Power checks for an active terrain first then looks at the biome for its secondary effect", async () => {
     game.override.startingBiome(Biome.VOLCANO).enemyMoveset([MoveId.SPLASH, MoveId.MISTY_TERRAIN]);
-    vi.spyOn(allMoves[MoveId.SECRET_POWER], "chance", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.SECRET_POWER), "chance", "get").mockReturnValue(100);
     await game.classicMode.startBattle([Species.FEEBAS]);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/test/moves/shell_side_arm.test.ts
+++ b/test/moves/shell_side_arm.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Moves - Shell Side Arm", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const shellSideArm = allMoves[MoveId.SHELL_SIDE_ARM];
+  const shellSideArm = allMoves.get(MoveId.SHELL_SIDE_ARM);
   const shellSideArmAttr = shellSideArm.getAttrs(ShellSideArmCategoryAttr)[0];
 
   beforeAll(() => {

--- a/test/moves/shell_trap.test.ts
+++ b/test/moves/shell_trap.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Shell Trap", () => {
       .startingLevel(100)
       .enemyLevel(100);
 
-    vi.spyOn(allMoves[MoveId.RAZOR_LEAF], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.RAZOR_LEAF), "accuracy", "get").mockReturnValue(100);
   });
 
   it("should activate after the user is hit by a physical attack", async () => {
@@ -130,7 +130,7 @@ describe("Moves - Shell Trap", () => {
 
   it("should not activate from a subsequent physical attack", async () => {
     game.override.battleType("single");
-    vi.spyOn(allMoves[MoveId.RAZOR_LEAF], "priority", "get").mockReturnValue(-4);
+    vi.spyOn(allMoves.get(MoveId.RAZOR_LEAF), "priority", "get").mockReturnValue(-4);
 
     await game.startBattle([Species.CHARIZARD]);
 

--- a/test/moves/sketch.test.ts
+++ b/test/moves/sketch.test.ts
@@ -81,9 +81,9 @@ describe("Moves - Sketch", () => {
   });
 
   it("should sketch moves that call other moves", async () => {
-    const randomMoveAttr = allMoves[MoveId.METRONOME].findAttr(
-      (attr) => attr instanceof MetronomeAttr,
-    ) as MetronomeAttr;
+    const randomMoveAttr = allMoves
+      .get(MoveId.METRONOME)
+      .findAttr((attr) => attr instanceof MetronomeAttr) as MetronomeAttr;
     vi.spyOn(randomMoveAttr, "getRandomMove").mockReturnValue(MoveId.FALSE_SWIPE);
 
     game.override.enemyMoveset([MoveId.METRONOME]);

--- a/test/moves/solar_beam.test.ts
+++ b/test/moves/solar_beam.test.ts
@@ -89,7 +89,7 @@ describe("Moves - Solar Beam", () => {
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
-    const solarBeam = allMoves[MoveId.SOLAR_BEAM];
+    const solarBeam = allMoves.get(MoveId.SOLAR_BEAM);
 
     vi.spyOn(solarBeam, "calculateBattlePower");
 

--- a/test/moves/sparkly_swirl.test.ts
+++ b/test/moves/sparkly_swirl.test.ts
@@ -30,7 +30,7 @@ describe("Moves - Sparkly Swirl", () => {
       .moveset([MoveId.SPARKLY_SWIRL, MoveId.SPLASH])
       .ability(Abilities.BALL_FETCH);
 
-    vi.spyOn(allMoves[MoveId.SPARKLY_SWIRL], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.SPARKLY_SWIRL), "accuracy", "get").mockReturnValue(100);
   });
 
   it("should cure status effect of the user, its ally, and all party pokemon", async () => {

--- a/test/moves/spectral_thief.test.ts
+++ b/test/moves/spectral_thief.test.ts
@@ -47,7 +47,7 @@ describe("Moves - Spectral Thief", () => {
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 
     await game.phaseInterceptor.to("MoveEndPhase");
-    const preEffectDamage = enemy.getAttackDamage(player, allMoves[MoveId.SPECTRAL_THIEF]).damage;
+    const preEffectDamage = enemy.getAttackDamage(player, allMoves.get(MoveId.SPECTRAL_THIEF)).damage;
 
     await game.phaseInterceptor.to("MoveEffectPhase");
 

--- a/test/moves/spit_up.test.ts
+++ b/test/moves/spit_up.test.ts
@@ -16,7 +16,7 @@ describe("Moves - Spit Up", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
-  const spitUp = allMoves[MoveId.SPIT_UP];
+  const spitUp = allMoves.get(MoveId.SPIT_UP);
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({ type: Phaser.HEADLESS });

--- a/test/moves/steamroller.test.ts
+++ b/test/moves/steamroller.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Steamroller", () => {
     const ditto = game.scene.getEnemyPokemon()!;
     vi.spyOn(ditto, "getAttackDamage");
     ditto.hp = 5000;
-    const steamroller = allMoves[MoveId.STEAMROLLER];
+    const steamroller = allMoves.get(MoveId.STEAMROLLER);
     vi.spyOn(steamroller, "calculateBattleAccuracy");
     const ironBoulder = game.scene.getPlayerPokemon()!;
     vi.spyOn(ironBoulder, "getAccuracyMultiplier");

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -83,7 +83,7 @@ describe("Moves - Substitute", () => {
   it("should fade after redirecting more damage than its remaining HP", async () => {
     // Giga Impact OHKOs Magikarp if substitute isn't up
     game.override.enemyMoveset(MoveId.GIGA_IMPACT);
-    vi.spyOn(allMoves[MoveId.GIGA_IMPACT], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.GIGA_IMPACT), "accuracy", "get").mockReturnValue(100);
 
     await game.classicMode.startBattle([Species.MAGIKARP]);
 
@@ -249,7 +249,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should protect the user from being trapped", async () => {
-    vi.spyOn(allMoves[MoveId.SAND_TOMB], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.SAND_TOMB), "accuracy", "get").mockReturnValue(100);
     game.override.enemyMoveset(MoveId.SAND_TOMB);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
@@ -266,7 +266,7 @@ describe("Moves - Substitute", () => {
   });
 
   it("should prevent the user's stats from being lowered", async () => {
-    vi.spyOn(allMoves[MoveId.LIQUIDATION], "chance", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.LIQUIDATION), "chance", "get").mockReturnValue(100);
     game.override.enemyMoveset(MoveId.LIQUIDATION);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
@@ -300,7 +300,7 @@ describe("Moves - Substitute", () => {
 
   it("should prevent the user's items from being stolen", async () => {
     game.override.enemyMoveset(MoveId.THIEF);
-    vi.spyOn(allMoves[MoveId.THIEF], "attrs", "get").mockReturnValue([new StealHeldItemChanceAttr(1.0)]); // give Thief 100% steal rate
+    vi.spyOn(allMoves.get(MoveId.THIEF), "attrs", "get").mockReturnValue([new StealHeldItemChanceAttr(1.0)]); // give Thief 100% steal rate
     game.override.startingHeldItems([{ name: "BERRY", type: BerryType.SITRUS }]);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
@@ -374,7 +374,7 @@ describe("Moves - Substitute", () => {
 
   it("should prevent the user from becoming confused", async () => {
     game.override.enemyMoveset(MoveId.MAGICAL_TORQUE);
-    vi.spyOn(allMoves[MoveId.MAGICAL_TORQUE], "chance", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.MAGICAL_TORQUE), "chance", "get").mockReturnValue(100);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 
@@ -432,7 +432,7 @@ describe("Moves - Substitute", () => {
     game.override.moveset([MoveId.FOCUS_PUNCH]);
 
     // Make Focus Punch 40 power to avoid a KO
-    vi.spyOn(allMoves[MoveId.FOCUS_PUNCH], "calculateBattlePower").mockReturnValue(40);
+    vi.spyOn(allMoves.get(MoveId.FOCUS_PUNCH), "calculateBattlePower").mockReturnValue(40);
 
     await game.classicMode.startBattle([Species.BLASTOISE]);
 

--- a/test/moves/telekinesis.test.ts
+++ b/test/moves/telekinesis.test.ts
@@ -44,7 +44,7 @@ describe("Moves - Telekinesis", () => {
     expect(enemyOpponent.getTag(BattlerTagType.FLOATING)).toBeDefined();
 
     await game.toNextTurn();
-    vi.spyOn(allMoves[MoveId.TACKLE], "accuracy", "get").mockReturnValue(0);
+    vi.spyOn(allMoves.get(MoveId.TACKLE), "accuracy", "get").mockReturnValue(0);
     game.move.select(MoveId.TACKLE);
     await game.toEndOfTurn();
     expect(enemyOpponent.isFullHp()).toBe(false);
@@ -61,7 +61,7 @@ describe("Moves - Telekinesis", () => {
     expect(enemyOpponent.getTag(BattlerTagType.FLOATING)).toBeDefined();
 
     await game.toNextTurn();
-    vi.spyOn(allMoves[MoveId.MUD_SHOT], "accuracy", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.MUD_SHOT), "accuracy", "get").mockReturnValue(100);
     game.move.select(MoveId.MUD_SHOT);
     await game.toEndOfTurn();
     expect(enemyOpponent.isFullHp()).toBe(true);
@@ -111,7 +111,7 @@ describe("Moves - Telekinesis", () => {
     expect(enemyOpponent.getTag(BattlerTagType.FLOATING)).toBeDefined();
 
     await game.toNextTurn();
-    vi.spyOn(allMoves[MoveId.MUD_SHOT], "accuracy", "get").mockReturnValue(0);
+    vi.spyOn(allMoves.get(MoveId.MUD_SHOT), "accuracy", "get").mockReturnValue(0);
     game.move.select(MoveId.MUD_SHOT);
     await game.forceEnemyMove(MoveId.INGRAIN);
     await game.toEndOfTurn();

--- a/test/moves/tera_blast.test.ts
+++ b/test/moves/tera_blast.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Moves - Tera Blast", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const moveToCheck = allMoves[MoveId.TERA_BLAST];
+  const moveToCheck = allMoves.get(MoveId.TERA_BLAST);
 
   beforeAll(() => {
     phaserGame = new Phaser.Game({

--- a/test/moves/thrash.test.ts
+++ b/test/moves/thrash.test.ts
@@ -35,7 +35,7 @@ describe("Moves - Thrash", () => {
       .startingLevel(100)
       .enemyLevel(100);
 
-    vi.spyOn(allMoves[MoveId.ASTONISH], "chance", "get").mockReturnValue(100);
+    vi.spyOn(allMoves.get(MoveId.ASTONISH), "chance", "get").mockReturnValue(100);
   });
 
   it("should lock the user into using Thrash for 1-2 turns, then confuse the user", async () => {

--- a/test/moves/toxic.test.ts
+++ b/test/moves/toxic.test.ts
@@ -27,7 +27,7 @@ describe("Moves - Toxic", () => {
   });
 
   it("should be guaranteed to hit if user is Poison-type", async () => {
-    vi.spyOn(allMoves[MoveId.TOXIC], "accuracy", "get").mockReturnValue(0);
+    vi.spyOn(allMoves.get(MoveId.TOXIC), "accuracy", "get").mockReturnValue(0);
     await game.classicMode.startBattle([Species.TOXAPEX]);
 
     game.move.select(MoveId.TOXIC);
@@ -37,7 +37,7 @@ describe("Moves - Toxic", () => {
   });
 
   it("may miss if user is not Poison-type", async () => {
-    vi.spyOn(allMoves[MoveId.TOXIC], "accuracy", "get").mockReturnValue(0);
+    vi.spyOn(allMoves.get(MoveId.TOXIC), "accuracy", "get").mockReturnValue(0);
     await game.classicMode.startBattle([Species.UMBREON]);
 
     game.move.select(MoveId.TOXIC);
@@ -47,7 +47,7 @@ describe("Moves - Toxic", () => {
   });
 
   it("should hit semi-invulnerable targets if user is Poison-type", async () => {
-    vi.spyOn(allMoves[MoveId.TOXIC], "accuracy", "get").mockReturnValue(0);
+    vi.spyOn(allMoves.get(MoveId.TOXIC), "accuracy", "get").mockReturnValue(0);
     game.override.enemyMoveset(MoveId.FLY);
     await game.classicMode.startBattle([Species.TOXAPEX]);
 
@@ -59,7 +59,7 @@ describe("Moves - Toxic", () => {
   });
 
   it("should miss semi-invulnerable targets if user is not Poison-type", async () => {
-    vi.spyOn(allMoves[MoveId.TOXIC], "accuracy", "get").mockReturnValue(-1);
+    vi.spyOn(allMoves.get(MoveId.TOXIC), "accuracy", "get").mockReturnValue(-1);
     game.override.enemyMoveset(MoveId.FLY);
     await game.classicMode.startBattle([Species.UMBREON]);
 

--- a/test/moves/triple_arrows.test.ts
+++ b/test/moves/triple_arrows.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 describe("Moves - Triple Arrows", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
-  const tripleArrows = allMoves[MoveId.TRIPLE_ARROWS];
+  const tripleArrows = allMoves.get(MoveId.TRIPLE_ARROWS);
   const flinchAttr = tripleArrows.getAttrs(FlinchAttr)[0];
   const defDropAttr = tripleArrows.getAttrs(StatStageChangeAttr)[0];
 

--- a/test/testUtils/gameManager.ts
+++ b/test/testUtils/gameManager.ts
@@ -401,12 +401,12 @@ export class GameManager {
     const legalTargets = getMoveTargets(enemy, moveId);
 
     vi.spyOn(enemy, "getNextMove").mockReturnValueOnce({
-      move: allMoves[moveId],
+      move: allMoves.get(moveId),
       targets:
         target !== undefined && !legalTargets.multiple && legalTargets.targets.includes(target)
           ? [target]
           : enemy.getNextTargets(moveId),
-      type: enemy.getMoveType(allMoves[moveId]),
+      type: enemy.getMoveType(allMoves.get(moveId)),
     });
 
     /**

--- a/test/testUtils/helpers/moveHelper.ts
+++ b/test/testUtils/helpers/moveHelper.ts
@@ -137,12 +137,12 @@ export class MoveHelper extends GameManagerHelper {
     const legalTargets = getMoveTargets(enemy, moveId);
 
     vi.spyOn(enemy, "getNextMove").mockReturnValueOnce({
-      move: allMoves[moveId],
+      move: allMoves.get(moveId),
       targets:
         target !== undefined && !legalTargets.multiple && legalTargets.targets.includes(target)
           ? [target]
           : enemy.getNextTargets(moveId),
-      type: enemy.getMoveType(allMoves[moveId]),
+      type: enemy.getMoveType(allMoves.get(moveId)),
     });
 
     /**
@@ -182,12 +182,12 @@ export class MoveHelper extends GameManagerHelper {
     const legalTargets = getMoveTargets(enemy, moveId);
 
     vi.spyOn(enemy, "getNextMove").mockReturnValueOnce({
-      move: allMoves[moveId],
+      move: allMoves.get(moveId),
       targets:
         target !== undefined && !legalTargets.multiple && legalTargets.targets.includes(target)
           ? [target]
           : enemy.getNextTargets(moveId),
-      type: enemy.getMoveType(allMoves[moveId]),
+      type: enemy.getMoveType(allMoves.get(moveId)),
     });
 
     /**

--- a/test/testUtils/testFileInitialization.ts
+++ b/test/testUtils/testFileInitialization.ts
@@ -28,7 +28,7 @@ import { initModifierPools } from "#app/modifier/init-modifier-pools";
  */
 export function initDataForTests() {
   // Initialize all of these things if and only if they have not been initialized yet
-  if (Object.values(allMoves).length === 0) {
+  if (allMoves.size === 0) {
     initModifierTypes();
     initModifierPools();
     initMoves();


### PR DESCRIPTION
## What are the changes the user will see?
Potentially faster loading and/or improved performance.

## Why am I making these changes?
https://thelinuxcode.com/mastering-javascript-maps-an-expert-guide/

## What are the changes from a developer perspective?
- The definition of `allMoves` was changed from an object to a `Map` in `src/data/data-lists.ts`.
- All uses of `allMoves[...]` were replaced with `allMoves.get(...)`.
- `Object.values(allMoves)` replaced with `allMoves.values()`.
- `allMoves[move.id] = move` replaced with `allMoves.set(move.id, move)` in `src/data/init-moves.ts`.
- `loadMoveAnimAssets()` in `src/utils/move-anim-utils.ts` simplified.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)