### PR TITLE
[Misc] `StatsContainer.updateIvs()` now has proper param typing

### DIFF
--- a/src/ui/starter-select-ui-handler.ts
+++ b/src/ui/starter-select-ui-handler.ts
@@ -3037,8 +3037,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
         this.showStats();
       } else {
         this.statsContainer.setVisible(false);
-        //@ts-ignore
-        this.statsContainer.updateIvs(null); // TODO: resolve ts-ignore. what. how? huh?
+        this.statsContainer.updateIvs(null);
       }
     }
 
@@ -4035,8 +4034,7 @@ export default class StarterSelectUiHandler extends MessageUiHandler {
       this.statsMode = false;
       this.statsContainer.setVisible(false);
       this.pokemonSprite.setVisible(!!this.speciesStarterDexEntry?.caughtAttr);
-      //@ts-ignore
-      this.statsContainer.updateIvs(null); // TODO: resolve ts-ignore. !?!?
+      this.statsContainer.updateIvs(null);
     }
   }
 

--- a/src/ui/stats-container.ts
+++ b/src/ui/stats-container.ts
@@ -105,68 +105,69 @@ export class StatsContainer extends Phaser.GameObjects.Container {
     }
   }
 
-  updateIvs(ivs: number[], originalIvs?: number[]): void {
-    if (ivs) {
-      const ivChartData = new Array(6)
-        .fill(null)
-        .map((_, i) => [
-          (ivs[ivChartStatIndexes[i]] / 31) * ivChartSize * ivChartStatCoordMultipliers[ivChartStatIndexes[i]][0],
-          (ivs[ivChartStatIndexes[i]] / 31) * ivChartSize * ivChartStatCoordMultipliers[ivChartStatIndexes[i]][1],
-        ])
-        .flat();
-      const lastIvChartData = this.statsIvsCache || defaultIvChartData;
-      this.statsIvsCache = ivChartData.slice(0);
-
-      this.ivStatValueTexts.map((t: BBCodeText, i: number) => {
-        let label = "";
-
-        // Check to see if IVs are 31, if so change the text style to gold, otherwise leave them be.
-        if (ivs[i] === 31) {
-          label += getBBCodeFragment(ivs[i].toString(), TextStyle.PERFECT_IV, true, true);
-        } else {
-          label = ivs[i].toString();
-        }
-        if (this.showDiff && originalIvs) {
-          if (originalIvs[i] < ivs[i]) {
-            label += ` (${getBBCodeFragment(`+${ivs[i] - originalIvs[i]}`, TextStyle.SUMMARY_BLUE, true)})`;
-          } else {
-            label += " (-)";
-          }
-        }
-        t.setText(`[shadow]${label}[/shadow]`);
-      });
-
-      const newColor = ivs.every((iv) => iv === 31) ? 0xe8e8a8 : 0x98d8a0;
-      const oldColor = this.ivChart.fillColor;
-      const interpolateColor =
-        oldColor !== newColor
-          ? [Phaser.Display.Color.IntegerToColor(oldColor), Phaser.Display.Color.IntegerToColor(newColor)]
-          : null;
-
-      globalScene.tweens.addCounter({
-        from: 0,
-        to: 1,
-        duration: 1000,
-        ease: "Cubic.easeOut",
-        onUpdate: (tween: Phaser.Tweens.Tween) => {
-          const progress = tween.getValue();
-          const interpolatedData = ivChartData.map(
-            (v: number, i: number) => v * progress + lastIvChartData[i] * (1 - progress),
-          );
-          if (interpolateColor) {
-            this.ivChart.setFillStyle(
-              Phaser.Display.Color.ValueToColor(
-                Phaser.Display.Color.Interpolate.ColorWithColor(interpolateColor[0], interpolateColor[1], 1, progress),
-              ).color,
-              0.75,
-            );
-          }
-          this.ivChart.setTo(interpolatedData);
-        },
-      });
-    } else {
+  updateIvs(ivs: number[] | null, originalIvs?: number[]): void {
+    if (!ivs) {
       this.statsIvsCache = defaultIvChartData;
       this.ivChart.setTo(defaultIvChartData);
+      return;
     }
+
+    const ivChartData = new Array(6)
+      .fill(null)
+      .map((_, i) => [
+        (ivs[ivChartStatIndexes[i]] / 31) * ivChartSize * ivChartStatCoordMultipliers[ivChartStatIndexes[i]][0],
+        (ivs[ivChartStatIndexes[i]] / 31) * ivChartSize * ivChartStatCoordMultipliers[ivChartStatIndexes[i]][1],
+      ])
+      .flat();
+    const lastIvChartData = this.statsIvsCache || defaultIvChartData;
+    this.statsIvsCache = ivChartData.slice(0);
+
+    this.ivStatValueTexts.map((t: BBCodeText, i: number) => {
+      let label = "";
+
+      // Check to see if IVs are 31, if so change the text style to gold, otherwise leave them be.
+      if (ivs[i] === 31) {
+        label += getBBCodeFragment(ivs[i].toString(), TextStyle.PERFECT_IV, true, true);
+      } else {
+        label = ivs[i].toString();
+      }
+      if (this.showDiff && originalIvs) {
+        if (originalIvs[i] < ivs[i]) {
+          label += ` (${getBBCodeFragment(`+${ivs[i] - originalIvs[i]}`, TextStyle.SUMMARY_BLUE, true)})`;
+        } else {
+          label += " (-)";
+        }
+      }
+      t.setText(`[shadow]${label}[/shadow]`);
+    });
+
+    const newColor = ivs.every((iv) => iv === 31) ? 0xe8e8a8 : 0x98d8a0;
+    const oldColor = this.ivChart.fillColor;
+    const interpolateColor =
+      oldColor !== newColor
+        ? [Phaser.Display.Color.IntegerToColor(oldColor), Phaser.Display.Color.IntegerToColor(newColor)]
+        : null;
+
+    globalScene.tweens.addCounter({
+      from: 0,
+      to: 1,
+      duration: 1000,
+      ease: "Cubic.easeOut",
+      onUpdate: (tween: Phaser.Tweens.Tween) => {
+        const progress = tween.getValue();
+        const interpolatedData = ivChartData.map(
+          (v: number, i: number) => v * progress + lastIvChartData[i] * (1 - progress),
+        );
+        if (interpolateColor) {
+          this.ivChart.setFillStyle(
+            Phaser.Display.Color.ValueToColor(
+              Phaser.Display.Color.Interpolate.ColorWithColor(interpolateColor[0], interpolateColor[1], 1, progress),
+            ).color,
+            0.75,
+          );
+        }
+        this.ivChart.setTo(interpolatedData);
+      },
+    });
   }
 }


### PR DESCRIPTION
> [!NOTE]
> It's best to review the changes with [whitespace-only changes hidden](https://github.com/Despair-Games/poketernity/pull/814/files?diff=unified&w=1) to see what the actual changes are.

## What are the changes the user will see?
N/A

## Why am I making these changes?
Removing `// @ts-ignore`s.

## What are the changes from a developer perspective?
The `StatsContainer.updateIvs()` function expected to be passed `null` sometimes but the param type hint incorrectly did not reflect this; the param now properly indicates it can be `null`, and the `// @ts-ignore`s that worked around this were removed.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?