### PR TITLE
[Bug] Perish Body now triggers even if the defender faints

### DIFF
--- a/src/data/abilities/ab-attrs/post-defend-perish-song-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-perish-song-ab-attr.ts
@@ -9,7 +9,7 @@ import { PostDefendAbAttr } from "./post-defend-ab-attr";
 /**
  * This ability applies the Perish Song tag to the attacking pokemon
  * and the defending pokemon if the move makes physical contact and
- * at least one pokemon doesn't already have the Perish Song tag.
+ * the attacker doesn't already have the Perish Song tag.
  * @extends PostDefendAbAttr
  */
 export class PostDefendPerishSongAbAttr extends PostDefendAbAttr {
@@ -17,13 +17,13 @@ export class PostDefendPerishSongAbAttr extends PostDefendAbAttr {
     if (move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)) {
       if (attacker.getTag(BattlerTagType.PERISH_SONG)) {
         return false;
-      } else {
-        if (!simulated) {
-          attacker.addTag(BattlerTagType.PERISH_SONG, 4);
-          pokemon.addTag(BattlerTagType.PERISH_SONG, 4);
-        }
-        return true;
       }
+
+      if (!simulated) {
+        attacker.addTag(BattlerTagType.PERISH_SONG, 4);
+        pokemon.addTag(BattlerTagType.PERISH_SONG, 4);
+      }
+      return true;
     }
     return false;
   }

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -1350,7 +1350,8 @@ export function initAbilities() {
     new Ability(AbilityId.STEELY_SPIRIT, 8)
       .attr(UserFieldMoveTypePowerBoostAbAttr, ElementalType.STEEL),
     new Ability(AbilityId.PERISH_BODY, 8)
-      .attr(PostDefendPerishSongAbAttr),
+      .attr(PostDefendPerishSongAbAttr)
+      .bypassFaint(),
     new Ability(AbilityId.WANDERING_SPIRIT, 8)
       .attr(PostDefendAbilitySwapAbAttr)
       .bypassFaint()

--- a/test/abilities/perish-body.test.ts
+++ b/test/abilities/perish-body.test.ts
@@ -69,4 +69,16 @@ describe("Abilities - Perish Body", () => {
     expect((milotic.getTag(BattlerTagType.PERISH_SONG) as PerishSongTag).turnCount).toBe(3);
     expect((enemy.getTag(BattlerTagType.PERISH_SONG) as PerishSongTag).turnCount).toBe(1);
   });
+
+  it("should trigger if the defender faints", async () => {
+    game.override.startingLevel(200);
+    await game.classicMode.startBattle([SpeciesId.MILOTIC]);
+
+    const player = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.EXTREME_SPEED);
+    await game.toEndOfTurn();
+
+    expect(player.hasTag(BattlerTagType.PERISH_SONG)).toBe(true);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
Perish Body will trigger even if the defending Pokémon faints from the attack that would trigger it.

## Why am I making these changes?
The current behavior is incorrect.

## What are the changes from a developer perspective?
Added `.bypassFaint()` to Perish Body. Also corrected the TSDocs for Perish Body's `AbAttr`.

## How to test the changes?
```ts
const overrides = {
  ENEMY_ABILITY_OVERRIDE: AbilityId.PERISH_BODY,
  STARTING_LEVEL_OVERRIDE: 200,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
Hit the opposing pokemon with a physical attack (this should easily cause it to faint). Perish Body should trigger.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?