### PR TITLE
[Misc] Remove unused `target` and `move` params from anonymous function in `IncrementMovePriorityAttr`

### DIFF
--- a/src/data/init-moves.ts
+++ b/src/data/init-moves.ts
@@ -3249,10 +3249,11 @@ export function initMoves() {
       )
       .condition(failIfDampCondition)
       .makesContact(false),
-    new AttackMove(MoveId.GRASSY_GLIDE, ElementalType.GRASS, MoveCategory.PHYSICAL, 55, 100, 20, -1, 0, 8).attr(
-      IncrementMovePriorityAttr,
-      (user, _target, _move) => globalScene.arena.hasTerrain(TerrainType.GRASSY) && user.isGrounded(),
-    ),
+    new AttackMove(MoveId.GRASSY_GLIDE, ElementalType.GRASS, MoveCategory.PHYSICAL, 55, 100, 20, -1, 0, 8)
+      .attr(
+        IncrementMovePriorityAttr,
+        (user) => globalScene.arena.hasTerrain(TerrainType.GRASSY) && user.isGrounded(),
+      ),
     new AttackMove(MoveId.RISING_VOLTAGE, ElementalType.ELECTRIC, MoveCategory.SPECIAL, 70, 100, 20, -1, 0, 8).attr(
       MovePowerMultiplierAttr,
       (_user, target, _move) => (globalScene.arena.hasTerrain(TerrainType.ELECTRIC) && target.isGrounded() ? 2 : 1),

--- a/src/data/move-attrs/increment-move-priority-attr.ts
+++ b/src/data/move-attrs/increment-move-priority-attr.ts
@@ -3,19 +3,20 @@ import type { NumberHolder } from "#app/utils";
 import type { Move } from "#app/data/move";
 import { MoveAttr } from "#app/data/move-attrs/move-attr";
 
+type MoveIncrementFunc = (pokemon: Pokemon, target: Pokemon | null, move: Move) => boolean;
+
 /**
  * Attribute used for moves that change priority in a turn given a condition.
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Grassy_Glide_(move) | Grassy Glide}.
  * @extends MoveAttr
  */
-
 export class IncrementMovePriorityAttr extends MoveAttr {
   /** The condition for a move's priority being incremented */
-  private moveIncrementFunc: (pokemon: Pokemon, target: Pokemon, move: Move) => boolean;
+  private moveIncrementFunc: MoveIncrementFunc;
   /** The amount to increment priority by, if condition passes. */
   private increaseAmount: number;
 
-  constructor(moveIncrementFunc: (pokemon: Pokemon, target: Pokemon, move: Move) => boolean, increaseAmount = 1) {
+  constructor(moveIncrementFunc: MoveIncrementFunc, increaseAmount = 1) {
     super();
 
     this.moveIncrementFunc = moveIncrementFunc;
@@ -30,7 +31,7 @@ export class IncrementMovePriorityAttr extends MoveAttr {
    * @param priority {@linkcode NumberHolder} containing the move's priority for this turn.
    * @returns true if function succeeds
    */
-  override apply(user: Pokemon, target: Pokemon, move: Move, priority: NumberHolder): boolean {
+  override apply(user: Pokemon, target: Pokemon | null, move: Move, priority: NumberHolder): boolean {
     if (!this.moveIncrementFunc(user, target, move)) {
       return false;
     }

--- a/src/data/move-attrs/increment-move-priority-attr.ts
+++ b/src/data/move-attrs/increment-move-priority-attr.ts
@@ -3,7 +3,7 @@ import type { NumberHolder } from "#app/utils";
 import type { Move } from "#app/data/move";
 import { MoveAttr } from "#app/data/move-attrs/move-attr";
 
-type MoveIncrementFunc = (pokemon: Pokemon, target: Pokemon | null, move: Move) => boolean;
+type MoveIncrementFunc = (pokemon: Pokemon) => boolean;
 
 /**
  * Attribute used for moves that change priority in a turn given a condition.
@@ -31,8 +31,8 @@ export class IncrementMovePriorityAttr extends MoveAttr {
    * @param priority {@linkcode NumberHolder} containing the move's priority for this turn.
    * @returns true if function succeeds
    */
-  override apply(user: Pokemon, target: Pokemon | null, move: Move, priority: NumberHolder): boolean {
-    if (!this.moveIncrementFunc(user, target, move)) {
+  override apply(user: Pokemon, _target: Pokemon | null, _move: Move, priority: NumberHolder): boolean {
+    if (!this.moveIncrementFunc(user)) {
       return false;
     }
 

--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -810,8 +810,6 @@ export abstract class Move implements Localizable {
   getPriority(user: Pokemon, simulated: boolean = true) {
     const priority = new NumberHolder(this.priority);
 
-    // TODO: Let this attribute accept null targets
-    // @ts-ignore
     applyMoveAttrs(IncrementMovePriorityAttr, user, null, this, priority);
     applyAbAttrs(AbAttrFlag.CHANGE_MOVE_PRIORITY, user, simulated, this, priority);
 

--- a/test/moves/grassy_glide.test.ts
+++ b/test/moves/grassy_glide.test.ts
@@ -1,0 +1,66 @@
+import { Abilities } from "#enums/abilities";
+import { BattlerIndex } from "#enums/battler-index";
+import { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { TerrainType } from "#enums/terrain-type";
+import { GameManager } from "#test/testUtils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Moves - Grassy Glide", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(Abilities.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(Species.REGIELEKI)
+      .enemyAbility(Abilities.BALL_FETCH)
+      .enemyPassiveAbility(Abilities.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should have increased priority with active Grassy Terrain", async () => {
+    game.override.ability(Abilities.GRASSY_SURGE);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
+
+    game.move.use(MoveId.GRASSY_GLIDE);
+    await game.toEndOfTurn();
+
+    expect(game.scene.arena.getTerrainType()).toEqual(TerrainType.GRASSY);
+    expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+  });
+
+  it.each([
+    { terrain: "active Electric Terrain", terrainAbility: Abilities.ELECTRIC_SURGE, terrainType: TerrainType.ELECTRIC },
+    { terrain: "active Misty Terrain", terrainAbility: Abilities.MISTY_SURGE, terrainType: TerrainType.MISTY },
+    { terrain: "active Psychic Terrain", terrainAbility: Abilities.PSYCHIC_SURGE, terrainType: TerrainType.PSYCHIC },
+    { terrain: "no active terrain", terrainAbility: Abilities.BALL_FETCH, terrainType: TerrainType.NONE },
+  ])("should not have increased priority with $terrain", async ({ terrainAbility, terrainType }) => {
+    game.override.ability(terrainAbility);
+    await game.classicMode.startBattle([Species.SHUCKLE]);
+
+    game.move.use(MoveId.GRASSY_GLIDE);
+    await game.toEndOfTurn();
+
+    expect(game.scene.arena.getTerrainType()).toEqual(terrainType);
+    expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
+  });
+});

--- a/test/moves/grassy_glide.test.ts
+++ b/test/moves/grassy_glide.test.ts
@@ -63,4 +63,16 @@ describe("Moves - Grassy Glide", () => {
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
   });
+
+  it("should not have increased priority if the user is ungrounded in Grassy Terrain", async () => {
+    game.override.ability(Abilities.GRASSY_SURGE);
+    await game.classicMode.startBattle([Species.VESPIQUEN]);
+
+    game.move.use(MoveId.GRASSY_GLIDE);
+    await game.toEndOfTurn();
+
+    expect(game.scene.arena.getTerrainType()).toEqual(TerrainType.GRASSY);
+    expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Removing a `// @ts-ignore`.

## What are the changes from a developer perspective?
`null` is now valid to be passed in as the `target` param of `IncrementMovePriorityAttr.apply()`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?