### PR TITLE
[Refactor] add "matcher" suffix to matchers & filenames

### DIFF
--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -6,18 +6,18 @@ import type { Pokemon } from "#app/field/pokemon";
 
 import type { MoveId } from "#enums/move-id";
 import type { MoveResult } from "#enums/move-result";
-import type { ToHaveMoveResultMatcherOptions } from "#test/matchers/to-have-move-result";
-import type { ToHaveUsedMoveMatcherOptions } from "#test/matchers/to-have-used-move";
+import type { ToHaveMoveResultMatcherOptions } from "#test/matchers/to-have-move-result-matcher";
+import type { ToHaveUsedMoveMatcherOptions } from "#test/matchers/to-have-used-move-matcher";
 import "vitest";
 
 declare module "vitest" {
   interface Assertion {
     /**
      * Matcher to check if a pokemon's {@linkcode MoveResult} is as expected.
-     * 
+     *
      * CAUTION: This only checks one move used by the Pokemon (by default, the most recent move).
      * It does not check the Pokemon's entire move history.
-     * 
+     *
      * @param expected The expected {@linkcode MoveResult}
      * @param options The {@linkcode ToHaveMoveResultMatcherOptions} (optional)
      * @see {@linkcode Pokemon.getLastXMoves}
@@ -26,7 +26,7 @@ declare module "vitest" {
 
     /**
      * Matcher to check if a pokemon used a move with a certain {@linkcode MoveId}.
-     * 
+     *
      * CAUTION: This only checks one move used by the Pokemon (by default, the most recent move).
      * It does not check the Pokemon's entire move history.
      *

--- a/test/matchers.setup.ts
+++ b/test/matchers.setup.ts
@@ -1,5 +1,5 @@
-import { toHaveMoveResult } from "#test/matchers/to-have-move-result";
-import { toHaveUsedMove } from "#test/matchers/to-have-used-move";
+import { toHaveMoveResultMatcher } from "#test/matchers/to-have-move-result-matcher";
+import { toHaveUsedMoveMatcher } from "#test/matchers/to-have-used-move-matcher";
 import { expect } from "vitest";
 
 /**
@@ -8,6 +8,6 @@ import { expect } from "vitest";
  */
 
 expect.extend({
-  toHaveMoveResult,
-  toHaveUsedMove,
+  toHaveMoveResult: toHaveMoveResultMatcher,
+  toHaveUsedMove: toHaveUsedMoveMatcher,
 });

--- a/test/matchers/to-have-move-result-matcher.ts
+++ b/test/matchers/to-have-move-result-matcher.ts
@@ -19,7 +19,7 @@ export interface ToHaveMoveResultMatcherOptions {
  * @param index The index of the move to check
  * @returns Whether the matcher passed
  */
-export function toHaveMoveResult(
+export function toHaveMoveResultMatcher(
   received: unknown,
   expectedResult: MoveResult,
   { index = 0, moveCount = 1 }: ToHaveMoveResultMatcherOptions = {},

--- a/test/matchers/to-have-used-move-matcher.ts
+++ b/test/matchers/to-have-used-move-matcher.ts
@@ -19,7 +19,7 @@ export interface ToHaveUsedMoveMatcherOptions {
  * @param index The index of the move to check
  * @returns Whether the matcher passed
  */
-export function toHaveUsedMove(
+export function toHaveUsedMoveMatcher(
   received: unknown,
   expectedResult: MoveId,
   { index = 0, moveCount = 1 }: ToHaveUsedMoveMatcherOptions = {},


### PR DESCRIPTION
## Why am I making these changes?

Cleanup/Chores

## What are the changes from a developer perspective?

- add `Matcher` suffix to functions being matchers
- add `-matcher` suffix to filenames containing matechers

## How to test the changes?

Tests still run successful

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [ x There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
