### PR TITLE
[P1] `WeatherEffectPhase` no longer requires an active Pokemon

### DIFF
--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -38,7 +38,8 @@ export class WeatherEffectPhase extends FieldPhase {
     const weatherAnim = new CommonBattleAnim(weatherAnimType, globalScene.getPlayerPokemon()!, undefined, true);
 
     globalScene.ui.showText(getWeatherLapseMessage(weather.weatherType) ?? "", null, () => {
-      weatherAnim.play(false, () => {
+      // (36, 80) is the player's center-field position
+      weatherAnim.playWithoutTargets(36, 80, 2, 5, () => {
         this.applyWeatherEffects(weather);
         this.end();
       });

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -16,6 +16,14 @@ import { HitResult } from "#enums/hit-result";
 import { PhaseId } from "#enums/phase-id";
 import { WeatherType } from "#enums/weather-type";
 
+/**
+ * Applies the end-of-turn effects from active {@linkcode Weather}, including
+ * - the weather's post-turn animation and message
+ * - the damaging effects of Hail and Sandstorm
+ * - all post-turn ability triggers dependent on the current weather
+ * (e.g. Rain Dish, Dry Skin)
+ * @extends FieldPhase
+ */
 export class WeatherEffectPhase extends FieldPhase {
   override readonly id = PhaseId.WEATHER_EFFECT;
 
@@ -35,6 +43,7 @@ export class WeatherEffectPhase extends FieldPhase {
     }
 
     const weatherAnimType: CommonAnim = CommonAnim.SUNNY + (weather.weatherType - 1);
+    /** @todo Rework animation params so that the placeholder "user" can be removed */
     const weatherAnim = new CommonBattleAnim(weatherAnimType, globalScene.getPlayerPokemon()!, undefined, true);
 
     globalScene.ui.showText(getWeatherLapseMessage(weather.weatherType) ?? "", null, () => {
@@ -50,9 +59,9 @@ export class WeatherEffectPhase extends FieldPhase {
    * Applies the end-of-turn effects from the current weather, including
    * - Damage from Sandstorm and Hail
    * - Ability triggers, e.g. healing from {@link https://bulbapedia.bulbagarden.net/wiki/Rain_Dish_(Ability) | Rain Dish}
-   * @param weather the current {@linkcode Weather} on the field
+   * @param weather - The current {@linkcode Weather} on the field
    */
-  protected applyWeatherEffects(weather: Weather): void {
+  private applyWeatherEffects(weather: Weather): void {
     if (this.tryCancelWeatherEffects(weather)) {
       return;
     }
@@ -68,14 +77,14 @@ export class WeatherEffectPhase extends FieldPhase {
 
   /**
    * Checks the field for effects that nullify the current weather's end-of-turn effects
-   * @param weather the current {@linkcode Weather} on the field
+   * @param weather - The current {@linkcode Weather} on the field
    * @returns `true` if the weather is suppressed
    *
    * @todo Merge this logic with {@linkcode Weather.isEffectSuppressed}. This method applies the suppressing attributes directly
    * while `isEffectSuppressed` uses a `hasAbility` check to avoid flyouts appearing at the wrong time. These may
    * be combined by rewriting `isEffectSuppressed` to support simulated application.
    */
-  protected tryCancelWeatherEffects(weather: Weather): boolean {
+  private tryCancelWeatherEffects(weather: Weather): boolean {
     const cancelled = new BooleanHolder(false);
 
     this.executeForAll((pokemon: Pokemon) =>
@@ -90,10 +99,10 @@ export class WeatherEffectPhase extends FieldPhase {
    * of specific {@linkcode WeatherType | types of weather}. This accounts for
    * immunity to weather-based damage from the Pokemon's typing, abilities, and
    * other effects.
-   * @param weather the current {@linkcode Weather} on the field
-   * @param pokemon the {@linkcode Pokemon} to which damage may apply
+   * @param weather - The current {@linkcode Weather} on the field
+   * @param pokemon - The {@linkcode Pokemon} to which damage may apply
    */
-  protected tryInflictWeatherDamage(weather: Weather, pokemon: Pokemon): void {
+  private tryInflictWeatherDamage(weather: Weather, pokemon: Pokemon): void {
     if (!weather.isDamaging()) {
       return;
     }

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -3,10 +3,11 @@ import type { PostWeatherLapseAbAttr } from "#app/data/abilities/ab-attrs/post-w
 import type { PreWeatherDamageAbAttr } from "#app/data/abilities/ab-attrs/pre-weather-damage-ab-attr";
 import type { SuppressWeatherEffectAbAttr } from "#app/data/abilities/ab-attrs/suppress-weather-effect-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { getWeatherDamageMessage, getWeatherLapseMessage } from "#app/data/weather";
+import { CommonBattleAnim } from "#app/data/animations/common-battle-anim";
+import { getWeatherDamageMessage, getWeatherLapseMessage, type Weather } from "#app/data/weather";
 import { type Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
-import { CommonAnimPhase } from "#app/phases/common-anim-phase";
+import { FieldPhase } from "#app/phases/abstract-field-phase";
 import { BooleanHolder, toDmgValue } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -15,7 +16,7 @@ import { HitResult } from "#enums/hit-result";
 import { PhaseId } from "#enums/phase-id";
 import { WeatherType } from "#enums/weather-type";
 
-export class WeatherEffectPhase extends CommonAnimPhase {
+export class WeatherEffectPhase extends FieldPhase {
   override readonly id = PhaseId.WEATHER_EFFECT;
 
   public override start(): void {
@@ -33,60 +34,86 @@ export class WeatherEffectPhase extends CommonAnimPhase {
       return this.end();
     }
 
-    this.setAnimation(CommonAnim.SUNNY + (weather.weatherType - 1));
+    const weatherAnimType: CommonAnim = CommonAnim.SUNNY + (weather.weatherType - 1);
+    const weatherAnim = new CommonBattleAnim(weatherAnimType, globalScene.getPlayerPokemon()!, undefined, true);
 
-    const end = (): void => {
-      globalScene.ui.showText(getWeatherLapseMessage(weather.weatherType) ?? "", null, () => {
-        this.executeForAll((pokemon: Pokemon) => {
-          if (!pokemon.switchOutStatus) {
-            applyAbAttrs<PostWeatherLapseAbAttr>(AbAttrFlag.POST_WEATHER_LAPSE, pokemon, false, weather);
-          }
-        });
-
-        super.start();
+    globalScene.ui.showText(getWeatherLapseMessage(weather.weatherType) ?? "", null, () => {
+      weatherAnim.play(false, () => {
+        this.applyWeatherEffects(weather);
+        this.end();
       });
-    };
+    });
+  }
 
-    if (!weather.isDamaging()) {
-      return end();
+  /**
+   * Applies the end-of-turn effects from the current weather, including
+   * - Damage from Sandstorm and Hail
+   * - Ability triggers, e.g. healing from {@link https://bulbapedia.bulbagarden.net/wiki/Rain_Dish_(Ability) | Rain Dish}
+   * @param weather the current {@linkcode Weather} on the field
+   */
+  protected applyWeatherEffects(weather: Weather): void {
+    if (this.tryCancelWeatherEffects(weather)) {
+      return;
     }
 
+    this.executeForAll((pokemon: Pokemon) => this.tryInflictWeatherDamage(weather, pokemon));
+
+    this.executeForAll((pokemon: Pokemon) => {
+      if (!pokemon.switchOutStatus) {
+        applyAbAttrs<PostWeatherLapseAbAttr>(AbAttrFlag.POST_WEATHER_LAPSE, pokemon, false, weather);
+      }
+    });
+  }
+
+  /**
+   * Checks the field for effects that nullify the current weather's end-of-turn effects
+   * @param weather the current {@linkcode Weather} on the field
+   * @returns `true` if the weather is suppressed
+   *
+   * @todo Merge this logic with {@linkcode Weather.isEffectSuppressed}. This method applies the suppressing attributes directly
+   * while `isEffectSuppressed` uses a `hasAbility` check to avoid flyouts appearing at the wrong time. These may
+   * be combined by rewriting `isEffectSuppressed` to support simulated application.
+   */
+  protected tryCancelWeatherEffects(weather: Weather): boolean {
     const cancelled = new BooleanHolder(false);
 
     this.executeForAll((pokemon: Pokemon) =>
       applyAbAttrs<SuppressWeatherEffectAbAttr>(AbAttrFlag.SUPPRESS_WEATHER_EFFECT, pokemon, false, weather, cancelled),
     );
 
-    if (cancelled.value) {
-      return end();
+    return cancelled.value;
+  }
+
+  /**
+   * Inflicts damage on the given Pokemon from the end-of-turn effects
+   * of specific {@linkcode WeatherType | types of weather}. This accounts for
+   * immunity to weather-based damage from the Pokemon's typing, abilities, and
+   * other effects.
+   * @param weather the current {@linkcode Weather} on the field
+   * @param pokemon the {@linkcode Pokemon} to which damage may apply
+   */
+  protected tryInflictWeatherDamage(weather: Weather, pokemon: Pokemon): void {
+    if (!weather.isDamaging()) {
+      return;
     }
 
-    const inflictDamage = (pokemon: Pokemon): void => {
-      const cancelled = new BooleanHolder(false);
+    const cancelled = new BooleanHolder(false);
 
-      applyAbAttrs<PreWeatherDamageAbAttr>(AbAttrFlag.PRE_WEATHER_DAMAGE, pokemon, false, weather, cancelled);
-      applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
+    applyAbAttrs<PreWeatherDamageAbAttr>(AbAttrFlag.PRE_WEATHER_DAMAGE, pokemon, false, weather, cancelled);
+    applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
 
-      if (cancelled.value || pokemon.getTag(BattlerTagType.UNDERGROUND) || pokemon.getTag(BattlerTagType.UNDERWATER)) {
-        return;
-      }
+    if (
+      cancelled.value
+      || pokemon.getTypes(true, true).some((t) => weather.isTypeDamageImmune(t))
+      || pokemon.getTag(BattlerTagType.UNDERGROUND, BattlerTagType.UNDERWATER)
+      || pokemon.switchOutStatus
+    ) {
+      return;
+    }
 
-      const damage = toDmgValue(pokemon.getMaxHp() / 16);
+    const damage = toDmgValue(pokemon.getMaxHp() / 16);
 
-      globalScene.queueMessage(getWeatherDamageMessage(weather.weatherType, pokemon) ?? "");
-      pokemon.damageAndUpdate(damage, { result: HitResult.EFFECTIVE, preventEndure: true });
-    };
-
-    this.executeForAll((pokemon: Pokemon) => {
-      const immune: boolean =
-        !pokemon
-        || pokemon.getTypes(true, true).filter((t) => weather?.isTypeDamageImmune(t)).length > 0
-        || pokemon.switchOutStatus;
-      if (!immune) {
-        inflictDamage(pokemon);
-      }
-    });
-
-    return end();
+    globalScene.queueMessage(getWeatherDamageMessage(weather.weatherType, pokemon) ?? "");
+    pokemon.damageAndUpdate(damage, { result: HitResult.EFFECTIVE, preventEndure: true });
   }
 }


### PR DESCRIPTION
> [!NOTE]
> **This is an [`Addendum`](https://github.com/Despair-Games/poketernity/labels/Addendum) for the [`post-action-phase`](https://github.com/Despair-Games/poketernity/tree/post-action-phase) branch** 
> Meaning the base branch is **not** ~~`beta`~~ 

## What are the changes the user will see?

The game should no longer crash (as seen in #885) when the field is empty at the end of a turn.

## Why am I making these changes?

Fixing a bug in #885. `WeatherEffectPhase` extending `PokemonPhase` caused issues after its scheduling was moved from the start of the turn (where at least one Pokemon is guaranteed to be on the field)

## What are the changes from a developer perspective?

`WeatherEffectPhase` has been rewritten as follows:
- It now extends `FieldPhase` instead of `CommonAnimPhase`
- The `CommonBattleAnims` used for weather in this phase should now play (to the best of their ability) without needing a reference to a Pokemon on the field
- Some of the internal `const` functions have been rewritten to protected methods
- Reorganized some logic to better reflect the timing of the phase's effects.

## Screenshots/Videos

<details><summary>Sun animation now plays on an empty field</summary>
<p>

https://github.com/user-attachments/assets/6636d0ed-6d07-40ad-8c9f-c2549e84e2a0

Overrides:
```ts
const overrides = {
  WEATHER_OVERRIDE: WeatherType.SUNNY,
  MOVESET_OVERRIDE: MoveId.EXPLOSION
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

</p>
</details> 

## How to test the changes?

`npm run test [aftermath | battle | destiny-bond]`: These fail in #885 due to `WeatherEffectPhase`'s implementation

## Checklist

- [x] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (dark and light)?