### PR TITLE
[Misc] Damage function refactor follow-up

### DIFF
--- a/src/@types/DamageFunctionOptions.ts
+++ b/src/@types/DamageFunctionOptions.ts
@@ -7,5 +7,4 @@ export interface DamageFunctionOptions {
   preventEndure?: boolean;
   ignoreFaintPhase?: boolean;
   source?: Pokemon;
-  ignoreDynamaxReduction?: boolean;
 }

--- a/src/data/abilities/ab-attrs/form-block-damage-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/form-block-damage-ab-attr.ts
@@ -50,7 +50,6 @@ export class FormBlockDamageAbAttr extends ReceivedMoveDamageMultiplierAbAttr {
             result: HitResult.OTHER,
             preventEndure: true,
             ignoreFaintPhase: true,
-            ignoreDynamaxReduction: true,
           });
         }
       }

--- a/src/data/abilities/ab-attrs/post-defend-contact-damage-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-contact-damage-ab-attr.ts
@@ -25,7 +25,6 @@ export class PostDefendContactDamageAbAttr extends PostDefendAbAttr {
     ) {
       attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio)), {
         result: HitResult.OTHER,
-        ignoreDynamaxReduction: true,
       });
       return true;
     }

--- a/src/data/abilities/ab-attrs/post-faint-contact-damage-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-faint-contact-damage-ab-attr.ts
@@ -55,7 +55,6 @@ export class PostFaintContactDamageAbAttr extends PostFaintAbAttr {
         attacker.damageAndUpdate(abilityDamage, {
           result: HitResult.OTHER,
           preventEndure: true,
-          ignoreDynamaxReduction: true,
         });
       }
       return true;

--- a/src/data/abilities/ab-attrs/post-turn-hurt-if-sleeping-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-turn-hurt-if-sleeping-ab-attr.ts
@@ -25,7 +25,6 @@ export class PostTurnHurtIfSleepingAbAttr extends PostTurnAbAttr {
         if (!simulated) {
           opp.damageAndUpdate(toDmgValue(opp.getMaxHp() / 8), {
             result: HitResult.OTHER,
-            ignoreDynamaxReduction: true,
           });
           globalScene.queueMessage(
             i18next.t("abilityTriggers:badDreams", { pokemonName: getPokemonNameWithAffix(opp) }),

--- a/src/data/abilities/ab-attrs/post-weather-lapse-damage-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-weather-lapse-damage-ab-attr.ts
@@ -37,7 +37,6 @@ export class PostWeatherLapseDamageAbAttr extends PostWeatherLapseAbAttr {
       );
       pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() * this.damageFactor), {
         result: HitResult.OTHER,
-        ignoreDynamaxReduction: true,
       });
     }
 

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -764,7 +764,7 @@ class SpikesTag extends EntryHazardTag {
         globalScene.queueMessage(
           i18next.t("arenaTag:spikesActivateTrap", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
         );
-        pokemon.damageAndUpdate(damage, { result: HitResult.OTHER, ignoreDynamaxReduction: true });
+        pokemon.damageAndUpdate(damage, { result: HitResult.OTHER });
         return true;
       }
     }
@@ -970,7 +970,7 @@ class TypeHazardTag extends EntryHazardTag {
       globalScene.queueMessage(
         i18next.t(this.activateTrapKey, { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       );
-      pokemon.damageAndUpdate(damage, { result: HitResult.OTHER, ignoreDynamaxReduction: true });
+      pokemon.damageAndUpdate(damage, { result: HitResult.OTHER });
       return true;
     }
 
@@ -1251,7 +1251,7 @@ class FireGrassPledgeTag extends ArenaTag {
         globalScene.unshiftPhase(
           new CommonAnimPhase(pokemon.getBattlerIndex(), pokemon.getBattlerIndex(), CommonAnim.MAGMA_STORM),
         );
-        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8), { ignoreDynamaxReduction: true });
+        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8));
       });
 
     return super.lapse(arena);
@@ -1367,7 +1367,7 @@ export class TypeImmuneDamageOverTimeTag extends ArenaTag {
         globalScene.unshiftPhase(
           new CommonAnimPhase(pokemon.getBattlerIndex(), pokemon.getBattlerIndex(), this.getAnimationForType()),
         );
-        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 6), { ignoreDynamaxReduction: true });
+        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 6));
       });
 
     return super.lapse(arena);

--- a/src/data/battler-tags/contact-damage-protected-tag.ts
+++ b/src/data/battler-tags/contact-damage-protected-tag.ts
@@ -41,7 +41,6 @@ export class ContactDamageProtectedTag extends DamageProtectedTag {
       if (!attacker.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
         attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() * (1 / this.damageRatio)), {
           result: HitResult.OTHER,
-          ignoreDynamaxReduction: true,
         });
       }
     }

--- a/src/data/battler-tags/cursed-tag.ts
+++ b/src/data/battler-tags/cursed-tag.ts
@@ -38,7 +38,7 @@ export class CursedTag extends BattlerTag {
       applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (!cancelled.value) {
-        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4), { ignoreDynamaxReduction: true });
+        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4));
         globalScene.queueMessage(
           i18next.t("battlerTags:cursedLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
         );

--- a/src/data/battler-tags/damaging-trap-tag.ts
+++ b/src/data/battler-tags/damaging-trap-tag.ts
@@ -63,7 +63,7 @@ export abstract class DamagingTrapTag extends TrappedTag {
       applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (!cancelled.value) {
-        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8), { ignoreDynamaxReduction: true });
+        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8));
       }
     }
 

--- a/src/data/battler-tags/destiny-bond-tag.ts
+++ b/src/data/battler-tags/destiny-bond-tag.ts
@@ -54,7 +54,6 @@ export class DestinyBondTag extends BattlerTag {
     pokemon.damageAndUpdate(pokemon.hp, {
       result: HitResult.ONE_HIT_KO,
       preventEndure: true,
-      ignoreDynamaxReduction: true,
     });
 
     return false;

--- a/src/data/battler-tags/gulp-missile-tag.ts
+++ b/src/data/battler-tags/gulp-missile-tag.ts
@@ -50,7 +50,6 @@ export class GulpMissileTag extends BattlerTag {
       if (!cancelled.value) {
         attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() / 4), {
           result: HitResult.OTHER,
-          ignoreDynamaxReduction: true,
         });
       }
 

--- a/src/data/battler-tags/nightmare-tag.ts
+++ b/src/data/battler-tags/nightmare-tag.ts
@@ -52,7 +52,7 @@ export class NightmareTag extends BattlerTag {
       applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
       if (!cancelled.value) {
-        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4), { ignoreDynamaxReduction: true });
+        pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 4));
       }
     }
 

--- a/src/data/battler-tags/perish-song-tag.ts
+++ b/src/data/battler-tags/perish-song-tag.ts
@@ -40,7 +40,6 @@ export class PerishSongTag extends BattlerTag {
         result: HitResult.ONE_HIT_KO,
         ignoreSegments: true,
         preventEndure: true,
-        ignoreDynamaxReduction: true,
       });
     }
 

--- a/src/data/battler-tags/powder-tag.ts
+++ b/src/data/battler-tags/powder-tag.ts
@@ -66,7 +66,6 @@ export class PowderTag extends BattlerTag {
           if (!cancelDamage.value) {
             pokemon.damageAndUpdate(Math.floor(pokemon.getMaxHp() / 4), {
               result: HitResult.OTHER,
-              ignoreDynamaxReduction: true,
             });
           }
 

--- a/src/data/battler-tags/salt-cured-tag.ts
+++ b/src/data/battler-tags/salt-cured-tag.ts
@@ -59,9 +59,7 @@ export class SaltCuredTag extends BattlerTag {
 
       if (!cancelled.value) {
         const pokemonSteelOrWater = pokemon.isOfType(ElementalType.STEEL) || pokemon.isOfType(ElementalType.WATER);
-        pokemon.damageAndUpdate(toDmgValue(pokemonSteelOrWater ? pokemon.getMaxHp() / 4 : pokemon.getMaxHp() / 8), {
-          ignoreDynamaxReduction: true,
-        });
+        pokemon.damageAndUpdate(toDmgValue(pokemonSteelOrWater ? pokemon.getMaxHp() / 4 : pokemon.getMaxHp() / 8));
 
         globalScene.queueMessage(
           i18next.t("battlerTags:saltCuredLapse", {

--- a/src/data/battler-tags/seed-tag.ts
+++ b/src/data/battler-tags/seed-tag.ts
@@ -63,7 +63,7 @@ export class SeedTag extends BattlerTag {
             new CommonAnimPhase(source.getBattlerIndex(), pokemon.getBattlerIndex(), CommonAnim.LEECH_SEED),
           );
 
-          const damage = pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8), { ignoreDynamaxReduction: true });
+          const damage = pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8));
           const reverseDrain = pokemon.hasAbilityWithAttr(AbAttrFlag.REVERSE_DRAIN, false);
 
           globalScene.queuePokemonHeal(true, source.getBattlerIndex(), !reverseDrain ? damage : damage * -1, {

--- a/src/data/moves/move-attrs/add-substitute-attr.ts
+++ b/src/data/moves/move-attrs/add-substitute-attr.ts
@@ -29,7 +29,6 @@ export class AddSubstituteAttr extends MoveEffectAttr {
       result: HitResult.OTHER,
       ignoreSegments: true,
       preventEndure: true,
-      ignoreDynamaxReduction: true,
     });
     user.addTag(BattlerTagType.SUBSTITUTE, 0, move.id, user.id);
     return true;

--- a/src/data/moves/move-attrs/curse-attr.ts
+++ b/src/data/moves/move-attrs/curse-attr.ts
@@ -31,7 +31,6 @@ export class CurseAttr extends MoveEffectAttr {
         result: HitResult.OTHER,
         ignoreSegments: true,
         preventEndure: true,
-        ignoreDynamaxReduction: true,
       });
       globalScene.queueMessage(
         i18next.t("battlerTags:cursedOnAdd", {

--- a/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
+++ b/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
@@ -33,7 +33,6 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
     user.damageAndUpdate(toDmgValue(user.getMaxHp() / this.cutRatio), {
       result: HitResult.OTHER,
       ignoreSegments: true,
-      ignoreDynamaxReduction: true,
     });
     user.updateInfo();
     const ret = super.applyEffect(user, target, move);

--- a/src/data/moves/move-attrs/flame-burst-attr.ts
+++ b/src/data/moves/move-attrs/flame-burst-attr.ts
@@ -36,7 +36,6 @@ export class FlameBurstAttr extends MoveEffectAttr {
 
     targetAlly.damageAndUpdate(toDmgValue((1 / 16) * targetAlly.getMaxHp()), {
       result: HitResult.OTHER,
-      ignoreDynamaxReduction: true,
     });
     return true;
   }

--- a/src/data/moves/move-attrs/half-sacrificial-attr.ts
+++ b/src/data/moves/move-attrs/half-sacrificial-attr.ts
@@ -31,7 +31,6 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
         result: HitResult.OTHER,
         ignoreSegments: true,
         preventEndure: true,
-        ignoreDynamaxReduction: true,
       });
       globalScene.queueMessage(
         i18next.t("moveTriggers:cutHpPowerUpMove", { pokemonName: getPokemonNameWithAffix(user) }),

--- a/src/data/moves/move-attrs/hp-split-attr.ts
+++ b/src/data/moves/move-attrs/hp-split-attr.ts
@@ -16,7 +16,7 @@ export class HpSplitAttr extends MoveEffectAttr {
       } else if (p.hp > hpValue) {
         // Neither ignoring nor not ignoring the dynamax damage reduction is correct,
         // but there's no alternative to picking one of them.
-        p.damageAndUpdate(p.hp - hpValue, { ignoreSegments: true, ignoreDynamaxReduction: true });
+        p.damageAndUpdate(p.hp - hpValue, { ignoreSegments: true });
       }
       p.updateInfo();
     });

--- a/src/data/moves/move-attrs/recoil-attr.ts
+++ b/src/data/moves/move-attrs/recoil-attr.ts
@@ -54,7 +54,6 @@ export class RecoilAttr extends MoveEffectAttr {
       result: HitResult.OTHER,
       ignoreSegments: true,
       preventEndure: true,
-      ignoreDynamaxReduction: this.useHp,
     });
     globalScene.queueMessage(i18next.t("moveTriggers:hitWithRecoil", { pokemonName: getPokemonNameWithAffix(user) }));
 

--- a/src/data/moves/move-attrs/sacrificial-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-attr.ts
@@ -15,10 +15,9 @@ export class SacrificialAttr extends MoveEffectAttr {
 
   override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     user.damageAndUpdate(user.hp, {
-      result: HitResult.OTHER,
+      result: HitResult.SELF_KO,
       ignoreSegments: true,
       preventEndure: true,
-      ignoreDynamaxReduction: true,
     });
 
     return true;

--- a/src/enums/hit-result.ts
+++ b/src/enums/hit-result.ts
@@ -10,4 +10,5 @@ export enum HitResult {
   MISS,
   OTHER,
   IMMUNE,
+  SELF_KO,
 }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3316,7 +3316,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param ignoreSegments - If `true`, boss bars are ignored. Only applies to {@linkcode EnemyPokemon}. Default `false`
    * @param preventEndure - If `true`, bypasses the effects of Endure, Sturdy, etc. Default `false`
    * @param ignoreFaintPhase - If `true`, doesn't push a {@linkcode FaintPhase}. Default `false`
-   * @param ignoreDynamaxReduction - If `true`, dynamax damage reduction will be ignored. Default `false`
    * @param source - The source of the damage if it was a {@linkcode Pokemon}. Optional.
    * @returns The amount of damage actually dealt.
    */
@@ -3328,7 +3327,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       ignoreSegments = false,
       preventEndure = false,
       ignoreFaintPhase = false,
-      ignoreDynamaxReduction = false,
       source,
     }: DamageFunctionOptions = {},
   ): number {
@@ -3337,6 +3335,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (this.switchOutStatus && source) {
       amount = 0;
     }
+
+    const ignoreDynamaxReduction = [HitResult.ONE_HIT_KO, HitResult.SELF_KO].includes(result) ? true : false;
 
     const damage = this.damage(amount, { ignoreSegments, preventEndure, ignoreFaintPhase, ignoreDynamaxReduction });
 
@@ -5439,7 +5439,8 @@ export type DamageResult =
   | HitResult.SUPER_EFFECTIVE
   | HitResult.NOT_VERY_EFFECTIVE
   | HitResult.ONE_HIT_KO
-  | HitResult.OTHER;
+  | HitResult.OTHER
+  | HitResult.SELF_KO;
 
 /** Interface containing the results of a damage calculation for a given move */
 export interface DamageCalculationResult {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3364,7 +3364,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const healAmount = Math.min(amount, this.getMaxHp() - this.hp);
     this.hp += healAmount;
     if (!quiet && this.isOnField()) {
-      globalScene.damageNumberHandler.add(this, amount, HitResult.HEAL);
+      globalScene.damageNumberHandler.add(this, healAmount, HitResult.HEAL);
     }
     return healAmount;
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3336,7 +3336,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       amount = 0;
     }
 
-    const ignoreDynamaxReduction = [HitResult.ONE_HIT_KO, HitResult.SELF_KO].includes(result) ? true : false;
+    const ignoreDynamaxReduction = [HitResult.ONE_HIT_KO, HitResult.SELF_KO].includes(result);
 
     const damage = this.damage(amount, { ignoreSegments, preventEndure, ignoreFaintPhase, ignoreDynamaxReduction });
 

--- a/src/phases/damage-anim-phase.ts
+++ b/src/phases/damage-anim-phase.ts
@@ -70,7 +70,7 @@ export class DamageAnimPhase extends PokemonPhase {
       globalScene.damageNumberHandler.add(this.getPokemon(), this.amount, this.damageResult, this.critical);
     }
 
-    if (this.damageResult !== HitResult.OTHER && this.amount > 0) {
+    if (![HitResult.OTHER, HitResult.SELF_KO].includes(this.damageResult) && this.amount > 0) {
       const flashTimer = globalScene.time.addEvent({
         delay: 100,
         repeat: 5,

--- a/src/utils/move-utils.ts
+++ b/src/utils/move-utils.ts
@@ -27,7 +27,6 @@ export const crashDamageFunc = (user: Pokemon, _move: Move) => {
   user.damageAndUpdate(toDmgValue(user.getMaxHp() / 2), {
     result: HitResult.OTHER,
     ignoreSegments: true,
-    ignoreDynamaxReduction: true,
   });
   globalScene.queueMessage(t("moveTriggers:keptGoingAndCrashed", { pokemonName: getPokemonNameWithAffix(user) }));
 


### PR DESCRIPTION
## What are the changes the user will see?
- The number pop-up for healing will no longer sometimes be incorrect.
- Percentage based damage will respect Dynamax damage reduction.

## Why am I making these changes?
Some issues were noticed after #753 was merged.

## What are the changes from a developer perspective?
- Variable usage in `Pokemon.heal()` was fixed so that the correct value will be shown when healing is capped.
- The `ignoreDynamaxReduction` parameter was removed from `Pokemon.damageAndHeal()` and it is now automatically determined based on whether the `result` parameter is `HitResult.ONE_HIT_KO` or the new `HitResult.SELF_KO`.
- The enum value `HitResult.SELF_KO` was added and used for moves that cause the user to self-KO (such as Explosion or Lunar Dance).

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?