### PR TITLE
[Test] Add more Corrosion tests

### DIFF
--- a/test/abilities/corrosion.test.ts
+++ b/test/abilities/corrosion.test.ts
@@ -1,4 +1,5 @@
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
@@ -23,7 +24,6 @@ describe("Abilities - Corrosion", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .moveset([MoveId.SPLASH])
       .battleType("single")
       .disableCrits()
       .enemySpecies(SpeciesId.GRIMER)
@@ -31,17 +31,54 @@ describe("Abilities - Corrosion", () => {
       .enemyMoveset(MoveId.TOXIC);
   });
 
-  it("If a Poison- or Steel-type Pokémon with this Ability poisons a target with Synchronize, Synchronize does not gain the ability to poison Poison- or Steel-type Pokémon.", async () => {
+  it("allows the user to poison a Poison or Steel type pokemon", async () => {
+    await game.classicMode.startBattle([SpeciesId.MUK]);
+
+    const playerPokemon = game.field.getPlayerPokemon();
+    const enemyPokemon = game.field.getEnemyPokemon();
+
+    game.move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
+    expect(playerPokemon.getStatusEffect()).toBe(StatusEffect.TOXIC);
+    expect(enemyPokemon.getStatusEffect()).toBe(StatusEffect.NONE);
+  });
+
+  it("does not allow the user to get poisoned if the user is Poison or Steel type and poisons a target with Synchronize", async () => {
     game.override.ability(AbilityId.SYNCHRONIZE);
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     const playerPokemon = game.field.getPlayerPokemon();
     const enemyPokemon = game.field.getEnemyPokemon();
-    expect(playerPokemon.getStatusEffect()).toBe(StatusEffect.NONE);
 
-    game.move.select(MoveId.SPLASH);
+    game.move.use(MoveId.SPLASH);
     await game.toEndOfTurn();
     expect(playerPokemon.getStatusEffect()).toBe(StatusEffect.TOXIC);
     expect(enemyPokemon.getStatusEffect()).toBe(StatusEffect.NONE);
+  });
+
+  it("does not allow the user to get poisoned if the user is Poison or Steel type and poisons a target with Magic Bounce", async () => {
+    game.override.ability(AbilityId.MAGIC_BOUNCE);
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+
+    const playerPokemon = game.field.getPlayerPokemon();
+    const enemyPokemon = game.field.getEnemyPokemon();
+
+    game.move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
+    expect(playerPokemon.getStatusEffect()).toBe(StatusEffect.NONE);
+    expect(enemyPokemon.getStatusEffect()).toBe(StatusEffect.NONE);
+  });
+
+  it("allows the user to poison a Poison or Steel type if the user reflects a status move that poisons", async () => {
+    game.override.enemyMoveset(MoveId.MAGIC_COAT);
+    await game.classicMode.startBattle([SpeciesId.MUK]);
+
+    const playerPokemon = game.field.getPlayerPokemon();
+
+    game.move.use(MoveId.TOXIC);
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    await game.toEndOfTurn();
+
+    expect(playerPokemon.getStatusEffect()).toBe(StatusEffect.TOXIC);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Noticed an outdated comment when reformatting `init-abilities.ts` and made tests to confirm the interaction was correct.

## What are the changes from a developer perspective?
New tests for Corrosion mechanics:
- Basic mechanics test (can poison a Poison type)
- Test that a reflected Poison status move (Corrosion vs Magic Bounce) won't affect the Corrosion user
- Test that a reflected Poison status move (Corrosion + Magic Coat vs Poison type using Toxic) will affect the reflection target

## How to test the changes?
`npm run test corrosion`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?