### PR TITLE
[P0] Fix memory leak when Save & Quitting

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1243,9 +1243,9 @@ export default class BattleScene extends SceneBase {
           this.clearPhaseQueue();
 
           // destroying those containers will call 'container.removeAll(true)', destroying all their children as well
-          this.uiContainer.destroy(true);
-          this.field.destroy(true);
-          this.fieldUI.destroy(true);
+          this.uiContainer.destroy();
+          this.field.destroy();
+          this.fieldUI.destroy();
 
           this.children.removeAll(true);
           this.game.domContainer.innerHTML = "";

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1248,6 +1248,11 @@ export default class BattleScene extends SceneBase {
         onComplete: () => {
           this.clearPhaseQueue();
 
+          this.ui.destroy();
+          this.uiContainer.removeAll(true);
+          this.field.removeAll(true);
+          this.fieldUI.removeAll(true);
+
           this.children.removeAll(true);
           this.game.domContainer.innerHTML = "";
           this.launchBattle();

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1236,9 +1236,6 @@ export default class BattleScene extends SceneBase {
     }
 
     if (clearScene) {
-      // Reload variant data in case sprite set has changed
-      this.initVariantData();
-
       this.audioManager.fadeOutBgm(250, false);
       this.tweens.add({
         targets: [this.uiContainer],

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1242,9 +1242,10 @@ export default class BattleScene extends SceneBase {
         onComplete: () => {
           this.clearPhaseQueue();
 
-          this.uiContainer.removeAll(true);
-          this.field.removeAll(true);
-          this.fieldUI.removeAll(true);
+          // destroying those containers will call 'container.removeAll(true)', destroying all their children as well
+          this.uiContainer.destroy(true);
+          this.field.destroy(true);
+          this.fieldUI.destroy(true);
 
           this.children.removeAll(true);
           this.game.domContainer.innerHTML = "";

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1252,6 +1252,8 @@ export default class BattleScene extends SceneBase {
 
           this.children.removeAll(true);
           this.game.domContainer.innerHTML = "";
+
+          // TODO: launchBattle will call reset(false, false, true) too, this can probably be done better
           this.launchBattle();
         },
       });

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1242,7 +1242,6 @@ export default class BattleScene extends SceneBase {
         onComplete: () => {
           this.clearPhaseQueue();
 
-          this.ui.destroy();
           this.uiContainer.removeAll(true);
           this.field.removeAll(true);
           this.fieldUI.removeAll(true);

--- a/src/ui/settings/navigation-menu.ts
+++ b/src/ui/settings/navigation-menu.ts
@@ -44,6 +44,10 @@ export class NavigationManager {
     ];
   }
 
+  public clearMenus() {
+    this.navigationMenus.splice(0, this.navigationMenus.length);
+  }
+
   public reset() {
     this.selectedMode = UiMode.SETTINGS;
     this.updateNavigationMenus();

--- a/src/ui/settings/navigation-menu.ts
+++ b/src/ui/settings/navigation-menu.ts
@@ -44,8 +44,11 @@ export class NavigationManager {
     ];
   }
 
+  /**
+   * Clear all references to {@linkcode NavigationMenu}s, allowing them to be garbage collected.
+   */
   public clearMenus() {
-    this.navigationMenus.splice(0, this.navigationMenus.length);
+    this.navigationMenus = [];
   }
 
   public reset() {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -42,6 +42,7 @@ import { TitleUiHandler } from "#app/ui/handlers/title-ui-handler";
 import { UnavailableModalUiHandler } from "#app/ui/handlers/unavailable-modal-ui-handler";
 import { GamepadBindingUiHandler } from "#app/ui/settings/gamepad-binding-ui-handler";
 import { KeyboardBindingUiHandler } from "#app/ui/settings/keyboard-binding-ui-handler";
+import { NavigationManager } from "#app/ui/settings/navigation-menu";
 import { SettingsAudioUiHandler } from "#app/ui/settings/settings-audio-ui-handler";
 import { SettingsDisplayUiHandler } from "#app/ui/settings/settings-display-ui-handler";
 import { SettingsGamepadUiHandler } from "#app/ui/settings/settings-gamepad-ui-handler";
@@ -423,6 +424,12 @@ export class UI extends Phaser.GameObjects.Container {
 
       this.tooltipContainer.setPosition(x, y);
     }
+  }
+
+  override destroy(fromScene?: boolean): void {
+    NavigationManager.getInstance().clearMenus();
+    this.removeAll(true);
+    super.destroy(fromScene);
   }
 
   clearText(): void {


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

The game will no longer take more and more memory every time the player saves & quits
<sub>and all other instances of calls to `battleScene.reset(true)`

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

Fixes #693 
The game is using a lot of memory as it is, no need for more

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

As explained in the Issue, when save & quitting BattleScene.reset() is called, with the `clearScene` parameter set to `true`. And when this happens the scene removes all its children elements, before recreating them and instantiating a new UI object. However before this the objects contained in the children containers never get destroyed, which results in the game keeping a lot of graphical elements of the previous instance of the UI in memory.

- In BattleScene.reset(), call `removeAll(true)` on all containers, which recursively destroys the Phaser elements contained within
- Add `clearMenus` function to the `NavigationManager` to delete existing references to menus it has
- override `ui.destroy` to do call `clearMenus` before the menus get destroyed
- Noticed a call to `BattleScene.initVariantData()` which was needed when changing the sprite type between consistent and experimental. That setting was removed in #101 so this call is no longer needed

Note:
This is kind of a "bruteforce" method and there are possibly some UI elements that get missed with this if they were created but not added to a container, but it is already a big improvement.
I also don't believe the approach of destroying the whole screen and UI is good in the first place. At the very least it could be very much optimized, but that is a much larger and different task

<sub>Another factor that could have minimized this issue would be for the `UI` to not keep a copy of each handler in memory at all times, which will be for another PR.

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

Memory usage of the game after sae & quitting, before and after:
**BEFORE:** ![image](https://github.com/user-attachments/assets/91e5cc0c-18ea-4604-b9f9-9e0605f4271b) **AFTER:** ![image](https://github.com/user-attachments/assets/a87f13c0-2ca5-4a0d-bf36-b7a67d655379)

JS heap size, each new snapshot is taken after save & quitting, before and after:
**BEFORE:** ![image](https://github.com/user-attachments/assets/56d2c237-479e-483e-8362-7d1d8d465399) **AFTER:** ![image](https://github.com/user-attachments/assets/91ad709e-7d9c-4031-97b6-c74408e916d2)

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

Run the game, start a run, save & quit.
Go through various UIs and make sure things work properly

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [X] Otherwise: **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [] Have I made sure that any UI change works for both UI themes (dark and light)?
