### PR TITLE
[GitHub] add "assign-author-to-pr" workflow

### DIFF
--- a/.github/workflows/assign-author-to-pr.yml
+++ b/.github/workflows/assign-author-to-pr.yml
@@ -1,0 +1,11 @@
+on:
+  pull_request:
+    types: [opened]
+name: Pull Request
+jobs:
+  assignAuthor:
+    name: Assign author to PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author to PR
+        uses: technote-space/assign-author@v1

--- a/.github/workflows/assign-author-to-pr.yml
+++ b/.github/workflows/assign-author-to-pr.yml
@@ -1,11 +1,14 @@
-on:
+name: Assign Author to PR
+
+on:  
   pull_request:
-    types: [opened]
-name: Pull Request
+    types: [opened, ready_for_review, reopened]
+     
 jobs:
-  assignAuthor:
-    name: Assign author to PR
+  assign-pr-author-as-assignee:
     runs-on: ubuntu-latest
     steps:
-      - name: Assign author to PR
-        uses: technote-space/assign-author@v1
+    - name: Assign Author to PR
+      uses: itsOliverBott/assign-pr-author-as-assignee@latest
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/assign-author-to-pr.yml
+++ b/.github/workflows/assign-author-to-pr.yml
@@ -1,14 +1,14 @@
 name: Assign Author to PR
 
-on:  
-  pull_request:
-    types: [opened, ready_for_review, reopened]
-     
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
 jobs:
-  assign-pr-author-as-assignee:
+  assign-author:
     runs-on: ubuntu-latest
     steps:
-    - name: Assign Author to PR
-      uses: itsOliverBott/assign-pr-author-as-assignee@latest
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: toshimaru/auto-author-assign@v2.1.1

--- a/.github/workflows/assign-author-to-pr.yml
+++ b/.github/workflows/assign-author-to-pr.yml
@@ -4,8 +4,9 @@ on:
   pull_request_target:
     types: [ opened, reopened ]
 
-permissions:
-  pull-requests: write
+permissions: write-all
+  # pull-requests: write
+  # permissions: write-all
 
 jobs:
   assign-author:


### PR DESCRIPTION
## Why am I making these changes?

To reduce the manual work to maintain the [Project board](https://github.com/orgs/Despair-Games/projects/3/views/3) I want to make sure that the PRs always automatically get assigned to the author, so one can see the person working on the PR on the board

## What are the changes from a developer perspective?

added the new workflow file

## How to test the changes?

_See this PR. It should be auto-assigned to me_

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
