### PR TITLE
[Misc] Re-add type safety to `applyAbAttrs()`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -8,8 +8,7 @@ import type { PokemonSpeciesFilter } from "#app/@types/PokemonSpeciesFilter";
 import type { AnySettingKey, SettingsUpdateEventArgs } from "#app/@types/Settings";
 import { Animation } from "#app/animations";
 import { AudioManager } from "#app/audio-manager";
-import type { FixedBattleConfig } from "#app/battle";
-import Battle from "#app/battle";
+import Battle, { type FixedBattleConfig } from "#app/battle";
 import {
   IV_MAX,
   IV_MIN,
@@ -18,6 +17,10 @@ import {
   ME_BASE_SPAWN_WEIGHT,
   ME_MAX_SPAWN_WEIGHT,
 } from "#app/constants";
+import type { BlockItemTheftAbAttr } from "#app/data/abilities/ab-attrs/block-item-theft-ab-attr";
+import type { DoubleBattleChanceAbAttr } from "#app/data/abilities/ab-attrs/double-battle-chance-ab-attr";
+import type { PostBattleInitAbAttr } from "#app/data/abilities/ab-attrs/post-battle-init-ab-attr";
+import type { PostItemLostAbAttr } from "#app/data/abilities/ab-attrs/post-item-lost-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { MoveChargeAnim } from "#app/data/animations/move-charge-anim";
 import { biomeDepths, getBiomeName } from "#app/data/balance/biomes";
@@ -1256,7 +1259,9 @@ export default class BattleScene extends SceneBase {
   getDoubleBattleChance(newWaveIndex: number, playerField: PlayerPokemon[]) {
     const doubleChance = new NumberHolder(newWaveIndex % 10 === 0 ? 32 : 8);
     this.applyModifiers(DoubleBattleChanceBoosterModifier, true, doubleChance);
-    playerField.forEach((p) => applyAbAttrs(AbAttrFlag.DOUBLE_BATTLE_CHANCE, p, false, doubleChance));
+    playerField.forEach((p) =>
+      applyAbAttrs<DoubleBattleChanceAbAttr>(AbAttrFlag.DOUBLE_BATTLE_CHANCE, p, false, doubleChance),
+    );
     return Math.max(doubleChance.value, 1);
   }
 
@@ -1439,7 +1444,7 @@ export default class BattleScene extends SceneBase {
 
         for (const pokemon of this.getPlayerParty()) {
           pokemon.resetBattleData();
-          applyAbAttrs(AbAttrFlag.POST_BATTLE_INIT, pokemon, false);
+          applyAbAttrs<PostBattleInitAbAttr>(AbAttrFlag.POST_BATTLE_INIT, pokemon, false);
         }
 
         if (!this.trainer.visible) {
@@ -2496,7 +2501,7 @@ export default class BattleScene extends SceneBase {
     const cancelled = new BooleanHolder(false);
 
     if (source && source.isPlayer() !== target.isPlayer()) {
-      applyAbAttrs(AbAttrFlag.BLOCK_ITEM_THEFT, source, false, cancelled);
+      applyAbAttrs<BlockItemTheftAbAttr>(AbAttrFlag.BLOCK_ITEM_THEFT, source, false, cancelled);
     }
 
     if (cancelled.value) {
@@ -2536,13 +2541,13 @@ export default class BattleScene extends SceneBase {
           if (target.isPlayer()) {
             this.addModifier(newItemModifier, ignoreUpdate, playSound, false, instant);
             if (source && itemLost) {
-              applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, source, false);
+              applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, source, false);
             }
             return true;
           } else {
             this.addEnemyModifier(newItemModifier, ignoreUpdate, instant);
             if (source && itemLost) {
-              applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, source, false);
+              applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, source, false);
             }
             return true;
           }

--- a/src/data/abilities/ab-attrs/post-damage-force-switch-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-damage-force-switch-ab-attr.ts
@@ -1,21 +1,22 @@
-import { type EnemyPokemon, type Pokemon } from "#app/field/pokemon";
-import { BooleanHolder, toDmgValue } from "#app/utils";
-import { Abilities } from "#enums/abilities";
-import { SwitchType } from "#enums/switch-type";
-import { PostDamageAbAttr } from "./post-damage-ab-attr";
+import type { ForceSwitchOutImmunityAbAttr } from "#app/data/abilities/ab-attrs/force-switch-out-immunity-ab-attr";
+import { PostDamageAbAttr } from "#app/data/abilities/ab-attrs/post-damage-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { allMoves } from "#app/data/data-lists";
 import type { Move } from "#app/data/moves/move";
-import { BattlerTagType } from "#enums/battler-tag-type";
+import { type EnemyPokemon, type Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { SwitchPhase } from "#app/phases/switch-phase";
 import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
-import { BattleType } from "#enums/battle-type";
-import i18next from "i18next";
+import { BooleanHolder, toDmgValue } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { Abilities } from "#enums/abilities";
+import { BattleType } from "#enums/battle-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { PhaseId } from "#enums/phase-id";
+import { SwitchType } from "#enums/switch-type";
+import i18next from "i18next";
 
 /**
  * Ability attribute for forcing a Pokémon to switch out after its health drops below half.
@@ -220,7 +221,12 @@ class ForceSwitchOutHelper {
 
     if (player) {
       const blockedByAbility = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY, pokemon, false, blockedByAbility);
+      applyAbAttrs<ForceSwitchOutImmunityAbAttr>(
+        AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY,
+        pokemon,
+        false,
+        blockedByAbility,
+      );
       return !blockedByAbility.value;
     }
 
@@ -257,7 +263,7 @@ class ForceSwitchOutHelper {
    */
   public getFailedText(target: Pokemon): string | null {
     const blockedByAbility = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY, target, false, blockedByAbility);
+    applyAbAttrs<ForceSwitchOutImmunityAbAttr>(AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY, target, false, blockedByAbility);
     return blockedByAbility.value
       ? i18next.t("moveTriggers:cannotBeSwitchedOut", { pokemonName: getPokemonNameWithAffix(target) })
       : null;

--- a/src/data/abilities/ab-attrs/post-faint-contact-damage-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-faint-contact-damage-ab-attr.ts
@@ -1,3 +1,5 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
+import type { FieldPreventExplosionLikeAbAttr } from "#app/data/abilities/ab-attrs/field-prevent-explosion-like-ab-attr";
 import { PostFaintAbAttr } from "#app/data/abilities/ab-attrs/post-faint-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Move } from "#app/data/moves/move";
@@ -34,7 +36,7 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
       globalScene
         .getField(true)
         .map((p) =>
-          applyAbAttrs(
+          applyAbAttrs<FieldPreventExplosionLikeAbAttr>(
             AbAttrFlag.FIELD_PREVENT_EXPLOSION_LIKE,
             p,
             simulated,
@@ -44,7 +46,7 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
           ),
         );
 
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, attacker, simulated, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, attacker, simulated, cancelled);
       if (cancelled.value) {
         return false;
       }

--- a/src/data/abilities/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
@@ -1,3 +1,6 @@
+import type { IntimidateImmunityAbAttr } from "#app/data/abilities/ab-attrs/intimidate-immunity-ab-attr";
+import type { PostIntimidateStatStageChangeAbAttr } from "#app/data/abilities/ab-attrs/post-intimidate-stat-stage-change-ab-attr";
+import { PostSummonAbAttr } from "#app/data/abilities/ab-attrs/post-summon-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
@@ -6,7 +9,6 @@ import { BooleanHolder } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import type { BattleStat } from "#enums/stat";
-import { PostSummonAbAttr } from "./post-summon-ab-attr";
 
 export class PostSummonStatStageChangeAbAttr extends PostSummonAbAttr {
   private readonly stats: BattleStat[];
@@ -37,8 +39,13 @@ export class PostSummonStatStageChangeAbAttr extends PostSummonAbAttr {
     for (const opponent of pokemon.getOpponents()) {
       const cancelled = new BooleanHolder(false);
       if (this.intimidate) {
-        applyAbAttrs(AbAttrFlag.INITIMIDATE_IMMUNITY, opponent, simulated, cancelled);
-        applyAbAttrs(AbAttrFlag.POST_INTIMIDATE_STAT_STAGE_CHANGE, opponent, simulated, cancelled);
+        applyAbAttrs<IntimidateImmunityAbAttr>(AbAttrFlag.INITIMIDATE_IMMUNITY, opponent, simulated, cancelled);
+        applyAbAttrs<PostIntimidateStatStageChangeAbAttr>(
+          AbAttrFlag.POST_INTIMIDATE_STAT_STAGE_CHANGE,
+          opponent,
+          simulated,
+          cancelled,
+        );
 
         if (opponent.getTag(BattlerTagType.SUBSTITUTE)) {
           cancelled.value = true;

--- a/src/data/abilities/apply-ab-attrs.ts
+++ b/src/data/abilities/apply-ab-attrs.ts
@@ -1,29 +1,28 @@
-import type { AbAttr } from "#app/data/abilities/ab-attrs/ab-attr";
 import type { AbilityFilterOptions } from "#app/@types/ability-filter-options";
-import { queueShowAbility } from "#app/utils/ability-utils";
+import type { AbAttr } from "#app/data/abilities/ab-attrs/ab-attr";
 import { globalScene } from "#app/global-scene";
-import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import { queueShowAbility } from "#app/utils/ability-utils";
 import type { AbAttrFlag } from "#enums/ab-attr-flag";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
 
 //#region Exports
 
-export function applyAbAttrs<TAttr extends AbAttr>(
+export function applyAbAttrs<TAttr extends AbAttr = never>(
   abAttrFlag: AbAttrFlag,
   ...params: Parameters<TAttr["apply"]>
 ): string[] {
-  return applyAbAttrsInternal({ canApplyOnly: true }, abAttrFlag, ...params);
+  return applyAbAttrsInternal<TAttr>({ canApplyOnly: true }, abAttrFlag, ...params);
 }
 
 /**
  * Obtains the function to apply abilities corresponding to the given mode
- * @param mode the {@linkcode AbilityApplyMode} determining how abilities are applied:
- * @returns the function to apply abilities based on the mode:
- * - {@linkcode AbilityApplyMode.DEFAULT} applies abilities without restriction
- * (as long as they meet conditions to apply).
- * - {@linkcode AbilityApplyMode.REVEALED} only applies abilities that have
- * previously applied in the current battle.
- * - {@linkcode AbilityApplyMode.IGNORE} does nothing and returns an empty
- * message array.
+ * @param mode - The {@linkcode AbilityApplyMode} determining how abilities are applied
+ * @returns The function to apply abilities based on the mode:
+ * - {@linkcode AbilityApplyMode.DEFAULT} - Applies abilities without restriction
+ *     (as long as they meet conditions to apply).
+ * - {@linkcode AbilityApplyMode.REVEALED} - Only applies abilities that have
+ *     previously applied in the current battle.
+ * - {@linkcode AbilityApplyMode.IGNORE} - Does nothing and returns an empty array.
  */
 export function getAbApplyFunc(mode: AbilityApplyMode) {
   switch (mode) {
@@ -49,7 +48,7 @@ export function getAbApplyFunc(mode: AbilityApplyMode) {
  * @returns The message(s) displayed when the ability applies
  * @see {@linkcode AbAttr}
  */
-function applyAbAttrsInternal<TAttr extends AbAttr>(
+function applyAbAttrsInternal<TAttr extends AbAttr = never>(
   abFilterOptions: AbilityFilterOptions,
   abAttrFlag: AbAttrFlag,
   ...params: Parameters<TAttr["apply"]>
@@ -108,7 +107,7 @@ function applyRevealedAbAttrs<TAttr extends AbAttr>(
   abAttrFlag: AbAttrFlag,
   ...params: Parameters<TAttr["apply"]>
 ): string[] {
-  return applyAbAttrsInternal({ canApplyOnly: true, revealedOnly: true }, abAttrFlag, ...params);
+  return applyAbAttrsInternal<TAttr>({ canApplyOnly: true, revealedOnly: true }, abAttrFlag, ...params);
 }
 
 //#endregion

--- a/src/data/abilities/apply-ab-attrs.ts
+++ b/src/data/abilities/apply-ab-attrs.ts
@@ -103,7 +103,7 @@ function applyAbAttrsInternal<TAttr extends AbAttr = never>(
   return messages;
 }
 
-function applyRevealedAbAttrs<TAttr extends AbAttr>(
+function applyRevealedAbAttrs<TAttr extends AbAttr = never>(
   abAttrFlag: AbAttrFlag,
   ...params: Parameters<TAttr["apply"]>
 ): string[] {

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -1,4 +1,7 @@
 import { SCREEN_DOUBLES_DMG_FACTOR, SCREEN_SINGLES_DMG_FACTOR } from "#app/constants";
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
+import type { InfiltratorAbAttr } from "#app/data/abilities/ab-attrs/infiltrator-ab-attr";
+import type { ProtectStatAbAttr } from "#app/data/abilities/ab-attrs/protect-stat-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { CommonBattleAnim } from "#app/data/animations/common-battle-anim";
 import type { SkyDropTag } from "#app/data/battler-tags/sky-drop-tag";
@@ -147,7 +150,7 @@ export class MistTag extends ArenaTag {
   override apply(_arena: Arena, simulated: boolean, attacker: Pokemon, cancelled: BooleanHolder): boolean {
     if (attacker?.isActive(true)) {
       const bypassed = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.INFILTRATOR, attacker, simulated, bypassed);
+      applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, simulated, bypassed);
       if (bypassed.value) {
         return false;
       }
@@ -212,7 +215,7 @@ export abstract class WeakenMoveScreenTag extends ArenaTag {
   ): boolean {
     if (this.weakenedCategories.includes(moveCategory)) {
       const bypassed = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.INFILTRATOR, attacker, simulated, bypassed);
+      applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, simulated, bypassed);
       if (bypassed.value) {
         return false;
       }
@@ -748,7 +751,7 @@ class SpikesTag extends EntryHazardTag {
   override activateTrap(pokemon: Pokemon, simulated: boolean): boolean {
     if (pokemon.isGrounded()) {
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, simulated, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, simulated, cancelled);
 
       if (simulated) {
         return !cancelled.value;
@@ -951,7 +954,7 @@ class TypeHazardTag extends EntryHazardTag {
 
   override activateTrap(pokemon: Pokemon, simulated: boolean): boolean {
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, simulated, cancelled);
+    applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, simulated, cancelled);
 
     if (cancelled.value) {
       return false;
@@ -1035,7 +1038,7 @@ class StickyWebTag extends EntryHazardTag {
   override activateTrap(pokemon: Pokemon, simulated: boolean): boolean {
     if (pokemon.isGrounded()) {
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.PROTECT_STAT, pokemon, simulated, Stat.SPD, cancelled);
+      applyAbAttrs<ProtectStatAbAttr>(AbAttrFlag.PROTECT_STAT, pokemon, simulated, Stat.SPD, cancelled);
 
       if (simulated) {
         return !cancelled.value;
@@ -1235,7 +1238,7 @@ class FireGrassPledgeTag extends ArenaTag {
       .filter((pokemon) => pokemon.isActive(true) && !pokemon.isOfType(ElementalType.FIRE) && !pokemon.switchOutStatus)
       .forEach((pokemon) => {
         const cancelled = new BooleanHolder(false);
-        applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+        applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
         if (cancelled.value) {
           return;
         }
@@ -1350,7 +1353,7 @@ export class TypeImmuneDamageOverTimeTag extends ArenaTag {
       .filter((pokemon) => pokemon.isActive(true) && !pokemon.isOfType(this.immuneType) && !pokemon.switchOutStatus)
       .forEach((pokemon) => {
         const cancelled = new BooleanHolder(false);
-        applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+        applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
         if (cancelled.value) {
           return;
         }

--- a/src/data/battler-tags/bypass-speed-tag.ts
+++ b/src/data/battler-tags/bypass-speed-tag.ts
@@ -1,3 +1,4 @@
+import type { PreventBypassSpeedChanceAbAttr } from "#app/data/abilities/ab-attrs/prevent-bypass-speed-chance-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
@@ -19,7 +20,7 @@ export class BypassSpeedTag extends BattlerTag {
 
   override canAdd(pokemon: Pokemon): boolean {
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.PREVENT_BYPASS_SPEED_CHANCE, pokemon, false, cancelled);
+    applyAbAttrs<PreventBypassSpeedChanceAbAttr>(AbAttrFlag.PREVENT_BYPASS_SPEED_CHANCE, pokemon, false, cancelled);
     return !cancelled.value;
   }
 }

--- a/src/data/battler-tags/confused-tag.ts
+++ b/src/data/battler-tags/confused-tag.ts
@@ -4,7 +4,7 @@ import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import type { MovePhase } from "#app/phases/move-phase";
-import { toDmgValue } from "#app/utils";
+import { isNullOrUndefined, toDmgValue } from "#app/utils";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -13,7 +13,6 @@ import type { MoveId } from "#enums/move-id";
 import { Stat } from "#enums/stat";
 import { TerrainType } from "#enums/terrain-type";
 import i18next from "i18next";
-import { isNullOrUndefined } from "util";
 import Overrides from "#app/overrides";
 
 /**

--- a/src/data/battler-tags/cursed-tag.ts
+++ b/src/data/battler-tags/cursed-tag.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
@@ -34,7 +35,7 @@ export class CursedTag extends BattlerTag {
       );
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4), { ignoreDynamaxReduction: true });

--- a/src/data/battler-tags/damaging-trap-tag.ts
+++ b/src/data/battler-tags/damaging-trap-tag.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import { TrappedTag } from "#app/data/battler-tags/trapped-tag";
@@ -59,7 +60,7 @@ export abstract class DamagingTrapTag extends TrappedTag {
       globalScene.unshiftPhase(new CommonAnimPhase(pokemon.getBattlerIndex(), undefined, this.commonAnim));
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8), { ignoreDynamaxReduction: true });

--- a/src/data/battler-tags/flinched-tag.ts
+++ b/src/data/battler-tags/flinched-tag.ts
@@ -1,3 +1,4 @@
+import type { FlinchEffectAbAttr } from "#app/data/abilities/ab-attrs/flinch-effect-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
@@ -26,7 +27,7 @@ export class FlinchedTag extends BattlerTag {
   override onAdd(pokemon: Pokemon): void {
     super.onAdd(pokemon);
 
-    applyAbAttrs(AbAttrFlag.FLINCH_EFFECT, pokemon, false);
+    applyAbAttrs<FlinchEffectAbAttr>(AbAttrFlag.FLINCH_EFFECT, pokemon, false);
   }
 
   /**

--- a/src/data/battler-tags/gulp-missile-tag.ts
+++ b/src/data/battler-tags/gulp-missile-tag.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import { SpeciesFormChangeManualTrigger } from "#app/data/species-form-change-triggers/species-form-change-manual-trigger";
@@ -44,7 +45,7 @@ export class GulpMissileTag extends BattlerTag {
       }
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, attacker, false, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, attacker, false, cancelled);
 
       if (!cancelled.value) {
         attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() / 4), {

--- a/src/data/battler-tags/nightmare-tag.ts
+++ b/src/data/battler-tags/nightmare-tag.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
@@ -48,7 +49,7 @@ export class NightmareTag extends BattlerTag {
       globalScene.unshiftPhase(new CommonAnimPhase(pokemon.getBattlerIndex(), undefined, CommonAnim.CURSE)); // TODO: Update animation type
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4), { ignoreDynamaxReduction: true });

--- a/src/data/battler-tags/powder-tag.ts
+++ b/src/data/battler-tags/powder-tag.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
@@ -61,7 +62,7 @@ export class PowderTag extends BattlerTag {
           );
 
           const cancelDamage = new BooleanHolder(false);
-          applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelDamage);
+          applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelDamage);
           if (!cancelDamage.value) {
             pokemon.damageAndUpdate(Math.floor(pokemon.getMaxHp() / 4), {
               result: HitResult.OTHER,

--- a/src/data/battler-tags/salt-cured-tag.ts
+++ b/src/data/battler-tags/salt-cured-tag.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
@@ -54,7 +55,7 @@ export class SaltCuredTag extends BattlerTag {
       );
 
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (!cancelled.value) {
         const pokemonSteelOrWater = pokemon.isOfType(ElementalType.STEEL) || pokemon.isOfType(ElementalType.WATER);

--- a/src/data/battler-tags/seed-tag.ts
+++ b/src/data/battler-tags/seed-tag.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
@@ -55,7 +56,7 @@ export class SeedTag extends BattlerTag {
       const source = pokemon.getOpponents().find((o) => o.getBattlerIndex() === this.sourceIndex);
       if (source) {
         const cancelled = new BooleanHolder(false);
-        applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+        applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
         if (!cancelled.value) {
           globalScene.unshiftPhase(

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -1,17 +1,20 @@
-import { getPokemonNameWithAffix } from "../messages";
-import type { Pokemon } from "../field/pokemon";
-import { HitResult } from "#enums/hit-result";
-import { getStatusEffectHealText } from "./status-effect";
-import { NumberHolder, toDmgValue, randSeedInt } from "#app/utils";
-import { applyAbAttrs } from "./abilities/apply-ab-attrs";
-import i18next from "i18next";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { BerryType } from "#enums/berry-type";
-import { Stat, type BattleStat } from "#enums/stat";
-import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
+import type { DoubleBerryEffectAbAttr } from "#app/data/abilities/ab-attrs/double-berry-effect-ab-attr";
+import type { PostItemLostAbAttr } from "#app/data/abilities/ab-attrs/post-item-lost-ab-attr";
+import type { ReduceBerryUseThresholdAbAttr } from "#app/data/abilities/ab-attrs/reduce-berry-use-threshold-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import { getStatusEffectHealText } from "#app/data/status-effect";
+import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
+import { getPokemonNameWithAffix } from "#app/messages";
+import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
+import { NumberHolder, randSeedInt, toDmgValue } from "#app/utils";
 import { getBerryName } from "#app/utils/berry-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { BerryType } from "#enums/berry-type";
+import { HitResult } from "#enums/hit-result";
+import { Stat, type BattleStat } from "#enums/stat";
+import i18next from "i18next";
 
 export type BerryPredicate = (pokemon: Pokemon) => boolean;
 
@@ -33,25 +36,25 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
         const threshold = new NumberHolder(0.25);
         // Offset BerryType such that LIECHI -> Stat.ATK = 1, GANLON -> Stat.DEF = 2, so on and so forth
         const stat: BattleStat = berryType - BerryType.ENIGMA;
-        applyAbAttrs(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
+        applyAbAttrs<ReduceBerryUseThresholdAbAttr>(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
         return pokemon.getHpRatio() < threshold.value && pokemon.getStatStage(stat) < 6;
       };
     case BerryType.LANSAT:
       return (pokemon: Pokemon) => {
         const threshold = new NumberHolder(0.25);
-        applyAbAttrs(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
+        applyAbAttrs<ReduceBerryUseThresholdAbAttr>(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
         return pokemon.getHpRatio() < 0.25 && !pokemon.getTag(BattlerTagType.CRIT_BOOST);
       };
     case BerryType.STARF:
       return (pokemon: Pokemon) => {
         const threshold = new NumberHolder(0.25);
-        applyAbAttrs(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
+        applyAbAttrs<ReduceBerryUseThresholdAbAttr>(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
         return pokemon.getHpRatio() < 0.25;
       };
     case BerryType.LEPPA:
       return (pokemon: Pokemon) => {
         const threshold = new NumberHolder(0.25);
-        applyAbAttrs(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
+        applyAbAttrs<ReduceBerryUseThresholdAbAttr>(AbAttrFlag.REDUCE_BERRY_USE_THRESHOLD, pokemon, false, threshold);
         return !!pokemon.getMoveset().find((m) => !m.getPpRatio());
       };
   }
@@ -68,14 +71,14 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
           pokemon.battleData.berriesEaten.push(berryType);
         }
         const hpHealed = new NumberHolder(toDmgValue(pokemon.getMaxHp() / 4));
-        applyAbAttrs(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, hpHealed);
+        applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, hpHealed);
         globalScene.queuePokemonHeal(true, pokemon.getBattlerIndex(), hpHealed.value, {
           message: i18next.t("battle:hpHealBerry", {
             pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
             berryName: getBerryName(berryType),
           }),
         });
-        applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
+        applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
       };
     case BerryType.LUM:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
@@ -89,7 +92,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         }
         pokemon.resetStatus(true);
         pokemon.updateInfo();
-        applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
+        applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
       };
     case BerryType.LIECHI:
     case BerryType.GANLON:
@@ -103,11 +106,11 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         // Offset BerryType such that LIECHI -> Stat.ATK = 1, GANLON -> Stat.DEF = 2, so on and so forth
         const stat: BattleStat = berryType - BerryType.ENIGMA;
         const statStages = new NumberHolder(1);
-        applyAbAttrs(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, statStages);
+        applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, statStages);
         globalScene.unshiftPhase(
           new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, [stat], statStages.value),
         );
-        applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
+        applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
       };
     case BerryType.LANSAT:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
@@ -115,7 +118,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
           pokemon.battleData.berriesEaten.push(berryType);
         }
         pokemon.addTag(BattlerTagType.CRIT_BOOST);
-        applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
+        applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
       };
     case BerryType.STARF:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
@@ -124,11 +127,11 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         }
         const randStat = randSeedInt(Stat.SPD, Stat.ATK);
         const stages = new NumberHolder(2);
-        applyAbAttrs(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, stages);
+        applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, stages);
         globalScene.unshiftPhase(
           new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, [randStat], stages.value),
         );
-        applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
+        applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
       };
     case BerryType.LEPPA:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
@@ -147,7 +150,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
               berryName: getBerryName(berryType),
             }),
           );
-          applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
+          applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
         }
       };
   }

--- a/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
+++ b/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
@@ -1,11 +1,13 @@
+import type { IgnoreMoveEffectsAbAttr } from "#app/data/abilities/ab-attrs/ignore-move-effects-ab-attr";
+import type { MoveEffectChanceMultiplierAbAttr } from "#app/data/abilities/ab-attrs/move-effect-chance-multiplier-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type { Move } from "#app/data/moves/move";
+import { MoveEffectAttr, type MoveEffectAttrOptions } from "#app/data/moves/move-attrs/move-effect-attr";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { NumberHolder } from "#app/utils";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { Move } from "../move";
-import { MoveEffectAttr, type MoveEffectAttrOptions } from "./move-effect-attr";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { ArenaTagType } from "#enums/arena-tag-type";
 
 export interface ChanceBasedMoveEffectAttrOptions extends MoveEffectAttrOptions {
   /** Overrides the secondary effect chance for this attr if set. */
@@ -61,13 +63,20 @@ export abstract class ChanceBasedMoveEffectAttr extends MoveEffectAttr {
   ): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER, user, false, moveChance, move, showAbility);
+    applyAbAttrs<MoveEffectChanceMultiplierAbAttr>(
+      AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER,
+      user,
+      false,
+      moveChance,
+      move,
+      showAbility,
+    );
 
     const userSide = user.getArenaTagSide();
     globalScene.arena.applyTagsForSide(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
 
     if (!selfEffect) {
-      applyAbAttrs(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);
+      applyAbAttrs<IgnoreMoveEffectsAbAttr>(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);
     }
     return moveChance.value;
   }

--- a/src/data/moves/move-attrs/eat-berry-attr.ts
+++ b/src/data/moves/move-attrs/eat-berry-attr.ts
@@ -1,11 +1,12 @@
-import type { Pokemon } from "#app/field/pokemon";
-import { globalScene } from "#app/global-scene";
-import { type BerryModifier, PreserveBerryModifier } from "#app/modifier/modifier";
-import { BooleanHolder } from "#app/utils";
+import type { HealFromBerryUseAbAttr } from "#app/data/abilities/ab-attrs/heal-from-berry-use-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { getBerryEffectFunc } from "#app/data/berry";
 import type { Move } from "#app/data/moves/move";
 import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
+import type { Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
+import { type BerryModifier, PreserveBerryModifier } from "#app/modifier/modifier";
+import { BooleanHolder } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 /**
@@ -53,6 +54,6 @@ export class EatBerryAttr extends MoveEffectAttr {
 
   eatBerry(consumer: Pokemon, berryOwner?: Pokemon) {
     getBerryEffectFunc(this.chosenBerry!.berryType)(consumer, berryOwner); // consumer eats the berry
-    applyAbAttrs(AbAttrFlag.HEAL_FROM_BERRY_USE, consumer, false);
+    applyAbAttrs<HealFromBerryUseAbAttr>(AbAttrFlag.HEAL_FROM_BERRY_USE, consumer, false);
   }
 }

--- a/src/data/moves/move-attrs/flame-burst-attr.ts
+++ b/src/data/moves/move-attrs/flame-burst-attr.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Move } from "#app/data/moves/move";
 import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
@@ -26,7 +27,7 @@ export class FlameBurstAttr extends MoveEffectAttr {
     const cancelled = new BooleanHolder(false);
 
     if (targetAlly) {
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, targetAlly, false, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, targetAlly, false, cancelled);
     }
 
     if (cancelled.value || !targetAlly || targetAlly.switchOutStatus) {

--- a/src/data/moves/move-attrs/flinch-attr.ts
+++ b/src/data/moves/move-attrs/flinch-attr.ts
@@ -1,12 +1,14 @@
+import type { IgnoreMoveEffectsAbAttr } from "#app/data/abilities/ab-attrs/ignore-move-effects-ab-attr";
+import type { MoveEffectChanceMultiplierAbAttr } from "#app/data/abilities/ab-attrs/move-effect-chance-multiplier-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type { Move } from "#app/data/moves/move";
+import { AddBattlerTagAttr } from "#app/data/moves/move-attrs/add-battler-tag-attr";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { NumberHolder } from "#app/utils";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { Move } from "#app/data/moves/move";
-import { AddBattlerTagAttr } from "./add-battler-tag-attr";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 /**
  * Attribute adding a chance to flinch the target.
@@ -27,7 +29,14 @@ export class FlinchAttr extends AddBattlerTagAttr {
   ): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER, user, false, moveChance, move, showAbility);
+    applyAbAttrs<MoveEffectChanceMultiplierAbAttr>(
+      AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER,
+      user,
+      false,
+      moveChance,
+      move,
+      showAbility,
+    );
 
     if (moveChance.value <= move.chance) {
       const userSide = user.getArenaTagSide();
@@ -35,7 +44,7 @@ export class FlinchAttr extends AddBattlerTagAttr {
     }
 
     if (!selfEffect) {
-      applyAbAttrs(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);
+      applyAbAttrs<IgnoreMoveEffectsAbAttr>(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);
     }
     return moveChance.value;
   }

--- a/src/data/moves/move-attrs/force-switch-out-attr.ts
+++ b/src/data/moves/move-attrs/force-switch-out-attr.ts
@@ -1,21 +1,22 @@
-import { BattleType } from "#enums/battle-type";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { MoveCategory } from "#enums/move-category";
-import { MoveId } from "#enums/move-id";
-import { SwitchType } from "#enums/switch-type";
-import type { Pokemon, EnemyPokemon } from "#app/field/pokemon";
+import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import type { ForceSwitchOutImmunityAbAttr } from "#app/data/abilities/ab-attrs/force-switch-out-immunity-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type { Move } from "#app/data/moves/move";
+import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
+import type { EnemyPokemon, Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { SwitchPhase } from "#app/phases/switch-phase";
 import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
 import { BooleanHolder } from "#app/utils";
-import i18next from "i18next";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { Move } from "#app/data/moves/move";
-import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
-import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { BattleType } from "#enums/battle-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { MoveCategory } from "#enums/move-category";
+import { MoveId } from "#enums/move-id";
 import { PhaseId } from "#enums/phase-id";
+import { SwitchType } from "#enums/switch-type";
+import i18next from "i18next";
 
 /**
  * Attribute to force either the user (e.g. {@link https://bulbapedia.bulbagarden.net/wiki/U-turn_(move) | U-turn})
@@ -189,7 +190,7 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
 
   override getFailedText(_user: Pokemon, target: Pokemon, _move: Move, _cancelled: BooleanHolder): string | null {
     const blockedByAbility = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY, target, false, blockedByAbility);
+    applyAbAttrs<ForceSwitchOutImmunityAbAttr>(AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY, target, false, blockedByAbility);
     return blockedByAbility.value
       ? i18next.t("moveTriggers:cannotBeSwitchedOut", { pokemonName: getPokemonNameWithAffix(target) })
       : null;
@@ -217,7 +218,12 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
         }
 
         const blockedByAbility = new BooleanHolder(false);
-        applyAbAttrs(AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY, target, false, blockedByAbility);
+        applyAbAttrs<ForceSwitchOutImmunityAbAttr>(
+          AbAttrFlag.FORCE_SWITCH_OUT_IMMUNITY,
+          target,
+          false,
+          blockedByAbility,
+        );
         return !blockedByAbility.value && !target.isMax();
       }
 

--- a/src/data/moves/move-attrs/half-sacrificial-attr.ts
+++ b/src/data/moves/move-attrs/half-sacrificial-attr.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Move } from "#app/data/moves/move";
 import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
@@ -24,7 +25,7 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
   override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     const cancelled = new BooleanHolder(false);
     // Check to see if the Pokemon has an ability that blocks non-direct damage
-    applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, user, false, cancelled);
+    applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, user, false, cancelled);
     if (!cancelled.value) {
       user.damageAndUpdate(toDmgValue(user.getMaxHp() / 2), {
         result: HitResult.OTHER,

--- a/src/data/moves/move-attrs/heal-attr.ts
+++ b/src/data/moves/move-attrs/heal-attr.ts
@@ -1,13 +1,13 @@
+import type { RecoveryBoostAbAttr } from "#app/data/abilities/ab-attrs/recovery-boost-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type { Move } from "#app/data/moves/move";
+import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { toDmgValue } from "#app/utils";
-import i18next from "i18next";
-import type { Move } from "#app/data/moves/move";
-import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { NumberHolder } from "#app/utils";
+import { NumberHolder, toDmgValue } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import i18next from "i18next";
 
 /**
  * Heals the user or target by {@linkcode healRatio} depending on the value of {@linkcode selfTarget}
@@ -37,7 +37,7 @@ export class HealAttr extends MoveEffectAttr {
    */
   protected getHealRatio(user: Pokemon, target: Pokemon, move: Move): number {
     const healRatio = new NumberHolder(this.healRatio);
-    applyAbAttrs(AbAttrFlag.RECOVERY_BOOST, user, false, move, target, healRatio);
+    applyAbAttrs<RecoveryBoostAbAttr>(AbAttrFlag.RECOVERY_BOOST, user, false, move, target, healRatio);
     return healRatio.value;
   }
 

--- a/src/data/moves/move-attrs/multi-hit-attr.ts
+++ b/src/data/moves/move-attrs/multi-hit-attr.ts
@@ -1,3 +1,4 @@
+import type { MaxMultiHitAbAttr } from "#app/data/abilities/ab-attrs/max-multi-hit-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { type Move } from "#app/data/moves/move";
 import { ChangeMultiHitTypeAttr } from "#app/data/moves/move-attrs/change-multi-hit-type-attr";
@@ -77,7 +78,7 @@ export class MultiHitAttr extends MoveAttr {
          */
         const rand = user.randSeedInt(20);
         const hitValue = new NumberHolder(rand);
-        applyAbAttrs(AbAttrFlag.MAX_MULTI_HIT, user, false, hitValue);
+        applyAbAttrs<MaxMultiHitAbAttr>(AbAttrFlag.MAX_MULTI_HIT, user, false, hitValue);
         if (hitValue.value >= 13) {
           return 2;
         } else if (hitValue.value >= 6) {

--- a/src/data/moves/move-attrs/one-hit-ko-attr.ts
+++ b/src/data/moves/move-attrs/one-hit-ko-attr.ts
@@ -1,9 +1,10 @@
-import type { Pokemon } from "#app/field/pokemon";
-import { BooleanHolder } from "#app/utils";
+import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import type { BlockOneHitKOAbAttr } from "#app/data/abilities/ab-attrs/block-one-hit-ko-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Move } from "#app/data/moves/move";
 import { MoveAttr } from "#app/data/moves/move-attrs/move-attr";
-import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import type { Pokemon } from "#app/field/pokemon";
+import { BooleanHolder } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 /**
@@ -30,7 +31,7 @@ export class OneHitKOAttr extends MoveAttr {
   override getCondition(): MoveConditionFunc {
     return (user, target, _move) => {
       const cancelled = new BooleanHolder(false);
-      applyAbAttrs(AbAttrFlag.BLOCK_ONE_HIT_KO, target, false, cancelled);
+      applyAbAttrs<BlockOneHitKOAbAttr>(AbAttrFlag.BLOCK_ONE_HIT_KO, target, false, cancelled);
       return !cancelled.value && user.level >= target.level && !target.isMax(false);
     };
   }

--- a/src/data/moves/move-attrs/recoil-attr.ts
+++ b/src/data/moves/move-attrs/recoil-attr.ts
@@ -1,3 +1,5 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
+import type { BlockRecoilDamageAbAttr } from "#app/data/abilities/ab-attrs/block-recoil-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Move } from "#app/data/moves/move";
 import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
@@ -29,8 +31,8 @@ export class RecoilAttr extends MoveEffectAttr {
   override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     const cancelled = new BooleanHolder(false);
     if (!this.unblockable) {
-      applyAbAttrs(AbAttrFlag.BLOCK_RECOIL_DAMAGE, user, false, cancelled);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, user, false, cancelled);
+      applyAbAttrs<BlockRecoilDamageAbAttr>(AbAttrFlag.BLOCK_RECOIL_DAMAGE, user, false, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, user, false, cancelled);
     }
 
     if (cancelled.value) {

--- a/src/data/moves/move-attrs/remove-held-item-attr.ts
+++ b/src/data/moves/move-attrs/remove-held-item-attr.ts
@@ -1,13 +1,14 @@
+import type { BlockItemTheftAbAttr } from "#app/data/abilities/ab-attrs/block-item-theft-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type { Move } from "#app/data/moves/move";
+import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { PokemonHeldItemModifier } from "#app/modifier/modifier";
 import { BooleanHolder } from "#app/utils";
-import i18next from "i18next";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { Move } from "#app/data/moves/move";
-import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import i18next from "i18next";
 
 /**
  * Removes a random held item (or berry) from target.
@@ -33,7 +34,7 @@ export class RemoveHeldItemAttr extends MoveEffectAttr {
 
     const cancelled = new BooleanHolder(false);
 
-    applyAbAttrs(AbAttrFlag.BLOCK_ITEM_THEFT, target, false, cancelled);
+    applyAbAttrs<BlockItemTheftAbAttr>(AbAttrFlag.BLOCK_ITEM_THEFT, target, false, cancelled);
 
     if (cancelled.value === true) {
       return false;

--- a/src/data/moves/move-attrs/secret-power-attr.ts
+++ b/src/data/moves/move-attrs/secret-power-attr.ts
@@ -1,18 +1,20 @@
+import type { IgnoreMoveEffectsAbAttr } from "#app/data/abilities/ab-attrs/ignore-move-effects-ab-attr";
+import type { MoveEffectChanceMultiplierAbAttr } from "#app/data/abilities/ab-attrs/move-effect-chance-multiplier-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import { type Move } from "#app/data/moves/move";
+import { AddBattlerTagAttr } from "#app/data/moves/move-attrs/add-battler-tag-attr";
+import { ChanceBasedMoveEffectAttr } from "#app/data/moves/move-attrs/chance-based-move-effect-attr";
+import { StatStageChangeAttr } from "#app/data/moves/move-attrs/stat-stage-change-attr";
+import { StatusEffectAttr } from "#app/data/moves/move-attrs/status-effect-attr";
+import type { Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
+import { NumberHolder } from "#app/utils";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { Biome } from "#enums/biome";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { TerrainType } from "#enums/terrain-type";
-import type { Pokemon } from "#app/field/pokemon";
-import { globalScene } from "#app/global-scene";
-import { type Move } from "#app/data/moves/move";
-import { AddBattlerTagAttr } from "./add-battler-tag-attr";
-import { StatStageChangeAttr } from "#app/data/moves/move-attrs/stat-stage-change-attr";
-import { StatusEffectAttr } from "#app/data/moves/move-attrs/status-effect-attr";
-import { NumberHolder } from "#app/utils";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { ChanceBasedMoveEffectAttr } from "./chance-based-move-effect-attr";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 /**
  * Attribute used to determine the Biome/Terrain-based secondary
@@ -136,10 +138,17 @@ export class SecretPowerAttr extends ChanceBasedMoveEffectAttr {
   ): number {
     const moveChance = new NumberHolder(this.effectChanceOverride ?? move.chance);
 
-    applyAbAttrs(AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER, user, false, moveChance, move, showAbility);
+    applyAbAttrs<MoveEffectChanceMultiplierAbAttr>(
+      AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER,
+      user,
+      false,
+      moveChance,
+      move,
+      showAbility,
+    );
 
     if (!selfEffect) {
-      applyAbAttrs(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);
+      applyAbAttrs<IgnoreMoveEffectsAbAttr>(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);
     }
     return moveChance.value;
   }

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -1,13 +1,14 @@
-import { MoveCategory } from "#enums/move-category";
-import type { StatusEffect } from "#enums/status-effect";
+import type { ConfusionOnStatusEffectAbAttr } from "#app/data/abilities/ab-attrs/confusion-on-status-effect-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type { Move } from "#app/data/moves/move";
+import { ChanceBasedMoveEffectAttr } from "#app/data/moves/move-attrs/chance-based-move-effect-attr";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import i18next from "i18next";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { Move } from "#app/data/moves/move";
-import { ChanceBasedMoveEffectAttr } from "./chance-based-move-effect-attr";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { MoveCategory } from "#enums/move-category";
+import type { StatusEffect } from "#enums/status-effect";
+import i18next from "i18next";
 
 /**
  * Attribute to add a non-volatile status condition to
@@ -55,7 +56,14 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
     }
 
     if (pokemon.trySetStatus(this.effect, true, user, this.turnsRemaining)) {
-      applyAbAttrs(AbAttrFlag.CONFUSION_ON_STATUS_EFFECT, user, false, target, move, this.effect);
+      applyAbAttrs<ConfusionOnStatusEffectAbAttr>(
+        AbAttrFlag.CONFUSION_ON_STATUS_EFFECT,
+        user,
+        false,
+        target,
+        move,
+        this.effect,
+      );
       return true;
     }
 

--- a/src/data/moves/move-attrs/steal-eat-berry-attr.ts
+++ b/src/data/moves/move-attrs/steal-eat-berry-attr.ts
@@ -1,11 +1,13 @@
-import type { Pokemon } from "#app/field/pokemon";
-import { globalScene } from "#app/global-scene";
-import { BooleanHolder } from "#app/utils";
-import i18next from "i18next";
+import type { BlockItemTheftAbAttr } from "#app/data/abilities/ab-attrs/block-item-theft-ab-attr";
+import type { PostItemLostAbAttr } from "#app/data/abilities/ab-attrs/post-item-lost-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Move } from "#app/data/moves/move";
 import { EatBerryAttr } from "#app/data/moves/move-attrs/eat-berry-attr";
+import type { Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
+import { BooleanHolder } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import i18next from "i18next";
 
 /**
  * Attribute used for moves that steal a random berry from the target. The user then eats the stolen berry.
@@ -19,7 +21,7 @@ export class StealEatBerryAttr extends EatBerryAttr {
 
   override apply(user: Pokemon, target: Pokemon, _move: Move): boolean {
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.BLOCK_ITEM_THEFT, target, false, cancelled); // check for abilities that block item theft
+    applyAbAttrs<BlockItemTheftAbAttr>(AbAttrFlag.BLOCK_ITEM_THEFT, target, false, cancelled); // check for abilities that block item theft
     if (cancelled.value === true) {
       return false;
     }
@@ -30,7 +32,7 @@ export class StealEatBerryAttr extends EatBerryAttr {
     }
     // if the target has berries, pick a random berry and steal it
     this.chosenBerry = heldBerries[user.randSeedInt(heldBerries.length)];
-    applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, target, false);
+    applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, target, false);
     const message = i18next.t("battle:stealEatBerry", {
       pokemonName: user.name,
       targetName: target.name,

--- a/src/data/moves/move-attrs/steal-positive-stats-attr.ts
+++ b/src/data/moves/move-attrs/steal-positive-stats-attr.ts
@@ -1,14 +1,15 @@
-import { MoveEffectTrigger } from "#enums/move-effect-trigger";
-import { BATTLE_STATS } from "#enums/stat";
+import type { StatStageChangeMultiplierAbAttr } from "#app/data/abilities/ab-attrs/stat-stage-change-multiplier-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type { Move } from "#app/data/moves/move";
+import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { NumberHolder } from "#app/utils";
-import i18next from "i18next";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { Move } from "#app/data/moves/move";
-import { MoveEffectAttr } from "#app/data/moves/move-attrs/move-effect-attr";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { MoveEffectTrigger } from "#enums/move-effect-trigger";
+import { BATTLE_STATS } from "#enums/stat";
+import i18next from "i18next";
 
 /**
  * Attribute to steal the target's positive stat stages.
@@ -25,7 +26,12 @@ export class StealPositiveStatsAttr extends MoveEffectAttr {
     for (const s of BATTLE_STATS) {
       if (target.getStatStage(s) > 0) {
         const userStatChange = new NumberHolder(target.getStatStage(s));
-        applyAbAttrs(AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER, user, false, userStatChange);
+        applyAbAttrs<StatStageChangeMultiplierAbAttr>(
+          AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER,
+          user,
+          false,
+          userStatChange,
+        );
         user.setStatStage(s, user.getStatStage(s) + userStatChange.value);
         target.setStatStage(s, 0);
       }

--- a/src/data/moves/move-conditions/fail-if-damp-condition.ts
+++ b/src/data/moves/move-conditions/fail-if-damp-condition.ts
@@ -1,4 +1,5 @@
 import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import type { FieldPreventExplosionLikeAbAttr } from "#app/data/abilities/ab-attrs/field-prevent-explosion-like-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -13,7 +14,7 @@ export const failIfDampCondition: MoveConditionFunc = (user, _target, move) => {
   globalScene
     .getField(true)
     .map((p) =>
-      applyAbAttrs(
+      applyAbAttrs<FieldPreventExplosionLikeAbAttr>(
         AbAttrFlag.FIELD_PREVENT_EXPLOSION_LIKE,
         p,
         false,

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -1,47 +1,50 @@
-import { BattlerIndex } from "#enums/battler-index";
-import { type Pokemon } from "#app/field/pokemon";
-import { globalScene } from "#app/global-scene";
-import type { Localizable } from "#app/interfaces/locales";
-import { AttackTypeBoosterModifier } from "#app/modifier/modifier";
-import type { AbstractConstructor, Constructor, nil } from "#app/utils";
-import { BooleanHolder, NumberHolder } from "#app/utils";
-import { Abilities } from "#enums/abilities";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { WeakenMoveTypeArenaTagTypes } from "#app/utils/arena-tag-type-utils";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { MoveCategory } from "#enums/move-category";
-import { MoveFlags } from "#enums/move-flags";
-import { MoveTarget } from "#enums/move-target";
-import { MoveId } from "#enums/move-id";
-import { ElementalType } from "#enums/elemental-type";
-import { WeatherType } from "#enums/weather-type";
-import i18next from "i18next";
+import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import { FOG_ACCURACY_MULTIPLIER } from "#app/constants";
+import type { ChangeMovePriorityAbAttr } from "#app/data/abilities/ab-attrs/change-move-priority-ab-attr";
 import { type FieldMoveTypePowerBoostAbAttr } from "#app/data/abilities/ab-attrs/field-move-type-power-boost-ab-attr";
+import type { InfiltratorAbAttr } from "#app/data/abilities/ab-attrs/infiltrator-ab-attr";
+import type { MoveAbilityBypassAbAttr } from "#app/data/abilities/ab-attrs/move-ability-bypass-ab-attr";
+import type { WonderSkinAbAttr } from "#app/data/abilities/ab-attrs/wonder-skin-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { type TypeBoostTag } from "#app/data/battler-tags/type-boost-tag";
+import { allMoves } from "#app/data/data-lists";
+import type { ChargingAttackMove } from "#app/data/moves/charging-attack-move";
+import type { ChargingSelfStatusMove } from "#app/data/moves/charging-self-status-move";
+import { GMaxPowerAttr } from "#app/data/moves/move-attrs/gmax-power-attr";
 import { IncrementMovePriorityAttr } from "#app/data/moves/move-attrs/increment-move-priority-attr";
 import type { MoveAttr } from "#app/data/moves/move-attrs/move-attr";
 import { MultiHitAttr } from "#app/data/moves/move-attrs/multi-hit-attr";
 import { OneHitKOAccuracyAttr } from "#app/data/moves/move-attrs/one-hit-ko-accuracy-attr";
 import { SacrificialAttr } from "#app/data/moves/move-attrs/sacrificial-attr";
+import { StatStageChangeAttr } from "#app/data/moves/move-attrs/stat-stage-change-attr";
 import { TypelessAttr } from "#app/data/moves/move-attrs/typeless-attr";
+import { UseHigherAttackingStatAttr } from "#app/data/moves/move-attrs/use-higher-attacking-stat-attr";
 import { VariableAccuracyAttr } from "#app/data/moves/move-attrs/variable-accuracy-attr";
 import { VariablePowerAttr } from "#app/data/moves/move-attrs/variable-power-attr";
 import { VariableTargetAttr } from "#app/data/moves/move-attrs/variable-target-attr";
-import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
 import { MoveCondition } from "#app/data/moves/move-conditions/move-condition";
-import { Stat } from "#enums/stat";
-import { allMoves } from "#app/data/data-lists";
-import { UseHigherAttackingStatAttr } from "#app/data/moves/move-attrs/use-higher-attacking-stat-attr";
-import { GMaxPowerAttr } from "#app/data/moves/move-attrs/gmax-power-attr";
-import type { Species } from "#enums/species";
-import { StatStageChangeAttr } from "#app/data/moves/move-attrs/stat-stage-change-attr";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { type Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
+import type { Localizable } from "#app/interfaces/locales";
+import { AttackTypeBoosterModifier } from "#app/modifier/modifier";
+import { BooleanHolder, NumberHolder, type AbstractConstructor, type Constructor, type nil } from "#app/utils";
+import { WeakenMoveTypeArenaTagTypes } from "#app/utils/arena-tag-type-utils";
 import { applyMoveAttrs } from "#app/utils/move-utils";
-import type { ChargingAttackMove } from "#app/data/moves/charging-attack-move";
-import type { ChargingSelfStatusMove } from "#app/data/moves/charging-self-status-move";
-import { FOG_ACCURACY_MULTIPLIER } from "#app/constants";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { Abilities } from "#enums/abilities";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { ElementalType } from "#enums/elemental-type";
+import { MoveCategory } from "#enums/move-category";
+import { MoveFlags } from "#enums/move-flags";
+import { MoveId } from "#enums/move-id";
+import { MoveTarget } from "#enums/move-target";
+import type { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
+import { WeatherType } from "#enums/weather-type";
+import i18next from "i18next";
 
 export abstract class Move implements Localizable {
   public id: MoveId;
@@ -313,7 +316,7 @@ export abstract class Move implements Localizable {
 
     const bypassed = new BooleanHolder(false);
     // TODO: Allow this to be simulated
-    applyAbAttrs(AbAttrFlag.INFILTRATOR, user, false, bypassed);
+    applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, user, false, bypassed);
 
     return !bypassed.value && !this.hasFlag(MoveFlags.SOUND_MOVE) && !this.hasFlag(MoveFlags.IGNORE_SUBSTITUTE);
   }
@@ -610,7 +613,13 @@ export abstract class Move implements Localizable {
       case MoveFlags.IGNORE_ABILITIES:
         if (user.hasAbilityWithAttr(AbAttrFlag.MOVE_ABILITY_BYPASS)) {
           const abilityEffectsIgnored = new BooleanHolder(false);
-          applyAbAttrs(AbAttrFlag.MOVE_ABILITY_BYPASS, user, false, abilityEffectsIgnored, this);
+          applyAbAttrs<MoveAbilityBypassAbAttr>(
+            AbAttrFlag.MOVE_ABILITY_BYPASS,
+            user,
+            false,
+            abilityEffectsIgnored,
+            this,
+          );
           if (abilityEffectsIgnored.value) {
             return true;
           }
@@ -720,7 +729,7 @@ export abstract class Move implements Localizable {
     const moveAccuracy = new NumberHolder(this.accuracy);
 
     applyMoveAttrs(VariableAccuracyAttr, user, target, this, moveAccuracy);
-    applyAbAttrs(AbAttrFlag.WONDER_SKIN, target, simulated, user, this, moveAccuracy);
+    applyAbAttrs<WonderSkinAbAttr>(AbAttrFlag.WONDER_SKIN, target, simulated, user, this, moveAccuracy);
 
     if (moveAccuracy.value === -1) {
       return moveAccuracy.value;
@@ -821,7 +830,7 @@ export abstract class Move implements Localizable {
     const priority = new NumberHolder(this.priority);
 
     applyMoveAttrs(IncrementMovePriorityAttr, user, null, this, priority);
-    applyAbAttrs(AbAttrFlag.CHANGE_MOVE_PRIORITY, user, simulated, this, priority);
+    applyAbAttrs<ChangeMovePriorityAbAttr>(AbAttrFlag.CHANGE_MOVE_PRIORITY, user, simulated, this, priority);
 
     return priority.value;
   }

--- a/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-winstrate-challenge-encounter.ts
@@ -1,40 +1,41 @@
-import type { EnemyPartyConfig } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
+import type { PostBattleInitAbAttr } from "#app/data/abilities/ab-attrs/post-battle-init-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
+import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
+import { showEncounterDialogue, showEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import {
   generateModifierType,
   generateModifierTypeOption,
   initBattleWithEnemyConfig,
   leaveEncounterWithoutBattle,
   setEncounterRewards,
+  type EnemyPartyConfig,
 } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { transitionMysteryEncounterIntroVisuals } from "../utils/encounter-visuals-utils";
+import { transitionMysteryEncounterIntroVisuals } from "#app/data/mystery-encounters/utils/encounter-visuals-utils";
+import { SpeciesFormChangeManualTrigger } from "#app/data/species-form-change-triggers/species-form-change-manual-trigger";
+import { globalScene } from "#app/global-scene";
 import type { PokemonHeldItemModifierType } from "#app/modifier/modifier-type";
 import { modifierTypes } from "#app/modifier/modifier-types";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { globalScene } from "#app/global-scene";
-import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { TrainerType } from "#enums/trainer-type";
-import { Species } from "#enums/species";
-import { Abilities } from "#enums/abilities";
-import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
-import { Nature } from "#enums/nature";
-import { ElementalType } from "#enums/elemental-type";
-import { BerryType } from "#enums/berry-type";
-import { Stat } from "#enums/stat";
-import { SpeciesFormChangeManualTrigger } from "#app/data/species-form-change-triggers/species-form-change-manual-trigger";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { showEncounterDialogue, showEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
-import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
 import { PartyHealPhase } from "#app/phases/party-heal-phase";
-import { ShowTrainerPhase } from "#app/phases/show-trainer-phase";
 import { ReturnPhase } from "#app/phases/return-phase";
-import i18next from "i18next";
-import { ModifierTier } from "#enums/modifier-tier";
-import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants";
-import { BattlerTagType } from "#enums/battler-tag-type";
+import { ShowTrainerPhase } from "#app/phases/show-trainer-phase";
+import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { Abilities } from "#enums/abilities";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { BerryType } from "#enums/berry-type";
+import { ElementalType } from "#enums/elemental-type";
+import { ModifierTier } from "#enums/modifier-tier";
 import { MoveId } from "#enums/move-id";
+import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { Nature } from "#enums/nature";
+import { Species } from "#enums/species";
+import { Stat } from "#enums/stat";
+import { TrainerType } from "#enums/trainer-type";
+import i18next from "i18next";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/theWinstrateChallenge";
@@ -213,7 +214,7 @@ function endTrainerBattleAndShowDialogue(): Promise<void> {
         }
 
         pokemon.resetBattleData();
-        applyAbAttrs(AbAttrFlag.POST_BATTLE_INIT, pokemon, false);
+        applyAbAttrs<PostBattleInitAbAttr>(AbAttrFlag.POST_BATTLE_INIT, pokemon, false);
       }
 
       globalScene.unshiftPhase(new ShowTrainerPhase());

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -1,36 +1,43 @@
-import { globalScene } from "#app/global-scene";
-import type { BiomeTierTrainerPools, PokemonPools } from "#app/data/balance/biomes";
-import { biomePokemonPools, biomeTrainerPools } from "#app/data/balance/biomes";
-import { BiomePoolTier } from "#enums/biome-pool-tier";
-import { type AbstractConstructor, randSeedInt } from "#app/utils";
-import type PokemonSpecies from "#app/data/pokemon-species";
-import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
-import { getWeatherClearMessage, getWeatherStartMessage, PRIMAL_WEATHER, Weather } from "#app/data/weather";
-import { CommonAnim } from "#enums/common-anim";
-import type { ElementalType } from "#enums/elemental-type";
-import type { Move } from "#app/data/moves/move";
+import type { PostTerrainChangeAbAttr } from "#app/data/abilities/ab-attrs/post-terrain-change-ab-attr";
+import type { PostWeatherChangeAbAttr } from "#app/data/abilities/ab-attrs/post-weather-change-ab-attr";
+import type { TerrainEventTypeChangeAbAttr } from "#app/data/abilities/ab-attrs/terrain-event-type-change-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { ArenaTag } from "#app/data/arena-tag";
 import { EntryHazardTag, getArenaTag } from "#app/data/arena-tag";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import type { BattlerIndex } from "#enums/battler-index";
-import { getTerrainClearMessage, getTerrainStartMessage, Terrain } from "#app/data/terrain";
-import { TerrainType } from "#enums/terrain-type";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { Pokemon } from "#app/field/pokemon";
-import Overrides from "#app/overrides";
-import { TagAddedEvent, TagRemovedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#app/events/arena";
-import type { ArenaTagType } from "#enums/arena-tag-type";
-import { Biome } from "#enums/biome";
-import type { MoveId } from "#enums/move-id";
-import { Species } from "#enums/species";
-import { TimeOfDay } from "#enums/time-of-day";
-import { TrainerType } from "#enums/trainer-type";
-import { Abilities } from "#enums/abilities";
+import {
+  biomePokemonPools,
+  type BiomeTierTrainerPools,
+  biomeTrainerPools,
+  type PokemonPools,
+} from "#app/data/balance/biomes";
+import type { Move } from "#app/data/moves/move";
 import { SpeciesFormChangeRevertWeatherFormTrigger, SpeciesFormChangeWeatherTrigger } from "#app/data/pokemon-forms";
+import type PokemonSpecies from "#app/data/pokemon-species";
+import { getTerrainClearMessage, getTerrainStartMessage, Terrain } from "#app/data/terrain";
+import { getWeatherClearMessage, getWeatherStartMessage, PRIMAL_WEATHER, Weather } from "#app/data/weather";
+import { TagAddedEvent, TagRemovedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#app/events/arena";
+import type { Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
+import Overrides from "#app/overrides";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
-import { WeatherType } from "#enums/weather-type";
+import { type AbstractConstructor, randSeedInt } from "#app/utils";
+import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { Abilities } from "#enums/abilities";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import type { ArenaTagType } from "#enums/arena-tag-type";
+import type { BattlerIndex } from "#enums/battler-index";
+import { Biome } from "#enums/biome";
+import { BiomePoolTier } from "#enums/biome-pool-tier";
+import { CommonAnim } from "#enums/common-anim";
+import type { ElementalType } from "#enums/elemental-type";
+import type { MoveId } from "#enums/move-id";
+import { Species } from "#enums/species";
+import { TerrainType } from "#enums/terrain-type";
+import { TimeOfDay } from "#enums/time-of-day";
+import { TrainerType } from "#enums/trainer-type";
+import { WeatherType } from "#enums/weather-type";
 
 export class Arena {
   public biomeType: Biome;
@@ -444,7 +451,7 @@ export class Arena {
         pokemon.findAndRemoveTags(
           (t) => "weatherTypes" in t && !(t.weatherTypes as WeatherType[]).find((t) => t === newWeatherType),
         );
-        applyAbAttrs(AbAttrFlag.POST_WEATHER_CHANGE, pokemon, false, newWeatherType);
+        applyAbAttrs<PostWeatherChangeAbAttr>(AbAttrFlag.POST_WEATHER_CHANGE, pokemon, false, newWeatherType);
       });
 
     return true;
@@ -517,8 +524,8 @@ export class Arena {
         pokemon.findAndRemoveTags(
           (t) => "terrainTypes" in t && !(t.terrainTypes as TerrainType[]).find((t) => t === terrain),
         );
-        applyAbAttrs(AbAttrFlag.POST_TERRAIN_CHANGE, pokemon, false, terrain);
-        applyAbAttrs(AbAttrFlag.TERRAIN_EVENT_TYPE_CHANGE, pokemon, false, false);
+        applyAbAttrs<PostTerrainChangeAbAttr>(AbAttrFlag.POST_TERRAIN_CHANGE, pokemon, false, terrain);
+        applyAbAttrs<TerrainEventTypeChangeAbAttr>(AbAttrFlag.TERRAIN_EVENT_TYPE_CHANGE, pokemon, false, false);
       });
 
     return true;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -14,23 +14,36 @@ import type { TurnMove } from "#app/@types/TurnMove";
 import type { AnySound } from "#app/audio-manager";
 import { DYNAMAX_DAMAGE_TAKEN_FACTOR, PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import type { AbAttr } from "#app/data/abilities/ab-attrs/ab-attr";
+import type { AddSecondStrikeAbAttr } from "#app/data/abilities/ab-attrs/add-second-strike-ab-attr";
+import type { AlliedFieldDamageReductionAbAttr } from "#app/data/abilities/ab-attrs/allied-field-damage-reduction-ab-attr";
 import type { ArenaTrapAbAttr } from "#app/data/abilities/ab-attrs/arena-trap-ab-attr";
 import type { BattlerTagImmunityAbAttr } from "#app/data/abilities/ab-attrs/battler-tag-immunity-ab-attr";
 import type { BlockCritAbAttr } from "#app/data/abilities/ab-attrs/block-crit-ab-attr";
 import type { BonusCritAbAttr } from "#app/data/abilities/ab-attrs/bonus-crit-ab-attr";
+import type { BypassBurnDamageReductionAbAttr } from "#app/data/abilities/ab-attrs/bypass-burn-damage-reduction-ab-attr";
+import type { BypassParaSpeedReductionAbAttr } from "#app/data/abilities/ab-attrs/bypass-para-speed-reduction-ab-attr";
 import type { ConditionalCritAbAttr } from "#app/data/abilities/ab-attrs/conditional-crit-ab-attr";
+import type { DamageBoostAbAttr } from "#app/data/abilities/ab-attrs/damage-boost-ab-attr";
+import type { FieldMultiplyStatAbAttr } from "#app/data/abilities/ab-attrs/field-multiply-stat-ab-attr";
+import type { FieldPriorityMoveImmunityAbAttr } from "#app/data/abilities/ab-attrs/field-priority-move-immunity-ab-attr";
+import type { FullHpResistTypeAbAttr } from "#app/data/abilities/ab-attrs/full-hp-resist-type-ab-attr";
 import type { IgnoreOpponentStatStagesAbAttr } from "#app/data/abilities/ab-attrs/ignore-opponent-stat-stages-ab-attr";
 import type { IgnoreTypeImmunityAbAttr } from "#app/data/abilities/ab-attrs/ignore-type-immunity-ab-attr";
 import type { IgnoreTypeStatusEffectImmunityAbAttr } from "#app/data/abilities/ab-attrs/ignore-type-status-effect-immunity-ab-attr";
 import type { InfiltratorAbAttr } from "#app/data/abilities/ab-attrs/infiltrator-ab-attr";
 import type { MockStatusEffectAbAttr } from "#app/data/abilities/ab-attrs/mock-status-effect-ab-attr";
+import type { MoveImmunityAbAttr } from "#app/data/abilities/ab-attrs/move-immunity-ab-attr";
 import type { MoveTypeChangeAbAttr } from "#app/data/abilities/ab-attrs/move-type-change-ab-attr";
 import type { MultCritAbAttr } from "#app/data/abilities/ab-attrs/mult-crit-ab-attr";
 import type { PostDamageAbAttr } from "#app/data/abilities/ab-attrs/post-damage-ab-attr";
 import type { PostItemLostAbAttr } from "#app/data/abilities/ab-attrs/post-item-lost-ab-attr";
+import type { PreDefendFullHpEndureAbAttr } from "#app/data/abilities/ab-attrs/pre-defend-full-hp-endure-ab-attr";
+import type { ReceivedMoveDamageMultiplierAbAttr } from "#app/data/abilities/ab-attrs/received-move-damage-multiplier-ab-attr";
+import type { StabBoostAbAttr } from "#app/data/abilities/ab-attrs/stab-boost-ab-attr";
 import type { StatMultiplierAbAttr } from "#app/data/abilities/ab-attrs/stat-multiplier-ab-attr";
 import type { StatusEffectImmunityAbAttr } from "#app/data/abilities/ab-attrs/status-effect-immunity-ab-attr";
 import type { SynchronizeStatusAbAttr } from "#app/data/abilities/ab-attrs/synchronize-status-ab-attr";
+import type { TypeImmunityAbAttr } from "#app/data/abilities/ab-attrs/type-immunity-ab-attr";
 import type { UserFieldBattlerTagImmunityAbAttr } from "#app/data/abilities/ab-attrs/user-field-battler-tag-immunity-ab-attr";
 import type { UserFieldStatusEffectImmunityAbAttr } from "#app/data/abilities/ab-attrs/user-field-status-effect-immunity-ab-attr";
 import type { WeightMultiplierAbAttr } from "#app/data/abilities/ab-attrs/weight-multiplier-ab-attr";
@@ -1070,13 +1083,21 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const fieldApplied = new BooleanHolder(false);
     for (const pokemon of globalScene.getField(true)) {
-      applyAbFunc(AbAttrFlag.FIELD_MULTIPLY_STAT, pokemon, simulated, stat, statValue, this, fieldApplied);
+      applyAbFunc<FieldMultiplyStatAbAttr>(
+        AbAttrFlag.FIELD_MULTIPLY_STAT,
+        pokemon,
+        simulated,
+        stat,
+        statValue,
+        this,
+        fieldApplied,
+      );
       if (fieldApplied.value) {
         break;
       }
     }
 
-    applyAbFunc(AbAttrFlag.STAT_MULTIPLIER, this, simulated, stat, statValue, move, opponent);
+    applyAbFunc<StatMultiplierAbAttr>(AbAttrFlag.STAT_MULTIPLIER, this, simulated, stat, statValue, move, opponent);
 
     let ret = statValue.value;
 
@@ -1112,7 +1133,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         }
         if (this.hasStatusEffect(StatusEffect.PARALYSIS)) {
           const paraSpeedReductionCancelled = new BooleanHolder(false);
-          applyAbFunc(AbAttrFlag.BYPASS_PARA_SPEED_REDUCTION, this, simulated, paraSpeedReductionCancelled);
+          applyAbFunc<BypassParaSpeedReductionAbAttr>(
+            AbAttrFlag.BYPASS_PARA_SPEED_REDUCTION,
+            this,
+            simulated,
+            paraSpeedReductionCancelled,
+          );
           if (!paraSpeedReductionCancelled.value) {
             ret >>= 1;
           }
@@ -1827,16 +1853,31 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const cancelledHolder = cancelled ?? new BooleanHolder(false);
 
-    applyAbFunc(AbAttrFlag.TYPE_IMMUNITY, this, simulated, source, move, cancelledHolder, typeMultiplier);
+    applyAbFunc<TypeImmunityAbAttr>(
+      AbAttrFlag.TYPE_IMMUNITY,
+      this,
+      simulated,
+      source,
+      move,
+      cancelledHolder,
+      typeMultiplier,
+    );
 
     if (!cancelledHolder.value) {
-      applyAbFunc(AbAttrFlag.MOVE_IMMUNITY, this, simulated, source, move, cancelledHolder);
+      applyAbFunc<MoveImmunityAbAttr>(AbAttrFlag.MOVE_IMMUNITY, this, simulated, source, move, cancelledHolder);
     }
 
     if (!cancelledHolder.value) {
       const defendingSidePlayField = this.getField();
       defendingSidePlayField.forEach((p) =>
-        applyAbFunc(AbAttrFlag.FIELD_PRIORITY_MOVE_IMMUNITY, p, simulated, source, move, cancelledHolder),
+        applyAbFunc<FieldPriorityMoveImmunityAbAttr>(
+          AbAttrFlag.FIELD_PRIORITY_MOVE_IMMUNITY,
+          p,
+          simulated,
+          source,
+          move,
+          cancelledHolder,
+        ),
       );
     }
 
@@ -1850,7 +1891,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     // Apply Tera Shell's effect to attacks after all immunities are accounted for
     if (move.category !== MoveCategory.STATUS) {
-      applyAbFunc(AbAttrFlag.FULL_HP_RESIST_TYPE, this, simulated, source, move, typeMultiplier);
+      applyAbFunc<FullHpResistTypeAbAttr>(
+        AbAttrFlag.FULL_HP_RESIST_TYPE,
+        this,
+        simulated,
+        source,
+        move,
+        typeMultiplier,
+      );
     }
 
     if (move.category === MoveCategory.STATUS && move.hitsSubstitute(source, this)) {
@@ -2686,7 +2734,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
             break;
         }
       }
-      applyAbFunc(AbAttrFlag.IGNORE_OPPONENT_STAT_STAGES, opponent, simulated, stat, ignoreStatStage);
+      applyAbFunc<IgnoreOpponentStatStagesAbAttr>(
+        AbAttrFlag.IGNORE_OPPONENT_STAT_STAGES,
+        opponent,
+        simulated,
+        stat,
+        ignoreStatStage,
+      );
 
       if (move) {
         applyMoveAttrs(IgnoreOpponentStatStagesAttr, this, opponent, move, ignoreStatStage);
@@ -2969,7 +3023,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     /** Multiplier for moves enhanced by Multi-Lens and/or Parental Bond */
     const multiStrikeEnhancementMultiplier = new NumberHolder(1);
     // TODO: re-add multi-lens calculation
-    applyAbFunc(
+    applyAbFunc<AddSecondStrikeAbAttr>(
       AbAttrFlag.ADD_SECOND_STRIKE,
       source,
       simulated,
@@ -3008,7 +3062,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       stabMultiplier.value += 0.5;
     }
 
-    applyAbFunc(AbAttrFlag.STAB_BOOST, source, simulated, stabMultiplier);
+    applyAbFunc<StabBoostAbAttr>(AbAttrFlag.STAB_BOOST, source, simulated, stabMultiplier);
 
     stabMultiplier.value = Math.min(stabMultiplier.value, 2.25);
 
@@ -3017,7 +3071,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (isPhysical && source.hasStatusEffect(StatusEffect.BURN)) {
       if (!move.hasAttr(BypassBurnDamageReductionAttr)) {
         const burnDamageReductionCancelled = new BooleanHolder(false);
-        applyAbFunc(AbAttrFlag.BYPASS_BURN_DAMAGE_REDUCTION, source, simulated, burnDamageReductionCancelled);
+        applyAbFunc<BypassBurnDamageReductionAbAttr>(
+          AbAttrFlag.BYPASS_BURN_DAMAGE_REDUCTION,
+          source,
+          simulated,
+          burnDamageReductionCancelled,
+        );
         if (!burnDamageReductionCancelled.value) {
           burnMultiplier.value = 0.5;
         }
@@ -3063,17 +3122,24 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     /** Doubles damage if the attacker has Tinted Lens and is using a resisted move */
     const tintedLensMultiplier = new NumberHolder(1);
-    applyAbFunc(AbAttrFlag.DAMAGE_BOOST, source, simulated, move, this, tintedLensMultiplier);
+    applyAbFunc<DamageBoostAbAttr>(AbAttrFlag.DAMAGE_BOOST, source, simulated, move, this, tintedLensMultiplier);
 
     /** Apply this Pokemon's post-calc defensive modifiers (e.g. Fur Coat) */
     const receivedDamageMultiplier = new NumberHolder(1);
     const alliedFieldDamageMultiplier = new NumberHolder(1);
 
-    applyAbFunc(AbAttrFlag.RECEIVED_MOVE_DAMAGE_MULTIPLIER, this, simulated, source, move, receivedDamageMultiplier);
+    applyAbFunc<ReceivedMoveDamageMultiplierAbAttr>(
+      AbAttrFlag.RECEIVED_MOVE_DAMAGE_MULTIPLIER,
+      this,
+      simulated,
+      source,
+      move,
+      receivedDamageMultiplier,
+    );
 
     /** Additionally apply friend guard damage reduction if ally has it. */
     if (globalScene.currentBattle.double && this.getAlly()?.isActive(true)) {
-      applyAbFunc(
+      applyAbFunc<AlliedFieldDamageReductionAbAttr>(
         AbAttrFlag.ALLIED_FIELD_DAMAGE_REDUCTION,
         this.getAlly(),
         simulated,
@@ -3112,7 +3178,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     applyMoveAttrs(ModifiedDamageAttr, source, this, move, damage);
 
     if (this.isFullHp()) {
-      applyAbFunc(AbAttrFlag.PRE_DEFEND_FULL_HP_ENDURE, this, simulated, source, move, damage);
+      applyAbFunc<PreDefendFullHpEndureAbAttr>(
+        AbAttrFlag.PRE_DEFEND_FULL_HP_ENDURE,
+        this,
+        simulated,
+        source,
+        move,
+        damage,
+      );
     }
 
     // debug message for when damage is applied (i.e. not simulated)

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -14,9 +14,28 @@ import type { TurnMove } from "#app/@types/TurnMove";
 import type { AnySound } from "#app/audio-manager";
 import { DYNAMAX_DAMAGE_TAKEN_FACTOR, PLAYER_PARTY_MAX_SIZE } from "#app/constants";
 import type { AbAttr } from "#app/data/abilities/ab-attrs/ab-attr";
+import type { ArenaTrapAbAttr } from "#app/data/abilities/ab-attrs/arena-trap-ab-attr";
+import type { BattlerTagImmunityAbAttr } from "#app/data/abilities/ab-attrs/battler-tag-immunity-ab-attr";
+import type { BlockCritAbAttr } from "#app/data/abilities/ab-attrs/block-crit-ab-attr";
+import type { BonusCritAbAttr } from "#app/data/abilities/ab-attrs/bonus-crit-ab-attr";
+import type { ConditionalCritAbAttr } from "#app/data/abilities/ab-attrs/conditional-crit-ab-attr";
+import type { IgnoreOpponentStatStagesAbAttr } from "#app/data/abilities/ab-attrs/ignore-opponent-stat-stages-ab-attr";
+import type { IgnoreTypeImmunityAbAttr } from "#app/data/abilities/ab-attrs/ignore-type-immunity-ab-attr";
+import type { IgnoreTypeStatusEffectImmunityAbAttr } from "#app/data/abilities/ab-attrs/ignore-type-status-effect-immunity-ab-attr";
+import type { InfiltratorAbAttr } from "#app/data/abilities/ab-attrs/infiltrator-ab-attr";
+import type { MockStatusEffectAbAttr } from "#app/data/abilities/ab-attrs/mock-status-effect-ab-attr";
+import type { MoveTypeChangeAbAttr } from "#app/data/abilities/ab-attrs/move-type-change-ab-attr";
+import type { MultCritAbAttr } from "#app/data/abilities/ab-attrs/mult-crit-ab-attr";
+import type { PostDamageAbAttr } from "#app/data/abilities/ab-attrs/post-damage-ab-attr";
+import type { PostItemLostAbAttr } from "#app/data/abilities/ab-attrs/post-item-lost-ab-attr";
+import type { StatMultiplierAbAttr } from "#app/data/abilities/ab-attrs/stat-multiplier-ab-attr";
+import type { StatusEffectImmunityAbAttr } from "#app/data/abilities/ab-attrs/status-effect-immunity-ab-attr";
+import type { SynchronizeStatusAbAttr } from "#app/data/abilities/ab-attrs/synchronize-status-ab-attr";
+import type { UserFieldBattlerTagImmunityAbAttr } from "#app/data/abilities/ab-attrs/user-field-battler-tag-immunity-ab-attr";
+import type { UserFieldStatusEffectImmunityAbAttr } from "#app/data/abilities/ab-attrs/user-field-status-effect-immunity-ab-attr";
+import type { WeightMultiplierAbAttr } from "#app/data/abilities/ab-attrs/weight-multiplier-ab-attr";
 import type { Ability } from "#app/data/abilities/ability";
 import { applyAbAttrs, getAbApplyFunc } from "#app/data/abilities/apply-ab-attrs";
-import { applyBattlerTags } from "#app/data/battler-tags/utils/apply-battler-tags";
 import { NoCritTag } from "#app/data/arena-tag";
 import { speciesEggMoves } from "#app/data/balance/egg-moves";
 import { starterPassiveAbilities } from "#app/data/balance/passives";
@@ -34,7 +53,6 @@ import {
   speciesStarterCosts,
 } from "#app/data/balance/starters";
 import { reverseCompatibleTms, tmPoolTiers, tmSpecies } from "#app/data/balance/tms";
-import { getBattlerTag } from "#app/data/battler-tags/utils/get-battler-tag";
 import type { AutotomizedTag } from "#app/data/battler-tags/autotomized-tag";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { CritBoostStackableTag } from "#app/data/battler-tags/crit-boost-stackable-tag";
@@ -49,6 +67,8 @@ import { type RestrictingBattlerTag } from "#app/data/battler-tags/restricting-b
 import type { SubstituteTag } from "#app/data/battler-tags/substitute-tag";
 import { TypeImmuneTag } from "#app/data/battler-tags/type-immune-tag";
 import type { UproarTag } from "#app/data/battler-tags/uproar-tag";
+import { applyBattlerTags } from "#app/data/battler-tags/utils/apply-battler-tags";
+import { getBattlerTag } from "#app/data/battler-tags/utils/get-battler-tag";
 import { CustomPokemonData } from "#app/data/custom-pokemon-data";
 import { allAbilities, allMoves } from "#app/data/data-lists";
 import { DexAttr } from "#app/data/dex-attributes";
@@ -975,7 +995,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     globalScene.applyModifiers(TempCritBoosterModifier, source.isPlayer(), critStage);
 
     // Applies the effects of the ability 'Super Luck' here
-    applyAbAttrs(AbAttrFlag.BONUS_CRIT, source, simulated, critStage);
+    applyAbAttrs<BonusCritAbAttr>(AbAttrFlag.BONUS_CRIT, source, simulated, critStage);
 
     const critBoostTag = source.getTag(...CritBoostBattlerTagTypes);
     if (critBoostTag) {
@@ -1642,7 +1662,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const weight = new NumberHolder(this.getSpeciesForm().weight - weightRemoved);
 
     // This will trigger the ability overlay so only call this function when necessary
-    applyAbAttrs(AbAttrFlag.WEIGHT_MULTIPLIER, this, false, weight);
+    applyAbAttrs<WeightMultiplierAbAttr>(AbAttrFlag.WEIGHT_MULTIPLIER, this, false, weight);
     return Math.max(minWeight, weight.value);
   }
 
@@ -1714,7 +1734,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const opposingField = opposingFieldUnfiltered.filter((enemyPkm) => enemyPkm.switchOutStatus === false);
 
     opposingField.forEach((opponent) =>
-      trappedAbMessages.push(...applyAbAttrs(AbAttrFlag.ARENA_TRAP, opponent, simulated, trappedByAbility, this)),
+      trappedAbMessages.push(
+        ...applyAbAttrs<ArenaTrapAbAttr>(AbAttrFlag.ARENA_TRAP, opponent, simulated, trappedByAbility, this),
+      ),
     );
 
     const side = this.getArenaTagSide();
@@ -1736,7 +1758,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const moveTypeHolder = new NumberHolder(move.type);
 
     applyMoveAttrs(VariableMoveTypeAttr, this, null, move, moveTypeHolder);
-    applyAbAttrs(AbAttrFlag.MOVE_TYPE_CHANGE, this, simulated, move, undefined, moveTypeHolder);
+    applyAbAttrs<MoveTypeChangeAbAttr>(AbAttrFlag.MOVE_TYPE_CHANGE, this, simulated, move, undefined, moveTypeHolder);
 
     globalScene.arena.applyTags(ArenaTagType.ION_DELUGE, simulated, moveTypeHolder);
     if (this.getTag(BattlerTagType.ELECTRIFIED)) {
@@ -1882,7 +1904,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         if (source) {
           const ignoreImmunity = new BooleanHolder(false);
           if (source.isActive(true) && source.hasAbilityWithAttr(AbAttrFlag.IGNORE_TYPE_IMMUNITY)) {
-            applyAbAttrs(AbAttrFlag.IGNORE_TYPE_IMMUNITY, source, simulated, ignoreImmunity, moveType, defType);
+            applyAbAttrs<IgnoreTypeImmunityAbAttr>(
+              AbAttrFlag.IGNORE_TYPE_IMMUNITY,
+              source,
+              simulated,
+              ignoreImmunity,
+              moveType,
+              defType,
+            );
           }
           if (ignoreImmunity.value) {
             if (multiplier.value === 0) {
@@ -2694,8 +2723,20 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const ignoreAccStatStage = new BooleanHolder(false);
     const ignoreEvaStatStage = new BooleanHolder(false);
 
-    applyAbAttrs(AbAttrFlag.IGNORE_OPPONENT_STAT_STAGES, target, false, Stat.ACC, ignoreAccStatStage);
-    applyAbAttrs(AbAttrFlag.IGNORE_OPPONENT_STAT_STAGES, this, false, Stat.EVA, ignoreEvaStatStage);
+    applyAbAttrs<IgnoreOpponentStatStagesAbAttr>(
+      AbAttrFlag.IGNORE_OPPONENT_STAT_STAGES,
+      target,
+      false,
+      Stat.ACC,
+      ignoreAccStatStage,
+    );
+    applyAbAttrs<IgnoreOpponentStatStagesAbAttr>(
+      AbAttrFlag.IGNORE_OPPONENT_STAT_STAGES,
+      this,
+      false,
+      Stat.EVA,
+      ignoreEvaStatStage,
+    );
     applyMoveAttrs(IgnoreOpponentStatStagesAttr, this, target, sourceMove, ignoreEvaStatStage);
 
     globalScene.applyModifiers(TempStatStageBoosterModifier, this.isPlayer(), Stat.ACC, userAccStage);
@@ -2715,10 +2756,24 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
           : 3 / (3 + Math.min(targetEvaStage.value - userAccStage.value, 6));
     }
 
-    applyAbAttrs(AbAttrFlag.STAT_MULTIPLIER, this, false, Stat.ACC, accuracyMultiplier, sourceMove);
+    applyAbAttrs<StatMultiplierAbAttr>(
+      AbAttrFlag.STAT_MULTIPLIER,
+      this,
+      false,
+      Stat.ACC,
+      accuracyMultiplier,
+      sourceMove,
+    );
 
     const evasionMultiplier = new NumberHolder(1);
-    applyAbAttrs(AbAttrFlag.STAT_MULTIPLIER, target, false, Stat.EVA, evasionMultiplier, sourceMove);
+    applyAbAttrs<StatMultiplierAbAttr>(
+      AbAttrFlag.STAT_MULTIPLIER,
+      target,
+      false,
+      Stat.EVA,
+      evasionMultiplier,
+      sourceMove,
+    );
 
     return accuracyMultiplier.value / evasionMultiplier.value;
   }
@@ -2932,7 +2987,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     /** The damage multiplier when the given move critically hits */
     const criticalMultiplier = new NumberHolder(isCritical ? 1.5 : 1);
-    applyAbAttrs(AbAttrFlag.MULT_CRIT, source, simulated, criticalMultiplier);
+    applyAbAttrs<MultCritAbAttr>(AbAttrFlag.MULT_CRIT, source, simulated, criticalMultiplier);
 
     /**
      * A multiplier for random damage spread in the range [0.85, 1]
@@ -3100,13 +3155,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       isCritical.value = true;
     }
     applyMoveAttrs(CritOnlyAttr, source, this, move, isCritical);
-    applyAbAttrs(AbAttrFlag.CONDITIONAL_CRIT, source, simulated, isCritical, this, move);
+    applyAbAttrs<ConditionalCritAbAttr>(AbAttrFlag.CONDITIONAL_CRIT, source, simulated, isCritical, this, move);
     if (!isCritical.value) {
       const critChance = [24, 8, 2, 1][Math.max(0, Math.min(this.getCritStage(source, move, false), 3))];
       isCritical.value = critChance === 1 || !globalScene.randBattleSeedInt(critChance);
     }
 
-    applyAbAttrs(AbAttrFlag.BLOCK_CRIT, this, simulated, isCritical);
+    applyAbAttrs<BlockCritAbAttr>(AbAttrFlag.BLOCK_CRIT, this, simulated, isCritical);
 
     return isCritical.value;
   }
@@ -3214,7 +3269,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
      * Multi-hits are handled in move-effect-phase.ts for PostDamageAbAttr
      */
     if (!source || source.turnData.hitCount <= 1) {
-      applyAbAttrs(AbAttrFlag.POST_DAMAGE, this, false, damage, source);
+      applyAbAttrs<PostDamageAbAttr>(AbAttrFlag.POST_DAMAGE, this, false, damage, source);
     }
 
     return damage;
@@ -3261,11 +3316,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const stubTag = new BattlerTag(tagType, 0, 0);
 
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.BATTLER_TAG_IMMUNITY, this, true, stubTag, cancelled);
+    applyAbAttrs<BattlerTagImmunityAbAttr>(AbAttrFlag.BATTLER_TAG_IMMUNITY, this, true, stubTag, cancelled);
 
     const userField = this.getField();
     userField.forEach((pokemon) =>
-      applyAbAttrs(AbAttrFlag.USER_FIELD_BATTLER_TAG_IMMUNITY, pokemon, true, stubTag, cancelled),
+      applyAbAttrs<UserFieldBattlerTagImmunityAbAttr>(
+        AbAttrFlag.USER_FIELD_BATTLER_TAG_IMMUNITY,
+        pokemon,
+        true,
+        stubTag,
+        cancelled,
+      ),
     );
 
     return !cancelled.value;
@@ -3281,11 +3342,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const newTag = getBattlerTag(tagType, turnCount, sourceMove!, sourceId!); // TODO: are the bangs correct?
 
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.BATTLER_TAG_IMMUNITY, this, false, newTag, cancelled);
+    applyAbAttrs<BattlerTagImmunityAbAttr>(AbAttrFlag.BATTLER_TAG_IMMUNITY, this, false, newTag, cancelled);
 
     const userField = this.getField();
     userField.forEach((pokemon) =>
-      applyAbAttrs(AbAttrFlag.USER_FIELD_BATTLER_TAG_IMMUNITY, pokemon, false, newTag, cancelled),
+      applyAbAttrs<UserFieldBattlerTagImmunityAbAttr>(
+        AbAttrFlag.USER_FIELD_BATTLER_TAG_IMMUNITY,
+        pokemon,
+        false,
+        newTag,
+        cancelled,
+      ),
     );
 
     if (!cancelled.value && newTag.canAdd(this)) {
@@ -3641,7 +3708,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       statusEffect.value = this.status.statusEffect;
     }
     if (!ignoreMockAbility) {
-      applyAbAttrs(AbAttrFlag.MOCK_STATUS_EFFECT, this, false, statusEffect);
+      applyAbAttrs<MockStatusEffectAbAttr>(AbAttrFlag.MOCK_STATUS_EFFECT, this, false, statusEffect);
     }
     return statusEffect.value as StatusEffect;
   }
@@ -3688,7 +3755,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
           // Check if the source Pokemon has an ability that cancels the Poison/Toxic immunity
           const cancelImmunity = new BooleanHolder(false);
           if (sourcePokemon) {
-            applyAbAttrs(
+            applyAbAttrs<IgnoreTypeStatusEffectImmunityAbAttr>(
               AbAttrFlag.IGNORE_TYPE_STATUS_EFFECT_IMMUNITY,
               sourcePokemon,
               false,
@@ -3743,11 +3810,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.STATUS_EFFECT_IMMUNITY, this, quiet, effect, cancelled);
+    applyAbAttrs<StatusEffectImmunityAbAttr>(AbAttrFlag.STATUS_EFFECT_IMMUNITY, this, quiet, effect, cancelled);
 
     const userField = this.getField();
     userField.forEach((pokemon) =>
-      applyAbAttrs(AbAttrFlag.USER_FIELD_STATUS_EFFECT_IMMUNITY, pokemon, quiet, effect, cancelled),
+      applyAbAttrs<UserFieldStatusEffectImmunityAbAttr>(
+        AbAttrFlag.USER_FIELD_STATUS_EFFECT_IMMUNITY,
+        pokemon,
+        quiet,
+        effect,
+        cancelled,
+      ),
     );
 
     if (cancelled.value) {
@@ -3810,7 +3883,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     globalScene.triggerPokemonFormChange(this, SpeciesFormChangeStatusEffectTrigger, true);
     if (sourcePokemon) {
-      applyAbAttrs(AbAttrFlag.SYNCHRONIZE_STATUS, this, false, sourcePokemon, effect);
+      applyAbAttrs<SynchronizeStatusAbAttr>(AbAttrFlag.SYNCHRONIZE_STATUS, this, false, sourcePokemon, effect);
     }
 
     return true;
@@ -3850,7 +3923,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (globalScene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, defendingSide)) {
       const bypassed = new BooleanHolder(false);
       if (attacker) {
-        applyAbAttrs(AbAttrFlag.INFILTRATOR, attacker, false, bypassed);
+        applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, false, bypassed);
       }
       return !bypassed.value;
     }
@@ -4102,7 +4175,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         globalScene.removeModifier(heldItem, !this.isPlayer());
       }
       if (forBattle) {
-        applyAbAttrs(AbAttrFlag.POST_ITEM_LOST, this, false);
+        applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, this, false);
       }
       return true;
     } else {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1,30 +1,15 @@
+import type { CommanderAbAttr } from "#app/data/abilities/ab-attrs/commander-ab-attr";
+import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { pokemonEvolutions } from "#app/data/balance/pokemon-evolutions/init-pokemon-evolutions";
+import { FRIENDSHIP_GAIN_FROM_RARE_CANDY } from "#app/data/balance/starters";
 import { getBerryEffectFunc, getBerryPredicate } from "#app/data/berry";
 import { getLevelTotalExp } from "#app/data/exp";
 import { MAX_PER_TYPE_POKEBALLS } from "#app/data/pokeball";
 import { SpeciesFormChangeLapseTeraTrigger, SpeciesFormChangeTeraTrigger } from "#app/data/pokemon-forms";
 import { SpeciesFormChangeItemTrigger } from "#app/data/species-form-change-triggers/species-form-change-item-trigger";
-import { type FormChangeItem } from "#enums/form-change-item";
-import { type Pokemon, type PlayerPokemon } from "#app/field/pokemon";
+import { type PlayerPokemon, type Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import Overrides from "#app/overrides";
-import { EvolutionPhase } from "#app/phases/evolution-phase";
-import { LearnMovePhase } from "#app/phases/learn-move-phase";
-import { LearnMoveType } from "#enums/learn-move-type";
-import { LevelUpPhase } from "#app/phases/level-up-phase";
-import { achvs } from "#app/system/achievements";
-import type { VoucherType } from "#enums/voucher-type";
-import { addTextObject } from "#app/ui/text/text-utils";
-import { TextStyle } from "#enums/text-style";
-import { BooleanHolder, hslToHex, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils";
-import { BerryType } from "#enums/berry-type";
-import type { Nature } from "#enums/nature";
-import type { PokeballType } from "#enums/pokeball";
-import { Species } from "#enums/species";
-import { type PermanentStat, type TempBattleStat, BATTLE_STATS, Stat, TEMP_BATTLE_STATS } from "#enums/stat";
-import { StatusEffect } from "#enums/status-effect";
-import { ElementalType } from "#enums/elemental-type";
-import i18next from "i18next";
 import {
   type AttackTypeBoosterModifierType,
   type DoubleBattleChanceBoosterModifierType,
@@ -37,15 +22,31 @@ import {
   type PokemonFriendshipBoosterModifierType,
   type TerastallizeModifierType,
   type TmModifierType,
-} from "./modifier-type";
+} from "#app/modifier/modifier-type";
+import { modifierTypes } from "#app/modifier/modifier-types";
+import Overrides from "#app/overrides";
+import { EvolutionPhase } from "#app/phases/evolution-phase";
+import { LearnMovePhase } from "#app/phases/learn-move-phase";
+import { LevelUpPhase } from "#app/phases/level-up-phase";
+import { achvs } from "#app/system/achievements";
+import { addTextObject } from "#app/ui/text/text-utils";
+import { BooleanHolder, hslToHex, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils";
 import { getModifierType } from "#app/utils/modifier-type-utils";
-import { modifierTypes } from "./modifier-types";
-import { ModifierPoolType } from "#enums/modifier-pool-type";
-import { FRIENDSHIP_GAIN_FROM_RARE_CANDY } from "#app/data/balance/starters";
-import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { globalScene } from "#app/global-scene";
-import { BattlerTagType } from "#enums/battler-tag-type";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { BerryType } from "#enums/berry-type";
+import { ElementalType } from "#enums/elemental-type";
+import { type FormChangeItem } from "#enums/form-change-item";
+import { LearnMoveType } from "#enums/learn-move-type";
+import { ModifierPoolType } from "#enums/modifier-pool-type";
+import type { Nature } from "#enums/nature";
+import type { PokeballType } from "#enums/pokeball";
+import { Species } from "#enums/species";
+import { type PermanentStat, type TempBattleStat, BATTLE_STATS, Stat, TEMP_BATTLE_STATS } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+import { TextStyle } from "#enums/text-style";
+import type { VoucherType } from "#enums/voucher-type";
+import i18next from "i18next";
 
 const iconOverflowIndex = 24;
 
@@ -2071,7 +2072,7 @@ export class PokemonInstantReviveModifier extends PokemonHeldItemModifier {
 
     // Reapply Commander on the Pokemon's side of the field, if applicable
     const field = pokemon.getField();
-    field.forEach((p) => applyAbAttrs(AbAttrFlag.COMMANDER, p, false));
+    field.forEach((p) => applyAbAttrs<CommanderAbAttr>(AbAttrFlag.COMMANDER, p, false));
     return true;
   }
 

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -1,13 +1,14 @@
+import type { RunSuccessAbAttr } from "#app/data/abilities/ab-attrs/run-success-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { EnemyPokemon, PlayerPokemon, Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
 import { NumberHolder } from "#app/utils";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { PhaseId } from "#enums/phase-id";
 import { Stat } from "#enums/stat";
 import i18next from "i18next";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
-import { PhaseId } from "#enums/phase-id";
 
 /**
  * Handles the player attempting to run away from a wild battle
@@ -34,7 +35,7 @@ export class AttemptRunPhase extends PokemonPhase {
 
     this.attemptRunAway(playerField, enemyField, escapeChance);
 
-    applyAbAttrs(AbAttrFlag.RUN_SUCCESS, playerPokemon, false, escapeChance);
+    applyAbAttrs<RunSuccessAbAttr>(AbAttrFlag.RUN_SUCCESS, playerPokemon, false, escapeChance);
 
     if (playerPokemon.randSeedInt(100) < escapeChance.value && !this.forceFailEscape) {
       globalScene.audioManager.playSound("se/flee");

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -1,3 +1,4 @@
+import type { PostBattleAbAttr } from "#app/data/abilities/ab-attrs/post-battle-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import type { LapsingPersistentModifier, LapsingPokemonHeldItemModifier } from "#app/modifier/modifier";
@@ -50,7 +51,7 @@ export class BattleEndPhase extends BattlePhase {
     }
 
     for (const pokemon of globalScene.getPokemonAllowedInBattle()) {
-      applyAbAttrs(AbAttrFlag.POST_BATTLE, pokemon, false, this.isVictory);
+      applyAbAttrs<PostBattleAbAttr>(AbAttrFlag.POST_BATTLE, pokemon, false, this.isVictory);
     }
 
     if (currentBattle.moneyScattered) {

--- a/src/phases/berry-phase.ts
+++ b/src/phases/berry-phase.ts
@@ -1,5 +1,6 @@
+import type { HealFromBerryUseAbAttr } from "#app/data/abilities/ab-attrs/heal-from-berry-use-ab-attr";
+import type { PreventBerryUseAbAttr } from "#app/data/abilities/ab-attrs/prevent-berry-use-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { CommonAnim } from "#enums/common-anim";
 import { BerryUsedEvent } from "#app/events/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -7,9 +8,10 @@ import { BerryModifier } from "#app/modifier/modifier";
 import { FieldPhase } from "#app/phases/abstract-field-phase";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { BooleanHolder } from "#app/utils";
-import i18next from "i18next";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { CommonAnim } from "#enums/common-anim";
 import { PhaseId } from "#enums/phase-id";
+import i18next from "i18next";
 
 /**
  * The phase after attacks where the pokemon eat berries
@@ -28,7 +30,9 @@ export class BerryPhase extends FieldPhase {
 
       if (hasUsableBerry) {
         const cancelled = new BooleanHolder(false);
-        pokemon.getOpponents().map((opp) => applyAbAttrs(AbAttrFlag.PREVENT_BERRY_USE, opp, false, cancelled));
+        pokemon
+          .getOpponents()
+          .map((opp) => applyAbAttrs<PreventBerryUseAbAttr>(AbAttrFlag.PREVENT_BERRY_USE, opp, false, cancelled));
 
         if (cancelled.value) {
           globalScene.queueMessage(
@@ -49,7 +53,7 @@ export class BerryPhase extends FieldPhase {
 
           globalScene.updateModifiers(pokemon.isPlayer());
 
-          applyAbAttrs(AbAttrFlag.HEAL_FROM_BERRY_USE, pokemon, false);
+          applyAbAttrs<HealFromBerryUseAbAttr>(AbAttrFlag.HEAL_FROM_BERRY_USE, pokemon, false);
         }
       }
     });

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -6,6 +6,7 @@ import { type NextEncounterPhase } from "#app/phases/next-encounter-phase";
 // -- end tsdoc imports --
 
 import { ME_WEIGHT_INCREMENT_ON_SPAWN_MISS, PLAYER_PARTY_MAX_SIZE } from "#app/constants";
+import type { SyncEncounterNatureAbAttr } from "#app/data/abilities/ab-attrs/sync-encounter-nature-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { getCharVariantFromDialogue } from "#app/data/dialogue";
 import { initEncounterAnims } from "#app/data/init/init-encounter-anims";
@@ -163,7 +164,12 @@ export class EncounterPhase extends BattlePhase {
             .slice(0, !double ? 1 : 2)
             .reverse()
             .forEach((playerPokemon) => {
-              applyAbAttrs(AbAttrFlag.SYNC_ENCOUNTER_NATURE, playerPokemon, false, currentBattle.enemyParty[e]);
+              applyAbAttrs<SyncEncounterNatureAbAttr>(
+                AbAttrFlag.SYNC_ENCOUNTER_NATURE,
+                playerPokemon,
+                false,
+                currentBattle.enemyParty[e],
+              );
             });
         }
       }

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -1,11 +1,14 @@
 // -- start tsdoc imports --
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type BattlerTag } from "#app/data/battler-tags/battler-tag";
+import { type GameOverPhase } from "#app/phases/game-over-phase";
 import { type MovePhase } from "#app/phases/move-phase";
-import { type GameOverPhase } from "./game-over-phase";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 // -- end tsdoc imports --
 
+import type { PostFaintAbAttr } from "#app/data/abilities/ab-attrs/post-faint-ab-attr";
+import type { PostKnockOutAbAttr } from "#app/data/abilities/ab-attrs/post-knock-out-ab-attr";
+import type { PostVictoryAbAttr } from "#app/data/abilities/ab-attrs/post-victory-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { FRIENDSHIP_LOSS_FROM_FAINT } from "#app/data/balance/starters";
 import type { DestinyBondTag } from "#app/data/battler-tags/destiny-bond-tag";
@@ -19,6 +22,12 @@ import type { EnemyPokemon, Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { PokemonInstantReviveModifier } from "#app/modifier/modifier";
+import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
+import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
+import { SwitchPhase } from "#app/phases/switch-phase";
+import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
+import { ToggleDoublePositionPhase } from "#app/phases/toggle-double-position-phase";
+import { VictoryPhase } from "#app/phases/victory-phase";
 import { isNullOrUndefined } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattleType } from "#enums/battle-type";
@@ -29,12 +38,6 @@ import { HitResult } from "#enums/hit-result";
 import { PhaseId } from "#enums/phase-id";
 import { SwitchType } from "#enums/switch-type";
 import i18next from "i18next";
-import { PokemonPhase } from "./abstract-pokemon-phase";
-import { DamageAnimPhase } from "./damage-anim-phase";
-import { SwitchPhase } from "./switch-phase";
-import { SwitchSummonPhase } from "./switch-summon-phase";
-import { ToggleDoublePositionPhase } from "./toggle-double-position-phase";
-import { VictoryPhase } from "./victory-phase";
 
 /**
  * Handles the effects of a pokemon fainting:
@@ -162,18 +165,24 @@ export class FaintPhase extends PokemonPhase {
 
     if (this.source && pokemon.turnData?.attacksReceived?.length) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
-      applyAbAttrs(AbAttrFlag.POST_FAINT, pokemon, false, this.source, allMoves.get(lastAttack.moveId));
+      applyAbAttrs<PostFaintAbAttr>(
+        AbAttrFlag.POST_FAINT,
+        pokemon,
+        false,
+        this.source,
+        allMoves.get(lastAttack.moveId),
+      );
     } else {
       //If killed by indirect damage, apply post-faint abilities without providing the source of fatal damage
-      applyAbAttrs(AbAttrFlag.POST_FAINT, pokemon, false);
+      applyAbAttrs<PostFaintAbAttr>(AbAttrFlag.POST_FAINT, pokemon, false);
     }
 
     const alivePlayField = globalScene.getField(true);
-    alivePlayField.forEach((p) => applyAbAttrs(AbAttrFlag.POST_KNOCK_OUT, p, false, pokemon));
+    alivePlayField.forEach((p) => applyAbAttrs<PostKnockOutAbAttr>(AbAttrFlag.POST_KNOCK_OUT, p, false, pokemon));
     if (pokemon.turnData?.attacksReceived?.length) {
       const defeatSource = globalScene.getPokemonById(pokemon.turnData.attacksReceived[0].sourceId);
       if (defeatSource?.isOnField()) {
-        applyAbAttrs(AbAttrFlag.POST_VICTORY, defeatSource, false);
+        applyAbAttrs<PostVictoryAbAttr>(AbAttrFlag.POST_VICTORY, defeatSource, false);
         // TODO: Refactor Fell Stinger
         const pvmove = allMoves.get(pokemon.turnData.attacksReceived[0].moveId);
         const pvattrs = pvmove.getAttrs(PostVictoryStatStageChangeAttr);

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -1,5 +1,9 @@
 import type { AttackMoveResult } from "#app/@types/AttackMoveResult";
 import type { TurnMove } from "#app/@types/TurnMove";
+import type { AddSecondStrikeAbAttr } from "#app/data/abilities/ab-attrs/add-second-strike-ab-attr";
+import type { PostAttackAbAttr } from "#app/data/abilities/ab-attrs/post-attack-ab-attr";
+import type { PostDamageAbAttr } from "#app/data/abilities/ab-attrs/post-damage-ab-attr";
+import type { PostDefendAbAttr } from "#app/data/abilities/ab-attrs/post-defend-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { MoveAnim } from "#app/data/animations/move-anim";
 import type { SubstituteTag } from "#app/data/battler-tags/substitute-tag";
@@ -132,7 +136,7 @@ export class MoveEffectPhase extends HitCheckPhase {
       // Assume single target for multi hit
       applyMoveAttrs(MultiHitAttr, user, targets[0], move, hitCount);
       // If Parental Bond is applicable, add another hit
-      applyAbAttrs(AbAttrFlag.ADD_SECOND_STRIKE, user, false, move, targets[0], hitCount);
+      applyAbAttrs<AddSecondStrikeAbAttr>(AbAttrFlag.ADD_SECOND_STRIKE, user, false, move, targets[0], hitCount);
       // TODO: re-add multi-lens calculation
       // Set the user's relevant turnData fields to reflect the final hit count
       user.turnData.hitCount = hitCount.value;
@@ -315,7 +319,7 @@ export class MoveEffectPhase extends HitCheckPhase {
 
       // Multi-hit check for Wimp Out/Emergency Exit
       if (user.turnData.hitCount > 1) {
-        applyAbAttrs(AbAttrFlag.POST_DAMAGE, target, false, 0, user);
+        applyAbAttrs<PostDamageAbAttr>(AbAttrFlag.POST_DAMAGE, target, false, 0, user);
       }
     }
   }
@@ -568,7 +572,7 @@ export class MoveEffectPhase extends HitCheckPhase {
     this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, target, firstTarget, false);
     this.applyHeldItemFlinchCheck(user, target, dealsDamage);
     this.applyOnGetHitAbEffects(user, target);
-    applyAbAttrs(AbAttrFlag.POST_ATTACK, user, false, target, move);
+    applyAbAttrs<PostAttackAbAttr>(AbAttrFlag.POST_ATTACK, user, false, target, move);
 
     // Apply Grip Claw's chance to steal an item from the target
     if (move.isAttackMove()) {
@@ -630,7 +634,7 @@ export class MoveEffectPhase extends HitCheckPhase {
    * @param target - {@linkcode Pokemon} the current target of this phase's invoked move
    */
   protected applyOnGetHitAbEffects(user: Pokemon, target: Pokemon): void {
-    applyAbAttrs(AbAttrFlag.POST_DEFEND, target, false, user, this.move.getMove());
+    applyAbAttrs<PostDefendAbAttr>(AbAttrFlag.POST_DEFEND, target, false, user, this.move.getMove());
     target.lapseTags(BattlerTagLapseType.AFTER_HIT);
   }
 

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -1,4 +1,7 @@
+import type { PokemonTypeChangeAbAttr } from "#app/data/abilities/ab-attrs/pokemon-type-change-ab-attr";
+import type { PostMoveUsedAbAttr } from "#app/data/abilities/ab-attrs/post-move-used-ab-attr";
 import type { RedirectMoveAbAttr } from "#app/data/abilities/ab-attrs/redirect-move-ab-attr";
+import type { ReduceSleepDurationAbAttr } from "#app/data/abilities/ab-attrs/reduce-sleep-duration-ab-attr";
 import type { ReflectMovesAbAttr } from "#app/data/abilities/ab-attrs/reflect-moves-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { CenterOfAttentionTag } from "#app/data/battler-tags/center-of-attention-tag";
@@ -259,7 +262,13 @@ export class MovePhase extends BattlePhase {
         case StatusEffect.SLEEP:
           applyMoveAttrs(BypassSleepAttr, this.pokemon, null, this.move.getMove());
           const turnsRemaining = new NumberHolder(this.pokemon.status!.sleepTurnsRemaining ?? 0);
-          applyAbAttrs(AbAttrFlag.REDUCE_SLEEP_DURATION, this.pokemon, false, statusEffect, turnsRemaining);
+          applyAbAttrs<ReduceSleepDurationAbAttr>(
+            AbAttrFlag.REDUCE_SLEEP_DURATION,
+            this.pokemon,
+            false,
+            statusEffect,
+            turnsRemaining,
+          );
           if (Overrides.STATUS_ACTIVATION_OVERRIDE === true) {
             turnsRemaining.value = Math.max(turnsRemaining.value, 1);
           } else if (Overrides.STATUS_ACTIVATION_OVERRIDE === false) {
@@ -480,12 +489,12 @@ export class MovePhase extends BattlePhase {
      * if the move fails.
      */
     if (success) {
-      applyAbAttrs(AbAttrFlag.POKEMON_TYPE_CHANGE, this.pokemon, false, this.move.getMove());
+      applyAbAttrs<PokemonTypeChangeAbAttr>(AbAttrFlag.POKEMON_TYPE_CHANGE, this.pokemon, false, this.move.getMove());
       this.showPreMoveMessages();
       globalScene.unshiftPhase(new MoveEffectPhase(this.pokemon.getBattlerIndex(), this.targets, this.move));
     } else {
       if ([MoveId.ROAR, MoveId.WHIRLWIND, MoveId.TRICK_OR_TREAT, MoveId.FORESTS_CURSE].includes(this.move.moveId)) {
-        applyAbAttrs(AbAttrFlag.POKEMON_TYPE_CHANGE, this.pokemon, false, this.move.getMove());
+        applyAbAttrs<PokemonTypeChangeAbAttr>(AbAttrFlag.POKEMON_TYPE_CHANGE, this.pokemon, false, this.move.getMove());
       }
 
       this.pokemon.pushMoveHistory({
@@ -523,7 +532,14 @@ export class MovePhase extends BattlePhase {
     // Note that the `!this.followUp` check here prevents an infinite Dancer loop.
     if (this.move.getMove().hasFlag(MoveFlags.DANCE_MOVE) && !this.followUp) {
       globalScene.getField(true).forEach((pokemon) => {
-        applyAbAttrs(AbAttrFlag.POST_MOVE_USED, pokemon, false, this.move, this.pokemon, this.targets);
+        applyAbAttrs<PostMoveUsedAbAttr>(
+          AbAttrFlag.POST_MOVE_USED,
+          pokemon,
+          false,
+          this.move,
+          this.pokemon,
+          this.targets,
+        );
       });
     }
   }
@@ -537,7 +553,7 @@ export class MovePhase extends BattlePhase {
       this.updateLastMoveId(true);
 
       // Protean and Libero apply on the charging turn of charge moves
-      applyAbAttrs(AbAttrFlag.POKEMON_TYPE_CHANGE, this.pokemon, false, this.move.getMove());
+      applyAbAttrs<PokemonTypeChangeAbAttr>(AbAttrFlag.POKEMON_TYPE_CHANGE, this.pokemon, false, this.move.getMove());
 
       globalScene.chargeMove(this.pokemon.getBattlerIndex(), this.targets, this.move);
     } else {

--- a/src/phases/new-biome-encounter-phase.ts
+++ b/src/phases/new-biome-encounter-phase.ts
@@ -1,9 +1,10 @@
+import type { PostBiomeChangeAbAttr } from "#app/data/abilities/ab-attrs/post-biome-change-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { getRandomWeatherType } from "#app/data/weather";
 import { globalScene } from "#app/global-scene";
+import { NextEncounterPhase } from "#app/phases/next-encounter-phase";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { PhaseId } from "#enums/phase-id";
-import { NextEncounterPhase } from "./next-encounter-phase";
 
 /**
  * Triggers the first encounter of a new biome
@@ -24,7 +25,7 @@ export class NewBiomeEncounterPhase extends NextEncounterPhase {
     }
 
     for (const pokemon of globalScene.getPlayerParty().filter((p) => p.isOnField())) {
-      applyAbAttrs(AbAttrFlag.POST_BIOME_CHANGE, pokemon, false);
+      applyAbAttrs<PostBiomeChangeAbAttr>(AbAttrFlag.POST_BIOME_CHANGE, pokemon, false);
     }
 
     const enemyField = globalScene.getEnemyField();

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -1,12 +1,14 @@
-import type { BattlerIndex } from "#enums/battler-index";
+import type { CommanderAbAttr } from "#app/data/abilities/ab-attrs/commander-ab-attr";
+import type { PostSummonAbAttr } from "#app/data/abilities/ab-attrs/post-summon-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { StatusEffect } from "#enums/status-effect";
-import { PokemonPhase } from "./abstract-pokemon-phase";
+import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
 import { EntryHazardArenaTagTypes } from "#app/utils/arena-tag-type-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import type { BattlerIndex } from "#enums/battler-index";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { PhaseId } from "#enums/phase-id";
+import { StatusEffect } from "#enums/status-effect";
 
 export class PostSummonPhase extends PokemonPhase {
   override readonly id = PhaseId.POST_SUMMON;
@@ -33,9 +35,9 @@ export class PostSummonPhase extends PokemonPhase {
       pokemon.lapseTag(BattlerTagType.MYSTERY_ENCOUNTER_POST_SUMMON);
     }
 
-    applyAbAttrs(AbAttrFlag.POST_SUMMON, pokemon, false);
+    applyAbAttrs<PostSummonAbAttr>(AbAttrFlag.POST_SUMMON, pokemon, false);
     const field = pokemon.getField();
-    field.forEach((p) => applyAbAttrs(AbAttrFlag.COMMANDER, p, false));
+    field.forEach((p) => applyAbAttrs<CommanderAbAttr>(AbAttrFlag.COMMANDER, p, false));
 
     this.end();
   }

--- a/src/phases/post-turn-status-effect-phase.ts
+++ b/src/phases/post-turn-status-effect-phase.ts
@@ -1,3 +1,7 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
+import type { BlockStatusDamageAbAttr } from "#app/data/abilities/ab-attrs/block-status-damage-ab-attr";
+import type { PostDamageAbAttr } from "#app/data/abilities/ab-attrs/post-damage-ab-attr";
+import type { ReduceBurnDamageAbAttr } from "#app/data/abilities/ab-attrs/reduce-burn-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { CommonBattleAnim } from "#app/data/animations/common-battle-anim";
 import { getStatusEffectActivationText } from "#app/data/status-effect";
@@ -31,8 +35,8 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
     pokemon.status!.incrementTurn();
 
     const cancelled = new BooleanHolder(false);
-    applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
-    applyAbAttrs(AbAttrFlag.BLOCK_STATUS_DAMAGE, pokemon, false, cancelled);
+    applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+    applyAbAttrs<BlockStatusDamageAbAttr>(AbAttrFlag.BLOCK_STATUS_DAMAGE, pokemon, false, cancelled);
 
     if (cancelled.value) {
       return this.end();
@@ -52,14 +56,14 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
         break;
       case StatusEffect.BURN:
         damage.value = pokemon.getMaxHp() / 16;
-        applyAbAttrs(AbAttrFlag.REDUCE_BURN_DAMAGE, pokemon, false, damage);
+        applyAbAttrs<ReduceBurnDamageAbAttr>(AbAttrFlag.REDUCE_BURN_DAMAGE, pokemon, false, damage);
         break;
     }
 
     if (damage.value) {
       // Set preventEndure flag to avoid pokemon surviving thanks to focus band, sturdy, endure ...
       pokemon.damageAndUpdate(toDmgValue(damage.value), { preventEndure: true });
-      applyAbAttrs(AbAttrFlag.POST_DAMAGE, pokemon, false, damage.value);
+      applyAbAttrs<PostDamageAbAttr>(AbAttrFlag.POST_DAMAGE, pokemon, false, damage.value);
     }
 
     // TODO: this should be handled by some sort of animation manager instead of instantiating a new `CommonBattleAnim` class

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -1,3 +1,8 @@
+import type { PostStatStageChangeAbAttr } from "#app/data/abilities/ab-attrs/post-stat-stage-change-ab-attr";
+import type { ProtectStatAbAttr } from "#app/data/abilities/ab-attrs/protect-stat-ab-attr";
+import type { ReflectStatStageChangeAbAttr } from "#app/data/abilities/ab-attrs/reflect-stat-stage-change-ab-attr";
+import type { StatStageChangeCopyAbAttr } from "#app/data/abilities/ab-attrs/stat-stage-change-copy-ab-attr";
+import type { StatStageChangeMultiplierAbAttr } from "#app/data/abilities/ab-attrs/stat-stage-change-multiplier-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
@@ -81,7 +86,7 @@ export class StatStageChangePhase extends PokemonPhase {
 
     if (!this.ignoreAbilities && !this.bypassReflect) {
       const reflected = new BooleanHolder(false);
-      applyAbAttrs(
+      applyAbAttrs<ReflectStatStageChangeAbAttr>(
         AbAttrFlag.REFLECT_STAT_STAGE_CHANGE,
         pokemon,
         false,
@@ -109,7 +114,7 @@ export class StatStageChangePhase extends PokemonPhase {
     const stages = new NumberHolder(this.stages);
 
     if (!this.ignoreAbilities) {
-      applyAbAttrs(AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER, pokemon, false, stages);
+      applyAbAttrs<StatStageChangeMultiplierAbAttr>(AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER, pokemon, false, stages);
     }
 
     let simulate = false;
@@ -122,7 +127,7 @@ export class StatStageChangePhase extends PokemonPhase {
       }
 
       if (!cancelled.value && !selfTarget && stages.value < 0) {
-        applyAbAttrs(AbAttrFlag.PROTECT_STAT, pokemon, simulate, stat, cancelled);
+        applyAbAttrs<ProtectStatAbAttr>(AbAttrFlag.PROTECT_STAT, pokemon, simulate, stat, cancelled);
       }
 
       // If one stat stage decrease is cancelled, simulate the rest of the applications
@@ -180,11 +185,24 @@ export class StatStageChangePhase extends PokemonPhase {
 
       if (stages.value > 0 && this.canBeCopied) {
         for (const opponent of pokemon.getOpponents()) {
-          applyAbAttrs(AbAttrFlag.STAT_STAGE_CHANGE_COPY, opponent, false, this.stats, stages.value);
+          applyAbAttrs<StatStageChangeCopyAbAttr>(
+            AbAttrFlag.STAT_STAGE_CHANGE_COPY,
+            opponent,
+            false,
+            this.stats,
+            stages.value,
+          );
         }
       }
 
-      applyAbAttrs(AbAttrFlag.POST_STAT_STAGE_CHANGE, pokemon, false, filteredStats, this.stages, selfTarget);
+      applyAbAttrs<PostStatStageChangeAbAttr>(
+        AbAttrFlag.POST_STAT_STAGE_CHANGE,
+        pokemon,
+        false,
+        filteredStats,
+        this.stages,
+        selfTarget,
+      );
 
       // Look for any other stat change phases; if this is the last one, do White Herb check
       const existingPhase = globalScene.findPhase(

--- a/src/phases/switch-summon-phase.ts
+++ b/src/phases/switch-summon-phase.ts
@@ -1,3 +1,4 @@
+import type { PreSwitchOutAbAttr } from "#app/data/abilities/ab-attrs/pre-switch-out-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { SubstituteTag } from "#app/data/battler-tags/substitute-tag";
 import { getPokeballTintColor } from "#app/data/pokeball";
@@ -115,7 +116,7 @@ export class SwitchSummonPhase extends SummonPhase {
     const party = this.getAlliedParty();
     const switchedInPokemon = party[this.slotIndex];
     this.lastPokemon = this.getPokemon();
-    applyAbAttrs(AbAttrFlag.PRE_SWITCH_OUT, this.lastPokemon, false);
+    applyAbAttrs<PreSwitchOutAbAttr>(AbAttrFlag.PRE_SWITCH_OUT, this.lastPokemon, false);
     if (this.switchType === SwitchType.BATON_PASS && switchedInPokemon) {
       this.getOpposingField().forEach((opposingPokemon: Pokemon) =>
         opposingPokemon.transferTagsBySourceId(this.lastPokemon.id, switchedInPokemon.id),

--- a/src/phases/turn-end-phase.ts
+++ b/src/phases/turn-end-phase.ts
@@ -1,15 +1,16 @@
+import type { PostTurnAbAttr } from "#app/data/abilities/ab-attrs/post-turn-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { TurnEndEvent } from "#app/events/battle-scene";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { TurnHealModifier, TurnHeldItemTransferModifier, TurnStatusEffectModifier } from "#app/modifier/modifier";
+import { FieldPhase } from "#app/phases/abstract-field-phase";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
+import { PhaseId } from "#enums/phase-id";
 import { TerrainType } from "#enums/terrain-type";
 import i18next from "i18next";
-import { FieldPhase } from "./abstract-field-phase";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
-import { PhaseId } from "#enums/phase-id";
 
 export class TurnEndPhase extends FieldPhase {
   override readonly id = PhaseId.TURN_END;
@@ -34,7 +35,7 @@ export class TurnEndPhase extends FieldPhase {
             message: i18next.t("battle:turnEndHpRestore", { pokemonName: getPokemonNameWithAffix(pokemon) }),
           });
         }
-        applyAbAttrs(AbAttrFlag.POST_TURN, pokemon, false);
+        applyAbAttrs<PostTurnAbAttr>(AbAttrFlag.POST_TURN, pokemon, false);
       }
 
       globalScene.applyModifiers(TurnStatusEffectModifier, pokemon.isPlayer(), pokemon);

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -1,3 +1,7 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
+import type { PostWeatherLapseAbAttr } from "#app/data/abilities/ab-attrs/post-weather-lapse-ab-attr";
+import type { PreWeatherDamageAbAttr } from "#app/data/abilities/ab-attrs/pre-weather-damage-ab-attr";
+import type { SuppressWeatherEffectAbAttr } from "#app/data/abilities/ab-attrs/suppress-weather-effect-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { getWeatherDamageMessage, getWeatherLapseMessage } from "#app/data/weather";
 import { type Pokemon } from "#app/field/pokemon";
@@ -35,7 +39,7 @@ export class WeatherEffectPhase extends CommonAnimPhase {
       globalScene.ui.showText(getWeatherLapseMessage(weather.weatherType) ?? "", null, () => {
         this.executeForAll((pokemon: Pokemon) => {
           if (!pokemon.switchOutStatus) {
-            applyAbAttrs(AbAttrFlag.POST_WEATHER_LAPSE, pokemon, false, weather);
+            applyAbAttrs<PostWeatherLapseAbAttr>(AbAttrFlag.POST_WEATHER_LAPSE, pokemon, false, weather);
           }
         });
 
@@ -50,7 +54,7 @@ export class WeatherEffectPhase extends CommonAnimPhase {
     const cancelled = new BooleanHolder(false);
 
     this.executeForAll((pokemon: Pokemon) =>
-      applyAbAttrs(AbAttrFlag.SUPPRESS_WEATHER_EFFECT, pokemon, false, weather, cancelled),
+      applyAbAttrs<SuppressWeatherEffectAbAttr>(AbAttrFlag.SUPPRESS_WEATHER_EFFECT, pokemon, false, weather, cancelled),
     );
 
     if (cancelled.value) {
@@ -60,8 +64,8 @@ export class WeatherEffectPhase extends CommonAnimPhase {
     const inflictDamage = (pokemon: Pokemon): void => {
       const cancelled = new BooleanHolder(false);
 
-      applyAbAttrs(AbAttrFlag.PRE_WEATHER_DAMAGE, pokemon, false, weather, cancelled);
-      applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+      applyAbAttrs<PreWeatherDamageAbAttr>(AbAttrFlag.PRE_WEATHER_DAMAGE, pokemon, false, weather, cancelled);
+      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (cancelled.value || pokemon.getTag(BattlerTagType.UNDERGROUND) || pokemon.getTag(BattlerTagType.UNDERWATER)) {
         return;

--- a/src/utils/move-utils.ts
+++ b/src/utils/move-utils.ts
@@ -1,3 +1,4 @@
+import type { BlockNonDirectDamageAbAttr } from "#app/data/abilities/ab-attrs/block-non-direct-damage-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { type Move, type MoveAttrFilter } from "#app/data/moves/move";
 import type { MoveAttr } from "#app/data/moves/move-attrs/move-attr";
@@ -18,7 +19,7 @@ export const FilterAllMoves = (_pokemonMove: PokemonMove) => null;
 
 export const crashDamageFunc = (user: Pokemon, _move: Move) => {
   const cancelled = new BooleanHolder(false);
-  applyAbAttrs(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, user, false, cancelled);
+  applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, user, false, cancelled);
   if (cancelled.value) {
     return false;
   }

--- a/test/abilities/shield-dust.test.ts
+++ b/test/abilities/shield-dust.test.ts
@@ -1,15 +1,17 @@
-import { BattlerIndex } from "#enums/battler-index";
+import type { IgnoreMoveEffectsAbAttr } from "#app/data/abilities/ab-attrs/ignore-move-effects-ab-attr";
+import type { MoveEffectChanceMultiplierAbAttr } from "#app/data/abilities/ab-attrs/move-effect-chance-multiplier-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { NumberHolder } from "#app/utils";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { Abilities } from "#enums/abilities";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { Species } from "#enums/species";
 import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 describe("Abilities - Shield Dust", () => {
   let phaserGame: Phaser.Game;
@@ -52,8 +54,22 @@ describe("Abilities - Shield Dust", () => {
     expect(move.id).toBe(MoveId.AIR_SLASH);
 
     const chance = new NumberHolder(move.chance);
-    applyAbAttrs(AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER, phase.getUserPokemon()!, false, chance, move, false);
-    applyAbAttrs(AbAttrFlag.IGNORE_MOVE_EFFECTS, phase.getFirstTarget()!, false, phase.getUserPokemon()!, move, chance);
+    applyAbAttrs<MoveEffectChanceMultiplierAbAttr>(
+      AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER,
+      phase.getUserPokemon()!,
+      false,
+      chance,
+      move,
+      false,
+    );
+    applyAbAttrs<IgnoreMoveEffectsAbAttr>(
+      AbAttrFlag.IGNORE_MOVE_EFFECTS,
+      phase.getFirstTarget()!,
+      false,
+      phase.getUserPokemon()!,
+      move,
+      chance,
+    );
     expect(chance.value).toBe(0);
   }, 20000);
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Automatic type safety was lost with the circular dependency removal.

## What are the changes from a developer perspective?
All `applyAbAttrs()` calls are now `applyAbAttrs<...>()` in order to manually apply type safety.
`applyAbAttrs()` now enforces developers to add type safety (see `src/data/abilities/apply-ab-attrs.ts`).

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?