### PR TITLE
[Test] Fix `EvolutionPhase` tests and add `LEVEL_CAP_OVERRIDE`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1914,10 +1914,14 @@ export default class BattleScene extends SceneBase {
     this.currentBattle.battleScore += Math.ceil(scoreIncrease);
   }
 
-  getMaxExpLevel(ignoreLevelCap?: boolean): number {
-    if (ignoreLevelCap) {
+  getMaxExpLevel(ignoreLevelCap: boolean = false): number {
+    if (Overrides.LEVEL_CAP_OVERRIDE > 0) {
+      return Overrides.LEVEL_CAP_OVERRIDE;
+    }
+    if (ignoreLevelCap || Overrides.LEVEL_CAP_OVERRIDE < 0) {
       return Number.MAX_SAFE_INTEGER;
     }
+
     const waveIndex = Math.ceil((this.currentBattle?.waveIndex || 1) / 10) * 10;
     const difficultyWaveIndex = this.gameMode.getWaveForDifficulty(waveIndex);
     const baseLevel = (1 + difficultyWaveIndex / 2 + Math.pow(difficultyWaveIndex / 25, 2)) * 1.2;

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -80,6 +80,8 @@ class DefaultOverrides {
   readonly ARENA_TINT_OVERRIDE: TimeOfDay | null = null;
   /** Multiplies XP gained by this value including 0. Set to null to ignore the override */
   readonly XP_MULTIPLIER_OVERRIDE: number | null = null;
+  /** Overrides the level cap to the number specified if greater than `0`. Negative numbers will disable the cap entirely. */
+  readonly LEVEL_CAP_OVERRIDE: number = 0;
   readonly NEVER_CRIT_OVERRIDE: boolean = false;
   /** default 1000 */
   readonly STARTING_MONEY_OVERRIDE: number = 0;

--- a/test/phases/evolution-phase.test.ts
+++ b/test/phases/evolution-phase.test.ts
@@ -25,7 +25,7 @@ describe("Evolution Phase", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
-      .startingWave(100) // Make sure level cap is high enough for evolution
+      .levelCap(-1)
       .ability(AbilityId.BALL_FETCH)
       .battleType("single")
       .disableCrits()

--- a/test/test-utils/helpers/overridesHelper.ts
+++ b/test/test-utils/helpers/overridesHelper.ts
@@ -75,6 +75,21 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
+   * Override the player pokemon level cap
+   * @param value - The level to set the cap to. Negative numbers disable the cap entirely, and `0` resets to default behavior.
+   * @returns `this`
+   */
+  public levelCap(value: number): this {
+    vi.spyOn(Overrides, "LEVEL_CAP_OVERRIDE", "get").mockReturnValue(value);
+    if (value === 0) {
+      this.log("Default level cap re-enabled!");
+    } else {
+      this.log(`Level Cap set to ${value < 0 ? Number.MAX_SAFE_INTEGER : value}!`);
+    }
+    return this;
+  }
+
+  /**
    * Override the player (pokemon) starting held items
    * @param items the items to hold
    * @returns `this`


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
The `EvolutionPhase` tests were flaky because sometimes the test would encounter a trainer battle instead of a wild pokemon.

## What are the changes from a developer perspective?
Added a new `LEVEL_CAP_OVERRIDE` (negative numbers disable the cap, positive numbers set the cap to that value) and changed the tests to use the new override instead of setting the wave to 100.

## How to test the changes?
`npm run test evolution-phase`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?