### PR TITLE
[Balance] Gym leaders now occur every 20 waves from 20-160

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -254,8 +254,8 @@ export default class BattleScene extends SceneBase {
 
   public seed: string;
   public waveSeed: string;
+  /** @todo what is this? */
   public waveCycleOffset: number;
-  public offsetGym: boolean;
 
   public damageNumberHandler: DamageNumberHandler;
   private spriteSparkleHandler: PokemonSpriteSparkleHandler;
@@ -1039,7 +1039,6 @@ export default class BattleScene extends SceneBase {
     this.seed = seed;
     this.rngCounter = 0;
     this.waveCycleOffset = this.getGeneratedWaveCycleOffset();
-    this.offsetGym = this.gameMode.isClassic && this.getGeneratedOffsetGym();
   }
 
   /**
@@ -1555,18 +1554,7 @@ export default class BattleScene extends SceneBase {
     return this.arena.getSpeciesFormIndex(species);
   }
 
-  private getGeneratedOffsetGym(): boolean {
-    let ret = false;
-    this.executeWithSeedOffset(
-      () => {
-        ret = !randSeedInt(2);
-      },
-      0,
-      this.seed.toString(),
-    );
-    return ret;
-  }
-
+  /** @todo what is this? */
   private getGeneratedWaveCycleOffset(): number {
     let ret = 0;
     this.executeWithSeedOffset(

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -254,7 +254,7 @@ export default class BattleScene extends SceneBase {
 
   public seed: string;
   public waveSeed: string;
-  /** @todo what is this? */
+  /** Random multiple of `5` between `0-35` used to start at a random time of day */
   public waveCycleOffset: number;
 
   public damageNumberHandler: DamageNumberHandler;
@@ -1554,7 +1554,7 @@ export default class BattleScene extends SceneBase {
     return this.arena.getSpeciesFormIndex(species);
   }
 
-  /** @todo what is this? */
+  /** @returns A random multiple of 5 between 0-35, used to start at a random time of day */
   private getGeneratedWaveCycleOffset(): number {
     let ret = 0;
     this.executeWithSeedOffset(

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -169,6 +169,7 @@ export const trainerPartyTemplates = {
   SIX_WEAK_SAME: new TrainerPartyTemplate(6, PartyMemberStrength.WEAK, true),
   SIX_WEAK_BALANCED: new TrainerPartyTemplate(6, PartyMemberStrength.WEAK, false, true),
 
+  // TODO: adjust gym leader templates
   GYM_LEADER_1: new TrainerPartyCompoundTemplate(
     new TrainerPartyTemplate(1, PartyMemberStrength.AVERAGE),
     new TrainerPartyTemplate(1, PartyMemberStrength.STRONG),
@@ -1579,17 +1580,11 @@ export function getWavePartyTemplate(...templates: TrainerPartyTemplate[]): Trai
   const wavesToScale = 30;
   const offsetWave = 20;
 
-  const wave = Overrides.STARTING_WAVE_OVERRIDE || 1;
-  return templates[
-    Phaser.Math.Clamp(
-      Math.ceil(
-        (globalScene.gameMode.getWaveForDifficulty(globalScene.currentBattle?.waveIndex || wave, true) - offsetWave)
-          / wavesToScale,
-      ),
-      0,
-      templates.length - 1,
-    )
-  ];
+  const wave = Overrides.STARTING_WAVE_OVERRIDE ?? 1;
+  const { currentBattle, gameMode } = globalScene;
+  const adjustedWave = gameMode.getWaveForDifficulty(currentBattle?.waveIndex ?? wave, true);
+  const targetTemplate = Math.ceil((adjustedWave - offsetWave) / wavesToScale);
+  return templates[Phaser.Math.Clamp(targetTemplate, 0, templates.length - 1)];
 }
 
 /**

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -287,13 +287,11 @@ export class Arena {
   randomTrainerType(waveIndex: number, isBoss: boolean = false): TrainerType {
     const isTrainerBoss =
       this.trainerPool[BiomePoolTier.BOSS].length > 0
-      && (globalScene.gameMode.isTrainerBoss(waveIndex, this.biomeId, globalScene.offsetGym) || isBoss);
-    console.log(isBoss, this.trainerPool);
+      && (globalScene.gameMode.isTrainerBoss(waveIndex, this.biomeId) || isBoss);
 
     // @todo Right now there are no super/ultra or rare boss trainers
     const tierValue = randSeedInt(!isTrainerBoss ? 512 : 64);
     let tier = isTrainerBoss ? this.generateBossBiomeTier(tierValue) : this.generateNonBossBiomeTier(tierValue);
-    console.log(BiomePoolTier[tier]);
 
     while (tier && !this.trainerPool[tier].length) {
       console.log(`Downgraded trainer rarity tier from ${BiomePoolTier[tier]} to ${BiomePoolTier[tier - 1]}`);

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -194,7 +194,7 @@ export class GameMode implements GameModeConfig {
     return this.isClassic && gymWaves.includes(waveIndex);
   }
 
-  isTrainerBoss(waveIndex: number, biomeId: BiomeId): boolean {
+  public isTrainerBoss(waveIndex: number, biomeId: BiomeId): boolean {
     switch (this.modeId) {
       case GameModes.DAILY:
         return waveIndex > 10 && waveIndex < 50 && !(waveIndex % 10);

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -142,19 +142,18 @@ export class GameMode implements GameModeConfig {
    * @returns `true` if a trainer should be generated, `false` otherwise
    */
   isWaveTrainer(waveIndex: number, arena: Arena): boolean {
-    /**
-     * Daily spawns trainers on floors 5, 15, 20, 25, 30, 35, 40, and 45
-     */
+    // Daily spawns trainers on floors 5, 15, 20, 25, 30, 35, 40, and 45
     if (this.isDaily) {
       return waveIndex % 10 === 5 || (!(waveIndex % 10) && waveIndex > 10 && !this.isWaveFinal(waveIndex));
     }
-    if (waveIndex % 30 === (globalScene.offsetGym ? 0 : 20) && !this.isWaveFinal(waveIndex)) {
+
+    if (this.isGymWave(waveIndex) && !this.isWaveFinal(waveIndex)) {
       return true;
-    } else if (waveIndex % 10 !== 1 && waveIndex % 10) {
-      /**
-       * Do not check X1 floors since there's a bug that stops trainer sprites from appearing
-       * after a X0 full party heal
-       */
+    }
+
+    // Trainers must not appear on X1 waves due to a bug that prevents trainer sprites from appearing
+    // after the full party heal that happens between X0 and X1 waves
+    if (waveIndex % 10 > 1) {
       const trainerChance = arena.getTrainerChance();
       let allowTrainerBattle = true;
       if (trainerChance) {
@@ -164,10 +163,13 @@ export class GameMode implements GameModeConfig {
           if (w === waveIndex) {
             continue;
           }
-          if (w % 30 === (globalScene.offsetGym ? 0 : 20) || this.isFixedBattle(w)) {
+
+          if (this.isGymWave(w) || this.isFixedBattle(w)) {
             allowTrainerBattle = false;
             break;
-          } else if (w < waveIndex) {
+          }
+
+          if (w < waveIndex) {
             globalScene.executeWithSeedOffset(() => {
               const waveTrainerChance = arena.getTrainerChance();
               if (!randSeedInt(waveTrainerChance)) {
@@ -182,18 +184,24 @@ export class GameMode implements GameModeConfig {
       }
       return Boolean(allowTrainerBattle && trainerChance && !randSeedInt(trainerChance));
     }
+
     return false;
   }
 
-  isTrainerBoss(waveIndex: number, biomeId: BiomeId, offsetGym: boolean): boolean {
+  /** @returns `true` if the wave is a multiple of `20` between `20-160` in classic mode */
+  public isGymWave(waveIndex: number): boolean {
+    return this.isClassic && waveIndex % 20 === 0 && waveIndex <= 160;
+  }
+
+  isTrainerBoss(waveIndex: number, biomeId: BiomeId): boolean {
     switch (this.modeId) {
       case GameModes.DAILY:
         return waveIndex > 10 && waveIndex < 50 && !(waveIndex % 10);
-      default:
-        return (
-          waveIndex % 30 === (offsetGym ? 0 : 20)
-          && (biomeId !== BiomeId.END || this.isClassic || this.isWaveFinal(waveIndex))
-        );
+      case GameModes.CLASSIC:
+      case GameModes.CHALLENGE:
+        return this.isGymWave(waveIndex) && (biomeId !== BiomeId.END || this.isWaveFinal(waveIndex));
+      case GameModes.ENDLESS:
+        return false;
     }
   }
 

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -190,7 +190,8 @@ export class GameMode implements GameModeConfig {
 
   /** @returns `true` if the wave is a multiple of `20` between `20-160` in classic mode */
   public isGymWave(waveIndex: number): boolean {
-    return this.isClassic && waveIndex % 20 === 0 && waveIndex <= 160;
+    const gymWaves = [20, 40, 60, 80, 100, 120, 140, 160];
+    return this.isClassic && gymWaves.includes(waveIndex);
   }
 
   isTrainerBoss(waveIndex: number, biomeId: BiomeId): boolean {

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -36,8 +36,8 @@ export class CallSourceLogger {
       const firefoxRegex = RegExp("(.*?(\\w+))(?:\\/<|)@.*\\/(.*\\.ts).*:(\\d*:\\d*)");
       const match = line.match(chromeRegex) ?? line.match(firefoxRegex);
       if (match) {
-        const fullFunctionName = match[1]; // e.g., "BattleScene.getGeneratedOffsetGym"
-        const rootFunctionName = match[2]; // e.g., "getGeneratedOffsetGym"
+        const fullFunctionName = match[1]; // e.g., "BattleScene.reset"
+        const rootFunctionName = match[2]; // e.g., "reset"
         const fileName = match[3]; // e.g., "battle-scene.ts"
         // const _lineNumbers = match[4]; // e.g., "1216:10". However, this is bugged due to the browser removing empty lines from TS files.
         if (!this.ignoredFnNames.includes(rootFunctionName)) {

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -81,8 +81,11 @@ export class VictoryPhase extends PokemonPhase {
             phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_SHARE));
           }
 
-          if (!isEndless && gameMode.isGymWave(waveIndex)) {
-            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_CHARM));
+          if (!isEndless) {
+            const modifierType = gameMode.isGymWave(waveIndex)
+              ? modifierTypes.SUPER_EXP_CHARM
+              : modifierTypes.EXP_CHARM;
+            phaseManager.pushPhase(new ModifierRewardPhase(modifierType));
           }
 
           if (isEndless && waveIndex <= 750 && (waveIndex <= 500 || waveIndex % 30 === 10)) {

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -29,7 +29,7 @@ export class VictoryPhase extends PokemonPhase {
   public override start(): void {
     super.start();
 
-    const { currentBattle, gameData, gameMode, offsetGym } = globalScene;
+    const { currentBattle, gameData, gameMode } = globalScene;
     const { battleType, mysteryEncounter, waveIndex } = currentBattle;
     const { isClassic, isDaily, isEndless } = gameMode;
 
@@ -77,15 +77,14 @@ export class VictoryPhase extends PokemonPhase {
             globalScene.phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
           }
         } else {
-          const superExpWave = !isEndless ? (offsetGym ? 0 : 20) : 10;
           if (isEndless && waveIndex === 10) {
             globalScene.phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_SHARE));
           }
 
-          if (waveIndex <= 750 && (waveIndex <= 500 || waveIndex % 30 === superExpWave)) {
+          if (waveIndex <= 750 && (waveIndex <= 500 || gameMode.isGymWave(waveIndex))) {
             globalScene.phaseManager.pushPhase(
               new ModifierRewardPhase(
-                waveIndex % 30 !== superExpWave || waveIndex > 250
+                !gameMode.isGymWave(waveIndex) || waveIndex > 250
                   ? modifierTypes.EXP_CHARM
                   : modifierTypes.SUPER_EXP_CHARM,
               ),

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -29,7 +29,7 @@ export class VictoryPhase extends PokemonPhase {
   public override start(): void {
     super.start();
 
-    const { currentBattle, gameData, gameMode } = globalScene;
+    const { currentBattle, gameData, gameMode, phaseManager } = globalScene;
     const { battleType, mysteryEncounter, waveIndex } = currentBattle;
     const { isClassic, isDaily, isEndless } = gameMode;
 
@@ -52,62 +52,64 @@ export class VictoryPhase extends PokemonPhase {
       // clear all queued delayed attacks (e.g. from Future Sight)
       globalScene.arena.removeTag(ArenaTagType.DELAYED_ATTACK);
 
-      globalScene.phaseManager.pushPhase(new BattleEndPhase(true));
+      phaseManager.pushPhase(new BattleEndPhase(true));
 
       if (battleType === BattleType.TRAINER) {
-        globalScene.phaseManager.pushPhase(new TrainerVictoryPhase());
+        phaseManager.pushPhase(new TrainerVictoryPhase());
       }
 
       if (isEndless || !gameMode.isWaveFinal(waveIndex)) {
-        globalScene.phaseManager.pushPhase(new EggLapsePhase());
+        phaseManager.pushPhase(new EggLapsePhase());
 
         if (isClassic && waveIndex === EVIL_BOSS_2_WAVE) {
           // Should get Lock Capsule on 165 before shop phase so it can be used in the rewards shop
-          globalScene.phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.LOCK_CAPSULE));
+          phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.LOCK_CAPSULE));
         }
 
         if (waveIndex % 10) {
-          globalScene.phaseManager.pushPhase(
+          phaseManager.pushPhase(
             new SelectModifierPhase({ customModifierSettings: this.getFixedBattleCustomModifiers() }),
           );
         } else if (isDaily) {
-          globalScene.phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_CHARM));
+          phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_CHARM));
 
           if (waveIndex > 10 && !gameMode.isWaveFinal(waveIndex)) {
-            globalScene.phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
+            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
           }
         } else {
           if (isEndless && waveIndex === 10) {
-            globalScene.phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_SHARE));
+            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_SHARE));
           }
 
-          if (waveIndex <= 750 && (waveIndex <= 500 || gameMode.isGymWave(waveIndex))) {
-            globalScene.phaseManager.pushPhase(
+          if (!isEndless && gameMode.isGymWave(waveIndex)) {
+            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_CHARM));
+          }
+
+          if (isEndless && waveIndex <= 750 && (waveIndex <= 500 || waveIndex % 30 === 10)) {
+            phaseManager.pushPhase(
               new ModifierRewardPhase(
-                !gameMode.isGymWave(waveIndex) || waveIndex > 250
-                  ? modifierTypes.EXP_CHARM
-                  : modifierTypes.SUPER_EXP_CHARM,
+                !(waveIndex % 30 === 10) || waveIndex > 250 ? modifierTypes.EXP_CHARM : modifierTypes.SUPER_EXP_CHARM,
               ),
             );
           }
 
           if (waveIndex <= 150 && !(waveIndex % 50)) {
-            globalScene.phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
+            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
           }
 
           if (isEndless && !(waveIndex % 50)) {
-            globalScene.phaseManager.pushPhase(
+            phaseManager.pushPhase(
               new ModifierRewardPhase(!(waveIndex % 250) ? modifierTypes.VOUCHER_PREMIUM : modifierTypes.VOUCHER_PLUS),
             );
           }
         }
 
-        globalScene.phaseManager.pushPhase(new NewBattlePhase());
+        phaseManager.pushPhase(new NewBattlePhase());
       } else {
         currentBattle.battleType = BattleType.CLEAR;
         globalScene.score += gameMode.getClearScoreBonus();
         globalScene.updateScoreText();
-        globalScene.phaseManager.queueGameOverPhase({ isVictory: true });
+        phaseManager.queueGameOverPhase({ isVictory: true });
       }
     }
 


### PR DESCRIPTION
## What are the changes the user will see?
Gym leaders will appear every 20 waves in classic from waves 20-160, instead of every 30 waves from 20-170 or 30-180.

## Why am I making these changes?
General consensus was to change it to 8 gym leaders per classic run.

## What are the changes from a developer perspective?
- `BattleScene#offsetGym` and `BattleScene#getGeneratedOffsetGym()` were removed.
- `GameMode#isGymWave()` created that returns `true` if it's classic mode, the current wave is a multiple of 20 and the current wave is less than or equal to 160.
- Various wave checks were replaced with `.isGymWave()`.

## How to test the changes?
Go to a wave that's a multiple of 20 in classic mode.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?