### PR TITLE
[Balance] Payday no longer awards money if flee

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -153,3 +153,6 @@ export const FRIENDSHIP_GAIN_CUTOFF = 150;
 export const FRIENDSHIP_GAIN_FROM_CANDY = 5;
 /** Penalty for losing friendship on faint. Used in {@link FaintPhase} */
 export const FRIENDSHIP_LOST_FROM_FAINTING = 10;
+
+/** Default amount of money the player starts with. Same for all game modes. */
+export const DEFAULT_STARTING_MONEY = 1000;

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -15,7 +15,11 @@ import { SpeciesId } from "#enums/species-id";
 import { Challenges } from "#enums/challenges";
 import { globalScene } from "#app/global-scene";
 import { GameModes } from "#enums/game-modes";
-import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES, CHALLENGE_MODE_MYSTERY_ENCOUNTER_WAVES } from "./constants";
+import {
+  CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES,
+  CHALLENGE_MODE_MYSTERY_ENCOUNTER_WAVES,
+  DEFAULT_STARTING_MONEY,
+} from "./constants";
 
 interface GameModeConfig {
   isClassic?: boolean;
@@ -98,7 +102,7 @@ export class GameMode implements GameModeConfig {
    * - 1000
    */
   getStartingMoney(): number {
-    return Overrides.STARTING_MONEY_OVERRIDE || 1000;
+    return Overrides.STARTING_MONEY_OVERRIDE || DEFAULT_STARTING_MONEY;
   }
 
   /**

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -31,6 +31,21 @@ export class BattleEndPhase extends BattlePhase {
       gameData.gameStats.highestEndlessWave = currentBattle.waveIndex + 1;
     }
 
+    // Endless graceful end
+    if (gameMode.isEndless && currentBattle.waveIndex >= 5850) {
+      globalScene.phaseManager.queueGameOverPhase({ clearPhaseQueue: true, isVictory: true });
+    }
+
+    for (const pokemon of globalScene.getField()) {
+      if (pokemon && pokemon.battleSummonData) {
+        pokemon.battleSummonData.waveTurnCount = 0;
+      }
+    }
+
+    for (const pokemon of globalScene.getPokemonAllowedInBattle()) {
+      applyAbAttrs<PostBattleAbAttr>(AbAttrFlag.POST_BATTLE, pokemon, false, this.isVictory);
+    }
+
     if (this.isVictory) {
       currentBattle.addBattleScore();
 
@@ -48,21 +63,6 @@ export class BattleEndPhase extends BattlePhase {
       if (currentBattle.moneyScattered) {
         currentBattle.pickUpScatteredMoney();
       }
-    }
-
-    // Endless graceful end
-    if (gameMode.isEndless && currentBattle.waveIndex >= 5850) {
-      globalScene.phaseManager.queueGameOverPhase({ clearPhaseQueue: true, isVictory: true });
-    }
-
-    for (const pokemon of globalScene.getField()) {
-      if (pokemon && pokemon.battleSummonData) {
-        pokemon.battleSummonData.waveTurnCount = 0;
-      }
-    }
-
-    for (const pokemon of globalScene.getPokemonAllowedInBattle()) {
-      applyAbAttrs<PostBattleAbAttr>(AbAttrFlag.POST_BATTLE, pokemon, false, this.isVictory);
     }
 
     globalScene.clearEnemyHeldItemModifiers();

--- a/src/phases/battle-end-phase.ts
+++ b/src/phases/battle-end-phase.ts
@@ -37,6 +37,17 @@ export class BattleEndPhase extends BattlePhase {
       if (currentBattle.trainer) {
         gameData.gameStats.trainersDefeated++;
       }
+
+      /**
+       * Custom behavior that differs slightly from mainline
+       * Will award money on defeating foe
+       * Will award money on capturing foe
+       * Will NOT award money on forcing foe to flee
+       * Will NOT award money if foe flees
+       */
+      if (currentBattle.moneyScattered) {
+        currentBattle.pickUpScatteredMoney();
+      }
     }
 
     // Endless graceful end
@@ -52,10 +63,6 @@ export class BattleEndPhase extends BattlePhase {
 
     for (const pokemon of globalScene.getPokemonAllowedInBattle()) {
       applyAbAttrs<PostBattleAbAttr>(AbAttrFlag.POST_BATTLE, pokemon, false, this.isVictory);
-    }
-
-    if (currentBattle.moneyScattered) {
-      currentBattle.pickUpScatteredMoney();
     }
 
     globalScene.clearEnemyHeldItemModifiers();

--- a/test/moves/pay-day-g-gmax-gold-rush.test.ts
+++ b/test/moves/pay-day-g-gmax-gold-rush.test.ts
@@ -1,0 +1,109 @@
+import { NewBattlePhase } from "#app/phases/new-battle-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { PokeballType } from "#enums/pokeball-type";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe.each([
+  { moveName: "Pay Day", moveId: MoveId.PAY_DAY },
+  { moveName: "G-Max Gold Rush", moveId: MoveId.G_MAX_GOLD_RUSH },
+])("Moves - $moveName", ({ moveId }) => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .moveset(moveId)
+      .starterSpecies(SpeciesId.CHARMANDER)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.SHUCKLE)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(1);
+  });
+
+  it(`should award money on KO victory`, async () => {
+    await game.classicMode.startBattle();
+
+    vi.spyOn(game.scene, "addMoney");
+
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to(SelectModifierPhase, false);
+
+    expect(game.scene.money).toBeGreaterThan(0);
+  });
+
+  it(`should award money on catch "victory"`, async () => {
+    game.override.enemyAbility(AbilityId.STURDY);
+    await game.classicMode.startBattle();
+
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.toNextTurn();
+    await game.throwPokeball(PokeballType.MASTER_BALL);
+    await game.phaseInterceptor.to(SelectModifierPhase, false);
+
+    expect(game.scene.money).toBeGreaterThan(0);
+  });
+
+  it(`should NOT award money when player runs away`, async () => {
+    game.override.enemyLevel(999).enemyAbility(AbilityId.STURDY).ability(AbilityId.RUN_AWAY);
+    await game.classicMode.startBattle();
+
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.toNextTurn();
+    await game.tryToRunAway();
+    await game.toNextTurn();
+
+    expect(game.scene.money).toBe(0);
+    expect(game.scene.currentBattle.waveIndex).toBe(2);
+  });
+
+  it(`should NOT award money when forcing foe to flee`, async () => {
+    game.override.enemyLevel(999).enemyAbility(AbilityId.STURDY).ability(AbilityId.RUN_AWAY);
+    await game.classicMode.startBattle();
+
+    vi.spyOn(game.scene, "addMoney");
+
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.toNextTurn();
+    game.move.use(MoveId.ROAR);
+    await game.phaseInterceptor.to(NewBattlePhase, false);
+
+    expect(game.scene.addMoney).not.toHaveBeenCalled();
+  });
+
+  it(`should NOT award money when foe flees`, async () => {
+    game.override.enemyMoveset(MoveId.TELEPORT).enemyLevel(999).enemyAbility(AbilityId.STURDY);
+    await game.classicMode.startBattle();
+
+    vi.spyOn(game.scene, "addMoney");
+
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to(NewBattlePhase, false);
+
+    expect(game.scene.addMoney).not.toHaveBeenCalled();
+  });
+});

--- a/test/moves/pay-day-g-gmax-gold-rush.test.ts
+++ b/test/moves/pay-day-g-gmax-gold-rush.test.ts
@@ -1,5 +1,3 @@
-import { NewBattlePhase } from "#app/phases/new-battle-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { PokeballType } from "#enums/pokeball-type";
@@ -40,19 +38,19 @@ describe.each([
       .enemyLevel(1);
   });
 
-  it(`should award money on KO victory`, async () => {
+  it("should award money on KO victory", async () => {
     await game.classicMode.startBattle();
 
     vi.spyOn(game.scene, "addMoney");
 
     game.move.select(moveId);
     await game.move.forceHit();
-    await game.phaseInterceptor.to(SelectModifierPhase, false);
+    await game.phaseInterceptor.to("SelectModifierPhase", false);
 
     expect(game.scene.money).toBeGreaterThan(0);
   });
 
-  it(`should award money on catch "victory"`, async () => {
+  it("should award money on successful capture", async () => {
     game.override.enemyAbility(AbilityId.STURDY);
     await game.classicMode.startBattle();
 
@@ -60,12 +58,12 @@ describe.each([
     await game.move.forceHit();
     await game.toNextTurn();
     await game.throwPokeball(PokeballType.MASTER_BALL);
-    await game.phaseInterceptor.to(SelectModifierPhase, false);
+    await game.phaseInterceptor.to("SelectModifierPhase", false);
 
     expect(game.scene.money).toBeGreaterThan(0);
   });
 
-  it(`should NOT award money when player runs away`, async () => {
+  it("should NOT award money when player runs away", async () => {
     game.override.enemyLevel(999).enemyAbility(AbilityId.STURDY).ability(AbilityId.RUN_AWAY);
     await game.classicMode.startBattle();
 
@@ -79,7 +77,7 @@ describe.each([
     expect(game.scene.currentBattle.waveIndex).toBe(2);
   });
 
-  it(`should NOT award money when forcing foe to flee`, async () => {
+  it("should NOT award money when forcing foe to flee", async () => {
     game.override.enemyLevel(999).enemyAbility(AbilityId.STURDY).ability(AbilityId.RUN_AWAY);
     await game.classicMode.startBattle();
 
@@ -89,12 +87,12 @@ describe.each([
     await game.move.forceHit();
     await game.toNextTurn();
     game.move.use(MoveId.ROAR);
-    await game.phaseInterceptor.to(NewBattlePhase, false);
+    await game.phaseInterceptor.to("NewBattlePhase", false);
 
     expect(game.scene.addMoney).not.toHaveBeenCalled();
   });
 
-  it(`should NOT award money when foe flees`, async () => {
+  it("should NOT award money when foe flees", async () => {
     game.override.enemyMoveset(MoveId.TELEPORT).enemyLevel(999).enemyAbility(AbilityId.STURDY);
     await game.classicMode.startBattle();
 
@@ -102,7 +100,7 @@ describe.each([
 
     game.move.select(moveId);
     await game.move.forceHit();
-    await game.phaseInterceptor.to(NewBattlePhase, false);
+    await game.phaseInterceptor.to("NewBattlePhase", false);
 
     expect(game.scene.addMoney).not.toHaveBeenCalled();
   });

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -31,6 +31,7 @@ import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
 import type { StarterSelectUiHandler } from "#app/ui/handlers/starter-select-ui-handler";
 import { isNullOrUndefined } from "#app/utils";
 import type { AbilityId } from "#enums/ability-id";
+import { BattleCommand } from "#enums/battle-command";
 import { BattleStyle } from "#enums/battle-style";
 import type { BattlerIndex } from "#enums/battler-index";
 import { Button } from "#enums/buttons";
@@ -40,6 +41,7 @@ import { GameModes } from "#enums/game-modes";
 import { HpBarSpeed } from "#enums/hp-bar-speed";
 import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PlayerGender } from "#enums/player-gender";
+import type { PokeballType } from "#enums/pokeball-type";
 import type { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
 import { ErrorInterceptor } from "#test/test-utils/errorInterceptor";
@@ -553,5 +555,29 @@ export class GameManager {
         this.field.mockAbility(p, abilityId);
       }
     }
+  }
+
+  /**
+   * Picks the {@linkcode BattleCommand.RUN} command and executes it.
+   * **Must** be called during the {@linkcode CommandPhase}.
+   */
+  async tryToRunAway() {
+    const commandPhase = this.scene.phaseManager.getCurrentPhase<CommandPhase>()!;
+    expect(commandPhase).toBeDefined();
+
+    commandPhase.handleCommand(BattleCommand.RUN, 0);
+  }
+
+  /**
+   * Picks the {@linkcode BattleCommand.BALL} command with the given {@linkcode ballType} and executes it.
+   * **Must** be called during the {@linkcode CommandPhase}.
+   * @param ballType The type of Pokeball to throw
+   * @see {@linkcode PokeballType}
+   */
+  async throwPokeball(ballType: PokeballType) {
+    const commandPhase = this.scene.phaseManager.getCurrentPhase<CommandPhase>()!;
+    expect(commandPhase).toBeDefined();
+
+    commandPhase.handleCommand(BattleCommand.BALL, ballType);
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?

The player or enemy fleeing from battle will no longer award money from pay day, or g-max gold rush

Honey Gather already has the functionality of not awarding money if fleeing happens by the player or opponent

## Why am I making these changes?

Closes #616

## What are the changes from a developer perspective?

Moved 
```ts
if (currentBattle.moneyScattered) {
      currentBattle.pickUpScatteredMoney();
    }
```
into the `if (this.victory)` check

## Screenshots/Videos

After using pay day and fleeing
![image](https://github.com/user-attachments/assets/7b07a3ae-3dd0-4efc-9ddf-f49ce13cc416)

After using pay day and capturing
![image](https://github.com/user-attachments/assets/b6d5cef7-c95a-4ae1-957b-891d42482d74)


## How to test the changes?

```ts
const overrides = {
  MOVESET_OVERRIDE:[MoveId.PAY_DAY, MoveId.ROAR],
  ENEMY_MOVESET_OVERRIDE:[MoveId.TELEPORT]
}
```

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
     -> #999 