### PR TITLE
[GitHub] Populate type field in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug Report
 description: Create a report to help us improve
 title: "[Bug] "
 labels: ["Bug", "Triage"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature Request
 description: Suggest an idea for this project
 title: "[Feature] "
 labels: ["Enhancement", "Triage"]
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## ~~What are the changes the user will see?~~

## Why am I making these changes?

Issues now support the `type` field and we should populate it.

## What are the changes from a developer perspective?

Add `type:` field to ISSUE_TEMPLATES

## Screenshots/Videos

https://github.com/Despair-Games/poketernity/blob/7b054d7efe7c725dbeddcc959d41d647702d62e0/.github/ISSUE_TEMPLATE/bug_report.yml

## How to test the changes?

You can't. It has to be merged to `beta` to see it taking effect

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
