### PR TITLE
[Bug] Fix wave skip from simultaneous KO in double battle

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1237,7 +1237,7 @@ export default class BattleScene extends SceneBase {
       }
 
       if (newBattleType === BattleType.TRAINER) {
-        const trainerType = this.arena.randomTrainerType(newWaveIndex);
+        const trainerType = Overrides.TRAINER_TYPE_OVERRIDE ?? this.arena.randomTrainerType(newWaveIndex);
         let doubleTrainer = false;
         if (allTrainerConfigs[trainerType].doubleOnly) {
           doubleTrainer = true;

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1225,10 +1225,7 @@ export default class BattleScene extends SceneBase {
         this.field.add(newTrainer);
       }
     } else {
-      if (
-        !this.gameMode.hasTrainers
-        || (Overrides.DISABLE_RANDOM_TRAINERS_OVERRIDE && isNullOrUndefined(trainerData))
-      ) {
+      if (!this.gameMode.hasTrainers) {
         newBattleType = BattleType.WILD;
       } else if (battleType === undefined) {
         newBattleType = this.gameMode.isWaveTrainer(newWaveIndex, this.arena) ? BattleType.TRAINER : BattleType.WILD;

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -875,12 +875,13 @@ export function handleMysteryEncounterVictory(addHealPhase: boolean = false, doN
     globalScene.phaseManager.pushPhase(new MysteryEncounterRewardsPhase(addHealPhase));
     globalScene.phaseManager.pushPhase(new EggLapsePhase());
   } else if (
+    // If any enemy Pokemon are still alive on the field or waiting for its fainting animation, do not advance a wave.
+    // Also, if the enemy is a Trainer with other Pokemon alive in their party backline, do not advance a wave.
     !globalScene
       .getEnemyParty()
-      .find((p) =>
-        encounter.encounterMode !== MysteryEncounterMode.TRAINER_BATTLE
-          ? p.isOnField()
-          : p.isOnField() || !p?.isFainted(),
+      .find(
+        (p) =>
+          p && (p.isOnField() || (encounter.encounterMode === MysteryEncounterMode.TRAINER_BATTLE && !p.isFainted())),
       )
   ) {
     globalScene.phaseManager.pushPhase(new BattleEndPhase(true));

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -877,7 +877,11 @@ export function handleMysteryEncounterVictory(addHealPhase: boolean = false, doN
   } else if (
     !globalScene
       .getEnemyParty()
-      .find((p) => (encounter.encounterMode !== MysteryEncounterMode.TRAINER_BATTLE ? p.isOnField() : !p?.isFainted()))
+      .find((p) =>
+        encounter.encounterMode !== MysteryEncounterMode.TRAINER_BATTLE
+          ? p.isOnField()
+          : p.isOnField() || !p?.isFainted(),
+      )
   ) {
     globalScene.phaseManager.pushPhase(new BattleEndPhase(true));
     if (encounter.encounterMode === MysteryEncounterMode.TRAINER_BATTLE) {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -559,7 +559,10 @@ export class Arena {
 
   /**
    * Gets the denominator for the chance for a trainer spawn
-   * @returns `0` if the biome has no trainer battles; otherwise, `n` where 1/n is the chance of a trainer battle.
+   * @returns A number `n` such that the probability of a trainer battle is `1/n`.
+   * Returns `0` if the {@linkcode Biome} does not support trainers; this disables random trainer spawns.
+   *
+   * Returns the value of {@linkcode Overrides.RANDOM_TRAINER_CHANCE_OVERRIDE} if it is set; this sets trainer spawn rates as above.
    */
   getTrainerChance(): number {
     return Overrides.RANDOM_TRAINER_CHANCE_OVERRIDE ?? allBiomes.get(this.biomeId).trainerChance;

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -559,10 +559,10 @@ export class Arena {
 
   /**
    * Gets the denominator for the chance for a trainer spawn
-   * @returns n where 1/n is the chance of a trainer battle
+   * @returns `0` if the biome has no trainer battles; otherwise, `n` where 1/n is the chance of a trainer battle.
    */
   getTrainerChance(): number {
-    return allBiomes.get(this.biomeId).trainerChance;
+    return Overrides.RANDOM_TRAINER_CHANCE_OVERRIDE ?? allBiomes.get(this.biomeId).trainerChance;
   }
 
   /**

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -259,8 +259,16 @@ class DefaultOverrides {
    */
   readonly ITEM_REWARD_OVERRIDE: ModifierOverride[] = [];
 
-  /** If `true`, disable all non-scripted enemy trainer encounters. */
-  readonly DISABLE_RANDOM_TRAINERS_OVERRIDE: boolean = false;
+  /**
+   * Possible values:
+   * - `null`: Ignore this override; each biome uses its normal trainer rate.
+   * - `0`: Disable all non-scripted enemy trainer encounters.
+   * - Positive number `n`: Sets the chance of a non-scripted enemy trainer encounter to be 1/n.
+   * 
+   * CAUTION: This function does not disable any rules that may prevent trainer spawns
+   * (e.g., The rule requiring trainers to be 3 waves apart, and the rule preventing trainer spawns on wave X1).
+   */
+  readonly RANDOM_TRAINER_CHANCE_OVERRIDE: number | null = null;
 
   /** If not `null`, force all non-scripted enemy trainer encounters to be of this trainer type. */
   readonly TRAINER_TYPE_OVERRIDE: TrainerType | null = null;

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -27,7 +27,7 @@ import { WeatherType } from "#enums/weather-type";
 /**
  * This comment block exists to prevent IDEs from automatically removing unused imports
  * {@linkcode BerryType}, {@linkcode ElementalType}, {@linkcode EvolutionItem}
- * {@linkcode FormChangeItem}, {@linkcode Stat}, {@linkcode TrainerType}
+ * {@linkcode FormChangeItem}, {@linkcode Stat}
  */
 /**
  * Overrides that are used to test different in game situations

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -19,6 +19,7 @@ import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import { TimeOfDay } from "#enums/time-of-day";
+import { TrainerType } from "#enums/trainer-type";
 import { Unlockables } from "#enums/unlockables";
 import { VariantTier } from "#enums/variant-tier";
 import { WeatherType } from "#enums/weather-type";
@@ -26,7 +27,7 @@ import { WeatherType } from "#enums/weather-type";
 /**
  * This comment block exists to prevent IDEs from automatically removing unused imports
  * {@linkcode BerryType}, {@linkcode ElementalType}, {@linkcode EvolutionItem}
- * {@linkcode FormChangeItem}, {@linkcode Stat}
+ * {@linkcode FormChangeItem}, {@linkcode Stat}, {@linkcode TrainerType}
  */
 /**
  * Overrides that are used to test different in game situations
@@ -260,6 +261,9 @@ class DefaultOverrides {
 
   /** If `true`, disable all non-scripted enemy trainer encounters. */
   readonly DISABLE_RANDOM_TRAINERS_OVERRIDE: boolean = false;
+
+  /** If not `null`, force all non-scripted enemy trainer encounters to be of this trainer type. */
+  readonly TRAINER_TYPE_OVERRIDE: TrainerType | null = null;
 }
 
 export const defaultOverrides = new DefaultOverrides();

--- a/src/phases/post-knockout-phase.ts
+++ b/src/phases/post-knockout-phase.ts
@@ -46,7 +46,11 @@ export class PostKnockoutPhase extends PokemonPhase {
       return this.end();
     }
 
-    if (!globalScene.getEnemyParty().some((p) => (battleType === BattleType.WILD ? p.isOnField() : !p?.isFainted()))) {
+    if (
+      !globalScene
+        .getEnemyParty()
+        .some((p) => (battleType === BattleType.WILD ? p.isOnField() : p.isOnField() || !p?.isFainted()))
+    ) {
       phaseManager.unshiftPhase(new VictoryPhase(this.battlerIndex));
     }
 

--- a/src/phases/post-knockout-phase.ts
+++ b/src/phases/post-knockout-phase.ts
@@ -46,10 +46,12 @@ export class PostKnockoutPhase extends PokemonPhase {
       return this.end();
     }
 
+    // If any enemy Pokemon are still alive on the field or waiting for its fainting animation, do not advance a wave.
+    // Also, if the enemy is a Trainer with other Pokemon alive in their party backline, do not advance a wave.
     if (
       !globalScene
         .getEnemyParty()
-        .some((p) => (battleType === BattleType.WILD ? p.isOnField() : p.isOnField() || !p?.isFainted()))
+        .some((p) => p && (p.isOnField() || (battleType !== BattleType.WILD && !p.isFainted())))
     ) {
       phaseManager.unshiftPhase(new VictoryPhase(this.battlerIndex));
     }

--- a/test/battle/boss-pokemon.test.ts
+++ b/test/battle/boss-pokemon.test.ts
@@ -27,7 +27,7 @@ describe("Boss Pokemon / Shields", () => {
 
     game.override
       .battleType("single")
-      .disableTrainerWaves()
+      .trainerChance(0)
       .disableCrits()
       .enemySpecies(SpeciesId.RATTATA)
       .enemyMoveset(MoveId.SPLASH)

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -106,36 +106,41 @@ describe("Double Battles", () => {
   describe("Trainer Double Battles", () => {
     it("should advance exactly one wave if both opponents are defeated at the same time", async () => {
       game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
-      await game.dailyMode.startBattle();
+      await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
-      game.move.use(MoveId.DAZZLING_GLEAM, 0);
-      game.move.use(MoveId.DAZZLING_GLEAM, 1);
-      await game.phaseInterceptor.to("SelectModifierPhase");
+      game.move.use(MoveId.DAZZLING_GLEAM);
+      await game.toNextWave();
 
+      expect(game.scene.currentBattle.waveIndex).toBe(13);
+      expect(game.phaseInterceptor.log.filter((phase) => phase === "SelectModifierPhase").length).toBe(1);
       expect(game.scene.phaseManager.hasPhase((phase) => phase.is(PhaseId.SELECT_MODIFIER), true)).toBe(false);
     });
 
     it("should advance exactly one wave if the left opponent is defeated first", async () => {
       game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
-      await game.dailyMode.startBattle();
+      await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.MILOTIC]);
 
       game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
       game.move.use(MoveId.MOONBLAST, 0, BattlerIndex.ENEMY);
       game.move.use(MoveId.MOONBLAST, 1, BattlerIndex.ENEMY_2);
-      await game.phaseInterceptor.to("SelectModifierPhase");
+      await game.toNextWave();
 
+      expect(game.scene.currentBattle.waveIndex).toBe(13);
+      expect(game.phaseInterceptor.log.filter((phase) => phase === "SelectModifierPhase").length).toBe(1);
       expect(game.scene.phaseManager.hasPhase((phase) => phase.is(PhaseId.SELECT_MODIFIER), true)).toBe(false);
     });
 
     it("should advance exactly one wave if the right opponent is defeated first", async () => {
       game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
-      await game.dailyMode.startBattle();
+      await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.MILOTIC]);
 
       game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
       game.move.use(MoveId.MOONBLAST, 0, BattlerIndex.ENEMY_2);
       game.move.use(MoveId.MOONBLAST, 1, BattlerIndex.ENEMY);
-      await game.phaseInterceptor.to("SelectModifierPhase");
+      await game.toNextWave();
 
+      expect(game.scene.currentBattle.waveIndex).toBe(13);
+      expect(game.phaseInterceptor.log.filter((phase) => phase === "SelectModifierPhase").length).toBe(1);
       expect(game.scene.phaseManager.hasPhase((phase) => phase.is(PhaseId.SELECT_MODIFIER), true)).toBe(false);
     });
   });

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -104,8 +104,11 @@ describe("Double Battles", () => {
   });
 
   describe("Trainer Double Battles", () => {
-    it("should advance exactly one wave if both opponents are defeated at the same time", async () => {
+    beforeEach(() => {
       game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
+    });
+
+    it("should advance exactly one wave if both opponents are defeated at the same time", async () => {
       await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
       game.move.use(MoveId.DAZZLING_GLEAM);
@@ -117,7 +120,6 @@ describe("Double Battles", () => {
     });
 
     it("should advance exactly one wave if the left opponent is defeated first", async () => {
-      game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
       await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.MILOTIC]);
 
       game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
@@ -131,7 +133,6 @@ describe("Double Battles", () => {
     });
 
     it("should advance exactly one wave if the right opponent is defeated first", async () => {
-      game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
       await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.MILOTIC]);
 
       game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -105,7 +105,7 @@ describe("Double Battles", () => {
 
   describe("Trainer Double Battles", () => {
     it("should advance exactly one wave if both opponents are defeated at the same time", async () => {
-      game.override.trainerType(TrainerType.TWINS).startingLevel(1000).startingWave(5);
+      game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
       await game.dailyMode.startBattle();
 
       game.move.use(MoveId.DAZZLING_GLEAM, 0);
@@ -116,7 +116,7 @@ describe("Double Battles", () => {
     });
 
     it("should advance exactly one wave if the left opponent is defeated first", async () => {
-      game.override.trainerType(TrainerType.TWINS).startingLevel(1000).startingWave(5);
+      game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
       await game.dailyMode.startBattle();
 
       game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
@@ -128,7 +128,7 @@ describe("Double Battles", () => {
     });
 
     it("should advance exactly one wave if the right opponent is defeated first", async () => {
-      game.override.trainerType(TrainerType.TWINS).startingLevel(1000).startingWave(5);
+      game.override.trainerType(TrainerType.TWINS).trainerChance(1).startingLevel(1000).startingWave(12);
       await game.dailyMode.startBattle();
 
       game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -9,6 +9,8 @@ import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { TrainerType } from "#enums/trainer-type";
+import { PhaseId } from "#enums/phase-id";
 
 describe("Double Battles", () => {
   const DOUBLE_CHANCE = 8; // Normal chance of double battle is 1/8
@@ -99,5 +101,42 @@ describe("Double Battles", () => {
     await game.toNextTurn();
 
     expect(milotic.isFullHp()).toBe(true);
+  });
+
+  describe("Trainer Double Battles", () => {
+    it("should advance exactly one wave if both opponents are defeated at the same time", async () => {
+      game.override.trainerType(TrainerType.TWINS).startingLevel(1000).startingWave(5);
+      await game.dailyMode.startBattle();
+
+      game.move.use(MoveId.DAZZLING_GLEAM, 0);
+      game.move.use(MoveId.DAZZLING_GLEAM, 1);
+      await game.phaseInterceptor.to("SelectModifierPhase");
+
+      expect(game.scene.phaseManager.hasPhase((phase) => phase.is(PhaseId.SELECT_MODIFIER), true)).toBe(false);
+    });
+
+    it("should advance exactly one wave if the left opponent is defeated first", async () => {
+      game.override.trainerType(TrainerType.TWINS).startingLevel(1000).startingWave(5);
+      await game.dailyMode.startBattle();
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+      game.move.use(MoveId.MOONBLAST, 0, BattlerIndex.ENEMY);
+      game.move.use(MoveId.MOONBLAST, 1, BattlerIndex.ENEMY_2);
+      await game.phaseInterceptor.to("SelectModifierPhase");
+
+      expect(game.scene.phaseManager.hasPhase((phase) => phase.is(PhaseId.SELECT_MODIFIER), true)).toBe(false);
+    });
+
+    it("should advance exactly one wave if the right opponent is defeated first", async () => {
+      game.override.trainerType(TrainerType.TWINS).startingLevel(1000).startingWave(5);
+      await game.dailyMode.startBattle();
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+      game.move.use(MoveId.MOONBLAST, 0, BattlerIndex.ENEMY_2);
+      game.move.use(MoveId.MOONBLAST, 1, BattlerIndex.ENEMY);
+      await game.phaseInterceptor.to("SelectModifierPhase");
+
+      expect(game.scene.phaseManager.hasPhase((phase) => phase.is(PhaseId.SELECT_MODIFIER), true)).toBe(false);
+    });
   });
 });

--- a/test/battle/reload.test.ts
+++ b/test/battle/reload.test.ts
@@ -47,7 +47,7 @@ describe("Reload", () => {
       .startingWave(10)
       .battleType("single")
       .startingLevel(100) // Avoid levelling up
-      .disableTrainerWaves()
+      .trainerChance(0)
       .moveset([MoveId.SPLASH])
       .enemyMoveset(MoveId.SPLASH);
     await game.dailyMode.startBattle();
@@ -77,7 +77,7 @@ describe("Reload", () => {
       .startingBiome(BiomeId.ICE_CAVE) // Will lead to Snowy Forest with randomly generated weather
       .battleType("single")
       .startingLevel(100) // Avoid levelling up
-      .disableTrainerWaves()
+      .trainerChance(0)
       .moveset([MoveId.SPLASH])
       .enemyMoveset(MoveId.SPLASH);
     await game.classicMode.startBattle(); // Apparently daily mode would override the biome

--- a/test/game-modes/daily-mode.test.ts
+++ b/test/game-modes/daily-mode.test.ts
@@ -59,7 +59,7 @@ describe("Shop modifications", async () => {
       .startingBiome(BiomeId.ICE_CAVE)
       .battleType("single")
       .startingLevel(100) // Avoid levelling up
-      .disableTrainerWaves()
+      .trainerChance(0)
       .moveset([MoveId.SPLASH])
       .enemyMoveset(MoveId.SPLASH);
     game.modifiers.addCheck("EVIOLITE").addCheck("MINI_BLACK_HOLE");

--- a/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
+++ b/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
@@ -41,7 +41,7 @@ describe("A Trainer's Test - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
+++ b/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
@@ -42,7 +42,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([

--- a/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -42,7 +42,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
       .mysteryEncounterChance(100)
       .startingWave(defaultWave)
       .startingBiome(defaultBiome)
-      .disableTrainerWaves()
+      .trainerChance(0)
       .ability(AbilityId.INTIMIDATE); // Extortion ability
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([

--- a/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -44,7 +44,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       .mysteryEncounterTier(MysteryEncounterTier.COMMON)
       .startingWave(defaultWave)
       .startingBiome(defaultBiome)
-      .disableTrainerWaves()
+      .trainerChance(0)
       .startingModifier([])
       .startingHeldItems([])
       .enemyAbility(AbilityId.BALL_FETCH)

--- a/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
+++ b/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
@@ -157,10 +157,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.BUG_TYPE_SUPERFAN]]]),

--- a/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
+++ b/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
@@ -160,7 +160,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.BUG_TYPE_SUPERFAN]]]),

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -61,7 +61,7 @@ describe("Clowning Around - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.CLOWNING_AROUND]]]),
@@ -200,7 +200,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       expect(movePhases.filter((p) => (p as MovePhase).move.moveId === MoveId.TAUNT).length).toBe(2);
     });
 
-    it.only("should advance exactly one wave if the clown's Pokemon get defeated simultaneously", async () => {
+    it("should advance exactly one wave if the clown's Pokemon get defeated simultaneously", async () => {
       game.override.startingLevel(1000);
 
       await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, [SpeciesId.FEEBAS]);

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -11,6 +11,7 @@ import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encount
 import { generateModifierType } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import {
   runMysteryEncounterToEnd,
+  runSelectMysteryEncounterOption,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
 import { MoveId } from "#enums/move-id";
@@ -197,6 +198,18 @@ describe("Clowning Around - Mystery Encounter", () => {
       expect(movePhases.length).toBe(3);
       expect(movePhases.filter((p) => (p as MovePhase).move.moveId === MoveId.ROLE_PLAY).length).toBe(1);
       expect(movePhases.filter((p) => (p as MovePhase).move.moveId === MoveId.TAUNT).length).toBe(2);
+    });
+
+    it.only("should advance exactly one wave if the clown's Pokemon get defeated simultaneously", async () => {
+      game.override.startingLevel(1000);
+
+      await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, [SpeciesId.FEEBAS]);
+      await runSelectMysteryEncounterOption(game, 1);
+
+      game.move.use(MoveId.DAZZLING_GLEAM);
+      await game.phaseInterceptor.to("MysteryEncounterRewardsPhase");
+
+      expect(game.scene.phaseManager.hasPhase((phase) => phase.is(PhaseId.ME_REWARDS), true)).toBe(false);
     });
 
     it("should let the player gain the ability after battle completion", async () => {

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -58,10 +58,7 @@ describe("Clowning Around - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.CLOWNING_AROUND]]]),

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -42,10 +42,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -45,7 +45,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([

--- a/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
+++ b/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
@@ -48,7 +48,7 @@ describe("Delibird-y - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.DELIBIRDY]]]),

--- a/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
+++ b/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
@@ -45,10 +45,7 @@ describe("Delibird-y - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.DELIBIRDY]]]),

--- a/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
+++ b/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
@@ -35,7 +35,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
+++ b/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
@@ -32,10 +32,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/field-trip-encounter.test.ts
+++ b/test/mystery-encounter/encounters/field-trip-encounter.test.ts
@@ -33,11 +33,12 @@ describe("Field Trip - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
-    game.override.moveset([MoveId.TACKLE, MoveId.UPROAR, MoveId.SWORDS_DANCE]);
+    game.override
+      .mysteryEncounterChance(100)
+      .startingWave(defaultWave)
+      .startingBiome(defaultBiome)
+      .trainerChance(0)
+      .moveset([MoveId.TACKLE, MoveId.UPROAR, MoveId.SWORDS_DANCE]);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.FIELD_TRIP]]]),

--- a/test/mystery-encounter/encounters/field-trip-encounter.test.ts
+++ b/test/mystery-encounter/encounters/field-trip-encounter.test.ts
@@ -36,7 +36,7 @@ describe("Field Trip - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
     game.override.moveset([MoveId.TACKLE, MoveId.UPROAR, MoveId.SWORDS_DANCE]);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(

--- a/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
@@ -55,7 +55,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       .mysteryEncounterChance(100)
       .startingWave(defaultWave)
       .startingBiome(defaultBiome)
-      .disableTrainerWaves()
+      .trainerChance(0)
       .moveset([MoveId.PAYBACK, MoveId.THUNDERBOLT]); // Required for attack type booster item generation
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -43,7 +43,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.FIGHT_OR_FLIGHT]]]),

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -40,10 +40,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.FIGHT_OR_FLIGHT]]]),

--- a/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
@@ -42,10 +42,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
@@ -45,7 +45,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
+++ b/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
@@ -40,7 +40,7 @@ describe("Global Trade System - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
+++ b/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
@@ -37,10 +37,7 @@ describe("Global Trade System - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
+++ b/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
@@ -37,10 +37,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([

--- a/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
+++ b/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
@@ -40,7 +40,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([

--- a/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
+++ b/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
@@ -44,7 +44,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
+++ b/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
@@ -41,10 +41,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -36,10 +36,7 @@ describe("Part-Timer - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -39,7 +39,7 @@ describe("Part-Timer - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/safari-zone.test.ts
+++ b/test/mystery-encounter/encounters/safari-zone.test.ts
@@ -39,10 +39,7 @@ describe("Safari Zone - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/safari-zone.test.ts
+++ b/test/mystery-encounter/encounters/safari-zone.test.ts
@@ -42,7 +42,7 @@ describe("Safari Zone - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -53,7 +53,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       .mysteryEncounterChance(100)
       .startingWave(defaultWave)
       .startingBiome(defaultBiome)
-      .disableTrainerWaves()
+      .trainerChance(0)
       .enemyAbility(AbilityId.BALL_FETCH)
       .enemyPassiveAbility(AbilityId.BALL_FETCH);
 

--- a/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
@@ -43,7 +43,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
@@ -40,10 +40,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
@@ -40,10 +40,7 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
@@ -43,7 +43,7 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.MYSTERIOUS_CHALLENGERS]],

--- a/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -53,7 +53,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       .mysteryEncounterChance(100)
       .startingWave(defaultWave)
       .startingBiome(defaultBiome)
-      .disableTrainerWaves()
+      .trainerChance(0)
       .enemyAbility(AbilityId.BALL_FETCH)
       .enemyPassiveAbility(AbilityId.BALL_FETCH);
 

--- a/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
@@ -42,10 +42,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
@@ -45,7 +45,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     const biomeMap = new Map<BiomeId, MysteryEncounterType[]>([
       [BiomeId.VOLCANO, [MysteryEncounterType.FIGHT_OR_FLIGHT]],

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -44,10 +44,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.TRASH_TO_TREASURE]]]),

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -47,7 +47,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.TRASH_TO_TREASURE]]]),

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -52,7 +52,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       .mysteryEncounterTier(MysteryEncounterTier.COMMON)
       .startingWave(defaultWave)
       .startingBiome(defaultBiome)
-      .disableTrainerWaves()
+      .trainerChance(0)
       .enemyAbility(AbilityId.BALL_FETCH)
       .enemyPassiveAbility(AbilityId.BALL_FETCH);
 

--- a/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -38,10 +38,7 @@ describe("Weird Dream - Mystery Encounter", () => {
   beforeEach(async () => {
     game = new GameManager(phaserGame);
     scene = game.scene;
-    game.override.mysteryEncounterChance(100);
-    game.override.startingWave(defaultWave);
-    game.override.startingBiome(defaultBiome);
-    game.override.trainerChance(0);
+    game.override.mysteryEncounterChance(100).startingWave(defaultWave).startingBiome(defaultBiome).trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.WEIRD_DREAM]]]),

--- a/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -41,7 +41,7 @@ describe("Weird Dream - Mystery Encounter", () => {
     game.override.mysteryEncounterChance(100);
     game.override.startingWave(defaultWave);
     game.override.startingBiome(defaultBiome);
-    game.override.disableTrainerWaves();
+    game.override.trainerChance(0);
 
     vi.spyOn(MysteryEncounters, "mysteryEncountersByBiome", "get").mockReturnValue(
       new Map<BiomeId, MysteryEncounterType[]>([[BiomeId.CAVE, [MysteryEncounterType.WEIRD_DREAM]]]),

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -242,7 +242,7 @@ export class GameManager {
    */
   async runToMysteryEncounter(encounterType?: MysteryEncounterType, species?: SpeciesId[]) {
     if (!isNullOrUndefined(encounterType)) {
-      this.override.disableTrainerWaves();
+      this.override.trainerChance(0);
       this.override.mysteryEncounter(encounterType);
     }
 

--- a/test/test-utils/helpers/overridesHelper.ts
+++ b/test/test-utils/helpers/overridesHelper.ts
@@ -20,6 +20,7 @@ import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
 import { shiftCharCodes } from "#app/utils";
 import type { TimedEvent } from "#app/@types/TimedEvent";
 import { timedEventManager } from "#app/timed-event-manager";
+import { TrainerType } from "#enums/trainer-type";
 
 /**
  * Helper to handle overrides in tests
@@ -179,7 +180,7 @@ export class OverridesHelper extends GameManagerHelper {
   /**
    * Override the player (pokemon) {@linkcode StatusEffect | status-effect}
    * @param statusEffect the {@linkcode StatusEffect | status-effect} to set
-   * @returns
+   * @returns `this`
    */
   public statusEffect(statusEffect: StatusEffect): this {
     vi.spyOn(Overrides, "STATUS_OVERRIDE", "get").mockReturnValue(statusEffect);
@@ -194,6 +195,17 @@ export class OverridesHelper extends GameManagerHelper {
   public disableTrainerWaves(): this {
     vi.spyOn(Overrides, "DISABLE_RANDOM_TRAINERS_OVERRIDE", "get").mockReturnValue(true);
     this.log("Random trainer waves are disabled!");
+    return this;
+  }
+
+  /**
+   * Override each random enemy trainer to be of a given type
+   * @param trainerType - The {@linkcode TrainerType} to set
+   * @returns `this`
+   */
+  public trainerType(trainerType: TrainerType): this {
+    vi.spyOn(Overrides, "TRAINER_TYPE_OVERRIDE", "get").mockReturnValue(trainerType);
+    this.log(`Mystery encounter override set to ${TrainerType[trainerType]} (=${trainerType})!`);
     return this;
   }
 

--- a/test/test-utils/helpers/overridesHelper.ts
+++ b/test/test-utils/helpers/overridesHelper.ts
@@ -189,12 +189,18 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
-   * Override each wave to not have random trainer battles
+   * Override the chance of encountering a random enemy trainer
+   * @param trainerChance - `0` to disable enemy trainer spawns, `1` to guarantee an enemy trainer spawn
+   * @see {@linkcode Overrides.RANDOM_TRAINER_CHANCE_OVERRIDE} for a more complete description of this override
    * @returns `this`
    */
-  public disableTrainerWaves(): this {
-    vi.spyOn(Overrides, "DISABLE_RANDOM_TRAINERS_OVERRIDE", "get").mockReturnValue(true);
-    this.log("Random trainer waves are disabled!");
+  public trainerChance(trainerChance: number): this {
+    vi.spyOn(Overrides, "RANDOM_TRAINER_CHANCE_OVERRIDE", "get").mockReturnValue(trainerChance);
+    if (trainerChance === 0 || trainerChance === 1) {
+      this.log(`Trainer chance override set to ${trainerChance}!`);
+    } else {
+      this.log(`Trainer chance override set to 1 / ${trainerChance}!`);
+    }
     return this;
   }
 
@@ -205,7 +211,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public trainerType(trainerType: TrainerType): this {
     vi.spyOn(Overrides, "TRAINER_TYPE_OVERRIDE", "get").mockReturnValue(trainerType);
-    this.log(`Mystery encounter override set to ${TrainerType[trainerType]} (=${trainerType})!`);
+    this.log(`Trainer type override set to ${TrainerType[trainerType]} (=${trainerType})!`);
     return this;
   }
 

--- a/test/test-utils/helpers/overridesHelper.ts
+++ b/test/test-utils/helpers/overridesHelper.ts
@@ -196,10 +196,12 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public trainerChance(trainerChance: number): this {
     vi.spyOn(Overrides, "RANDOM_TRAINER_CHANCE_OVERRIDE", "get").mockReturnValue(trainerChance);
-    if (trainerChance === 0 || trainerChance === 1) {
-      this.log(`Trainer chance override set to ${trainerChance}!`);
+    if (trainerChance === 0) {
+      this.log("Random trainers disabled!");
+    } else if (trainerChance === 1) {
+      this.log("Random trainer guaranteed for one wave!");
     } else {
-      this.log(`Trainer chance override set to 1 / ${trainerChance}!`);
+      this.log(`Trainer chance set to 1 / ${trainerChance}!`);
     }
     return this;
   }
@@ -211,7 +213,7 @@ export class OverridesHelper extends GameManagerHelper {
    */
   public trainerType(trainerType: TrainerType): this {
     vi.spyOn(Overrides, "TRAINER_TYPE_OVERRIDE", "get").mockReturnValue(trainerType);
-    this.log(`Trainer type override set to ${TrainerType[trainerType]} (=${trainerType})!`);
+    this.log(`Trainer type set to ${TrainerType[trainerType]} (=${trainerType})!`);
     return this;
   }
 


### PR DESCRIPTION
## What are the changes the user will see?

Simultaneously KO'ing both opponents in a double trainer battle now correctly advances 1 wave instead of skipping a wave.

## Why am I making these changes?

Fixes #740.
Also introduces a few trainer-related overrides that could help with testing trainer-related changes (e.g., tweaking gym leaders) in the future.

## What are the changes from a developer perspective?

- Prior to #432, `VictoryPhase`/`PostKnockoutPhase` would check whether or not some enemy Pokemon were still "waiting to faint" by checking whether or not they have a FNT status. This PR now replaces that check with a check for whether or not the enemy Pokemon is on the field. This should work because `FaintPhase` also removes the fainted Pokemon from the field, close to the location where `FaintPhase` previously set a FNT status:
https://github.com/Despair-Games/poketernity/blob/4114748a9b2d50ed635cdff0382180379a91413e/src/phases/faint-phase.ts#L265
- Added a new `TRAINER_TYPE_OVERRIDE`, and replaced `DISABLE_RANDOM_TRAINERS_OVERRIDE` with `RANDOM_TRAINER_CHANCE_OVERRIDE`.
- Added some tests.

## Screenshots/Videos

<details><summary>Simultaneous double KO</summary>
<p>

https://github.com/user-attachments/assets/077ec70c-d215-46be-ae88-480c8eacb643

</p>
</details> 
<details><summary>Regression test: One KO at a time</summary>
<p>

https://github.com/user-attachments/assets/dc878c66-2427-4d20-a008-1887761d3682

</p>
</details> 

## How to test the changes?

```ts
const overrides = {
  TRAINER_TYPE_OVERRIDE: TrainerType.TWINS,
  RANDOM_TRAINER_CHANCE_OVERRIDE: 1,
  STARTING_WAVE_OVERRIDE: 12,
  STARTING_LEVEL_OVERRIDE: 1000,
  MOVESET_OVERRIDE: MoveId.DAZZLING_GLEAM,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?