### PR TITLE
[UI/UX] Add horizontal padding to buttons

### DIFF
--- a/src/ui/handlers/modal-ui-handler.ts
+++ b/src/ui/handlers/modal-ui-handler.ts
@@ -77,7 +77,7 @@ export abstract class ModalUiHandler extends UiHandler {
     const buttonLabel = addTextObject(0, 8, label, TextStyle.TOOLTIP_CONTENT);
     buttonLabel.setOrigin(0.5, 0.5);
 
-    const buttonBg = addWindow(0, 0, buttonLabel.getBounds().width + 8, 16, false, false, 0, 0, WindowVariant.THIN);
+    const buttonBg = addWindow(0, 0, buttonLabel.getBounds().width + 11, 16, false, false, 0, 0, WindowVariant.THIN);
     buttonBg.setOrigin(0.5, 0);
     buttonBg.setInteractive(
       new Phaser.Geom.Rectangle(0, 0, buttonBg.width, buttonBg.height),


### PR DESCRIPTION
## What are the changes the user will see?

Better looking buttons on the login and register screens :)
(more horizontal padding)

## Why am I making these changes?

The text is too close to the border. Requested by Swain


![image](https://github.com/user-attachments/assets/4b828e31-d755-4a32-9d25-11b4a8e3583a)


## What are the changes from a developer perspective?

In the modal ui handler, that both login and register ui extend, changes the horizontal padding. Changes the value from 8 to 11

11 is the limit, as 12 makes the buttons overlap on the register screen for Spanish (ES), see screenshots

## Screenshots/Videos

Spanish (ES) is included here as it has the longest cumulative string length for the login and register buttons texts.

<details><summary>English login before</summary>
<p>

![padding_login-en_before](https://github.com/user-attachments/assets/3497dee6-f8fb-4a50-8a02-c78eadcc3a0c)

</p>
</details> 


<details><summary>English login after</summary>
<p>

![padding_login-en_after](https://github.com/user-attachments/assets/da093b38-81a5-4ae8-a0ce-470cab7dba8a)

</p>
</details> 


<details><summary>English register before</summary>
<p>

![padding_register-en_before](https://github.com/user-attachments/assets/700b8b26-ffc9-4123-a554-50d02caa2f00)

</p>
</details> 


<details><summary>English register after</summary>
<p>

![padding_register-en_after](https://github.com/user-attachments/assets/5754ef48-d006-4176-ba28-24497789963d)

</p>
</details> 


<details><summary>Spanish login before</summary>
<p>

![padding_login-es_before](https://github.com/user-attachments/assets/2a56a83f-bde3-4ebc-aea4-756e2853b787)

</p>
</details> 


<details><summary>Spanish login after</summary>
<p>

![padding_login-es_after](https://github.com/user-attachments/assets/e999a27c-a1c4-46da-9ee8-3ceb8f73650d)

</p>
</details> 


<details><summary>Spanish register before</summary>
<p>

![padding_register-es_before](https://github.com/user-attachments/assets/522354b6-6afb-4341-a7a8-5fb4be74805f)

</p>
</details> 


<details><summary>Spanish register after</summary>
<p>

![padding_register-es_after](https://github.com/user-attachments/assets/4265b366-b6c7-4b8c-8f49-80b417605d74)

</p>
</details> 


## How to test the changes?

In `env.development` change the first line to VITE_BYPASS_LOGIN=0 (to get the login screen on a local instance), then look at the buttons. Click register to see those of the register screen

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### If there are no locale changes:
- [x] Have I made sure **not** to commit any changes to the locale repo on this branch?