### PR TITLE
[Refactor] Add `Pokemon#hasTag()` function

### DIFF
--- a/src/data/battler-tags/interrupted-tag.ts
+++ b/src/data/battler-tags/interrupted-tag.ts
@@ -20,7 +20,7 @@ export class InterruptedTag extends BattlerTag {
   }
 
   override canAdd(pokemon: Pokemon): boolean {
-    return !!pokemon.getTag(BattlerTagType.FLYING);
+    return pokemon.hasTag(BattlerTagType.FLYING);
   }
 
   override onAdd(pokemon: Pokemon): void {

--- a/src/data/battler-tags/roosted-tag.ts
+++ b/src/data/battler-tags/roosted-tag.ts
@@ -60,7 +60,7 @@ export class RoostedTag extends BattlerTag {
       if (this.isBasePureFlying && !isCurrentlyDualType) {
         modifiedTypes = [ElementalType.NORMAL];
       } else {
-        if (!!pokemon.getTag(...RemoveTypeBattlerTagTypes) && isOriginallyDualType && !isCurrentlyDualType) {
+        if (pokemon.hasTag(...RemoveTypeBattlerTagTypes) && isOriginallyDualType && !isCurrentlyDualType) {
           modifiedTypes = [ElementalType.UNKNOWN];
         } else {
           modifiedTypes = currentTypes.filter((type) => type !== ElementalType.FLYING);

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -473,7 +473,7 @@ export function initAbilities() {
       .attr(PostFaintUnsuppressedWeatherFormChangeAbAttr)
       .bypassFaint(),
     new Ability(AbilityId.TANGLED_FEET, 4)
-      .conditionalAttr((pokemon) => !!pokemon.getTag(BattlerTagType.CONFUSED), StatMultiplierAbAttr, Stat.EVA, 2)
+      .conditionalAttr((pokemon) => pokemon.hasTag(BattlerTagType.CONFUSED), StatMultiplierAbAttr, Stat.EVA, 2)
       .ignorable(),
     new Ability(AbilityId.MOTOR_DRIVE, 4)
       .attr(TypeImmunityStatStageChangeAbAttr, ElementalType.ELECTRIC, Stat.SPD, 1)
@@ -1078,7 +1078,7 @@ export function initAbilities() {
       )
       .attr(
         FormBlockDamageAbAttr,
-        (target, user, move) => !!target.getTag(BattlerTagType.DISGUISE) && target.getMoveEffectiveness(user, move) > 0,
+        (target, user, move) => target.hasTag(BattlerTagType.DISGUISE) && target.getMoveEffectiveness(user, move) > 0,
         0,
         BattlerTagType.DISGUISE,
         (pokemon, abilityName) =>
@@ -1329,7 +1329,7 @@ export function initAbilities() {
       .attr(PostWeatherChangeAddBattlerTagAbAttr, BattlerTagType.ICE_FACE, 0, WeatherType.HAIL, WeatherType.SNOW)
       .attr(
         FormBlockDamageAbAttr,
-        (target, _user, move) => move.category === MoveCategory.PHYSICAL && !!target.getTag(BattlerTagType.ICE_FACE),
+        (target, _user, move) => move.category === MoveCategory.PHYSICAL && target.hasTag(BattlerTagType.ICE_FACE),
         0,
         BattlerTagType.ICE_FACE,
         (pokemon, abilityName) =>

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -1079,7 +1079,7 @@ export function initMoves() {
     new AttackMove(MoveId.UPROAR, ElementalType.NORMAL, MoveCategory.SPECIAL, 90, 100, 10, -1, 0, 3)
       .attr(AddBattlerTagAttr, BattlerTagType.UPROAR, true)
       .attr(MessageHeaderAttr, (user, _move) =>
-        !!user.getTag(BattlerTagType.UPROAR)
+        user.hasTag(BattlerTagType.UPROAR)
           // "{pokemonNameWithAffix} is making an uproar!"
           ? i18next.t("moveTriggers:isMakingAnUproar", { pokemonNameWithAffix: getPokemonNameWithAffix(user) })
           : undefined,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1716,7 +1716,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // Note: This code is also copied in `GroundedTag.onAdd()`, to check whether or not the Pokemon
     // was grounded before receiving the `GroundedTag`.
     return (
-      !!this.getTag(BattlerTagType.IGNORE_FLYING)
+      this.hasTag(BattlerTagType.IGNORE_FLYING)
       || (!this.isOfType(ElementalType.FLYING, true, true)
         && !this.hasAbility(AbilityId.LEVITATE)
         && !this.getTag(BattlerTagType.FLOATING)
@@ -1726,7 +1726,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   public isSemiInvulnerable(): boolean {
-    return !!this.getTag(...SemiInvulnerableBattlerTagTypes) || !!this.getTag(BattlerTagType.SKY_DROP);
+    return this.hasTag(...SemiInvulnerableBattlerTagTypes) || this.hasTag(BattlerTagType.SKY_DROP);
   }
 
   /**
@@ -1768,7 +1768,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const side = this.getArenaTagSide();
     return (
       trappedByAbility.value
-      || !!this.getTag(...TrappedBattlerTagTypes)
+      || this.hasTag(...TrappedBattlerTagTypes)
       || !!globalScene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, side)
     );
   }
@@ -4933,7 +4933,7 @@ export class EnemyPokemon extends Pokemon {
               .targets.map((ind) => globalScene.getFieldPokemonByBattlerIndex(ind))
               .filter((p) => !isNullOrUndefined(p) && this.isPlayer() !== p.isPlayer()) as Pokemon[];
             // Only considers critical hits for crit-only moves or when this Pokemon is under the effect of Laser Focus
-            const isCritical = move.hasAttr(CritOnlyAttr) || !!this.getTag(BattlerTagType.ALWAYS_CRIT);
+            const isCritical = move.hasAttr(CritOnlyAttr) || this.hasTag(BattlerTagType.ALWAYS_CRIT);
 
             return (
               move.category !== MoveCategory.STATUS

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3451,6 +3451,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.summonData.tags.find((t) => tagTypes.includes(t.tagType)) as T | undefined;
   }
 
+  /**
+   * Helper function to check if a Pokemon has any of the input tag types.
+   * @param tagTypes - The battler tag types to search for
+   * @returns `true` if the Pokemon has at least one of the battler tags, `false` otherwise
+   */
   public hasTag(...tagTypes: BattlerTagType[]): boolean {
     if (!this.summonData) {
       return false;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3451,6 +3451,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.summonData.tags.find((t) => tagTypes.includes(t.tagType)) as T | undefined;
   }
 
+  public hasTag(...tagTypes: BattlerTagType[]): boolean {
+    if (!this.summonData) {
+      return false;
+    }
+    return this.summonData.tags.some((t) => tagTypes.includes(t.tagType));
+  }
+
   findTag<T extends BattlerTag = BattlerTag>(tagFilter: (tag: BattlerTag) => boolean): T | nil {
     if (!this.summonData) {
       return null;

--- a/src/phases/hit-check-phase.ts
+++ b/src/phases/hit-check-phase.ts
@@ -84,7 +84,7 @@ export abstract class HitCheckPhase extends PokemonPhase {
       [user, target].some((p) => p.hasAbilityWithAttr(AbAttrFlag.ALWAYS_HIT))
       || (user.getTag(BattlerTagType.IGNORE_ACCURACY)
         && (user.getLastXMoves()[0]?.targets ?? []).indexOf(target.getBattlerIndex()) !== -1)
-      || !!target.getTag(BattlerTagType.ALWAYS_GET_HIT);
+      || target.hasTag(BattlerTagType.ALWAYS_GET_HIT);
 
     const semiInvulnerableTag =
       target.getTag(...SemiInvulnerableBattlerTagTypes) ?? target.getTag(BattlerTagType.SKY_DROP);

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -332,7 +332,7 @@ export class TurnCommandManager {
           return -1;
         }
       } else if (a.command === BattleCommand.FIGHT) {
-        const [aQuashed, bQuashed] = [a, b].map((tc) => !!tc.pokemon.getTag(BattlerTagType.QUASHED));
+        const [aQuashed, bQuashed] = [a, b].map((tc) => tc.pokemon.hasTag(BattlerTagType.QUASHED));
         if ((aQuashed || bQuashed) && aQuashed !== bQuashed) {
           return aQuashed ? 1 : -1;
         }
@@ -343,7 +343,7 @@ export class TurnCommandManager {
         });
 
         const priorityBrackets = priority.map((p) => Math.ceil(p));
-        const bypassSpeed = [a, b].map((tc) => !!tc.pokemon.getTag(BattlerTagType.BYPASS_SPEED));
+        const bypassSpeed = [a, b].map((tc) => tc.pokemon.hasTag(BattlerTagType.BYPASS_SPEED));
 
         if (priority[0] !== priority[1]) {
           if (priorityBrackets[0] !== priorityBrackets[1] || bypassSpeed[0] === bypassSpeed[1]) {

--- a/src/ui/handlers/target-select-ui-handler.ts
+++ b/src/ui/handlers/target-select-ui-handler.ts
@@ -162,7 +162,7 @@ export class TargetSelectUiHandler extends UiHandler {
     if (this.targetFlashTween) {
       this.targetFlashTween.stop();
       for (const pokemon of allTargets) {
-        pokemon.setAlpha(!!pokemon.getTag(BattlerTagType.SUBSTITUTE) ? 0.5 : 1);
+        pokemon.setAlpha(pokemon.hasTag(BattlerTagType.SUBSTITUTE) ? 0.5 : 1);
         this.highlightItems(pokemon.id, 1);
       }
     }
@@ -214,7 +214,7 @@ export class TargetSelectUiHandler extends UiHandler {
     }
 
     for (const pokemon of this.targetsHighlighted) {
-      pokemon.setAlpha(!!pokemon.getTag(BattlerTagType.SUBSTITUTE) ? 0.5 : 1);
+      pokemon.setAlpha(pokemon.hasTag(BattlerTagType.SUBSTITUTE) ? 0.5 : 1);
       this.highlightItems(pokemon.id, 1);
     }
 

--- a/test/abilities/sweet-veil.test.ts
+++ b/test/abilities/sweet-veil.test.ts
@@ -68,7 +68,7 @@ describe("Abilities - Sweet Veil", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.getPlayerField().some((p) => !!p.getTag(BattlerTagType.DROWSY))).toBe(false);
+    expect(game.scene.getPlayerField().some((p) => p.hasTag(BattlerTagType.DROWSY))).toBe(false);
   });
 
   it("prevents the user and its allies already drowsy due to Yawn from falling asleep.", async () => {
@@ -81,7 +81,7 @@ describe("Abilities - Sweet Veil", () => {
 
     await game.toNextTurn();
 
-    expect(game.scene.getPlayerField().some((p) => !!p.getTag(BattlerTagType.DROWSY))).toBe(true);
+    expect(game.scene.getPlayerField().some((p) => p.hasTag(BattlerTagType.DROWSY))).toBe(true);
 
     // Turn 2: Switch into Swirlix with Sweet Veil
     game.move.use(MoveId.SPLASH);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Less `!!`.

## What are the changes from a developer perspective?
New `Pokemon#hasTag()` function added which returns `true`/`false` for if a Pokémon has one of the listed `BattlerTag`s.
Existing uses of `!!*.getTag()` were replaced with `*.hasTag()`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)