### PR TITLE
[Bug] Fix crash with trapping move animations

### DIFF
--- a/src/data/animations/anim-config-schema.ts
+++ b/src/data/animations/anim-config-schema.ts
@@ -1,18 +1,12 @@
 // -- start tsdoc imports --
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-  type AnimConfig,
-  type AnimTimedSoundEvent,
-  type AnimTimedAddBgEvent,
-  AnimFrame,
-} from "#app/data/animations/anim-config";
-import { easeFunctions } from "#app/data/animations/ease-functions";
+import type { AnimConfig, AnimTimedAddBgEvent, AnimTimedSoundEvent } from "#app/data/animations/anim-config";
 import type { MoveAnim } from "#app/data/animations/move-anim";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 // -- end tsdoc imports --
 
+import { easeFunctions } from "#app/data/animations/ease-functions";
 import { AnimBlendType } from "#enums/anim-blend-type";
-import { AnimFrameTarget } from "#enums/anim-frame-target";
 import { MoveId } from "#enums/move-id";
 import type { Schema } from "ajv";
 

--- a/src/data/animations/anim-config-schema.ts
+++ b/src/data/animations/anim-config-schema.ts
@@ -12,6 +12,7 @@ import type { MoveAnim } from "#app/data/animations/move-anim";
 // -- end tsdoc imports --
 
 import { AnimBlendType } from "#enums/anim-blend-type";
+import { AnimFrameTarget } from "#enums/anim-frame-target";
 import { MoveId } from "#enums/move-id";
 import type { Schema } from "ajv";
 

--- a/src/data/animations/anim-config.ts
+++ b/src/data/animations/anim-config.ts
@@ -2,7 +2,7 @@ import { globalScene } from "#app/global-scene";
 import { getFrameMs, isNullOrUndefined } from "#app/utils";
 import { AnimBlendType } from "#enums/anim-blend-type";
 import { AnimFocus } from "#enums/anim-focus";
-import { AnimFrameTargets, type AnimFrameTarget } from "#enums/anim-frame-target";
+import { AnimFrameTarget } from "#enums/anim-frame-target";
 import type Phaser from "phaser";
 import type { BattleAnim } from "./battle-anims";
 import type { MoveAnim } from "./move-anim";
@@ -216,13 +216,13 @@ export class AnimFrame {
       this.blendType = AnimBlendType.NORMAL;
     }
     if (!init) {
-      let target: AnimFrameTarget = AnimFrameTargets.IMAGE;
+      let target: AnimFrameTarget = AnimFrameTarget.IMAGE;
       switch (pattern) {
         case -2:
-          target = AnimFrameTargets.TARGET;
+          target = AnimFrameTarget.TARGET;
           break;
         case -1:
-          target = AnimFrameTargets.SOURCE;
+          target = AnimFrameTarget.SOURCE;
           break;
       }
       this.target = target;

--- a/src/data/animations/battle-anims.ts
+++ b/src/data/animations/battle-anims.ts
@@ -6,7 +6,7 @@ import { settings } from "#app/system/settings/settings-manager";
 import { getEnumValues, getFrameMs, isNullOrUndefined } from "#app/utils";
 import { AnimBlendType } from "#enums/anim-blend-type";
 import { AnimFocus } from "#enums/anim-focus";
-import { AnimFrameTargets, type AnimFrameTarget } from "#enums/anim-frame-target";
+import { AnimFrameTarget } from "#enums/anim-frame-target";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import Phaser from "phaser";
 
@@ -41,7 +41,7 @@ export abstract class BattleAnim {
   /** The background sprite to show during the animation */
   public bgSprite: Phaser.GameObjects.TileSprite | Phaser.GameObjects.Rectangle;
   /**
-   * If `true`, allows the animation to show its {@linkcode AnimFrameTargets.IMAGE | graphic} components
+   * If `true`, allows the animation to show its {@linkcode AnimFrameTarget.IMAGE | graphic} components
    * without requiring a user or target to be defined. This also causes the animation to play regardless
    * of whether the player has "Move Animations" enabled or disabled in Settings.
    */
@@ -97,9 +97,9 @@ export abstract class BattleAnim {
     onSubstitute: boolean = false,
   ): Map<AnimFrameTarget, Map<number, GraphicFrameData>> {
     const ret: Map<AnimFrameTarget, Map<number, GraphicFrameData>> = new Map([
-      [AnimFrameTargets.IMAGE, new Map<number, GraphicFrameData>()],
-      [AnimFrameTargets.SOURCE, new Map<number, GraphicFrameData>()],
-      [AnimFrameTargets.TARGET, new Map<number, GraphicFrameData>()],
+      [AnimFrameTarget.IMAGE, new Map<number, GraphicFrameData>()],
+      [AnimFrameTarget.SOURCE, new Map<number, GraphicFrameData>()],
+      [AnimFrameTarget.TARGET, new Map<number, GraphicFrameData>()],
     ]);
 
     const isOppAnim = this.isOppAnim();
@@ -156,7 +156,7 @@ export abstract class BattleAnim {
           x = point[0];
           y = point[1];
           if (
-            frame.target === AnimFrameTargets.IMAGE
+            frame.target === AnimFrameTarget.IMAGE
             && isReversed(this.srcLine[0], this.srcLine[2], this.dstLine[0], this.dstLine[2])
           ) {
             zoomX = zoomX * -1;
@@ -164,7 +164,7 @@ export abstract class BattleAnim {
           break;
       }
       const angle = -frame.angle;
-      const key = frame.target === AnimFrameTargets.IMAGE ? g++ : frame.target === AnimFrameTargets.SOURCE ? u++ : t++;
+      const key = frame.target === AnimFrameTarget.IMAGE ? g++ : frame.target === AnimFrameTarget.SOURCE ? u++ : t++;
       ret.get(frame.target)!.set(key, { x, y, zoomX, zoomY, angle }); // TODO: is the bang correct?
     }
 
@@ -204,9 +204,9 @@ export abstract class BattleAnim {
     const targetSprite = targetSubstitute?.sprite ?? target.getSprite();
 
     const spriteCache: SpriteCache = {
-      [AnimFrameTargets.IMAGE]: [],
-      [AnimFrameTargets.SOURCE]: [],
-      [AnimFrameTargets.TARGET]: [],
+      [AnimFrameTarget.IMAGE]: [],
+      [AnimFrameTarget.SOURCE]: [],
+      [AnimFrameTarget.TARGET]: [],
     };
     const spritePriorities: number[] = [];
 
@@ -307,8 +307,8 @@ export abstract class BattleAnim {
           let t = 0;
           let g = 0;
           for (const frame of spriteFrames) {
-            if (frame.target !== AnimFrameTargets.IMAGE) {
-              const isUser = frame.target === AnimFrameTargets.SOURCE;
+            if (frame.target !== AnimFrameTarget.IMAGE) {
+              const isUser = frame.target === AnimFrameTarget.SOURCE;
               if (isUser && target === user) {
                 continue;
               } else if (
@@ -380,7 +380,7 @@ export abstract class BattleAnim {
                     : Phaser.BlendModes.DIFFERENCE,
               );
             } else {
-              const sprites = spriteCache[AnimFrameTargets.IMAGE];
+              const sprites = spriteCache[AnimFrameTarget.IMAGE];
               if (g === sprites.length) {
                 const newSprite: Phaser.GameObjects.Sprite = globalScene.addFieldSprite(0, 0, anim!.graphic, 1); // TODO: is the bang correct?
                 sprites.push(newSprite);
@@ -464,16 +464,16 @@ export abstract class BattleAnim {
               r = Math.max(anim.frames.length - f + event.execute(this), r);
             }
           }
-          const targets = Object.values(AnimFrameTargets);
+          const targets = Object.values(AnimFrameTarget);
           for (const i of targets) {
-            const count = i === AnimFrameTargets.IMAGE ? g : i === AnimFrameTargets.SOURCE ? u : t;
+            const count = i === AnimFrameTarget.IMAGE ? g : i === AnimFrameTarget.SOURCE ? u : t;
             if (count < spriteCache[i].length) {
               const spritesToRemove = spriteCache[i].slice(count, spriteCache[i].length);
               for (const rs of spritesToRemove) {
                 if (!rs.getData("locked") as boolean) {
                   const spriteCacheIndex = spriteCache[i].indexOf(rs);
                   spriteCache[i].splice(spriteCacheIndex, 1);
-                  if (i === AnimFrameTargets.IMAGE) {
+                  if (i === AnimFrameTarget.IMAGE) {
                     spritePriorities.splice(spriteCacheIndex, 1);
                   }
                   rs.destroy();
@@ -511,9 +511,9 @@ export abstract class BattleAnim {
     targetInitialY: number,
   ): Map<AnimFrameTarget, Map<number, GraphicFrameData>> {
     const ret: Map<AnimFrameTarget, Map<number, GraphicFrameData>> = new Map([
-      [AnimFrameTargets.IMAGE, new Map<number, GraphicFrameData>()],
-      [AnimFrameTargets.SOURCE, new Map<number, GraphicFrameData>()],
-      [AnimFrameTargets.TARGET, new Map<number, GraphicFrameData>()],
+      [AnimFrameTarget.IMAGE, new Map<number, GraphicFrameData>()],
+      [AnimFrameTarget.SOURCE, new Map<number, GraphicFrameData>()],
+      [AnimFrameTarget.TARGET, new Map<number, GraphicFrameData>()],
     ]);
 
     let g = 0;
@@ -528,7 +528,7 @@ export abstract class BattleAnim {
       x += targetInitialX;
       y += targetInitialY;
       const angle = -frame.angle;
-      const key = frame.target === AnimFrameTargets.IMAGE ? g++ : frame.target === AnimFrameTargets.SOURCE ? u++ : t++;
+      const key = frame.target === AnimFrameTarget.IMAGE ? g++ : frame.target === AnimFrameTarget.SOURCE ? u++ : t++;
       ret.get(frame.target)?.set(key, { x, y, zoomX, zoomY, angle });
     }
 
@@ -537,7 +537,7 @@ export abstract class BattleAnim {
 
   /**
    * Plays this animation ignoring frame data for "user" or
-   * "target" Pokemon. This only plays the {@linkcode AnimFrameTargets.IMAGE | graphic}
+   * "target" Pokemon. This only plays the {@linkcode AnimFrameTarget.IMAGE | graphic}
    * components of the animation.
    * @param targetInitialX - The x-coordinate of the animation's start point,
    * relative to {@linkcode userFocusX}
@@ -559,9 +559,9 @@ export abstract class BattleAnim {
     callback?: () => void,
   ) {
     const spriteCache: SpriteCache = {
-      [AnimFrameTargets.IMAGE]: [],
-      [AnimFrameTargets.SOURCE]: [],
-      [AnimFrameTargets.TARGET]: [],
+      [AnimFrameTarget.IMAGE]: [],
+      [AnimFrameTarget.SOURCE]: [],
+      [AnimFrameTarget.TARGET]: [],
     };
 
     const cleanUpAndComplete = () => {
@@ -605,12 +605,12 @@ export abstract class BattleAnim {
         );
         let graphicFrameCount = 0;
         for (const frame of spriteFrames) {
-          if (frame.target !== AnimFrameTargets.IMAGE) {
+          if (frame.target !== AnimFrameTarget.IMAGE) {
             console.log("Encounter animations do not support targets");
             continue;
           }
 
-          const sprites = spriteCache[AnimFrameTargets.IMAGE];
+          const sprites = spriteCache[AnimFrameTarget.IMAGE];
           if (graphicFrameCount === sprites.length) {
             const newSprite: Phaser.GameObjects.Sprite = globalScene.addFieldSprite(0, 0, anim!.graphic, 1);
             sprites.push(newSprite);
@@ -659,7 +659,7 @@ export abstract class BattleAnim {
             );
           }
         }
-        const targets = getEnumValues(AnimFrameTargets);
+        const targets = getEnumValues(AnimFrameTarget);
         for (const i of targets) {
           const count = graphicFrameCount;
           if (count < spriteCache[i].length) {

--- a/src/data/animations/battle-anims.ts
+++ b/src/data/animations/battle-anims.ts
@@ -313,12 +313,12 @@ export abstract class BattleAnim {
                 continue;
               } else if (
                 this.playRegardlessOfIssues
-                && frame.target === AnimFrameTargets.TARGET
+                && frame.target === AnimFrameTarget.TARGET
                 && !target.isOnField()
               ) {
                 continue;
               }
-              const sprites = spriteCache[isUser ? AnimFrameTargets.SOURCE : AnimFrameTargets.TARGET];
+              const sprites = spriteCache[isUser ? AnimFrameTarget.SOURCE : AnimFrameTarget.TARGET];
               const spriteSource = isUser ? userSprite : targetSprite;
               if ((isUser ? u : t) === sprites.length) {
                 if (isUser || !targetSubstitute) {
@@ -388,53 +388,53 @@ export abstract class BattleAnim {
                 spritePriorities.push(1);
               }
 
-            const graphicIndex = g++;
-            const moveSprite = sprites[graphicIndex];
-            if (spritePriorities[graphicIndex] !== frame.priority) {
-              spritePriorities[graphicIndex] = frame.priority;
-              /** Move the position that the moveSprite is rendered in based on the priority.
-               * @param priority The priority level to draw the sprite.
-               * - 0: Draw the sprite in front of the pokemon on the field.
-               * - 1: Draw the sprite in front of the user pokemon.
-               * - 2: Draw the sprite in front of its `bgSprite` (if it has one), or its
-               * `AnimFocus` (if that is user/target), otherwise behind everything.
-               * - 3: Draw the sprite behind its `AnimFocus` (if that is user/target), otherwise in front of everything.
-               */
-              const setSpritePriority = (priority: number) => {
-                /** The sprite we are moving the moveSprite in relation to */
-                let targetSprite: Phaser.GameObjects.GameObject | nil;
-                /** The method that is being used to move the sprite.*/
-                let moveFunc:
-                  | ((sprite: Phaser.GameObjects.GameObject, target: Phaser.GameObjects.GameObject) => void)
-                  | ((sprite: Phaser.GameObjects.GameObject) => void) = globalScene.field.bringToTop;
+              const graphicIndex = g++;
+              const moveSprite = sprites[graphicIndex];
+              if (spritePriorities[graphicIndex] !== frame.priority) {
+                spritePriorities[graphicIndex] = frame.priority;
+                /** Move the position that the moveSprite is rendered in based on the priority.
+                 * @param priority The priority level to draw the sprite.
+                 * - 0: Draw the sprite in front of the pokemon on the field.
+                 * - 1: Draw the sprite in front of the user pokemon.
+                 * - 2: Draw the sprite in front of its `bgSprite` (if it has one), or its
+                 * `AnimFocus` (if that is user/target), otherwise behind everything.
+                 * - 3: Draw the sprite behind its `AnimFocus` (if that is user/target), otherwise in front of everything.
+                 */
+                const setSpritePriority = (priority: number) => {
+                  /** The sprite we are moving the moveSprite in relation to */
+                  let targetSprite: Phaser.GameObjects.GameObject | nil;
+                  /** The method that is being used to move the sprite.*/
+                  let moveFunc:
+                    | ((sprite: Phaser.GameObjects.GameObject, target: Phaser.GameObjects.GameObject) => void)
+                    | ((sprite: Phaser.GameObjects.GameObject) => void) = globalScene.field.bringToTop;
 
-                if (priority === 0) {
-                  // Place the sprite in front of the pokemon on the field.
-                  targetSprite =
-                    globalScene.getEnemyField().find((p) => p) ?? globalScene.getPlayerField().find((p) => p);
-                  moveFunc = globalScene.field.moveBelow;
-                } else if (priority === 2 && this.bgSprite) {
-                  moveFunc = globalScene.field.moveAbove;
-                  targetSprite = this.bgSprite;
-                } else if (priority === 2 || priority === 3) {
-                  moveFunc = priority === 2 ? globalScene.field.moveBelow : globalScene.field.moveAbove;
-                  if (frame.focus === AnimFocus.USER) {
-                    targetSprite = this.user;
-                  } else if (frame.focus === AnimFocus.TARGET) {
-                    targetSprite = this.target;
+                  if (priority === 0) {
+                    // Place the sprite in front of the pokemon on the field.
+                    targetSprite =
+                      globalScene.getEnemyField().find((p) => p) ?? globalScene.getPlayerField().find((p) => p);
+                    moveFunc = globalScene.field.moveBelow;
+                  } else if (priority === 2 && this.bgSprite) {
+                    moveFunc = globalScene.field.moveAbove;
+                    targetSprite = this.bgSprite;
+                  } else if (priority === 2 || priority === 3) {
+                    moveFunc = priority === 2 ? globalScene.field.moveBelow : globalScene.field.moveAbove;
+                    if (frame.focus === AnimFocus.USER) {
+                      targetSprite = this.user;
+                    } else if (frame.focus === AnimFocus.TARGET) {
+                      targetSprite = this.target;
+                    }
                   }
-                }
-                // If target sprite is not undefined and exists in the field container, then move the sprite using the moveFunc.
-                // Otherwise, default to just bringing it to the top.
-                if (targetSprite && globalScene.field.exists(targetSprite)) {
-                  moveFunc.bind(globalScene.field)(moveSprite, targetSprite);
-                } else {
-                  globalScene.field.bringToTop(moveSprite);
-                }
-              };
-              setSpritePriority(frame.priority);
-            }
-            moveSprite.setFrame(frame.graphicFrame);
+                  // If target sprite is not undefined and exists in the field container, then move the sprite using the moveFunc.
+                  // Otherwise, default to just bringing it to the top.
+                  if (targetSprite && globalScene.field.exists(targetSprite)) {
+                    moveFunc.bind(globalScene.field)(moveSprite, targetSprite);
+                  } else {
+                    globalScene.field.bringToTop(moveSprite);
+                  }
+                };
+                setSpritePriority(frame.priority);
+              }
+              moveSprite.setFrame(frame.graphicFrame);
 
               const graphicFrameData = frameData.get(frame.target)!.get(graphicIndex)!; // TODO: are those bangs correct?
               moveSprite.setPosition(graphicFrameData.x, graphicFrameData.y);

--- a/src/data/animations/battle-anims.ts
+++ b/src/data/animations/battle-anims.ts
@@ -412,7 +412,6 @@ export abstract class BattleAnim {
                   // Place the sprite in front of the pokemon on the field.
                   targetSprite =
                     globalScene.getEnemyField().find((p) => p) ?? globalScene.getPlayerField().find((p) => p);
-                  console.log(typeof targetSprite);
                   moveFunc = globalScene.field.moveBelow;
                 } else if (priority === 2 && this.bgSprite) {
                   moveFunc = globalScene.field.moveAbove;
@@ -427,14 +426,15 @@ export abstract class BattleAnim {
                 }
                 // If target sprite is not undefined and exists in the field container, then move the sprite using the moveFunc.
                 // Otherwise, default to just bringing it to the top.
-                targetSprite && globalScene.field.exists(targetSprite)
-                  ? moveFunc.bind(globalScene.field)(moveSprite as Phaser.GameObjects.GameObject, targetSprite)
-                  : globalScene.field.bringToTop(moveSprite as Phaser.GameObjects.GameObject);
+                if (targetSprite && globalScene.field.exists(targetSprite)) {
+                  moveFunc.bind(globalScene.field)(moveSprite, targetSprite);
+                } else {
+                  globalScene.field.bringToTop(moveSprite);
+                }
               };
               setSpritePriority(frame.priority);
             }
             moveSprite.setFrame(frame.graphicFrame);
-            //console.log(AnimFocus[frame.focus]);
 
               const graphicFrameData = frameData.get(frame.target)!.get(graphicIndex)!; // TODO: are those bangs correct?
               moveSprite.setPosition(graphicFrameData.x, graphicFrameData.y);

--- a/src/data/animations/battle-anims.ts
+++ b/src/data/animations/battle-anims.ts
@@ -302,7 +302,7 @@ export abstract class BattleAnim {
 
           /** The properties of all assets for the current frame */
           const spriteFrames = anim!.frames[f]; // TODO: is the bang correct?
-          const frameData = this.getGraphicFrameData(anim!.frames[f], onSubstitute); // TODO: is the bang correct?
+          const frameData = this.getGraphicFrameData(spriteFrames, onSubstitute);
           let u = 0;
           let t = 0;
           let g = 0;

--- a/src/data/animations/battle-anims.ts
+++ b/src/data/animations/battle-anims.ts
@@ -3,7 +3,7 @@ import type { SubstituteTag } from "#app/data/battler-tags/substitute-tag";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
-import { getEnumValues, getFrameMs, isNullOrUndefined } from "#app/utils";
+import { getEnumValues, getFrameMs, isNullOrUndefined, type nil } from "#app/utils";
 import { AnimBlendType } from "#enums/anim-blend-type";
 import { AnimFocus } from "#enums/anim-focus";
 import { AnimFrameTarget } from "#enums/anim-frame-target";
@@ -388,59 +388,53 @@ export abstract class BattleAnim {
                 spritePriorities.push(1);
               }
 
-              const graphicIndex = g++;
-              const moveSprite = sprites[graphicIndex];
-              if (spritePriorities[graphicIndex] !== frame.priority) {
-                spritePriorities[graphicIndex] = frame.priority;
-                const setSpritePriority = (priority: number) => {
-                  switch (priority) {
-                    case 0:
-                      globalScene.field.moveBelow(
-                        moveSprite as Phaser.GameObjects.GameObject,
-                        globalScene.getEnemyPokemon(false) ?? globalScene.getPlayerPokemon(false)!,
-                      ); // TODO: is this bang correct?
-                      break;
-                    case 1:
-                      globalScene.field.moveTo(moveSprite, globalScene.field.getAll().length - 1);
-                      break;
-                    case 2:
-                      switch (frame.focus) {
-                        case AnimFocus.USER:
-                          if (this.bgSprite) {
-                            globalScene.field.moveAbove(moveSprite as Phaser.GameObjects.GameObject, this.bgSprite);
-                          } else {
-                            globalScene.field.moveBelow(moveSprite as Phaser.GameObjects.GameObject, this.user!); // TODO: is this bang correct?
-                          }
-                          break;
-                        case AnimFocus.TARGET:
-                          globalScene.field.moveBelow(moveSprite as Phaser.GameObjects.GameObject, this.target!); // TODO: is this bang correct?
-                          break;
-                        default:
-                          setSpritePriority(1);
-                          break;
-                      }
-                      break;
-                    case 3:
-                      switch (frame.focus) {
-                        case AnimFocus.USER:
-                          globalScene.field.moveAbove(moveSprite as Phaser.GameObjects.GameObject, this.user!); // TODO: is this bang correct?
-                          break;
-                        case AnimFocus.TARGET:
-                          globalScene.field.moveAbove(moveSprite as Phaser.GameObjects.GameObject, this.target!); // TODO: is this bang correct?
-                          break;
-                        default:
-                          setSpritePriority(1);
-                          break;
-                      }
-                      break;
-                    default:
-                      setSpritePriority(1);
+            const graphicIndex = g++;
+            const moveSprite = sprites[graphicIndex];
+            if (spritePriorities[graphicIndex] !== frame.priority) {
+              spritePriorities[graphicIndex] = frame.priority;
+              /** Move the position that the moveSprite is rendered in based on the priority.
+               * @param priority The priority level to draw the sprite.
+               * - 0: Draw the sprite in front of the pokemon on the field.
+               * - 1: Draw the sprite in front of the user pokemon.
+               * - 2: Draw the sprite in front of its `bgSprite` (if it has one), or its
+               * `AnimFocus` (if that is user/target), otherwise behind everything.
+               * - 3: Draw the sprite behind its `AnimFocus` (if that is user/target), otherwise in front of everything.
+               */
+              const setSpritePriority = (priority: number) => {
+                /** The sprite we are moving the moveSprite in relation to */
+                let targetSprite: Phaser.GameObjects.GameObject | nil;
+                /** The method that is being used to move the sprite.*/
+                let moveFunc:
+                  | ((sprite: Phaser.GameObjects.GameObject, target: Phaser.GameObjects.GameObject) => void)
+                  | ((sprite: Phaser.GameObjects.GameObject) => void) = globalScene.field.bringToTop;
+
+                if (priority === 0) {
+                  // Place the sprite in front of the pokemon on the field.
+                  targetSprite =
+                    globalScene.getEnemyField().find((p) => p) ?? globalScene.getPlayerField().find((p) => p);
+                  console.log(typeof targetSprite);
+                  moveFunc = globalScene.field.moveBelow;
+                } else if (priority === 2 && this.bgSprite) {
+                  moveFunc = globalScene.field.moveAbove;
+                  targetSprite = this.bgSprite;
+                } else if (priority === 2 || priority === 3) {
+                  moveFunc = priority === 2 ? globalScene.field.moveBelow : globalScene.field.moveAbove;
+                  if (frame.focus === AnimFocus.USER) {
+                    targetSprite = this.user;
+                  } else if (frame.focus === AnimFocus.TARGET) {
+                    targetSprite = this.target;
                   }
-                };
-                setSpritePriority(frame.priority);
-              }
-              moveSprite.setFrame(frame.graphicFrame);
-              //console.log(AnimFocus[frame.focus]);
+                }
+                // If target sprite is not undefined and exists in the field container, then move the sprite using the moveFunc.
+                // Otherwise, default to just bringing it to the top.
+                targetSprite && globalScene.field.exists(targetSprite)
+                  ? moveFunc.bind(globalScene.field)(moveSprite as Phaser.GameObjects.GameObject, targetSprite)
+                  : globalScene.field.bringToTop(moveSprite as Phaser.GameObjects.GameObject);
+              };
+              setSpritePriority(frame.priority);
+            }
+            moveSprite.setFrame(frame.graphicFrame);
+            //console.log(AnimFocus[frame.focus]);
 
               const graphicFrameData = frameData.get(frame.target)!.get(graphicIndex)!; // TODO: are those bangs correct?
               moveSprite.setPosition(graphicFrameData.x, graphicFrameData.y);

--- a/src/data/animations/move-anim.ts
+++ b/src/data/animations/move-anim.ts
@@ -23,9 +23,8 @@ export class MoveAnim extends BattleAnim {
   }
 
   getAnim(): AnimConfig {
-    return moveAnims.get(this.moveId) instanceof AnimConfig
-      ? (moveAnims.get(this.moveId) as AnimConfig)
-      : (moveAnims.get(this.moveId)?.[this.user?.isPlayer() ? 0 : 1] as AnimConfig);
+    const anim = moveAnims.get(this.moveId);
+    return anim instanceof AnimConfig ? anim : anim?.[this.user?.isPlayer() ? 0 : 1]!; // TODO: resolve bang
   }
 
   isOppAnim(): boolean {

--- a/src/data/animations/move-anim.ts
+++ b/src/data/animations/move-anim.ts
@@ -24,7 +24,8 @@ export class MoveAnim extends BattleAnim {
 
   getAnim(): AnimConfig {
     const anim = moveAnims.get(this.moveId);
-    return anim instanceof AnimConfig ? anim : anim?.[this.user?.isPlayer() ? 0 : 1]!; // TODO: resolve bang
+    const animSource = this.user?.isPlayer() ? 0 : 1;
+    return anim instanceof AnimConfig ? anim : anim?.[animSource]!; // TODO: resolve bang
   }
 
   isOppAnim(): boolean {

--- a/src/enums/anim-frame-target.ts
+++ b/src/enums/anim-frame-target.ts
@@ -1,5 +1,5 @@
 /** Specifies the type of sprite affected by an animation */
-export const AnimFrameTargets = {
+export const AnimFrameTarget = {
   /**
    * Affects the animation's source or start point, e.g.
    * a Pokemon using a move.
@@ -15,4 +15,4 @@ export const AnimFrameTargets = {
 } as const;
 
 /** The sprite types affected by an animation */
-export type AnimFrameTarget = (typeof AnimFrameTargets)[keyof typeof AnimFrameTargets];
+export type AnimFrameTarget = (typeof AnimFrameTarget)[keyof typeof AnimFrameTarget];

--- a/src/enums/anim-frame-target.ts
+++ b/src/enums/anim-frame-target.ts
@@ -4,14 +4,14 @@ export const AnimFrameTarget = {
    * Affects the animation's source or start point, e.g.
    * a Pokemon using a move.
    */
-  SOURCE: "source",
+  SOURCE: 0,
   /**
    * Affects the animation's end point, e.g. a Pokemon
    * hit by a move.
    */
-  TARGET: "target",
+  TARGET: 1,
   /** Affects a component of the animation's visual effects */
-  IMAGE: "image",
+  IMAGE: 2,
 } as const;
 
 /** The sprite types affected by an animation */


### PR DESCRIPTION
## What are the changes the user will see?
If a Pokémon faints to the residual damage of a trapping move when both Pokémon are affected by trapping moves, the game will no longer crash.

## Why am I making these changes?
Fixes #617 
Fixes #992 

## What are the changes from a developer perspective?
(Copied from the original PR)
The `setSpritePriority` submethod within `src/data/battle-anims.ts`'s `BattleAnim.play` has been refactored and fixed.
The cause of the bug was due to `gameScene.field.moveBelow()` possibly being called with an undefined value. It may have also possible for it to be called with a value that did not exist in the `gameScene.field` container.
In either case, that method has now been rewritten to be substantially shorter (~20 lines WITH comments compared to ~40 beforehand, which didn't even have comments).

---

Additional changes not from the original PR:
- Renamed `AnimFrameTargets` to `AnimFrameTarget` to match the type name.
- Removed type casting from `MoveAnim#getAnim` and added a `TODO` note so that it can be fixed in the future.

## Screenshots/Videos
<details><summary>Before fix (crash)</summary>
<p>

https://github.com/user-attachments/assets/4c9796ce-3a9e-4705-b734-308278f838e6

</p>
</details> 
<details><summary>After fix (no crash)</summary>
<p>

https://github.com/user-attachments/assets/0689dc55-a13b-44d6-8ada-68741d8521f6

</p>
</details> 

## How to test the changes?
```ts
const overrides = {
  MOVESET_OVERRIDE: [ MoveId.SALT_CURE ],
  ABILITY_OVERRIDE: AbilityId.STURDY,

  ENEMY_LEVEL_OVERRIDE: 5,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.FLETCHINDER,
  ENEMY_MOVESET_OVERRIDE: [ MoveId.FIRE_SPIN ],
  ENEMY_IVS_OVERRIDE: [ 0, 31, 0, 31, 0, 0 ],
  ENEMY_ABILITY_OVERRIDE: AbilityId.STURDY,

  STARTING_HELD_ITEMS_OVERRIDE: [{ name: "ATTACK_TYPE_BOOSTER", type: ElementalType.ROCK, count: 50 }],
  ENEMY_HELD_ITEMS_OVERRIDE: [{ name: "ATTACK_TYPE_BOOSTER", type: ElementalType.FIRE, count: 50 }],
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?