### PR TITLE
[Refactor] Simplify/clarify `VictoryPhase` and add TSDocs

### DIFF
--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -1,23 +1,46 @@
-import { type BattlerIndex } from "#enums/battler-index";
-import { BattleType } from "#enums/battle-type";
+// -- start tsdoc imports --
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { GameOverPhase } from "#app/phases/game-over-phase";
+// -- end tsdoc imports--
+
 import { handleMysteryEncounterVictory } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { EVIL_BOSS_2_WAVE } from "#app/data/special-waves";
 import { globalScene } from "#app/global-scene";
 import { type CustomModifierSettings } from "#app/modifier/modifier-type";
 import { modifierTypes } from "#app/modifier/modifier-types";
-import { PokemonPhase } from "./abstract-pokemon-phase";
-import { BattleEndPhase } from "./battle-end-phase";
-import { EggLapsePhase } from "./egg-lapse-phase";
-import { ModifierRewardPhase } from "./modifier-reward-phase";
-import { NewBattlePhase } from "./new-battle-phase";
-import { SelectModifierPhase } from "./select-modifier-phase";
-import { TrainerVictoryPhase } from "./trainer-victory-phase";
+import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
+import { BattleEndPhase } from "#app/phases/battle-end-phase";
+import { EggLapsePhase } from "#app/phases/egg-lapse-phase";
+import { ModifierRewardPhase } from "#app/phases/modifier-reward-phase";
+import { NewBattlePhase } from "#app/phases/new-battle-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { TrainerVictoryPhase } from "#app/phases/trainer-victory-phase";
 import { ArenaTagType } from "#enums/arena-tag-type";
-import { EVIL_BOSS_2_WAVE } from "#app/data/special-waves";
+import { BattleType } from "#enums/battle-type";
+import { type BattlerIndex } from "#enums/battler-index";
 import { PhaseId } from "#enums/phase-id";
 
+/**
+ * Handles the actions after the player KOs a pokemon:
+ * - Increases {@linkcode globalScene.gameData.gameStats.pokemonDefeated | pokemon defeated} count in game stats
+ * - Applies EXP gain
+ * - Ends the phase early:
+ *   - If this is a Mystery Encounter, in which case execution is handed off to a ME function; or
+ *   - If there are still unfainted pokemon on the enemy team
+ * - Clears "delayed attack" arena tags (Future Sight / Doom Desire)
+ * - Pushes a {@linkcode BattleEndPhase}
+ * - Pushes a {@linkcode TrainerVictoryPhase} if this was a trainer battle
+ * - If this was the final wave in a non-Endless mode, pushes a {@linkcode GameOverPhase} and ends the current phase
+ * - Pushes an {@linkcode EggLapsePhase}
+ * - Gives item rewards based on wave and game mode
+ * - Pushes a {@linkcode NewBattlePhase}
+ */
 export class VictoryPhase extends PokemonPhase {
   override readonly id = PhaseId.VICTORY;
-  /** If true, indicates that the phase is intended for EXP purposes only, and not to continue a battle to next phase */
+  /**
+   * If `true`, indicates that the phase is intended for EXP purposes only, and not to continue a battle to next phase.
+   * Only used by Mystery Encounters.
+   */
   public readonly isExpOnly: boolean;
 
   constructor(battlerIndex: BattlerIndex | number, isExpOnly: boolean = false) {
@@ -45,83 +68,89 @@ export class VictoryPhase extends PokemonPhase {
 
     if (isMysteryEncounter) {
       handleMysteryEncounterVictory(false, this.isExpOnly);
+      return super.end();
+    }
+
+    if (globalScene.getEnemyParty().some((p) => (battleType === BattleType.WILD ? p.isOnField() : !p?.isFainted()))) {
+      return super.end();
+    }
+
+    // clear all queued delayed attacks (e.g. from Future Sight)
+    globalScene.arena.removeTag(ArenaTagType.DELAYED_ATTACK);
+
+    phaseManager.pushPhase(new BattleEndPhase(true));
+
+    if (battleType === BattleType.TRAINER) {
+      phaseManager.pushPhase(new TrainerVictoryPhase());
+    }
+
+    if (!isEndless && gameMode.isWaveFinal(waveIndex)) {
+      currentBattle.battleType = BattleType.CLEAR;
+      globalScene.score += gameMode.getClearScoreBonus();
+      globalScene.updateScoreText();
+      phaseManager.queueGameOverPhase({ isVictory: true });
+      return super.end();
+    }
+
+    phaseManager.pushPhase(new EggLapsePhase());
+
+    if (isClassic && waveIndex === EVIL_BOSS_2_WAVE) {
+      // Should get Lock Capsule on 165 before shop phase so it can be used in the rewards shop
+      phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.LOCK_CAPSULE));
+    }
+
+    if (waveIndex % 10 > 0) {
+      phaseManager.pushPhase(new SelectModifierPhase({ customModifierSettings: this.getFixedBattleCustomModifiers() }));
+      return this.end();
+    }
+    if (isDaily) {
+      phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_CHARM));
+
+      if ([20, 30, 40].includes(waveIndex)) {
+        phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
+      }
+
       return this.end();
     }
 
-    if (!globalScene.getEnemyParty().find((p) => (battleType === BattleType.WILD ? p.isOnField() : !p?.isFainted()))) {
-      // clear all queued delayed attacks (e.g. from Future Sight)
-      globalScene.arena.removeTag(ArenaTagType.DELAYED_ATTACK);
-
-      phaseManager.pushPhase(new BattleEndPhase(true));
-
-      if (battleType === BattleType.TRAINER) {
-        phaseManager.pushPhase(new TrainerVictoryPhase());
+    if (isEndless) {
+      if (waveIndex === 10) {
+        phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_SHARE));
       }
 
-      if (isEndless || !gameMode.isWaveFinal(waveIndex)) {
-        phaseManager.pushPhase(new EggLapsePhase());
-
-        if (isClassic && waveIndex === EVIL_BOSS_2_WAVE) {
-          // Should get Lock Capsule on 165 before shop phase so it can be used in the rewards shop
-          phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.LOCK_CAPSULE));
-        }
-
-        if (waveIndex % 10) {
-          phaseManager.pushPhase(
-            new SelectModifierPhase({ customModifierSettings: this.getFixedBattleCustomModifiers() }),
-          );
-        } else if (isDaily) {
-          phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_CHARM));
-
-          if (waveIndex > 10 && !gameMode.isWaveFinal(waveIndex)) {
-            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
-          }
-        } else {
-          if (isEndless && waveIndex === 10) {
-            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.EXP_SHARE));
-          }
-
-          if (!isEndless) {
-            const modifierType = gameMode.isGymWave(waveIndex)
-              ? modifierTypes.SUPER_EXP_CHARM
-              : modifierTypes.EXP_CHARM;
-            phaseManager.pushPhase(new ModifierRewardPhase(modifierType));
-          }
-
-          if (isEndless && waveIndex <= 750 && (waveIndex <= 500 || waveIndex % 30 === 10)) {
-            phaseManager.pushPhase(
-              new ModifierRewardPhase(
-                !(waveIndex % 30 === 10) || waveIndex > 250 ? modifierTypes.EXP_CHARM : modifierTypes.SUPER_EXP_CHARM,
-              ),
-            );
-          }
-
-          if (waveIndex <= 150 && !(waveIndex % 50)) {
-            phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
-          }
-
-          if (isEndless && !(waveIndex % 50)) {
-            phaseManager.pushPhase(
-              new ModifierRewardPhase(!(waveIndex % 250) ? modifierTypes.VOUCHER_PREMIUM : modifierTypes.VOUCHER_PLUS),
-            );
-          }
-        }
-
-        phaseManager.pushPhase(new NewBattlePhase());
-      } else {
-        currentBattle.battleType = BattleType.CLEAR;
-        globalScene.score += gameMode.getClearScoreBonus();
-        globalScene.updateScoreText();
-        phaseManager.queueGameOverPhase({ isVictory: true });
+      if (waveIndex <= 750 && (waveIndex <= 500 || waveIndex % 30 === 10)) {
+        phaseManager.pushPhase(
+          new ModifierRewardPhase(
+            !(waveIndex % 30 === 10) || waveIndex > 250 ? modifierTypes.EXP_CHARM : modifierTypes.SUPER_EXP_CHARM,
+          ),
+        );
       }
+
+      if (waveIndex % 50 === 0) {
+        phaseManager.pushPhase(
+          new ModifierRewardPhase(!(waveIndex % 250) ? modifierTypes.VOUCHER_PREMIUM : modifierTypes.VOUCHER_PLUS),
+        );
+      }
+    } else {
+      const modifierType = gameMode.isGymWave(waveIndex) ? modifierTypes.SUPER_EXP_CHARM : modifierTypes.EXP_CHARM;
+      phaseManager.pushPhase(new ModifierRewardPhase(modifierType));
+    }
+
+    if ([50, 100, 150].includes(waveIndex)) {
+      phaseManager.pushPhase(new ModifierRewardPhase(modifierTypes.GOLDEN_POKEBALL));
     }
 
     this.end();
   }
 
+  public override end(): void {
+    globalScene.phaseManager.pushPhase(new NewBattlePhase());
+    super.end();
+  }
+
   /**
    * If this wave is a fixed battle with special custom modifier rewards,
-   * will pass those settings to the upcoming {@linkcode SelectModifierPhase}`.
+   * pass those settings to the upcoming {@linkcode SelectModifierPhase}.
    */
   protected getFixedBattleCustomModifiers(): CustomModifierSettings | undefined {
     const gameMode = globalScene.gameMode;
@@ -129,7 +158,5 @@ export class VictoryPhase extends PokemonPhase {
     if (gameMode.isFixedBattle(waveIndex)) {
       return gameMode.getFixedBattle(waveIndex).customModifierRewardSettings;
     }
-
-    return undefined;
   }
 }

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { GameOverPhase } from "#app/phases/game-over-phase";
+/* eslint-enable @typescript-eslint/no-unused-vars */
 // -- end tsdoc imports--
 
 import { handleMysteryEncounterVictory } from "#app/data/mystery-encounters/utils/encounter-phase-utils";


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The phase was a bit confusing and undocumented.

## What are the changes from a developer perspective?
- `if/else` blocks moved around and early returns added to reduce indentation and improve readability / code flow.
- TSDocs added.

## How to test the changes?
Defeat some pokemon on various waves.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?