### PR TITLE
[BUG] Fix Locked Reroll not using Luck Score

### DIFF
--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -2078,10 +2078,10 @@ function getNewModifierTypeOption(
   } else if (upgradeCount === undefined && player) {
     upgradeCount = 0;
     if (tier < ModifierTier.MASTER && allowLuckUpgrades) {
-      const partyShinyCount = party.filter((p) => p.isShiny() && !p.isFainted()).length;
-      const upgradeOdds = Math.floor(32 / ((partyShinyCount + 2) / 2));
+      const partyLuckValue = getPartyLuckValue(party);
+      const upgradeOdds = Math.floor(128 / ((partyLuckValue + 4) / 4));
       while (modifierPool.hasOwnProperty(tier + upgradeCount + 1) && modifierPool[tier + upgradeCount + 1].length) {
-        if (!randSeedInt(upgradeOdds)) {
+        if (randSeedInt(upgradeOdds) < 4) {
           upgradeCount++;
         } else {
           break;


### PR DESCRIPTION
## What are the changes the user will see?

When locking your reroll using Lock Capsule, it now correctly uses your Luck Value

## Why am I making these changes?

It is currently simply counting the number of shiny pokemon you have

From : https://github.com/pagefaultgames/pokerogue/pull/5502

Fixes #526

## What are the changes from a developer perspective?

Stop using partyShinyCount and instead use getPartyLuckValue.

```typescript
Math.floor(32 / ((partyShinyCount + 2) / 2));
```

VS

```typescript
Math.floor(128 / ((partyLuckValue + 4) / 4));
```

## Screenshots/Videos

N/A

## How to test the changes?

Check that locked rerolls are giving the proper upgrades. Testing without automation is impossible to check without just "feeling lucky"

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)

#### If there are no locale changes:
- [x] Have I made sure **not** to commit any changes to the locale repo on this branch?
