### PR TITLE
[Refactor] Mark `Move.hasFlag()` as deprecated

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -205,9 +205,20 @@ export abstract class Move implements Localizable {
    * Getter function that returns if this Move has a MoveFlag
    * @param flag - {@linkcode MoveFlags} to check
    * @returns `true` if the checked flag is on the move
-   * @todo make `private`?
+   * @deprecated **Use {@linkcode checkFlag} instead**. *Will be removed in the future*
    */
   hasFlag(flag: MoveFlags): boolean {
+    // internally it is taking the bitwise AND (MoveFlags are represented as bit-shifts) and returning False if result is 0 and true otherwise
+    return (this.flags & flag) > 0;
+  }
+
+  /**
+   * Getter function that returns if this Move has a MoveFlag
+   * @param flag - {@linkcode MoveFlags} to check
+   * @returns `true` if the checked flag is on the move
+   * @todo Remove rename to `_hasFlag` but keep `private` scope as soon as {@linkcode hasFlag} is removed.
+   */
+  private _hasFlag(flag: MoveFlags): boolean {
     // internally it is taking the bitwise AND (MoveFlags are represented as bit-shifts) and returning False if result is 0 and true otherwise
     return (this.flags & flag) > 0;
   }
@@ -292,7 +303,7 @@ export abstract class Move implements Localizable {
 
     switch (type) {
       case ElementalType.GRASS:
-        if (this.hasFlag(MoveFlags.POWDER_MOVE)) {
+        if (this._hasFlag(MoveFlags.POWDER_MOVE)) {
           return true;
         }
         break;
@@ -327,7 +338,7 @@ export abstract class Move implements Localizable {
     // TODO: Allow this to be simulated
     applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, user, false, bypassed);
 
-    return !bypassed.value && !this.hasFlag(MoveFlags.SOUND_MOVE) && !this.hasFlag(MoveFlags.IGNORE_SUBSTITUTE);
+    return !bypassed.value && !this._hasFlag(MoveFlags.SOUND_MOVE) && !this._hasFlag(MoveFlags.IGNORE_SUBSTITUTE);
   }
 
   /**
@@ -379,7 +390,7 @@ export abstract class Move implements Localizable {
     // bitwise OR and bitwise XOR respectively
     if (on) {
       this.flags |= flag;
-    } else if (this.hasFlag(flag)) {
+    } else if (this._hasFlag(flag)) {
       this.flags ^= flag;
     }
   }
@@ -654,7 +665,7 @@ export abstract class Move implements Localizable {
         break;
     }
 
-    return this.hasFlag(flag);
+    return this._hasFlag(flag);
   }
 
   /**


### PR DESCRIPTION
## Why am I making these changes?

See #949 

Closes #951 

## What are the changes from a developer perspective?

- Added a private `Move._hasFlag()` as a placeholder until `hasFlag()` is removed with #949 
- Marked `Move.hasFlag()` as `@deprecated` with an info to use `Move.checkFlag()` instead

## Screenshots/Videos

https://github.com/Despair-Games/poketernity/blob/4df16258587f1515bd0033ed3ae852705788918b/src/data/moves/move.ts#L204-L213

## How to test the changes?

Code review only.

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)

