### PR TITLE
[P3] Fix rounding error in hp bar UI

### DIFF
--- a/src/ui/components/battle-info.ts
+++ b/src/ui/components/battle-info.ts
@@ -663,9 +663,8 @@ export class BattleInfo extends Phaser.GameObjects.Container {
           duration: duration,
           onUpdate: () => {
             if (this.player && this.lastHp !== pokemon.hp) {
-              const tweenHp = Math.ceil(this.hpBar.scaleX * pokemon.getMaxHp());
-              this.setHpNumbers(tweenHp, pokemon.getMaxHp());
-              this.lastHp = tweenHp;
+              this.setHpNumbers(pokemon.hp, pokemon.getMaxHp());
+              this.lastHp = pokemon.hp;
             }
 
             updateHpFrame();
@@ -830,6 +829,11 @@ export class BattleInfo extends Phaser.GameObjects.Container {
     this.levelContainer.setX((this.player ? -41 : -50) - 8 * Math.max(levelStr.length - 3, 0));
   }
 
+  /**
+   * Updates the hp / maxHp display
+   * @param hp the current HP
+   * @param maxHp the max HP
+   */
   setHpNumbers(hp: number, maxHp: number): void {
     if (!this.player || !globalScene) {
       return;


### PR DESCRIPTION
## What are the changes the user will see?

HP Bar UI will no longer have a off by 1 rounding error

## Why am I making these changes?

Fixes #1007

## What are the changes from a developer perspective?

Changed the `updatePokemonHp.onUpdate` to use `pokemon.hp` instead of recalculating it with `Math.ceil(this.hpBar.scaleX * pokemon.getMaxHp());`

## Screenshots/Videos

![](https://private-user-images.githubusercontent.com/163687446/435351676-84dd5cd1-218e-440d-9101-69036085358f.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDUwMzIwODMsIm5iZiI6MTc0NTAzMTc4MywicGF0aCI6Ii8xNjM2ODc0NDYvNDM1MzUxNjc2LTg0ZGQ1Y2QxLTIxOGUtNDQwZC05MTAxLTY5MDM2MDg1MzU4Zi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNDE5JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDQxOVQwMzAzMDNaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1iMjU3Y2Y5MGUyOTYxZWE2NTNmY2MyZTBmN2ZiMmI0YWQxYmYzNGRiZWJmNWEzMmRkNDg0OTJhMzQ5ZGMzYTk3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.mzecz5PxJiKzMxdD4TSRAvZmu_8ZBXatNMxtCq5H3pM)

## How to test the changes?

A savefile is linked in the issue

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->