### PR TITLE
[Move][P2] Spicy extract is now bounceable

### DIFF
--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -3202,7 +3202,8 @@ export function initMoves() {
       .punchingMove(),
     new StatusMove(MoveId.SPICY_EXTRACT, ElementalType.GRASS, -1, 15, -1, 0, 9)
       .attr(StatStageChangeAttr, [Stat.ATK], 2)
-      .attr(StatStageChangeAttr, [Stat.DEF], -2),
+      .attr(StatStageChangeAttr, [Stat.DEF], -2)
+      .bounceable(),
     new AttackMove(MoveId.SPIN_OUT, ElementalType.STEEL, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 9)
       .attr(StatStageChangeAttr, [Stat.SPD], -2, true),
     new AttackMove(MoveId.POPULATION_BOMB, ElementalType.NORMAL, MoveCategory.PHYSICAL, 20, 90, 10, -1, 0, 9)

--- a/test/data/all-moves.json
+++ b/test/data/all-moves.json
@@ -12867,7 +12867,7 @@
     "damage_class_id": 1,
     "effect_id": "",
     "effect_chance": -1,
-    "flags": ""
+    "flags": [5]
   },
   {
     "id": 859,


### PR DESCRIPTION
## What are the changes the user will see?

Spicy Extract will now be bounced by magic coat/bounce

## Why am I making these changes?

Noticed in #750 since Bulbapedia list of moves that are bounceable were not updated for gen 9.

The status moves that gen 9 introduced were:
* burning bulwark
* chilly reception
* doodle
* dragon cheer
* fillet away
* revival blessing
* shed tail
* silk trap
* spicy extract
* tidy up

Out of all these, doodle and spicy extract are the only ones that specifically target a Pokemon. According to the smogondex, only spicy extract is bounceable.

## What are the changes from a developer perspective?

Added `bounceable()` flag to spicy extract and the 5 flag to it in all-moves.json

## Screenshots/Videos

n/a

## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.SPICY_EXTRACT],
  ENEMY_ABILITY_OVERRIDE: AbilityId.MAGIC_BOUNCE
}
```

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->