### PR TITLE
PR review for 858 - `Pokemon.getAlly()` changes

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -908,39 +908,36 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Used in doubles battles to redirect moves from one pokemon to another when one faints or is removed from the field
-   * @param removedPokemon {@linkcode Pokemon} the pokemon that is being removed from the field (flee, faint), moves to be redirected FROM
-   * @param allyPokemon {@linkcode Pokemon} the pokemon that will have the moves be redirected TO
+   * @param removedPokemon - The {@linkcode Pokemon} that is being removed from the field (flee, faint), moves to be redirected FROM
+   * @param secondPokemon - The Pokemon that will have the moves be redirected TO
    */
-  redirectPokemonMoves(removedPokemon: Pokemon, allyPokemon: Pokemon): void {
-    // failsafe: if not a double battle just return
-    if (this.currentBattle.double === false) {
+  redirectPokemonMoves(removedPokemon: Pokemon, secondPokemon: Pokemon): void {
+    if (this.currentBattle.double === false || !secondPokemon?.isActive(true)) {
       return;
     }
 
-    if (allyPokemon?.isActive(true)) {
-      const { turnManager } = this.currentBattle;
-      turnManager.redirectMoveCommandTargetsToAlly(removedPokemon);
+    const { turnManager } = this.currentBattle;
+    turnManager.redirectMoveCommandTargetsToAlly(removedPokemon);
 
-      /**
-       * If the removed Pokemon fainted before the turn's first move (e.g. from an entry hazard),
-       * A move phase targeting the removed Pokemon may already be queued. Therefore, in addition
-       * to redirecting commands in the turn manager, we also need to redirect any applicable commands
-       * queued for execution.
-       */
-      let targetingMovePhase: MovePhase | undefined;
-      do {
-        targetingMovePhase = this.findPhase(
-          (mp) =>
-            mp.is<MovePhase>(PhaseId.MOVE)
-            && mp.targets.length === 1
-            && mp.targets[0] === removedPokemon.getBattlerIndex()
-            && mp.pokemon.isPlayer() !== allyPokemon.isPlayer(),
-        );
-        if (targetingMovePhase && targetingMovePhase.targets[0] !== allyPokemon.getBattlerIndex()) {
-          targetingMovePhase.targets[0] = allyPokemon.getBattlerIndex();
-        }
-      } while (targetingMovePhase);
-    }
+    /**
+     * If the removed Pokemon fainted before the turn's first move (e.g. from an entry hazard),
+     * a move phase targeting the removed Pokemon may already be queued. Therefore, in addition
+     * to redirecting commands in the turn manager, we also need to redirect any applicable commands
+     * queued for execution.
+     */
+    let targetingMovePhase: MovePhase | undefined;
+    do {
+      targetingMovePhase = this.findPhase(
+        (mp) =>
+          mp.is<MovePhase>(PhaseId.MOVE)
+          && mp.targets.length === 1
+          && mp.targets[0] === removedPokemon.getBattlerIndex()
+          && mp.pokemon.isPlayer() !== secondPokemon.isPlayer(),
+      );
+      if (targetingMovePhase && targetingMovePhase.targets[0] !== secondPokemon.getBattlerIndex()) {
+        targetingMovePhase.targets[0] = secondPokemon.getBattlerIndex();
+      }
+    } while (targetingMovePhase);
   }
 
   /**

--- a/src/data/abilities/ab-attrs/post-damage-force-switch-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-damage-force-switch-ab-attr.ts
@@ -133,8 +133,9 @@ class ForceSwitchOutHelper {
    * @param pokemon The {@linkcode Pokemon} attempting to switch out.
    * @returns `true` if the switch is successful
    */
-  public switchOutLogic(pokemon: Pokemon): boolean {
-    const switchOutTarget = pokemon;
+  public switchOutLogic(switchOutTarget: Pokemon): boolean {
+    const { currentBattle } = globalScene;
+    const { battleType, trainer, waveIndex } = currentBattle;
     /**
      * If the switch-out target is a player-controlled Pokémon, the function checks:
      * - Whether there are available party members to switch in.
@@ -157,15 +158,13 @@ class ForceSwitchOutHelper {
        * For non-wild battles, it checks if the opposing party has any available Pokémon to switch in.
        * If yes, the Pokémon leaves the field and a new SwitchSummonPhase is initiated.
        */
-    } else if (globalScene.currentBattle.battleType !== BattleType.WILD) {
+    } else if (battleType !== BattleType.WILD) {
       if (globalScene.getEnemyParty().filter((p) => p.isAllowedInBattle() && !p.isOnField()).length < 1) {
         return false;
       }
       if (switchOutTarget.hp > 0) {
         switchOutTarget.leaveField(this.switchType === SwitchType.SWITCH);
-        const summonIndex = globalScene.currentBattle.trainer
-          ? globalScene.currentBattle.trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot)
-          : 0;
+        const summonIndex = trainer ? trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot) : 0;
         globalScene.prependToPhase(
           new SwitchSummonPhase(this.switchType, switchOutTarget.getFieldIndex(), summonIndex, false, false),
           PhaseId.MOVE_END,
@@ -177,9 +176,11 @@ class ForceSwitchOutHelper {
        * It will not flee if it is a Mystery Encounter with fleeing disabled (checked in `getSwitchOutCondition()`) or if it is a wave 10x wild boss
        */
     } else {
-      if (!globalScene.currentBattle.waveIndex || globalScene.currentBattle.waveIndex % 10 === 0) {
+      if (waveIndex === 0 || waveIndex % 10 === 0) {
         return false;
       }
+
+      const allyPokemon = switchOutTarget.getAlly();
 
       if (switchOutTarget.hp > 0) {
         switchOutTarget.leaveField(false);
@@ -190,12 +191,12 @@ class ForceSwitchOutHelper {
           500,
         );
 
-        if (globalScene.currentBattle.double && switchOutTarget.getAlly()) {
-          globalScene.redirectPokemonMoves(switchOutTarget, switchOutTarget.getAlly()!);
+        if (currentBattle.double && allyPokemon) {
+          globalScene.redirectPokemonMoves(switchOutTarget, allyPokemon);
         }
       }
 
-      if (!switchOutTarget.getAlly()?.isActive(true)) {
+      if (!allyPokemon?.isActive(true)) {
         globalScene.clearEnemyHeldItemModifiers();
 
         if (switchOutTarget.hp) {

--- a/src/data/abilities/ab-attrs/post-defend-stat-stage-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-stat-stage-change-ab-attr.ts
@@ -50,9 +50,11 @@ export class PostDefendStatStageChangeAbAttr extends PostDefendAbAttr {
       }
 
       if (this.allOthers) {
-        const otherPokemon = pokemon.getAlly()
-          ? pokemon.getOpponents().concat([pokemon.getAlly()!])
-          : pokemon.getOpponents();
+        const otherPokemon = pokemon.getOpponents();
+        const allyPokemon = pokemon.getAlly();
+        if (allyPokemon) {
+          otherPokemon.push(allyPokemon);
+        }
         for (const other of otherPokemon) {
           globalScene.unshiftPhase(
             new StatStageChangePhase(other.getBattlerIndex(), pokemon, [this.stat], this.stages),

--- a/src/data/abilities/ab-attrs/post-turn-reset-status-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-turn-reset-status-ab-attr.ts
@@ -6,12 +6,12 @@ import { PostTurnAbAttr } from "./post-turn-ab-attr";
 
 /**
  * After the turn ends, resets the status of either the ability holder or their ally
- * @param allyTarget Whether to target ally, defaults to `false` (self-target)
+ * @param allyTarget - Whether to target ally, defaults to `false` (self-target)
  * @extends PostTurnAbAttr
  */
 export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
   private readonly allyTarget: boolean;
-  private target: Pokemon;
+  private target?: Pokemon;
 
   constructor(allyTarget: boolean = false) {
     super(true);
@@ -19,12 +19,12 @@ export class PostTurnResetStatusAbAttr extends PostTurnAbAttr {
   }
 
   override apply(pokemon: Pokemon, simulated: boolean): boolean {
-    if (this.allyTarget && pokemon.getAlly()) {
-      this.target = pokemon.getAlly()!;
+    if (this.allyTarget) {
+      this.target = pokemon.getAlly();
     } else {
       this.target = pokemon;
     }
-    if (this.target.hasNonVolatileStatusEffect(false, true)) {
+    if (this.target?.hasNonVolatileStatusEffect(false, true)) {
       if (!simulated) {
         globalScene.queueMessage(
           getStatusEffectHealText(this.target.getStatusEffect(true), getPokemonNameWithAffix(this.target)),

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -2257,9 +2257,9 @@ export function initMoves() {
       .target(MoveTarget.USER_AND_ALLIES)
       .condition(
         (user, _target, _move) =>
-          !![user, user.getAlly()!]
+          [user, user.getAlly()]
             .filter((p) => p?.isActive())
-            .find((p) => !![Abilities.PLUS, Abilities.MINUS].find((a) => p.hasAbility(a, false))),
+            .some((p) => [Abilities.PLUS, Abilities.MINUS].some((a) => p?.hasAbility(a, false))),
       ),
     new StatusMove(MoveId.HAPPY_HOUR, ElementalType.NORMAL, -1, 30, -1, 0, 6) // No animation
       .attr(AddArenaTagAttr, ArenaTagType.HAPPY_HOUR, ArenaTagRelativeSide.USER, { failOnOverlap: true })

--- a/src/data/moves/move-attrs/ability-copy-attr.ts
+++ b/src/data/moves/move-attrs/ability-copy-attr.ts
@@ -34,13 +34,14 @@ export class AbilityCopyAttr extends MoveEffectAttr {
       }),
     );
 
-    if (this.copyToPartner && globalScene.currentBattle?.double && user.getAlly()?.hp) {
-      user.getAlly()!.summonData.ability = target.getAbility().id;
+    const allyPokemon = user.getAlly();
+    if (this.copyToPartner && globalScene.currentBattle?.double && allyPokemon?.hp) {
+      allyPokemon.summonData.ability = target.getAbility().id;
       globalScene.queueMessage(
         i18next.t("moveTriggers:copiedTargetAbility", {
-          pokemonName: getPokemonNameWithAffix(user.getAlly()),
+          pokemonName: getPokemonNameWithAffix(allyPokemon),
           targetName: getPokemonNameWithAffix(target),
-          abilityName: allAbilities[target.getAbility().id].name,
+          abilityName: target.getAbility().name,
         }),
       );
     }
@@ -55,7 +56,8 @@ export class AbilityCopyAttr extends MoveEffectAttr {
         && !user.getAbility().hasAttrFlag(AbAttrFlag.UNSUPPRESSABLE_ABILITY);
       if (this.copyToPartner && globalScene.currentBattle?.double) {
         ret =
-          ret && (!user.getAlly()?.hp || !user.getAlly()?.getAbility().hasAttrFlag(AbAttrFlag.UNSUPPRESSABLE_ABILITY));
+          ret
+          && (user.getAlly()?.hp === 0 || !user.getAlly()?.getAbility().hasAttrFlag(AbAttrFlag.UNSUPPRESSABLE_ABILITY));
       } else {
         ret = ret && user.getAbility().id !== target.getAbility().id;
       }

--- a/src/data/moves/move-attrs/force-switch-out-attr.ts
+++ b/src/data/moves/move-attrs/force-switch-out-attr.ts
@@ -36,6 +36,8 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
   }
 
   override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+    const { currentBattle } = globalScene;
+    const { battleType, double, trainer, waveIndex } = currentBattle;
     // Check if the move category is not STATUS or if the switch out condition is not met
     if (!this.getSwitchOutCondition()(user, target, move)) {
       return false;
@@ -92,7 +94,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
         }
       }
       return false;
-    } else if (globalScene.currentBattle.battleType !== BattleType.WILD) {
+    } else if (battleType !== BattleType.WILD) {
       // Switch out logic for enemy trainers
       // Find indices of off-field Pokemon that are eligible to be switched into
       const eligibleNewIndices: number[] = [];
@@ -120,9 +122,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
             new SwitchSummonPhase(
               this.switchType,
               switchOutTarget.getFieldIndex(),
-              globalScene.currentBattle.trainer
-                ? globalScene.currentBattle.trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot)
-                : 0,
+              trainer ? trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot) : 0,
               false,
               false,
             ),
@@ -145,7 +145,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
         }
       }
 
-      if (globalScene.currentBattle.waveIndex % 10 === 0) {
+      if (waveIndex % 10 === 0) {
         return false;
       }
 
@@ -153,6 +153,8 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
       if (this.selfSwitch && !user.isPlayer() && move.category !== MoveCategory.STATUS) {
         return false;
       }
+
+      const allyPokemon = switchOutTarget.getAlly();
 
       if (switchOutTarget.hp > 0) {
         switchOutTarget.leaveField(false);
@@ -164,12 +166,12 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
         );
 
         // in double battles redirect potential moves off fled pokemon
-        if (globalScene.currentBattle.double && switchOutTarget.getAlly()) {
-          globalScene.redirectPokemonMoves(switchOutTarget, switchOutTarget.getAlly()!);
+        if (double && allyPokemon) {
+          globalScene.redirectPokemonMoves(switchOutTarget, allyPokemon);
         }
       }
 
-      if (!switchOutTarget.getAlly()?.isActive(true)) {
+      if (!allyPokemon?.isActive(true)) {
         globalScene.clearEnemyHeldItemModifiers();
 
         if (switchOutTarget.hp) {

--- a/src/data/moves/move-attrs/revival-blessing-attr.ts
+++ b/src/data/moves/move-attrs/revival-blessing-attr.ts
@@ -45,7 +45,7 @@ export class RevivalBlessingAttr extends MoveEffectAttr {
           globalScene.unshiftPhase(
             new SwitchSummonPhase(SwitchType.SWITCH, pokemon.getFieldIndex(), slotIndex, false, false),
           );
-        } else if (allyPokemon && allyPokemon.isFainted()) {
+        } else if (allyPokemon?.isFainted()) {
           globalScene.unshiftPhase(
             new SwitchSummonPhase(SwitchType.SWITCH, allyPokemon.getFieldIndex(), slotIndex, false, false),
           );

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -991,6 +991,7 @@ export function getMoveTargets(user: Pokemon, moveId: MoveId, replaceTarget?: Mo
     moveTarget = MoveTarget.NEAR_ENEMY;
   }
   const opponents = user.getOpponents();
+  const allyPokemon = user.getAlly();
 
   let set: Pokemon[] = [];
   let targets: BattlerIndex[] | undefined;
@@ -1006,8 +1007,9 @@ export function getMoveTargets(user: Pokemon, moveId: MoveId, replaceTarget?: Mo
     case MoveTarget.DRAGON_DARTS:
     case MoveTarget.ALL_NEAR_OTHERS:
     case MoveTarget.ALL_OTHERS:
-      if (user.getAlly()) {
-        set = opponents.concat([user.getAlly()!]);
+      set = opponents;
+      if (allyPokemon) {
+        set.push(allyPokemon);
       }
       multiple = moveTarget === MoveTarget.ALL_NEAR_OTHERS || moveTarget === MoveTarget.ALL_OTHERS;
       break;
@@ -1024,22 +1026,24 @@ export function getMoveTargets(user: Pokemon, moveId: MoveId, replaceTarget?: Mo
       return { targets: [-1 as BattlerIndex], multiple: false };
     case MoveTarget.NEAR_ALLY:
     case MoveTarget.ALLY:
-      set = [user.getAlly()!];
+      if (allyPokemon) {
+        set.push(allyPokemon);
+      }
       break;
     case MoveTarget.USER_OR_NEAR_ALLY:
     case MoveTarget.USER_AND_ALLIES:
       set = [user];
-      if (user.getAlly()) {
-        set.concat(user.getAlly()!);
+      if (allyPokemon) {
+        set.push(allyPokemon);
       }
       multiple = moveTarget !== MoveTarget.USER_OR_NEAR_ALLY;
       break;
     case MoveTarget.ALL:
       set = [user];
-      if (user.getAlly()) {
-        set.concat([user.getAlly()!]);
+      if (allyPokemon) {
+        set.push(allyPokemon);
       }
-      set.concat(opponents);
+      set.push(...opponents);
       multiple = true;
       break;
     case MoveTarget.USER_SIDE:
@@ -1054,8 +1058,9 @@ export function getMoveTargets(user: Pokemon, moveId: MoveId, replaceTarget?: Mo
       break;
     case MoveTarget.CURSE:
       if (user.getTypes(true).includes(ElementalType.GHOST)) {
-        if (user.getAlly()) {
-          set = opponents.concat([user.getAlly()!]);
+        set = opponents;
+        if (allyPokemon) {
+          set.push(allyPokemon);
         }
       } else {
         set = [user];

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2569,7 +2569,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * @returns the ally Pokemon or undefined if the ally is a PlayerPokemon illegal in the challenge
+   * @returns The allied {@linkcode Pokemon} or `undefined` if there is no allied pokemon
+   * or the ally is {@linkcode Pokemon.isAllowedInBattle | not allowed} on the field
+   * @see {@linkcode PlayerPokemon.getAlly}
    */
   getAlly(): Pokemon | undefined {
     return this.getField()[this.getFieldIndex() ? 0 : 1];
@@ -4197,7 +4199,7 @@ export class PlayerPokemon extends Pokemon {
 
   override getAlly(): Pokemon | undefined {
     const ally = super.getAlly();
-    if (ally && ally.isAllowedInChallenge()) {
+    if (ally?.isAllowedInChallenge()) {
       return ally;
     }
     return undefined;

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -71,8 +71,9 @@ export class CommandPhase extends FieldPhase {
       if (globalScene.getPlayerField().filter((p) => p.isActive()).length === 1) {
         this.fieldIndex = FieldPosition.CENTER;
       } else {
-        if (pokemon.getAlly()) {
-          const allyCommand = turnManager.findCommandFromPokemon(pokemon.getAlly()!);
+        const allyPokemon = pokemon.getAlly();
+        if (allyPokemon) {
+          const allyCommand = turnManager.findCommandFromPokemon(allyPokemon);
           if (allyCommand?.command === BattleCommand.BALL || allyCommand?.command === BattleCommand.RUN) {
             return this.end();
           }

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -218,8 +218,9 @@ export class FaintPhase extends PokemonPhase {
     }
 
     // in double battles redirect potential moves off fainted pokemon
-    if (double && pokemon.getAlly()) {
-      globalScene.redirectPokemonMoves(pokemon, pokemon.getAlly()!);
+    const allyPokemon = pokemon.getAlly();
+    if (double && allyPokemon) {
+      globalScene.redirectPokemonMoves(pokemon, allyPokemon);
     }
 
     pokemon.faintCry(() => {

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -369,8 +369,9 @@ export class MoveEffectPhase extends HitCheckPhase {
     this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, target, firstTarget, true);
 
     // G-Max Gold Rush should not give money twice for double battles
-    if (this.move.getMove().id !== MoveId.G_MAX_GOLD_RUSH && user.getAlly()?.isActive(true)) {
-      this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user.getAlly()!, target, firstTarget, true);
+    const allyPokemon = user.getAlly();
+    if (this.move.getMove().id !== MoveId.G_MAX_GOLD_RUSH && allyPokemon?.isActive(true)) {
+      this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, allyPokemon, target, firstTarget, true);
     }
   }
 
@@ -390,8 +391,9 @@ export class MoveEffectPhase extends HitCheckPhase {
     }
 
     // G-Max Snooze is the only G-Max move to only apply its effect on a single target
-    if (move.id !== MoveId.G_MAX_SNOOZE && target.getAlly()?.isActive(true)) {
-      this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, target.getAlly()!, firstTarget, false);
+    const allyPokemon = target.getAlly();
+    if (move.id !== MoveId.G_MAX_SNOOZE && allyPokemon?.isActive(true)) {
+      this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, allyPokemon, firstTarget, false);
     }
   }
 
@@ -587,12 +589,9 @@ export class MoveEffectPhase extends HitCheckPhase {
      */
     if (this.move.getMove().moveTarget === MoveTarget.DRAGON_DARTS) {
       const ogTarget = globalScene.getFieldPokemonByBattlerIndex(this.targets[0]);
-      if (
-        ogTarget?.isFainted()
-        && ogTarget.getAlly()?.isActive(true)
-        && ogTarget.getAlly()!.id !== this.getUserPokemon()?.id
-      ) {
-        this.targets = [ogTarget.getAlly()!.getBattlerIndex()];
+      const allyPokemon = ogTarget?.getAlly();
+      if (ogTarget?.isFainted() && allyPokemon?.isActive(true) && allyPokemon.id !== this.getUserPokemon()?.id) {
+        this.targets = [allyPokemon.getBattlerIndex()];
       }
     }
     /**


### PR DESCRIPTION
Various files:
- Use `const allyPokemon = pokemon.getAlly();` to prevent the need for `!`.

`battle-scene.ts`:
- Use early return to reduce nesting.

`post-turn-reset-status-ab-attr.ts`:
- Restore original functionality for `if/else` block.

`init-moves.ts`:
- Replace `!!array.find(...)` with `array.some(...)`.

`move.ts`:
- Use `array.push()` instead of `array.concat()` to fix array construction.
- Fix `if` usage / variable assignment for `MoveTarget.ALL_OTHERS` and `MoveTarget.CURSE`.

`pokemon.ts`:
- Clarify tsdocs.