### PR TITLE
[Refactor] Remove `any` from `PokemonData` constructor

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1107,6 +1107,10 @@ export class GameData {
           v = [];
         }
         for (const pd of v) {
+          // TODO: remove this later
+          if (pd.hasOwnProperty("species")) {
+            pd.speciesId = pd.species;
+          }
           ret.push(new PokemonData(pd));
         }
         return ret;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1107,7 +1107,8 @@ export class GameData {
           v = [];
         }
         for (const pd of v) {
-          // TODO: remove this later
+          // TODO: remove later, temporary to prevent devs from needing to wipe their local storage
+          // due to the field in `PokemonData` being renamed from `species` to `speciesId`
           if (pd.hasOwnProperty("species")) {
             pd.speciesId = pd.species;
           }

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -2,17 +2,17 @@ import { loadBattlerTag } from "#app/data/battler-tags/utils/load-battler-tag";
 import { CustomPokemonData } from "#app/data/custom-pokemon-data";
 import { Status } from "#app/data/status-effect";
 import type { Variant } from "#app/data/variant";
-import { EnemyPokemon } from "#app/field/enemy-pokemon";
 import type { Pokemon } from "#app/field/pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
 import { PokemonSummonData } from "#app/field/pokemon-summon-data";
 import { globalScene } from "#app/global-scene";
+import { isPokemon } from "#app/utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-species-utils";
 import { BattleType } from "#enums/battle-type";
 import type { BiomeId } from "#enums/biome-id";
 import type { Gender } from "#enums/gender";
 import { MoveId } from "#enums/move-id";
-import type { Nature } from "#enums/nature";
+import { Nature } from "#enums/nature";
 import type { PokeballType } from "#enums/pokeball-type";
 import type { SpeciesId } from "#enums/species-id";
 import { TrainerSlot } from "#enums/trainer-slot";
@@ -20,7 +20,7 @@ import { TrainerSlot } from "#enums/trainer-slot";
 export default class PokemonData {
   public id: number;
   public player: boolean;
-  public species: SpeciesId;
+  public speciesId: SpeciesId;
   public nickname: string;
   public formIndex: number;
   public abilityIndex: number;
@@ -37,7 +37,7 @@ export default class PokemonData {
   public ivs: number[];
   public nature: Nature;
   public moveset: PokemonMove[];
-  public status: Status | null;
+  public status: Status | null = null;
   public friendship: number;
   public metLevel: number;
   public metBiome: BiomeId | -1; // -1 for starters
@@ -49,7 +49,7 @@ export default class PokemonData {
   public usedTMs: MoveId[];
   public evoCounter: number;
 
-  public boss: boolean;
+  public boss: boolean = false;
   public bossSegments?: number;
 
   public summonData: PokemonSummonData;
@@ -57,14 +57,12 @@ export default class PokemonData {
   /** Data that can customize a Pokemon in non-standard ways from its Species */
   public customPokemonData: CustomPokemonData;
 
-  // TODO: this shouldn't be `| any`
-  constructor(source: Pokemon | any) {
-    const sourcePokemon = source.type === "Pokemon" ? source : null;
+  constructor(source: Pokemon | PokemonData) {
     this.id = source.id;
-    this.player = sourcePokemon ? sourcePokemon.isPlayer() : source.player;
-    this.species = sourcePokemon ? sourcePokemon.species.speciesId : source.species;
-    this.nickname = sourcePokemon ? sourcePokemon.nickname : source.nickname;
-    this.formIndex = Math.max(Math.min(source.formIndex, getPokemonSpecies(this.species).forms.length - 1), 0);
+    this.player = isPokemon(source) ? source.isPlayer() : source.player;
+    this.speciesId = isPokemon(source) ? source.species.speciesId : source.speciesId;
+    this.nickname = source.nickname;
+    this.formIndex = Phaser.Math.Clamp(source.formIndex, 0, getPokemonSpecies(this.speciesId).forms.length - 1);
     this.abilityIndex = source.abilityIndex;
     this.passive = source.passive;
     this.shiny = source.shiny;
@@ -77,61 +75,66 @@ export default class PokemonData {
     this.hp = source.hp;
     this.stats = source.stats;
     this.ivs = source.ivs;
-    this.nature = source.nature !== undefined ? source.nature : (0 as Nature);
-    this.friendship =
-      source.friendship !== undefined ? source.friendship : getPokemonSpecies(this.species).baseFriendship;
+    this.nature = source.nature ?? Nature.HARDY;
+    this.friendship = source.friendship ?? getPokemonSpecies(this.speciesId).baseFriendship;
     this.metLevel = source.metLevel || 5;
-    this.metBiome = source.metBiome !== undefined ? source.metBiome : -1;
+    this.metBiome = source.metBiome ?? -1;
     this.metSpecies = source.metSpecies;
     this.metWave = source.metWave ?? (this.metBiome === -1 ? -1 : 0);
-    this.luck = source.luck !== undefined ? source.luck : source.shiny ? source.variant + 1 : 0;
-    this.pauseEvolutions = !!source.pauseEvolutions;
+    this.luck = (source.luck ?? source.shiny) ? source.variant + 1 : 0;
+    this.pauseEvolutions = source.pauseEvolutions;
     this.evoCounter = source.evoCounter ?? 0;
-    this.pokerus = !!source.pokerus;
+    this.pokerus = source.pokerus;
     this.usedTMs = source.usedTMs ?? [];
 
     this.customPokemonData = new CustomPokemonData(source.customPokemonData);
 
-    this.boss = (source instanceof EnemyPokemon && source.bossSegments > 0) || (!this.player && !!source.boss);
-    this.bossSegments = source.bossSegments;
-
-    if (sourcePokemon) {
-      this.moveset = sourcePokemon.moveset;
-      this.status = sourcePokemon.status;
-      if (this.player) {
-        this.summonData = sourcePokemon.summonData;
-      }
-    } else {
-      this.moveset = (source.moveset || [new PokemonMove(MoveId.TACKLE), new PokemonMove(MoveId.GROWL)])
-        .filter((m) => m)
-        .map((m: any) => new PokemonMove(m.moveId, m.ppUsed, m.ppUp, m.virtual, m.maxPpOverride));
-      this.status = source.status
-        ? new Status(source.status.effect, source.status.toxicTurnCount, source.status.sleepTurnsRemaining)
-        : null;
-
-      this.summonData = new PokemonSummonData();
-      if (source.summonData) {
-        this.summonData.stats = source.summonData.stats;
-        this.summonData.statStages = source.summonData.statStages;
-        this.summonData.moveQueue = source.summonData.moveQueue;
-        this.summonData.abilitySuppressed = source.summonData.abilitySuppressed;
-        this.summonData.abilitiesApplied = source.summonData.abilitiesApplied;
-
-        this.summonData.ability = source.summonData.ability;
-        this.summonData.moveset = source.summonData.moveset?.map((m) => PokemonMove.loadMove(m));
-        this.summonData.types = source.summonData.types;
-
-        if (source.summonData.tags) {
-          this.summonData.tags = source.summonData.tags?.map((t) => loadBattlerTag(t));
-        } else {
-          this.summonData.tags = [];
-        }
-      }
+    if (source.hasOwnProperty("bossSegments")) {
+      // @ts-expect-error
+      this.boss = source.bossSegments > 0;
+      // @ts-expect-error
+      this.bossSegments = source.bossSegments;
     }
+
+    if (isPokemon(source)) {
+      this.moveset = source.moveset;
+      this.status = source.status;
+      if (this.player) {
+        this.summonData = source.summonData;
+      }
+      return;
+    }
+
+    // TODO: is this `.map()` needed? why?
+    this.moveset = (source.moveset || [new PokemonMove(MoveId.TACKLE), new PokemonMove(MoveId.GROWL)]).map(
+      (m) => new PokemonMove(m.moveId, m.ppUsed, m.ppUp, m.virtual, m.maxPpOverride),
+    );
+    // TODO: can this just be `this.status = source.status`?
+    if (source.status) {
+      // @ts-expect-error - `Status#effect` is protected but we need to use the raw values when parsing save data
+      this.status = new Status(source.status.effect, source.status.toxicTurnCount, source.status.sleepTurnsRemaining);
+    }
+
+    this.summonData = new PokemonSummonData();
+    if (!source.summonData) {
+      return;
+    }
+    this.summonData.stats = source.summonData.stats;
+    this.summonData.statStages = source.summonData.statStages;
+    this.summonData.moveQueue = source.summonData.moveQueue;
+    this.summonData.abilitySuppressed = source.summonData.abilitySuppressed;
+    this.summonData.abilitiesApplied = source.summonData.abilitiesApplied;
+    this.summonData.ability = source.summonData.ability;
+    this.summonData.types = source.summonData.types;
+
+    // TODO: is this `.map()` needed? why?
+    this.summonData.moveset = source.summonData.moveset?.map((m) => PokemonMove.loadMove(m)) ?? [];
+    // TODO: is this `.map()` needed? why?
+    this.summonData.tags = source.summonData.tags?.map((t) => loadBattlerTag(t)) ?? [];
   }
 
   toPokemon(battleType?: BattleType, partyMemberIndex: number = 0, double: boolean = false): Pokemon {
-    const species = getPokemonSpecies(this.species);
+    const species = getPokemonSpecies(this.speciesId);
     const ret: Pokemon = this.player
       ? globalScene.addPlayerPokemon(
           species,

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -57,6 +57,10 @@ export default class PokemonData {
   /** Data that can customize a Pokemon in non-standard ways from its Species */
   public customPokemonData: CustomPokemonData;
 
+  /**
+   * @param source - The typing of `source` as `PokemonData` (approximately?) matches the typing of
+   * the `json` object passed in to it in `GameData#parseSessionData`
+   */
   constructor(source: Pokemon | PokemonData) {
     this.id = source.id;
     this.player = isPokemon(source) ? source.isPlayer() : source.player;

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -90,9 +90,9 @@ export default class PokemonData {
     this.customPokemonData = new CustomPokemonData(source.customPokemonData);
 
     if (source.hasOwnProperty("bossSegments")) {
-      // @ts-expect-error
+      // @ts-expect-error - The `if` statement doesn't tell TS that this isn't a `Pokemon` object
       this.boss = source.bossSegments > 0;
-      // @ts-expect-error
+      // @ts-expect-error - The `if` statement doesn't tell TS that this isn't a `Pokemon` object
       this.bossSegments = source.bossSegments;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -685,6 +685,7 @@ export function deepFreeze<T>(obj: T): Readonly<T> {
   return obj;
 }
 
+/** @returns `true` if the input is a `Pokemon` object */
 export function isPokemon(data: any): data is Pokemon {
   return data.hasOwnProperty("type") && data.type === "Pokemon";
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -684,3 +684,7 @@ export function deepFreeze<T>(obj: T): Readonly<T> {
   }
   return obj;
 }
+
+export function isPokemon(data: any): data is Pokemon {
+  return data.hasOwnProperty("type") && data.type === "Pokemon";
+}


### PR DESCRIPTION
> [!TIP]
> It's best to view the changes with the "[ignore whitespace](https://github.com/Despair-Games/poketernity/pull/1013/files?diff=unified&w=1)" option enabled

## What are the changes the user will see?
N/A

## Why am I making these changes?
The `PokemonData` constructor could use some cleaning up.

## What are the changes from a developer perspective?
- The constructor of `PokemonData` now has the `source` parameter typed as `Pokemon | PokemonData`.
- Remove `sourcePokemon` variable and replace with new utility function `isPokemon` in the couple of places it's necessary.
- Replace `x !== undefined ? y : z` with `??`.

## How to test the changes?
Load some session save data.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?