### PR TITLE
[Bug] (draft) Indication for Status Move Failure on Misty Terrain

### DIFF
--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -83,8 +83,11 @@ export class Terrain {
         break;
 
       case TerrainType.MISTY:
-        if (move.hasAttr(StatusEffectAttr)) {
-          return user.getOpponents().some((o) => targets.includes(o.getBattlerIndex()) && o.isGrounded());
+        if (!move.hasAttr(ProtectAttr)) {
+          return (
+            move.hasAttr(StatusEffectAttr)
+            && user.getOpponents().some((o) => targets.includes(o.getBattlerIndex()) && o.isGrounded())
+          );
         }
         break;
     }

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -6,6 +6,7 @@ import type { BattlerIndex } from "#enums/battler-index";
 import i18next from "i18next";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { TerrainType } from "#enums/terrain-type";
+import { StatusEffectAttr } from "./moves/move-attrs/status-effect-attr";
 
 /**
  * Class representing Terrain effects
@@ -79,6 +80,13 @@ export class Terrain {
             && user.getOpponents().some((o) => targets.includes(o.getBattlerIndex()) && o.isGrounded())
           );
         }
+        break;
+
+      case TerrainType.MISTY:
+        if (move.hasAttr(StatusEffectAttr)) {
+          return user.getOpponents().some((o) => targets.includes(o.getBattlerIndex()) && o.isGrounded());
+        }
+        break;
     }
 
     return false;


### PR DESCRIPTION
## What are the changes the user will see?

When using a status move with Misty terrain active, an indicative message will be displayed when it fails to inflict status.

⚠️ In its current state, it would also introduce the bug of canceling any move with a secondary effect of status infliction when Misty Terrain is active.

## Why am I making these changes?

When using a status move with Misty Terrain on the field, there should be a message that shows a pokemon was protected;
"xxxxx surrounds itself with a protective mist"

⚠️ -Message should not appear in cases where a Pokémon would be given status by the secondary effect of a move.
(code doesn't do that yet)

Fixes #512 

## What are the changes from a developer perspective?

In `data/terrain.ts`, adds a case to `isMoveTerrainCancelled` which currently triggers the display message for Psychic Terrain. The message displayed will be the proper one, because `getTerrainBlockMessage` in the same file checks for the type of terrain active before fetching the locales string.

Currently checks if the move used has the `StatusEffectAttr` attr to consider that the status infliction fails.

⚠️ TODO:
- not trigger on secondary effects like paralysis from Nuzzle
- not trigger on with status immunity when terrain is active
- trigger for Drowsy on its second turn
- check for other 'edge' cases

## Screenshots/Videos

<details><summary>Before</summary>
<p>


https://github.com/user-attachments/assets/dc27efd1-9640-469c-af03-4d4f5b688d1b


</p>
</details> 

<details><summary>After</summary>
<p>


https://github.com/user-attachments/assets/4f2ea732-6f72-4572-bec4-8bd3ab228aac


</p>
</details> 



## How to test the changes?
Change line 46 of `overrides.ts` to :
```
const overrides = {
  MOVESET_OVERRIDE: [ MoveId.NUZZLE, MoveId.SPLASH ],
  ABILITY_OVERRIDE: Abilities.MISTY_SURGE,
  ENEMY_MOVESET_OVERRIDE: [ MoveId.SPORE, MoveId.SPLASH ],
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### If there are no locale changes:
- [x] Have I made sure **not** to commit any changes to the locale repo on this branch?