### PR TITLE
[Refactor] Ensure stale object deletion doesn't fail early

### DIFF
--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -60,10 +60,12 @@ export class BattleEndPhase extends BattlePhase {
 
     globalScene.clearEnemyHeldItemModifiers();
 
-    try {
-      globalScene.getEnemyParty().forEach((p) => p.destroy());
-    } catch {
-      console.warn("Unable to destroy stale pokemon objects in BattleEndPhase.");
+    for (const p of globalScene.getEnemyParty()) {
+      try {
+        p.destroy();
+      } catch {
+        console.warn("Unable to destroy stale pokemon object in BattleEndPhase:", p);
+      }
     }
 
     const lapsingModifiers = globalScene.findModifiers(


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Mistake found in stale Pokémon object deletion.

## What are the changes from a developer perspective?
The `try/catch` is moved inside the `for` loop in `BattleEndPhase`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?