### PR TITLE
[Misc] `ENEMY_FORM_OVERRIDES` now accepts 0 as valid input

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4547,10 +4547,10 @@ export class EnemyPokemon extends Pokemon {
 
     if (
       speciesId in Overrides.ENEMY_FORM_OVERRIDES
-      && Overrides.ENEMY_FORM_OVERRIDES[speciesId]
+      && !isNullOrUndefined(Overrides.ENEMY_FORM_OVERRIDES[speciesId])
       && this.species.forms[Overrides.ENEMY_FORM_OVERRIDES[speciesId]]
     ) {
-      this.formIndex = Overrides.ENEMY_FORM_OVERRIDES[speciesId] ?? 0;
+      this.formIndex = Overrides.ENEMY_FORM_OVERRIDES[speciesId];
     }
 
     if (!dataSource) {

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -1,17 +1,18 @@
-import { applyChallenges } from "#app/utils/challenge-utils";
-import { ChallengeType } from "#enums/challenge-type";
 import { SpeciesFormChangeMoveLearnedTrigger } from "#app/data/species-form-change-triggers/species-form-change-move-learned-trigger";
-import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
 import { globalScene } from "#app/global-scene";
 import { overrideHeldItems, overrideModifiers } from "#app/modifier/modifier";
 import Overrides from "#app/overrides";
 import { Phase } from "#app/phase";
-import { SaveSlotUiMode } from "#enums/save-slot-ui-mode";
 import type { Starter } from "#app/ui/starter-select-ui-handler";
-import { UiMode } from "#enums/ui-mode";
+import { isNullOrUndefined } from "#app/utils";
+import { applyChallenges } from "#app/utils/challenge-utils";
+import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
+import { ChallengeType } from "#enums/challenge-type";
 import { Gender } from "#enums/gender";
-import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 import { PhaseId } from "#enums/phase-id";
+import { SaveSlotUiMode } from "#enums/save-slot-ui-mode";
+import { UiMode } from "#enums/ui-mode";
+import SoundFade from "phaser3-rex-plugins/plugins/soundfade";
 
 export class SelectStarterPhase extends Phase {
   override readonly id = PhaseId.SELECT_STARTER;
@@ -59,9 +60,10 @@ export class SelectStarterPhase extends Phase {
 
       if (
         speciesId in Overrides.STARTER_FORM_OVERRIDES
-        && species.forms[Overrides.STARTER_FORM_OVERRIDES[speciesId]!]
+        && !isNullOrUndefined(Overrides.STARTER_FORM_OVERRIDES[speciesId])
+        && species.forms[Overrides.STARTER_FORM_OVERRIDES[speciesId]]
       ) {
-        starterFormIndex = Overrides.STARTER_FORM_OVERRIDES[speciesId]!;
+        starterFormIndex = Overrides.STARTER_FORM_OVERRIDES[speciesId];
       }
 
       let starterGender =


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
`ENEMY_FORM_OVERRIDES` was broken and didn't allow setting form index 0.

## What are the changes from a developer perspective?
The check that `ENEMY_FORM_OVERRIDES` is not `undefined` now explicitly checks that it's not `undefined` instead of doing a falsy check which erroneously sees a value of `0` as not valid.
Also made the player override match the enemy override (removing the need for the `!`s).

## How to test the changes?
Use the following overrides and observe that the opponent is always Unown-A.
```ts
const overrides = {
  ENEMY_SPECIES_OVERRIDE: Species.UNOWN,
  ENEMY_FORM_OVERRIDES: {[Species.UNOWN]: 0},
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?