### PR TITLE
[Bug] Fix HP bar rounding errors

### DIFF
--- a/src/ui/components/battle-info.ts
+++ b/src/ui/components/battle-info.ts
@@ -834,15 +834,13 @@ export class BattleInfo extends Phaser.GameObjects.Container {
 
   /**
    * Updates the UI to display the Pokemon's HP numbers.
-   * @param hp - The Pokemon's current HP
-   * @param maxHp - The Pokemon's maximum HP
    */
-  setHpNumbers(hp: number, maxHp: number): void {
+  setHpNumbers(currentHp: number, maxHp: number): void {
     if (!this.player || !globalScene) {
       return;
     }
     this.hpNumbersContainer.removeAll(true);
-    const hpStr = hp.toString();
+    const hpStr = currentHp.toString();
     const maxHpStr = maxHp.toString();
     let offset = 0;
     for (let i = maxHpStr.length - 1; i >= 0; i--) {
@@ -853,7 +851,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
       this.hpNumbersContainer.add(globalScene.add.image(offset++ * -8, 0, "numbers", hpStr[i]));
     }
 
-    this.lastHp = hp;
+    this.lastHp = currentHp;
   }
 
   updateStats(stats: number[]): void {

--- a/src/ui/components/battle-info.ts
+++ b/src/ui/components/battle-info.ts
@@ -423,7 +423,6 @@ export class BattleInfo extends Phaser.GameObjects.Container {
     if (this.player) {
       this.setHpNumbers(pokemon.hp, pokemon.getMaxHp());
     }
-    this.lastHp = pokemon.hp;
     this.lastMaxHp = pokemon.getMaxHp();
 
     this.setLevel(pokemon.level);
@@ -642,6 +641,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
         this.type3Icon.setFrame(ElementalType[types[2]].toLowerCase());
       }
 
+      // Updates the color of the HP bar (50-100% HP: Green, 25-50% HP: Yellow, 0-25% HP: Red)
       const updateHpFrame = () => {
         const hpFrame = this.hpBar.scaleX > 0.5 ? "high" : this.hpBar.scaleX > 0.25 ? "medium" : "low";
         if (hpFrame !== this.lastHpFrame) {
@@ -650,6 +650,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
         }
       };
 
+      // Plays the animation of the Pokemon's HP bar increasing or decreasing.
       const updatePokemonHp = () => {
         let duration = !instant ? Phaser.Math.Clamp(Math.abs(this.lastHp - pokemon.hp) * 5, 250, 5000) : 0;
         const speed = settings.general.hpBarSpeed;
@@ -665,12 +666,13 @@ export class BattleInfo extends Phaser.GameObjects.Container {
             if (this.player && this.lastHp !== pokemon.hp) {
               const tweenHp = Math.ceil(this.hpBar.scaleX * pokemon.getMaxHp());
               this.setHpNumbers(tweenHp, pokemon.getMaxHp());
-              this.lastHp = tweenHp;
             }
 
             updateHpFrame();
           },
           onComplete: () => {
+            this.setHpNumbers(pokemon.hp, pokemon.getMaxHp());
+
             updateHpFrame();
             resolve();
           },
@@ -830,6 +832,11 @@ export class BattleInfo extends Phaser.GameObjects.Container {
     this.levelContainer.setX((this.player ? -41 : -50) - 8 * Math.max(levelStr.length - 3, 0));
   }
 
+  /**
+   * Updates the UI to display the Pokemon's HP numbers.
+   * @param hp - The Pokemon's current HP
+   * @param maxHp - The Pokemon's maximum HP
+   */
   setHpNumbers(hp: number, maxHp: number): void {
     if (!this.player || !globalScene) {
       return;
@@ -845,6 +852,8 @@ export class BattleInfo extends Phaser.GameObjects.Container {
     for (let i = hpStr.length - 1; i >= 0; i--) {
       this.hpNumbersContainer.add(globalScene.add.image(offset++ * -8, 0, "numbers", hpStr[i]));
     }
+
+    this.lastHp = hp;
   }
 
   updateStats(stats: number[]): void {


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

The HP bar should no longer have rounding errors.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

Fixes #1007.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

- Added a line to set the UI's HP numbers to the Pokemon's final HP during `onComplete`.
- `setHpNumbers()` now also updates `this.lastHp`, for some small cleanup.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->
<details><summary>Before the changes: HP bar displays 2 HP after Sturdy</summary>
<p>

https://github.com/user-attachments/assets/dfa41b47-e1af-4968-b8d9-5bbebed3f438

</p>
</details> 
<details><summary>After the changes HP bar displays 1 HP after Sturdy</summary>
<p>

https://github.com/user-attachments/assets/5b71ff7f-d8f4-41cf-a1de-5b562cead4cc

</p>
</details> 

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

Activate Sturdy on different player Pokemon with different max HP values.

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [ ] There is no overlap with another PR? (Same as #1008, except this PR also preserves the animation of the HP numbers increasing/decreasing alongside the HP bar)
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes? (N/A due to the tests mocking out all animations)
- [x] Have I provided screenshots/videos of the changes (if applicable)?