### PR TITLE
[P2] Shed tail hp cost rounds up

### DIFF
--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -3369,7 +3369,7 @@ export function initMoves() {
       )
       .makesContact(),
     new SelfStatusMove(MoveId.SHED_TAIL, ElementalType.NORMAL, -1, 10, -1, 0, 9)
-      .attr(AddSubstituteAttr, 0.5)
+      .attr(AddSubstituteAttr, true)
       .attr(ForceSwitchOutAttr, true, SwitchType.SHED_TAIL)
       .snatchable() // Custom
       .condition(failIfLastInPartyCondition),

--- a/src/data/moves/move-attrs/add-substitute-attr.ts
+++ b/src/data/moves/move-attrs/add-substitute-attr.ts
@@ -15,17 +15,22 @@ import i18next from "i18next";
  * @see {@linkcode apply}
  */
 export class AddSubstituteAttr extends MoveEffectAttr {
-  /** The ratio of the user's max HP that is required to apply this effect */
-  private hpCost: number;
+  /**
+   * This attr is only used for Substitute and Shed Tail.
+   * Substitute costs 1/4 of the user's max hp and rounds down
+   * Shed tail costs 1/2 of the user's max hp and rounds up
+   */
+  private forShedTail: boolean;
 
-  constructor(hpCost: number = 0.25) {
+  constructor(forShedTail: boolean = false) {
     super(true);
 
-    this.hpCost = hpCost;
+    this.forShedTail = forShedTail;
   }
 
   override applyEffect(user: Pokemon, _target: Pokemon, move: Move): boolean {
-    user.damageAndUpdate(Math.floor(user.getMaxHp() * this.hpCost), {
+    const hpCost = this.forShedTail ? Math.ceil(user.getMaxHp() * 0.5) : Math.floor(user.getMaxHp() * 0.25);
+    user.damageAndUpdate(hpCost, {
       result: HitResult.OTHER,
       ignoreSegments: true,
       preventEndure: true,
@@ -42,9 +47,15 @@ export class AddSubstituteAttr extends MoveEffectAttr {
   }
 
   override getCondition(): MoveConditionFunc {
+    /**
+     * Only works if
+     * - The user does not have a substitute out already
+     * - The user has enough HP
+     * - THe user has more than 1 max hp (wonder guard users)
+     */
     return (user, _target, _move) =>
       !user.getTag(BattlerTagType.SUBSTITUTE)
-      && user.hp > Math.floor(user.getMaxHp() * this.hpCost)
+      && user.hp > (this.forShedTail ? Math.ceil(user.getMaxHp() * 0.5) : Math.floor(user.getMaxHp() * 0.25))
       && user.getMaxHp() > 1;
   }
 

--- a/src/data/moves/move-attrs/add-substitute-attr.ts
+++ b/src/data/moves/move-attrs/add-substitute-attr.ts
@@ -11,25 +11,33 @@ import i18next from "i18next";
 /**
  * Attribute to put in a {@link https://bulbapedia.bulbagarden.net/wiki/Substitute_(doll) | Substitute Doll}
  * for the user.
+ *
+ * This attr is only used for Substitute and Shed Tail.
+ * Substitute costs 1/4 of the user's max hp and rounds down
+ * Shed tail costs 1/2 of the user's max hp and rounds up
+ *
  * @extends MoveEffectAttr
  * @see {@linkcode apply}
  */
 export class AddSubstituteAttr extends MoveEffectAttr {
-  /**
-   * This attr is only used for Substitute and Shed Tail.
-   * Substitute costs 1/4 of the user's max hp and rounds down
-   * Shed tail costs 1/2 of the user's max hp and rounds up
-   */
-  private forShedTail: boolean;
+  private isShedTail: boolean;
 
-  constructor(forShedTail: boolean = false) {
+  constructor(isShedTail: boolean = false) {
     super(true);
 
-    this.forShedTail = forShedTail;
+    this.isShedTail = isShedTail;
+  }
+
+  private getHpCost(user: Pokemon): number {
+    if (this.isShedTail) {
+      return Math.ceil(user.getMaxHp() * 0.5);
+    } else {
+      return Math.floor(user.getMaxHp() * 0.25);
+    }
   }
 
   override applyEffect(user: Pokemon, _target: Pokemon, move: Move): boolean {
-    const hpCost = this.forShedTail ? Math.ceil(user.getMaxHp() * 0.5) : Math.floor(user.getMaxHp() * 0.25);
+    const hpCost = this.getHpCost(user);
     user.damageAndUpdate(hpCost, {
       result: HitResult.OTHER,
       ignoreSegments: true,
@@ -54,15 +62,13 @@ export class AddSubstituteAttr extends MoveEffectAttr {
      * - THe user has more than 1 max hp (wonder guard users)
      */
     return (user, _target, _move) =>
-      !user.getTag(BattlerTagType.SUBSTITUTE)
-      && user.hp > (this.forShedTail ? Math.ceil(user.getMaxHp() * 0.5) : Math.floor(user.getMaxHp() * 0.25))
-      && user.getMaxHp() > 1;
+      !user.getTag(BattlerTagType.SUBSTITUTE) && user.hp > this.getHpCost(user) && user.getMaxHp() > 1;
   }
 
   override getFailedText(user: Pokemon, _target: Pokemon, _move: Move, _cancelled: BooleanHolder): string | null {
     if (user.getTag(BattlerTagType.SUBSTITUTE)) {
       return i18next.t("moveTriggers:substituteOnOverlap", { pokemonName: getPokemonNameWithAffix(user) });
-    } else if (user.hp <= Math.floor(user.getMaxHp() / 4) || user.getMaxHp() === 1) {
+    } else if (user.hp <= this.getHpCost(user) || user.getMaxHp() === 1) {
       return i18next.t("moveTriggers:substituteNotEnoughHp");
     } else {
       return i18next.t("battle:attackFailed");

--- a/test/moves/shed-tail.test.ts
+++ b/test/moves/shed-tail.test.ts
@@ -47,11 +47,7 @@ describe("Moves - Shed Tail", () => {
 
     expect(feebas).not.toBe(magikarp);
     expect(feebas.hp).toBe(feebas.getMaxHp());
-    // Note: Shed Tail's HP cost is currently not accurate to mainline, as it
-    // should cost ceil(maxHP / 2) instead of max(floor(maxHp / 2), 1). The current
-    // implementation is consistent with Substitute's HP cost logic, but that's not
-    // the case in mainline for some reason :regiDespair:.
-    expect(magikarp.hp).toBe(Math.ceil(magikarp.getMaxHp() / 2));
+    expect(magikarp.hp).toBe(magikarp.getMaxHp() - Math.ceil(magikarp.getMaxHp() / 2));
     expect(substituteTag).toBeDefined();
     expect(substituteTag?.hp).toBe(Math.floor(magikarp.getMaxHp() / 4));
   });


### PR DESCRIPTION
## What are the changes the user will see?

Shed tail's hp cost is rounded up instead of down

## Why am I making these changes?

Move was not accurate to mainline

## What are the changes from a developer perspective?

add-substitute-attr
* Replaced `hpCost` with a boolean for whether the move is shed tail

shed-tail.test
* Updated test

init-moves
* Updated Substitute and Shed tail's AddSubstituteAttr params

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/4f0c5b35-6c85-45e9-9452-92cb9ea318d3)


## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.SHED_TAIL]
}
```

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->