### PR TITLE
[P2] Fix Rattled activating at end of turn when intimidated

### DIFF
--- a/src/data/abilities/ab-attrs/intimidate-immunity-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/intimidate-immunity-ab-attr.ts
@@ -6,14 +6,21 @@ import { AbAttr } from "./ab-attr";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 export class IntimidateImmunityAbAttr extends AbAttr {
-  constructor() {
+  protected readonly hasTriggerMessage: boolean;
+
+  constructor(hasTriggerMessage: boolean = true) {
     super(false);
-    this._flags.add(AbAttrFlag.INITIMIDATE_IMMUNITY);
+    this.hasTriggerMessage = hasTriggerMessage;
+
+    this._flags.add(AbAttrFlag.INTIMIDATE_IMMUNITY);
   }
 
   override apply(_pokemon: Pokemon, _simulated: boolean, cancelled: BooleanHolder): boolean {
-    cancelled.value = true;
-    return true;
+    if (!cancelled.value) {
+      cancelled.value = true;
+      return true;
+    }
+    return false;
   }
 
   override getTriggerMessage(pokemon: Pokemon, abilityName: string, ..._args: any[]): string {

--- a/src/data/abilities/ab-attrs/intimidate-immunity-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/intimidate-immunity-ab-attr.ts
@@ -24,9 +24,12 @@ export class IntimidateImmunityAbAttr extends AbAttr {
   }
 
   override getTriggerMessage(pokemon: Pokemon, abilityName: string, ..._args: any[]): string {
-    return i18next.t("abilityTriggers:intimidateImmunity", {
-      pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-      abilityName,
-    });
+    if (this.hasTriggerMessage) {
+      return i18next.t("abilityTriggers:intimidateImmunity", {
+        pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
+        abilityName,
+      });
+    }
+    return "";
   }
 }

--- a/src/data/abilities/ab-attrs/post-intimidate-stat-stage-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-intimidate-stat-stage-change-ab-attr.ts
@@ -17,9 +17,10 @@ export class PostIntimidateStatStageChangeAbAttr extends AbAttr {
   }
 
   override apply(pokemon: Pokemon, simulated: boolean): boolean {
-    const { phaseManager } = globalScene;
     if (!simulated) {
-      phaseManager.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, this.stats, this.stages));
+      globalScene.phaseManager.unshiftPhase(
+        new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, this.stats, this.stages),
+      );
     }
     return true;
   }

--- a/src/data/abilities/ab-attrs/post-intimidate-stat-stage-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-intimidate-stat-stage-change-ab-attr.ts
@@ -1,7 +1,6 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
-import type { BooleanHolder } from "#app/utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import type { BattleStat } from "#enums/stat";
 import { AbAttr } from "./ab-attr";
@@ -9,23 +8,19 @@ import { AbAttr } from "./ab-attr";
 export class PostIntimidateStatStageChangeAbAttr extends AbAttr {
   private readonly stats: BattleStat[];
   private readonly stages: number;
-  private readonly overwrites: boolean;
 
-  constructor(stats: BattleStat[], stages: number, overwrites: boolean = false) {
+  constructor(stats: BattleStat[], stages: number) {
     super(true);
     this._flags.add(AbAttrFlag.POST_INTIMIDATE_STAT_STAGE_CHANGE);
     this.stats = stats;
     this.stages = stages;
-    this.overwrites = overwrites;
   }
 
-  override apply(pokemon: Pokemon, simulated: boolean, cancelled: BooleanHolder): boolean {
+  override apply(pokemon: Pokemon, simulated: boolean): boolean {
+    const { phaseManager } = globalScene;
     if (!simulated) {
-      globalScene.phaseManager.pushPhase(
-        new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, this.stats, this.stages),
-      );
+      phaseManager.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, this.stats, this.stages));
     }
-    cancelled.value = this.overwrites;
     return true;
   }
 }

--- a/src/data/abilities/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
@@ -53,11 +53,13 @@ export class PostSummonStatStageChangeAbAttr extends PostSummonAbAttr {
         );
       }
 
-      applyAbAttrs<PostIntimidateStatStageChangeAbAttr>(
-        AbAttrFlag.POST_INTIMIDATE_STAT_STAGE_CHANGE,
-        opponent,
-        simulated,
-      );
+      if (this.intimidate) {
+        applyAbAttrs<PostIntimidateStatStageChangeAbAttr>(
+          AbAttrFlag.POST_INTIMIDATE_STAT_STAGE_CHANGE,
+          opponent,
+          simulated,
+        );
+      }
     }
     return true;
   }

--- a/src/data/abilities/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-stat-stage-change-ab-attr.ts
@@ -30,34 +30,34 @@ export class PostSummonStatStageChangeAbAttr extends PostSummonAbAttr {
       return true;
     }
 
+    const { phaseManager } = globalScene;
+
     if (this.selfTarget) {
-      // we unshift the StatStageChangePhase to put it right after the showAbility and not at the end of the
-      // phase list (which could be after CommandPhase for example)
-      globalScene.phaseManager.unshiftPhase(
-        new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, this.stats, this.stages),
-      );
+      phaseManager.unshiftPhase(new StatStageChangePhase(pokemon.getBattlerIndex(), pokemon, this.stats, this.stages));
       return true;
     }
+
     for (const opponent of pokemon.getOpponents()) {
       const cancelled = new BooleanHolder(false);
       if (this.intimidate) {
-        applyAbAttrs<IntimidateImmunityAbAttr>(AbAttrFlag.INITIMIDATE_IMMUNITY, opponent, simulated, cancelled);
-        applyAbAttrs<PostIntimidateStatStageChangeAbAttr>(
-          AbAttrFlag.POST_INTIMIDATE_STAT_STAGE_CHANGE,
-          opponent,
-          simulated,
-          cancelled,
-        );
-
         if (opponent.getTag(BattlerTagType.SUBSTITUTE)) {
-          cancelled.value = true;
+          return false;
         }
+
+        applyAbAttrs<IntimidateImmunityAbAttr>(AbAttrFlag.INTIMIDATE_IMMUNITY, opponent, simulated, cancelled);
       }
+
       if (!cancelled.value) {
-        globalScene.phaseManager.unshiftPhase(
+        phaseManager.unshiftPhase(
           new StatStageChangePhase(opponent.getBattlerIndex(), pokemon, this.stats, this.stages),
         );
       }
+
+      applyAbAttrs<PostIntimidateStatStageChangeAbAttr>(
+        AbAttrFlag.POST_INTIMIDATE_STAT_STAGE_CHANGE,
+        opponent,
+        simulated,
+      );
     }
     return true;
   }

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -1466,7 +1466,8 @@ export function initAbilities() {
       .attr(PostSummonStatStageChangeOnArenaAbAttr, ArenaTagType.TAILWIND)
       .ignorable(),
     new Ability(AbilityId.GUARD_DOG, 9)
-      .attr(PostIntimidateStatStageChangeAbAttr, [Stat.ATK], 1, true)
+      .attr(IntimidateImmunityAbAttr, false)
+      .attr(PostIntimidateStatStageChangeAbAttr, [Stat.ATK], 1)
       .attr(ForceSwitchOutImmunityAbAttr)
       .ignorable(),
     new Ability(AbilityId.ROCKY_PAYLOAD, 9)

--- a/src/enums/ab-attr-flag.ts
+++ b/src/enums/ab-attr-flag.ts
@@ -178,7 +178,7 @@ export enum AbAttrFlag {
   /** @see {@linkcode FieldPreventExplosionLikeAbAttr} */
   FIELD_PREVENT_EXPLOSION_LIKE,
   /** @see {@linkcode IntimidateImmunityAbAttr} */
-  INITIMIDATE_IMMUNITY,
+  INTIMIDATE_IMMUNITY,
   /** @see {@linkcode PostIntimidateStatStageChangeAbAttr} */
   POST_INTIMIDATE_STAT_STAGE_CHANGE,
   /** @see {@linkcode InfiltratorAbAttr} */

--- a/test/abilities/rattled.test.ts
+++ b/test/abilities/rattled.test.ts
@@ -1,0 +1,91 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Abilities - Rattled", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.RATTLED)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it.each([
+    { typeName: "Dark", moveId: MoveId.BITE },
+    { typeName: "Bug", moveId: MoveId.BUG_BITE },
+    { typeName: "Ghost", moveId: MoveId.ASTONISH },
+  ])("should increase the source's Speed by 1 stage when hit by a $typeName-type move", async ({ moveId }) => {
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.use(moveId);
+    await game.toEndOfTurn();
+
+    expect(enemy.getStatStage(Stat.SPD)).toBe(1);
+  });
+
+  it("should not increase the source's Speed when hit by a Normal-type move", async () => {
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.use(MoveId.TACKLE);
+    await game.toEndOfTurn();
+
+    expect(enemy.getStatStage(Stat.SPD)).toBe(0);
+  });
+
+  it("should increase the source's Speed by 1 stage for each hit of Beat Up", async () => {
+    await game.classicMode.startBattle([SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.GOLDEEN]);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.use(MoveId.BEAT_UP);
+    await game.toEndOfTurn();
+
+    expect(enemy.getStatStage(Stat.SPD)).toBe(3);
+  });
+
+  it("should increase the source's Speed after the source is Intimidated", async () => {
+    game.override.ability(AbilityId.INTIMIDATE);
+
+    await game.classicMode.startBattle([SpeciesId.MAGIKARP, SpeciesId.FEEBAS]);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    // Rattled should have activated before the turn starts due to the player Magikarp's Intimidate
+    expect(enemy.getStatStage(Stat.SPD)).toBe(1);
+
+    game.doSwitchPokemon(1);
+
+    // advance to before the enemy makes a move
+    await game.phaseInterceptor.to("MovePhase", false);
+
+    // Rattled should activate again after the player Feebas with Intimidate enters the field
+    expect(enemy.getStatStage(Stat.SPD)).toBe(2);
+  });
+});

--- a/test/abilities/rattled.test.ts
+++ b/test/abilities/rattled.test.ts
@@ -59,6 +59,19 @@ describe("Abilities - Rattled", () => {
     expect(enemy.getStatStage(Stat.SPD)).toBe(0);
   });
 
+  it("should not increase the source's Speed from moves that have no effect", async () => {
+    game.override.enemySpecies(SpeciesId.SNORLAX);
+
+    await game.classicMode.startBattle([SpeciesId.FEEBAS]);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    game.move.use(MoveId.ASTONISH);
+    await game.toEndOfTurn();
+
+    expect(enemy.getStatStage(Stat.SPD)).toBe(0);
+  });
+
   it("should increase the source's Speed by 1 stage for each hit of Beat Up", async () => {
     await game.classicMode.startBattle([SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.GOLDEEN]);
 
@@ -87,5 +100,23 @@ describe("Abilities - Rattled", () => {
 
     // Rattled should activate again after the player Feebas with Intimidate enters the field
     expect(enemy.getStatStage(Stat.SPD)).toBe(2);
+  });
+
+  it("should not increase the source's Speed if the source's substitute blocks Intimidate", async () => {
+    game.override.ability(AbilityId.INTIMIDATE).enemyMoveset(MoveId.SUBSTITUTE);
+
+    await game.classicMode.startBattle([SpeciesId.MAGIKARP, SpeciesId.FEEBAS]);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy.getStatStage(Stat.SPD)).toBe(1);
+
+    game.move.use(MoveId.SPLASH);
+    await game.toNextTurn();
+
+    game.doSwitchPokemon(1);
+
+    await game.toEndOfTurn();
+
+    expect(enemy.getStatStage(Stat.SPD)).toBe(1);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Rattled and Guard Dog now apply their stat boost immediately after being intimidated instead of at the end of the turn.

## Why am I making these changes?

Fixes #833 

## What are the changes from a developer perspective?

- Rearranged some phase scheduling in `PostSummonStatStageChangeAbAttr` and `PostIntimidateStatStageChangeAbAttr`
- Created integration test suite for Rattled

## Screenshots/Videos

Provided on request

## How to test the changes?

`npm run test rattled`

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [?] Have I provided screenshots/videos of the changes (if applicable)?
  - [?] Have I made sure that any UI change works for both UI themes (dark and light)?
