### PR TITLE
[Test] Add helper for mocking a pokemon's ability

### DIFF
--- a/test/abilities/arena-trap.test.ts
+++ b/test/abilities/arena-trap.test.ts
@@ -1,10 +1,9 @@
-import { allAbilities } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Abilities - Arena Trap", () => {
   let phaserGame: Phaser.Game;
@@ -70,7 +69,7 @@ describe("Abilities - Arena Trap", () => {
     const [enemy1, enemy2] = game.scene.getEnemyField();
     const [player1, player2] = game.scene.getPlayerField();
 
-    vi.spyOn(enemy1, "getAbility").mockReturnValue(allAbilities[Abilities.ARENA_TRAP]);
+    game.field.mockAbility(enemy1, Abilities.ARENA_TRAP);
 
     game.move.select(MoveId.ROAR);
     game.move.select(MoveId.SPLASH, 1);

--- a/test/abilities/forecast.test.ts
+++ b/test/abilities/forecast.test.ts
@@ -1,12 +1,11 @@
-import { BattlerIndex } from "#enums/battler-index";
-import { allAbilities } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
-import { WeatherType } from "#enums/weather-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
+import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Abilities - Forecast", () => {
   let phaserGame: Phaser.Game;
@@ -86,7 +85,7 @@ describe("Abilities - Forecast", () => {
         Species.ALTARIA,
       ]);
 
-      vi.spyOn(game.scene.getPlayerParty()[5], "getAbility").mockReturnValue(allAbilities[Abilities.CLOUD_NINE]);
+      game.field.mockAbility(game.scene.getPlayerParty()[5], Abilities.CLOUD_NINE);
 
       const castform = game.scene.getPlayerField()[0];
       expect(castform.formIndex).toBe(NORMAL_FORM);

--- a/test/abilities/friend-guard.test.ts
+++ b/test/abilities/friend-guard.test.ts
@@ -1,12 +1,12 @@
+import { allMoves } from "#app/data/data-lists";
+import { Abilities } from "#enums/abilities";
+import { BattlerIndex } from "#enums/battler-index";
+import { MoveCategory } from "#enums/move-category";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
-import { Abilities } from "#enums/abilities";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { BattlerIndex } from "#enums/battler-index";
-import { allAbilities, allMoves } from "#app/data/data-lists";
-import { MoveCategory } from "#enums/move-category";
 
 describe("Moves - Friend Guard", () => {
   let phaserGame: Phaser.Game;
@@ -52,7 +52,7 @@ describe("Moves - Friend Guard", () => {
       Math.floor(player1.getBaseDamage(enemy1, allMoves.get(MoveId.TACKLE), MoveCategory.PHYSICAL)),
     );
 
-    vi.spyOn(player2, "getAbility").mockReturnValue(allAbilities[Abilities.FRIEND_GUARD]);
+    game.field.mockAbility(player2, Abilities.FRIEND_GUARD);
 
     game.move.select(MoveId.SPLASH);
     game.move.select(MoveId.SPLASH, 1);
@@ -82,7 +82,7 @@ describe("Moves - Friend Guard", () => {
 
     const turn1Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
 
-    vi.spyOn(player2, "getAbility").mockReturnValue(allAbilities[Abilities.FRIEND_GUARD]);
+    game.field.mockAbility(player2, Abilities.FRIEND_GUARD);
 
     game.move.select(MoveId.SPLASH);
     game.move.select(MoveId.SPLASH, 1);
@@ -109,7 +109,7 @@ describe("Moves - Friend Guard", () => {
     const turn1Damage = spy.mock.results[spy.mock.results.length - 1].value.damage;
     expect(turn1Damage).toBe(40);
 
-    vi.spyOn(player2, "getAbility").mockReturnValue(allAbilities[Abilities.FRIEND_GUARD]);
+    game.field.mockAbility(player2, Abilities.FRIEND_GUARD);
 
     game.move.select(MoveId.SPLASH);
     game.move.select(MoveId.SPLASH, 1);

--- a/test/abilities/lightning-rod.test.ts
+++ b/test/abilities/lightning-rod.test.ts
@@ -1,4 +1,3 @@
-import { allAbilities } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
@@ -6,7 +5,7 @@ import { Species } from "#enums/species";
 import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Abilities - Lightning Rod", () => {
   let phaserGame: Phaser.Game;
@@ -40,7 +39,7 @@ describe("Abilities - Lightning Rod", () => {
 
     const enemyPokemon = game.scene.getEnemyField();
 
-    vi.spyOn(enemyPokemon[0], "getAbility").mockReturnValue(allAbilities[Abilities.LIGHTNING_ROD]);
+    game.field.mockAbility(enemyPokemon[0], Abilities.LIGHTNING_ROD);
 
     game.move.use(MoveId.THUNDER_SHOCK, 0, BattlerIndex.ENEMY_2);
     game.move.use(MoveId.SPLASH, 1);
@@ -56,7 +55,7 @@ describe("Abilities - Lightning Rod", () => {
     const playerPokemon = game.scene.getPlayerField();
     const enemyPokemon = game.scene.getEnemyField();
 
-    vi.spyOn(playerPokemon[0], "getAbility").mockReturnValue(allAbilities[Abilities.LIGHTNING_ROD]);
+    game.field.mockAbility(playerPokemon[0], Abilities.LIGHTNING_ROD);
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     game.move.use(MoveId.THUNDER_SHOCK, 0, BattlerIndex.ENEMY);
@@ -78,7 +77,7 @@ describe("Abilities - Lightning Rod", () => {
 
     const enemyPokemon = game.scene.getEnemyField();
 
-    vi.spyOn(enemyPokemon[0], "getAbility").mockReturnValue(allAbilities[Abilities.LIGHTNING_ROD]);
+    game.field.mockAbility(enemyPokemon[0], Abilities.LIGHTNING_ROD);
 
     game.move.use(MoveId.DISCHARGE, 0);
     game.move.use(MoveId.SPLASH, 1);
@@ -96,7 +95,7 @@ describe("Abilities - Lightning Rod", () => {
 
     const enemyPokemon = game.scene.getEnemyField();
 
-    vi.spyOn(enemyPokemon[0], "getAbility").mockReturnValue(allAbilities[Abilities.LIGHTNING_ROD]);
+    game.field.mockAbility(enemyPokemon[0], Abilities.LIGHTNING_ROD);
 
     game.move.use(MoveId.THUNDER_SHOCK, 0, BattlerIndex.ENEMY_2);
     game.move.use(MoveId.SPLASH, 1);

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -1,5 +1,5 @@
 import type { EncoreTag } from "#app/data/battler-tags";
-import { allAbilities, allMoves } from "#app/data/data-lists";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -11,7 +11,7 @@ import { Species } from "#enums/species";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
-import { describe, beforeAll, afterEach, beforeEach, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Abilities - Magic Bounce", () => {
   let phaserGame: Phaser.Game;
@@ -211,7 +211,7 @@ describe("Abilities - Magic Bounce", () => {
     const enemy = game.field.getEnemyPokemon();
 
     // Give the player MOLD_BREAKER for this turn to bypass Magic Bounce.
-    vi.spyOn(player, "getAbility").mockReturnValue(allAbilities[Abilities.MOLD_BREAKER]);
+    game.field.mockAbility(player, Abilities.MOLD_BREAKER);
 
     // turn 1
     game.move.use(MoveId.ENCORE);
@@ -246,7 +246,7 @@ describe("Abilities - Magic Bounce", () => {
     await game.toNextTurn();
 
     // Give the player MOLD_BREAKER for this turn to bypass Magic Bounce.
-    vi.spyOn(playerPokemon, "getAbility").mockReturnValue(allAbilities[Abilities.MOLD_BREAKER]);
+    game.field.mockAbility(playerPokemon, Abilities.MOLD_BREAKER);
 
     // turn 2
     game.move.use(MoveId.ENCORE);

--- a/test/abilities/mirror-armor.test.ts
+++ b/test/abilities/mirror-armor.test.ts
@@ -1,4 +1,3 @@
-import { allAbilities } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
@@ -6,7 +5,7 @@ import { Species } from "#enums/species";
 import { Stat, type BattleStat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Abilities - Mirror Armor", () => {
   let phaserGame: Phaser.Game;
@@ -169,7 +168,7 @@ describe("Abilities - Mirror Armor", () => {
     await game.classicMode.startBattle([Species.FEEBAS, Species.MAGIKARP]);
 
     const enemyPokemon = game.scene.getEnemyField();
-    vi.spyOn(enemyPokemon[0], "getAbility").mockReturnValue(allAbilities[Abilities.MIRROR_ARMOR]);
+    game.field.mockAbility(enemyPokemon[0], Abilities.MIRROR_ARMOR);
 
     const [player] = game.scene.getPlayerField();
 

--- a/test/abilities/sand-veil.test.ts
+++ b/test/abilities/sand-veil.test.ts
@@ -1,8 +1,9 @@
-import { allAbilities } from "#app/data/data-lists";
 import { type StatMultiplierAbAttr } from "#app/data/abilities/ab-attrs/stat-multiplier-ab-attr";
+import { allAbilities } from "#app/data/data-lists";
 import { CommandPhase } from "#app/phases/command-phase";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { MoveEndPhase } from "#app/phases/move-end-phase";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { Abilities } from "#enums/abilities";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
@@ -11,7 +12,6 @@ import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 describe("Abilities - Sand Veil", () => {
   let phaserGame: Phaser.Game;
@@ -43,7 +43,7 @@ describe("Abilities - Sand Veil", () => {
 
     const leadPokemon = game.scene.getPlayerField();
 
-    vi.spyOn(leadPokemon[0], "getAbility").mockReturnValue(allAbilities[Abilities.SAND_VEIL]);
+    game.field.mockAbility(leadPokemon[0], Abilities.SAND_VEIL);
 
     const sandVeilAttr = allAbilities[Abilities.SAND_VEIL].getAttrs<StatMultiplierAbAttr>(
       AbAttrFlag.STAT_MULTIPLIER,

--- a/test/abilities/steely-spirit.test.ts
+++ b/test/abilities/steely-spirit.test.ts
@@ -1,4 +1,4 @@
-import { allAbilities, allMoves } from "#app/data/data-lists";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
@@ -38,7 +38,7 @@ describe("Abilities - Steely Spirit", () => {
     const boostSource = game.scene.getPlayerField()[1];
     const enemyToCheck = game.scene.getEnemyPokemon()!;
 
-    vi.spyOn(boostSource, "getAbility").mockReturnValue(allAbilities[Abilities.STEELY_SPIRIT]);
+    game.field.mockAbility(boostSource, Abilities.STEELY_SPIRIT);
 
     expect(boostSource.hasAbility(Abilities.STEELY_SPIRIT)).toBe(true);
 
@@ -54,7 +54,7 @@ describe("Abilities - Steely Spirit", () => {
     const enemyToCheck = game.scene.getEnemyPokemon()!;
 
     game.scene.getPlayerField().forEach((p) => {
-      vi.spyOn(p, "getAbility").mockReturnValue(allAbilities[Abilities.STEELY_SPIRIT]);
+      game.field.mockAbility(p, Abilities.STEELY_SPIRIT);
     });
 
     expect(game.scene.getPlayerField().every((p) => p.hasAbility(Abilities.STEELY_SPIRIT))).toBe(true);
@@ -73,7 +73,7 @@ describe("Abilities - Steely Spirit", () => {
     const boostSource = game.scene.getPlayerField()[1];
     const enemyToCheck = game.scene.getEnemyPokemon()!;
 
-    vi.spyOn(boostSource, "getAbility").mockReturnValue(allAbilities[Abilities.STEELY_SPIRIT]);
+    game.field.mockAbility(boostSource, Abilities.STEELY_SPIRIT);
     expect(boostSource.hasAbility(Abilities.STEELY_SPIRIT)).toBe(true);
 
     boostSource.summonData.abilitySuppressed = true;

--- a/test/moves/flame-burst.test.ts
+++ b/test/moves/flame-burst.test.ts
@@ -1,12 +1,11 @@
-import { BattlerIndex } from "#enums/battler-index";
-import { allAbilities } from "#app/data/data-lists";
-import { Abilities } from "#enums/abilities";
 import type { Pokemon } from "#app/field/pokemon";
+import { Abilities } from "#enums/abilities";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Flame Burst", () => {
   let phaserGame: Phaser.Game;
@@ -75,7 +74,7 @@ describe("Moves - Flame Burst", () => {
     await game.classicMode.startBattle([Species.PIKACHU, Species.PIKACHU]);
     const [leftEnemy, rightEnemy] = game.scene.getEnemyField();
 
-    vi.spyOn(rightEnemy, "getAbility").mockReturnValue(allAbilities[Abilities.FLASH_FIRE]);
+    game.field.mockAbility(rightEnemy, Abilities.FLASH_FIRE);
 
     game.move.select(MoveId.FLAME_BURST, 0, leftEnemy.getBattlerIndex());
     game.move.select(MoveId.SPLASH, 1);
@@ -89,7 +88,7 @@ describe("Moves - Flame Burst", () => {
     await game.classicMode.startBattle([Species.PIKACHU, Species.PIKACHU]);
     const [leftEnemy, rightEnemy] = game.scene.getEnemyField();
 
-    vi.spyOn(rightEnemy, "getAbility").mockReturnValue(allAbilities[Abilities.MAGIC_GUARD]);
+    game.field.mockAbility(rightEnemy, Abilities.MAGIC_GUARD);
 
     game.move.select(MoveId.FLAME_BURST, 0, leftEnemy.getBattlerIndex());
     game.move.select(MoveId.SPLASH, 1);

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -1,5 +1,5 @@
 import type { EncoreTag } from "#app/data/battler-tags";
-import { allAbilities, allMoves } from "#app/data/data-lists";
+import { allMoves } from "#app/data/data-lists";
 import { Abilities } from "#enums/abilities";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -190,7 +190,7 @@ describe("Moves - Magic Coat", () => {
     const enemy = game.field.getEnemyPokemon();
 
     // Give the player MOLD_BREAKER for this turn to bypass Magic Bounce.
-    vi.spyOn(player, "getAbility").mockReturnValue(allAbilities[Abilities.MOLD_BREAKER]);
+    game.field.mockAbility(player, Abilities.MOLD_BREAKER);
 
     // turn 1
     game.move.use(MoveId.ENCORE);
@@ -225,7 +225,7 @@ describe("Moves - Magic Coat", () => {
     await game.toNextTurn();
 
     // Give the player MOLD_BREAKER for this turn to bypass Magic Bounce.
-    vi.spyOn(playerPokemon, "getAbility").mockReturnValue(allAbilities[Abilities.MOLD_BREAKER]);
+    game.field.mockAbility(playerPokemon, Abilities.MOLD_BREAKER);
 
     // turn 2
     game.move.use(MoveId.ENCORE);

--- a/test/moves/pledge-moves.test.ts
+++ b/test/moves/pledge-moves.test.ts
@@ -1,17 +1,17 @@
-import { BattlerIndex } from "#enums/battler-index";
-import { allAbilities, allMoves } from "#app/data/data-lists";
-import { ArenaTagSide } from "#enums/arena-tag-side";
+import { allMoves } from "#app/data/data-lists";
 import { FlinchAttr } from "#app/data/moves/move-attrs/flinch-attr";
-import { ElementalType } from "#enums/elemental-type";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { Stat } from "#enums/stat";
 import { toDmgValue } from "#app/utils";
 import { Abilities } from "#enums/abilities";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Pledge Moves", () => {
   let phaserGame: Phaser.Game;
@@ -299,7 +299,7 @@ describe("Moves - Pledge Moves", () => {
     await game.classicMode.startBattle([Species.BLASTOISE, Species.CHARIZARD]);
 
     const enemyPokemon = game.scene.getEnemyField();
-    vi.spyOn(enemyPokemon[1], "getAbility").mockReturnValue(allAbilities[Abilities.STORM_DRAIN]);
+    game.field.mockAbility(enemyPokemon[1], Abilities.STORM_DRAIN);
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -6,13 +6,11 @@ import { type TurnEndPhase } from "#app/phases/turn-end-phase";
 // -- end tsdoc imports --
 
 import { updateUserInfo } from "#app/account";
-import type { BattlerIndex } from "#enums/battler-index";
 import BattleScene from "#app/battle-scene";
-import { settings } from "#app/system/settings/settings-manager";
 import type { EnemyPokemon, PlayerPokemon, Pokemon } from "#app/field/pokemon";
 import Trainer from "#app/field/trainer";
 import { getGameMode } from "#app/game-mode";
-import { GameModes } from "#enums/game-modes";
+import { globalScene } from "#app/global-scene";
 import { ModifierTypeOption } from "#app/modifier/modifier-type";
 import { modifierTypes } from "#app/modifier/modifier-types";
 import overrides from "#app/overrides";
@@ -21,45 +19,45 @@ import { FaintPhase } from "#app/phases/faint-phase";
 import { LoginPhase } from "#app/phases/login-phase";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
 import { TitlePhase } from "#app/phases/title-phase";
+import { settings } from "#app/system/settings/settings-manager";
+import type { TurnCommand } from "#app/turn-command-manager";
 import type { BattleMessageUiHandler } from "#app/ui/handlers/battle-message-ui-handler";
 import type { CommandUiHandler } from "#app/ui/handlers/command-ui-handler";
 import type { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
-import { UiMode } from "#enums/ui-mode";
+import type { StarterSelectUiHandler } from "#app/ui/handlers/starter-select-ui-handler";
 import { isNullOrUndefined } from "#app/utils";
+import type { Abilities } from "#enums/abilities";
 import { BattleStyle } from "#enums/battle-style";
+import type { BattlerIndex } from "#enums/battler-index";
 import { Button } from "#enums/buttons";
 import { ExpGainsSpeed } from "#enums/exp-gains-speed";
 import { ExpNotification } from "#enums/exp-notification";
+import { GameModes } from "#enums/game-modes";
 import { HpBarSpeed } from "#enums/hp-bar-speed";
 import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PlayerGender } from "#enums/player-gender";
 import type { Species } from "#enums/species";
+import { UiMode } from "#enums/ui-mode";
 import { ErrorInterceptor } from "#test/test-utils/errorInterceptor";
 import { generateStarter, waitUntil } from "#test/test-utils/gameManagerUtils";
 import { GameWrapper } from "#test/test-utils/gameWrapper";
 import { ChallengeModeHelper } from "#test/test-utils/helpers/challengeModeHelper";
 import { ClassicModeHelper } from "#test/test-utils/helpers/classicModeHelper";
 import { DailyModeHelper } from "#test/test-utils/helpers/dailyModeHelper";
+import { FieldHelper } from "#test/test-utils/helpers/fieldHelper";
 import { ModifierHelper } from "#test/test-utils/helpers/modifiersHelper";
 import { MoveHelper } from "#test/test-utils/helpers/moveHelper";
 import { OverridesHelper } from "#test/test-utils/helpers/overridesHelper";
-import { FieldHelper } from "#test/test-utils/helpers/fieldHelper";
 import { ReloadHelper } from "#test/test-utils/helpers/reloadHelper";
 import { SettingsHelper } from "#test/test-utils/helpers/settingsHelper";
 import type { InputsHandler } from "#test/test-utils/inputsHandler";
-import type { PhaseInterceptorPhase } from "#test/test-utils/phaseInterceptor";
-import { PhaseInterceptor } from "#test/test-utils/phaseInterceptor";
+import { MockFetch } from "#test/test-utils/mocks/mockFetch";
+import { PhaseInterceptor, type PhaseInterceptorPhase } from "#test/test-utils/phaseInterceptor";
 import { TextInterceptor } from "#test/test-utils/TextInterceptor";
 import { AES, enc } from "crypto-js";
 import fs from "fs";
 import { expect, vi } from "vitest";
-import { globalScene } from "#app/global-scene";
-import type { StarterSelectUiHandler } from "#app/ui/handlers/starter-select-ui-handler";
-import { MockFetch } from "#test/test-utils/mocks/mockFetch";
-import type { TurnCommand } from "#app/turn-command-manager";
-import type { Abilities } from "#enums/abilities";
-import { allAbilities } from "#app/data/data-lists";
 
 /**
  * Class to manage the game state and transitions between phases.
@@ -539,13 +537,13 @@ export class GameManager {
    * and {@linkcode OverridesHelper.enemyAbility | override.enemyAbility}.
    * Also, unlike the overrides, this function can only be called after `startBattle()` has finished.
    *
-   * @param speciesId The ID of the species that is to receive the ability.
-   * @param abilityId The ID of the ability to give.
+   * @param speciesId - The ID of the species that is to receive the ability.
+   * @param abilityId - The ID of the ability to give.
    */
   forceSpeciesSpecificAbility(speciesId: Species, abilityId: Abilities): void {
     for (const p of (this.scene.getPlayerParty() as Pokemon[]).concat(this.scene.getEnemyParty())) {
       if (p.species.speciesId === speciesId) {
-        vi.spyOn(p, "getAbility").mockReturnValue(allAbilities[abilityId]);
+        this.field.mockAbility(p, abilityId);
       }
     }
   }

--- a/test/test-utils/helpers/fieldHelper.ts
+++ b/test/test-utils/helpers/fieldHelper.ts
@@ -1,11 +1,16 @@
-import type { EnemyPokemon, PlayerPokemon } from "#app/field/pokemon";
-import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
-import { expect } from "vitest";
-// tsdoc imports
+// -- start tsdoc imports --
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { type globalScene } from "#app/global-scene";
+// -- end tsdoc imports --
+
+import type { Ability } from "#app/data/abilities/ability";
+import { allAbilities } from "#app/data/data-lists";
+import type { EnemyPokemon, PlayerPokemon, Pokemon } from "#app/field/pokemon";
+import type { Abilities } from "#enums/abilities";
 import type { BattlerIndex } from "#enums/battler-index";
 import { Stat } from "#enums/stat";
+import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
+import { expect, type MockInstance, vi } from "vitest";
 
 /** Helper to manage pokemon */
 export class FieldHelper extends GameManagerHelper {
@@ -56,5 +61,17 @@ export class FieldHelper extends GameManagerHelper {
       .getField(true)
       .sort((pA, pB) => pB.getEffectiveStat(Stat.SPD) - pA.getEffectiveStat(Stat.SPD))
       .map((p) => p.getBattlerIndex());
+  }
+
+  /**
+   * Mocks a pokemon's ability, overriding its existing ability (takes precedence over global overrides)
+   * @param pokemon - The pokemon to mock the ability of
+   * @param ability - The ability to be mocked
+   * @returns A {@linkcode MockInstance} object
+   * @see {@linkcode vi.spyOn}
+   * @see https://vitest.dev/api/mock#mockreturnvalue
+   */
+  public mockAbility(pokemon: Pokemon, ability: Abilities): MockInstance<(baseOnly?: boolean) => Ability> {
+    return vi.spyOn(pokemon, "getAbility").mockReturnValue(allAbilities[ability]);
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Simplify the process of mocking pokemon abilities during tests.

## What are the changes from a developer perspective?
`mockAbility()` method added to `FieldHelper` that can be used to mock the ability of a pokemon.
Example: `game.field.mockAbility(pokemon, Abilities.PURE_POWER);`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?