### PR TITLE
[Addendum #994] Fix STAB multiplier for combined Pledge moves + complete tests in `stab.test.ts`

### DIFF
--- a/src/data/moves/move-attrs/combined-pledge-stab-boost-attr.ts
+++ b/src/data/moves/move-attrs/combined-pledge-stab-boost-attr.ts
@@ -13,7 +13,7 @@ export class CombinedPledgeStabBoostAttr extends MoveAttr {
    * @param user the {@linkcode Pokemon} using the move
    * @param _target the {@linkcode Pokemon} targeted by the move
    * @param move the {@linkcode Move} being used
-   * @param stabMultiplier a {@linkcode NumberHolder} containing the move's STAB multiplier for the current attack
+   * @param appliesStab a {@linkcode BooleanHolder} containing wheter the STAB boost, for the current attack should, be applied
    * @returns `true` if the STAB multiplier is modified
    */
   override apply(user: Pokemon, _target: Pokemon, move: Move, appliesStab: BooleanHolder): boolean {

--- a/src/data/moves/move-attrs/combined-pledge-stab-boost-attr.ts
+++ b/src/data/moves/move-attrs/combined-pledge-stab-boost-attr.ts
@@ -1,7 +1,7 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { NumberHolder } from "#app/utils";
 import type { Move } from "#app/data/moves/move";
 import { MoveAttr } from "#app/data/moves/move-attrs/move-attr";
+import type { BooleanHolder } from "#app/utils";
 
 /**
  * Attribute to apply STAB to the given {@link https://bulbapedia.bulbagarden.net/wiki/Move_variations#Pledge_moves | Pledge move}
@@ -16,11 +16,11 @@ export class CombinedPledgeStabBoostAttr extends MoveAttr {
    * @param stabMultiplier a {@linkcode NumberHolder} containing the move's STAB multiplier for the current attack
    * @returns `true` if the STAB multiplier is modified
    */
-  override apply(user: Pokemon, _target: Pokemon, move: Move, stabMultiplier: NumberHolder): boolean {
+  override apply(user: Pokemon, _target: Pokemon, move: Move, appliesStab: BooleanHolder): boolean {
     const combinedPledgeMove = user.turnData.combiningPledge;
 
     if (combinedPledgeMove && combinedPledgeMove !== move.id) {
-      stabMultiplier.value = 1.5;
+      appliesStab.value = true;
       return true;
     }
     return false;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4296,11 +4296,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const sourceTeraType = source.getTeraType();
     const sourceMoveType = source.getMoveType(move);
     const matchesSourceType = sourceTypes.includes(sourceMoveType);
-    if (matchesSourceType) {
+    /** Combined Pledge moves gain STAB regardless of the user's type */
+    const pledgeAppliesStab = new BooleanHolder(false);
+    applyMoveAttrs(CombinedPledgeStabBoostAttr, source, this, move, pledgeAppliesStab);
+
+    if (matchesSourceType || pledgeAppliesStab.value) {
       stabMultiplier.value += 0.5;
     }
-    applyMoveAttrs(CombinedPledgeStabBoostAttr, source, this, move, stabMultiplier);
-    if (sourceTeraType !== ElementalType.UNKNOWN && sourceTeraType === sourceMoveType) {
+    if (
+      sourceTeraType !== ElementalType.UNKNOWN
+      && (sourceTeraType === sourceMoveType || (pledgeAppliesStab.value && sourceTypes.includes(sourceTeraType)))
+    ) {
       stabMultiplier.value += 0.5;
     }
 

--- a/test/pokemon/stab.test.ts
+++ b/test/pokemon/stab.test.ts
@@ -113,7 +113,7 @@ describe("STAB", () => {
     expect(enemyPokemon.calcStabMultiplierForTakingDamage).toHaveReturnedWith(1.5);
   });
 
-  it("should have a 1.5 STAB on pledge moves", async () => {
+  it("combined Pledge moves should have a 1.5 STAB regardless of the user's type", async () => {
     game.override.battleType("double");
 
     await game.classicMode.startBattle([SpeciesId.CHARMANDER, SpeciesId.SQUIRTLE]);

--- a/test/pokemon/stab.test.ts
+++ b/test/pokemon/stab.test.ts
@@ -118,8 +118,8 @@ describe("STAB", () => {
 
     await game.classicMode.startBattle([SpeciesId.CHARMANDER, SpeciesId.SQUIRTLE]);
 
-    const enemyPokemon = game.scene.getEnemyField();
-    vi.spyOn(enemyPokemon[1], "calcStabMultiplierForTakingDamage");
+    const [, enemyPkm2] = game.scene.getEnemyField();
+    vi.spyOn(enemyPkm2, "calcStabMultiplierForTakingDamage");
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
@@ -133,7 +133,7 @@ describe("STAB", () => {
       await game.phaseInterceptor.to("MoveEndPhase");
     }
 
-    expect(enemyPokemon[1].calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(1.5);
+    expect(enemyPkm2.calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(1.5);
   });
 
   it("should have a 1.5 STAB on pledge moves if tera type DOES NOT match user's type", async () => {
@@ -141,12 +141,12 @@ describe("STAB", () => {
 
     await game.classicMode.startBattle([SpeciesId.CHARMANDER, SpeciesId.SQUIRTLE]);
 
-    const playerPokemon = game.scene.getPlayerField();
-    expect(playerPokemon[0].isTerastallized()).toBeTruthy();
-    expect(playerPokemon[0].getTeraType()).toBe(ElementalType.WATER);
+    const playerPokemon = game.field.getPlayerPokemon();
+    expect(playerPokemon.isTerastallized()).toBeTruthy();
+    expect(playerPokemon.getTeraType()).toBe(ElementalType.WATER);
 
-    const enemyPokemon = game.scene.getEnemyField();
-    vi.spyOn(enemyPokemon[1], "calcStabMultiplierForTakingDamage");
+    const [, enemyPkm2] = game.scene.getEnemyField();
+    vi.spyOn(enemyPkm2, "calcStabMultiplierForTakingDamage");
 
     game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
@@ -160,7 +160,7 @@ describe("STAB", () => {
       await game.phaseInterceptor.to("MoveEndPhase");
     }
 
-    expect(enemyPokemon[1].calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(1.5);
+    expect(enemyPkm2.calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(1.5);
   });
 
   it("should have a 2.0 STAB on pledge moves if tera type matches user's type", async () => {
@@ -168,12 +168,12 @@ describe("STAB", () => {
 
     await game.classicMode.startBattle([SpeciesId.CHARMANDER, SpeciesId.SQUIRTLE]);
 
-    const playerPokemon = game.scene.getPlayerField();
-    expect(playerPokemon[0].isTerastallized()).toBeTruthy();
-    expect(playerPokemon[0].getTeraType()).toBe(ElementalType.FIRE);
+    const playerPkm = game.field.getPlayerPokemon();
+    expect(playerPkm.isTerastallized()).toBeTruthy();
+    expect(playerPkm.getTeraType()).toBe(ElementalType.FIRE);
 
-    const enemyPokemon = game.scene.getEnemyField();
-    vi.spyOn(enemyPokemon[1], "calcStabMultiplierForTakingDamage");
+    const [, enemyPkm2] = game.scene.getEnemyField();
+    vi.spyOn(enemyPkm2, "calcStabMultiplierForTakingDamage");
 
     game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
@@ -187,6 +187,6 @@ describe("STAB", () => {
       await game.phaseInterceptor.to("MoveEndPhase");
     }
 
-    expect(enemyPokemon[1].calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(2.0);
+    expect(enemyPkm2.calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(2.0);
   });
 });

--- a/test/pokemon/stab.test.ts
+++ b/test/pokemon/stab.test.ts
@@ -1,4 +1,5 @@
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -26,8 +27,10 @@ describe("STAB", () => {
       .disableCrits()
       .ability(AbilityId.BALL_FETCH)
       .battleType("single")
-      .enemySpecies(SpeciesId.MAGIKARP)
-      .enemyMoveset(MoveId.SPLASH);
+      .enemySpecies(SpeciesId.BLISSEY)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
   });
 
   it("should have NO STAB (1.0) on type mismatch", async () => {
@@ -110,9 +113,80 @@ describe("STAB", () => {
     expect(enemyPokemon.calcStabMultiplierForTakingDamage).toHaveReturnedWith(1.5);
   });
 
-  it.todo("should have a 1.5 STAB on pledge moves");
+  it("should have a 1.5 STAB on pledge moves", async () => {
+    game.override.battleType("double");
 
-  it.todo("should have a 2.0 STAB on pledge moves if tera type DOES NOT match default type");
+    await game.classicMode.startBattle([SpeciesId.CHARMANDER, SpeciesId.SQUIRTLE]);
 
-  it.todo("should have a 2.25 STAB on pledge moves if tera type does match default type");
+    const enemyPokemon = game.scene.getEnemyField();
+    vi.spyOn(enemyPokemon[1], "calcStabMultiplierForTakingDamage");
+
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+
+    // Charmander uses Water Pledge, then Squirtle uses Grass Pledge.
+    // The combined Pledge is Grass-type, but should still gain STAB.
+    game.move.use(MoveId.WATER_PLEDGE, 0, BattlerIndex.ENEMY);
+    game.move.use(MoveId.GRASS_PLEDGE, 1, BattlerIndex.ENEMY_2);
+
+    // Wait until both Pledges have been used
+    for (let i = 0; i < 2; i++) {
+      await game.phaseInterceptor.to("MoveEndPhase");
+    }
+
+    expect(enemyPokemon[1].calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(1.5);
+  });
+
+  it("should have a 1.5 STAB on pledge moves if tera type DOES NOT match user's type", async () => {
+    game.override.battleType("double").startingHeldItems([{ name: "TERA_SHARD", type: ElementalType.WATER }]);
+
+    await game.classicMode.startBattle([SpeciesId.CHARMANDER, SpeciesId.SQUIRTLE]);
+
+    const playerPokemon = game.scene.getPlayerField();
+    expect(playerPokemon[0].isTerastallized()).toBeTruthy();
+    expect(playerPokemon[0].getTeraType()).toBe(ElementalType.WATER);
+
+    const enemyPokemon = game.scene.getEnemyField();
+    vi.spyOn(enemyPokemon[1], "calcStabMultiplierForTakingDamage");
+
+    game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+
+    // Squirtle uses Grass Pledge, then Charmander uses Water Pledge.
+    // The combined Pledge is Grass-type, but should still gain STAB.
+    game.move.use(MoveId.WATER_PLEDGE, 0, BattlerIndex.ENEMY_2);
+    game.move.use(MoveId.GRASS_PLEDGE, 1, BattlerIndex.ENEMY);
+
+    // Wait until both Pledges have been used
+    for (let i = 0; i < 2; i++) {
+      await game.phaseInterceptor.to("MoveEndPhase");
+    }
+
+    expect(enemyPokemon[1].calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(1.5);
+  });
+
+  it("should have a 2.0 STAB on pledge moves if tera type matches user's type", async () => {
+    game.override.battleType("double").startingHeldItems([{ name: "TERA_SHARD", type: ElementalType.FIRE }]);
+
+    await game.classicMode.startBattle([SpeciesId.CHARMANDER, SpeciesId.SQUIRTLE]);
+
+    const playerPokemon = game.scene.getPlayerField();
+    expect(playerPokemon[0].isTerastallized()).toBeTruthy();
+    expect(playerPokemon[0].getTeraType()).toBe(ElementalType.FIRE);
+
+    const enemyPokemon = game.scene.getEnemyField();
+    vi.spyOn(enemyPokemon[1], "calcStabMultiplierForTakingDamage");
+
+    game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.PLAYER, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+
+    // Squirtle uses Fire Pledge, then Charmander uses Grass Pledge.
+    // The combined Pledge is Grass-type, but should still gain enhanced STAB from matching Tera type
+    game.move.use(MoveId.GRASS_PLEDGE, 0, BattlerIndex.ENEMY_2);
+    game.move.use(MoveId.WATER_PLEDGE, 1, BattlerIndex.ENEMY);
+
+    // Wait until both Pledges have been used
+    for (let i = 0; i < 2; i++) {
+      await game.phaseInterceptor.to("MoveEndPhase");
+    }
+
+    expect(enemyPokemon[1].calcStabMultiplierForTakingDamage).toHaveLastReturnedWith(2.0);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Combined Pledge moves should now use the correct STAB multiplier:
- 1.5 when used by a non-Tera Pokemon of any type
- 1.5 when used by a Terastallized Pokemon whose Tera type does not match any of their base types
- 2.0 when used by a Terastallized Pokemon whose Tera type matches any of their base types

> [!NOTE]
> Adaptability's interaction with Pledge combos in mainline is unclear. With this PR its bonus only applies in cases where the combined move's type matches the user's type (or Tera type).

## Why am I making these changes?

In review of #994

## What are the changes from a developer perspective?

- Rewrote `CombinedPledgeStabBoostAttr` to modify a flag (`BooleanHolder`) instead of directly modifying the STAB multiplier
- Updated STAB calculations with logic for combined Pledge moves

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/51c005fa-e50a-4bc4-9630-c5499bf4a0aa)

## How to test the changes?

`npm run test stab`

## Checklist

- [n/a] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [n/a] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?
