### PR TITLE
[Dev] Add enum inlining plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "typedoc": "^0.28.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.29.1",
+        "unplugin-inline-enum": "^0.3.1",
         "vite": "^6.2.6",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.5",
@@ -2139,6 +2140,13 @@
         "win32"
       ]
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
@@ -2187,6 +2195,19 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@stylistic/eslint-plugin-ts": {
       "version": "4.2.0",
@@ -2976,6 +2997,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-kit": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-1.4.2.tgz",
+      "integrity": "sha512-lvGehj1XsrIoQrD5CfPduIzQbcpuX2EPjlk/vDMDQF9U9HLRB6WwMTdighj5n52hdhh8xg9VgPTU7Q25MuJ/rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.26.9",
+        "pathe": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/balanced-match": {
@@ -3957,6 +3995,33 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/execa": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.3",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.0",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
@@ -4054,6 +4119,22 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4212,6 +4293,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4458,6 +4556,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
       }
     },
     "node_modules/i18next": {
@@ -4718,12 +4826,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isarray": {
       "version": "2.0.5",
@@ -5597,6 +5744,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.20",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
@@ -5712,6 +5889,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -5927,6 +6117,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/process-nextick-args": {
@@ -6511,6 +6717,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6895,6 +7114,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -6903,6 +7135,78 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.2.tgz",
+      "integrity": "sha512-3n7YA46rROb3zSj8fFxtxC/PqoyvYQ0llwz9wtUPUutr9ig09C8gGo5CWCwHrUzlqC1LLR43kxp5vEIyH1ac1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.1",
+        "picomatch": "^4.0.2",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/unplugin-inline-enum": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unplugin-inline-enum/-/unplugin-inline-enum-0.3.1.tgz",
+      "integrity": "sha512-HvaqkaUK917ojxSi+0oM1ZqzJn91r96+u9SDuyxBMImFBOy8EotMa3RdzeFaiYXe2U9yZJE1fkXoBq4px631OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-kit": "^1.4.0",
+        "execa": "^9.5.2",
+        "fast-glob": "^3.3.3",
+        "magic-string": "^0.30.17",
+        "picomatch": "^4.0.2",
+        "unplugin": "^2.2.0",
+        "unplugin-replace": "^0.5.0",
+        "unplugin-utils": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/unplugin-replace": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/unplugin-replace/-/unplugin-replace-0.5.2.tgz",
+      "integrity": "sha512-aM7U69NncPE0lAqF6gVaXtGNG8B1bHy66jQYfYmBqC+2yTM0fspz8WKtmdXHwo92Ebf0FtCl/84xjRffizXmRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "unplugin": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.4.tgz",
+      "integrity": "sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/unrs-resolver": {
@@ -7230,6 +7534,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -7526,6 +7837,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typedoc": "^0.28.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.29.1",
+    "unplugin-inline-enum": "^0.3.1",
     "vite": "^6.2.6",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5",

--- a/test/data/all-moves.test.ts
+++ b/test/data/all-moves.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import { readFileSync } from "fs";
 import { describe, expect, it } from "vitest";
 import { MoveCategory } from "#enums/move-category";
-import { MoveId } from "#enums/move-id";
+import type { MoveId } from "#enums/move-id";
 import type { Move } from "#app/data/moves/move";
 import { MoveFlags } from "#enums/move-flags";
 import { ElementalType } from "#enums/elemental-type";
@@ -74,35 +74,35 @@ describe("All Moves", async () => {
   it.each(moveData)("$identifier, if implemented, should have correct move data", async (move: MoveData) => {
     const pktyMove = allMoves.get(move.id as MoveId) as Move;
     if (pktyMove && !isUnimplemented(pktyMove.name)) {
-      expect(
-        pktyMove.type,
-        `Elemntal type of ${MoveId[pktyMove.id]} should be ${ElementalType[move.type_id - 1]} but is ${ElementalType[pktyMove.type]}`,
-      ).toBe(move.type_id - 1); // PokeAPI begins its list of types with the number 1
-      expect(
-        pktyMove.accuracy,
-        `Accuracy of ${MoveId[pktyMove.id]} should be ${move.accuracy} but is ${pktyMove.accuracy}`,
-      ).toBe(move.accuracy);
-      expect(
-        pktyMove.priority,
-        `Priority of ${MoveId[pktyMove.id]} should be ${move.priority} but is ${pktyMove.priority}`,
-      ).toBe(move.priority);
-      expect(pktyMove.power, `Power of ${MoveId[pktyMove.id]} should be ${move.power} but is ${pktyMove.power}`).toBe(
-        move.power,
+      const moveName = pktyMove.name;
+      const expectedMoveType = ElementalType[move.type_id - 1];
+      const actualMoveType = ElementalType[pktyMove.type];
+      const expectedCategory = MoveCategory[move.damage_class_id];
+      const actualCategory = MoveCategory[pktyMove.category];
+      expect(pktyMove.type, `Elemntal type of ${moveName} should be ${expectedMoveType} but is ${actualMoveType}`).toBe(
+        move.type_id - 1,
+      ); // PokeAPI begins its list of types with the number 1
+      expect(pktyMove.accuracy, `Accuracy of ${moveName} should be ${move.accuracy} but is ${pktyMove.accuracy}`).toBe(
+        move.accuracy,
       );
-      expect(pktyMove.pp, `PP of ${MoveId[pktyMove.id]} should be ${move.pp} but is ${pktyMove.pp}`).toBe(move.pp);
+      expect(pktyMove.priority, `Priority of ${moveName} should be ${move.priority} but is ${pktyMove.priority}`).toBe(
+        move.priority,
+      );
+      expect(pktyMove.power, `Power of ${moveName} should be ${move.power} but is ${pktyMove.power}`).toBe(move.power);
+      expect(pktyMove.pp, `PP of ${moveName} should be ${move.pp} but is ${pktyMove.pp}`).toBe(move.pp);
       expect(
         pktyMove.category,
-        `Move category of ${MoveId[pktyMove.id]} should be ${MoveCategory[move.damage_class_id]} but is ${MoveCategory[pktyMove.category]}`,
+        `Move category of ${moveName} should be ${expectedCategory} but is ${actualCategory}`,
       ).toBe(move.damage_class_id);
-      expect(
-        pktyMove.chance,
-        `Chance of ${MoveId[pktyMove.id]} should be ${move.effect_chance} but is ${pktyMove.chance}`,
-      ).toBe(move.effect_chance);
+      expect(pktyMove.chance, `Chance of ${moveName} should be ${move.effect_chance} but is ${pktyMove.chance}`).toBe(
+        move.effect_chance,
+      );
       if (Array.isArray(move.flags)) {
         for (const f of Object.keys(flagsToCheck)) {
+          const flagName = MoveFlags[flagsToCheck[f]];
           const actualHasFlag = pktyMove.hasFlag(flagsToCheck[f]);
           const expectedHasFlag = move.flags.includes(Number(f));
-          const errOutput = `${MoveId[pktyMove.id]}'s usage of flag ${MoveFlags[flagsToCheck[f]]} should be ${expectedHasFlag} but is ${actualHasFlag}!`;
+          const errOutput = `${moveName}'s usage of flag ${flagName} should be ${expectedHasFlag} but is ${actualHasFlag}!`;
           expect(actualHasFlag, errOutput).toBe(expectedHasFlag);
         }
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,14 @@
-import { defineConfig, loadEnv, Rollup, UserConfig } from "vite";
+import InlineEnum from "unplugin-inline-enum/vite";
+import { defineConfig, loadEnv, Rollup, type UserConfig } from "vite";
 import ViteTsconfigPaths from "vite-tsconfig-paths";
 import { minifyPublicJsonFiles as ViteMinifyPublicJsonFiles } from "./src/plugins/vite/vite-minify-public-json-files";
 
 export const defaultConfig: UserConfig = {
-  plugins: [ViteTsconfigPaths(), ViteMinifyPublicJsonFiles()],
+  plugins: [
+    ViteTsconfigPaths(),
+    ViteMinifyPublicJsonFiles(),
+    InlineEnum({ scanPattern: ["**/*.{cts,mts,ts,tsx}", "!**/*.d.ts"] }),
+  ],
   clearScreen: false,
   appType: "mpa",
   build: {
@@ -33,7 +38,7 @@ export default defineConfig(({ mode }) => {
       keepNames: true,
     },
     server: {
-      port: !isNaN(envPort) ? envPort : 8000,
+      port: !Number.isNaN(envPort) ? envPort : 8000,
     },
   };
 });


### PR DESCRIPTION
## What are the changes the user will see?
Improved performance and/or memory usage.

## Why am I making these changes?
TS enums are transformed into some crazy JS, this plugin transforms them into `const` objects instead and inlines most references to them.

## What are the changes from a developer perspective?
`unplugin-inline-enum` package installed and added to `vite.config.ts`.

## How to test the changes?
`npm run build`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?