### PR TITLE
[Refactor][Tests] Remove `kill` wording from `GameManager`

### DIFF
--- a/test/abilities/battle-bond.test.ts
+++ b/test/abilities/battle-bond.test.ts
@@ -48,7 +48,7 @@ describe("Abilities - BATTLE BOND", () => {
     expect(greninja.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toEndOfTurn();
     game.doSelectModifier();
     await game.phaseInterceptor.to("QuietFormChangePhase");
@@ -78,7 +78,7 @@ describe("Abilities - BATTLE BOND", () => {
     expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
     expect(actualMultiHitType).toBe(expectedMultiHitType);
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     // Wave 5: Use Water Shuriken in base form

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -141,7 +141,7 @@ describe("Abilities - Disguise", () => {
     expect(mimikyu.formIndex).toBe(bustedForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     expect(mimikyu.formIndex).toBe(bustedForm);
@@ -161,7 +161,7 @@ describe("Abilities - Disguise", () => {
     expect(mimikyu.formIndex).toBe(bustedForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     expect(mimikyu.formIndex).toBe(disguisedForm);
@@ -185,7 +185,7 @@ describe("Abilities - Disguise", () => {
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to("PartyHealPhase");
 
     expect(mimikyu1.formIndex).toBe(disguisedForm);

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -181,7 +181,7 @@ describe("Abilities - Disguise", () => {
     expect(mimikyu1.formIndex).toBe(bustedForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.killPokemon(mimikyu1);
+    await game.faintPokemon(mimikyu1);
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);

--- a/test/abilities/ice-face.test.ts
+++ b/test/abilities/ice-face.test.ts
@@ -214,7 +214,7 @@ describe("Abilities - Ice Face", () => {
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
 
     game.move.select(MoveId.ICE_BEAM);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(TurnInitPhase);

--- a/test/abilities/power-construct.test.ts
+++ b/test/abilities/power-construct.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - POWER CONSTRUCT", () => {
     expect(zygarde.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);
@@ -73,7 +73,7 @@ describe("Abilities - POWER CONSTRUCT", () => {
     expect(zygarde.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/schooling.test.ts
+++ b/test/abilities/schooling.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - SCHOOLING", () => {
     expect(wishiwashi.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/shields-down.test.ts
+++ b/test/abilities/shields-down.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - SHIELDS DOWN", () => {
     expect(minior.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/zen-mode.test.ts
+++ b/test/abilities/zen-mode.test.ts
@@ -74,7 +74,7 @@ describe("Abilities - ZEN MODE", () => {
     expect(darmanitan.formIndex).toBe(zenForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.killPokemon(darmanitan);
+    await game.faintPokemon(darmanitan);
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
 

--- a/test/abilities/zen-mode.test.ts
+++ b/test/abilities/zen-mode.test.ts
@@ -98,7 +98,7 @@ describe("Abilities - ZEN MODE", () => {
     expect(darmanitan.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     expect(darmanitan.formIndex).toBe(baseForm);

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - ZERO TO HERO", () => {
     expect(palafin2.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -75,7 +75,7 @@ describe("Abilities - ZERO TO HERO", () => {
     expect(palafin.formIndex).toBe(baseForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.killPokemon(palafin);
+    await game.faintPokemon(palafin);
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
     expect(palafin.formIndex).toBe(baseForm);
@@ -92,7 +92,7 @@ describe("Abilities - ZERO TO HERO", () => {
     expect(palafin.formIndex).toBe(heroForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.killPokemon(palafin);
+    await game.faintPokemon(palafin);
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
 

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -268,7 +268,7 @@ describe("Test Battle Phase", () => {
 
     game.move.select(moveToUse);
     await game.phaseInterceptor.to("DamageAnimPhase", false);
-    await game.killPokemon(game.scene.currentBattle.enemyParty[0]);
+    await game.faintPokemon(game.scene.currentBattle.enemyParty[0]);
     expect(game.scene.currentBattle.enemyParty[0].isFainted()).toBe(true);
     await game.phaseInterceptor.to("VictoryPhase", false);
   });

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -309,7 +309,7 @@ describe("Test Battle Phase", () => {
     game.move.select(moveToUse);
 
     vi.spyOn(game.scene.arena, "trySetWeather");
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
     expect(game.scene.arena.trySetWeather).not.toHaveBeenCalled();
     expect(game.scene.currentBattle.waveIndex).toBeGreaterThan(waveIndex);

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -52,7 +52,7 @@ describe("Double Battles", () => {
       expect(pokemon.isFainted()).toBe(true);
     }
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     await game.phaseInterceptor.to(BattleEndPhase);
     game.doSelectModifier();
@@ -76,7 +76,7 @@ describe("Double Battles", () => {
     // Play through endless, waves 1 to 9, counting number of double battles from waves 2 to 9
     await game.rng.equalSample(DOUBLE_CHANCE, async () => {
       game.move.select(MoveId.SPLASH);
-      await game.doKillOpponents();
+      await game.doFaintOpponents();
       await game.toNextWave();
 
       if (game.scene.getEnemyParty().length === 1) {

--- a/test/battle/reload.test.ts
+++ b/test/battle/reload.test.ts
@@ -57,7 +57,7 @@ describe("Reload", () => {
       // Input first option for Map
       game.scene.ui.getHandler().processInput(Button.ACTION);
     });
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
     expect(game.phaseInterceptor.log).toContain("NewBiomeEncounterPhase");
 
@@ -83,7 +83,7 @@ describe("Reload", () => {
 
     // Transition from Wave 10 to Wave 11 in order to trigger biome switch
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
     expect(game.phaseInterceptor.log).toContain("NewBiomeEncounterPhase");
 
@@ -167,7 +167,7 @@ describe("Reload", () => {
     game.move.use(MoveId.SPLASH);
     await game.toNextTurn();
     game.move.use(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     expect(game.field.getPlayerPokemon().getStatusEffect(true)).toBe(StatusEffect.TOXIC);

--- a/test/game-modes/daily-mode.test.ts
+++ b/test/game-modes/daily-mode.test.ts
@@ -74,7 +74,7 @@ describe("Shop modifications", async () => {
   it("should not have Eviolite and Mini Black Hole available in Classic if not unlocked", async () => {
     await game.classicMode.startBattle([SpeciesId.BULBASAUR]);
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to("BattleEndPhase");
     game.onNextPrompt("SelectModifierPhase", UiMode.MODIFIER_SELECT, () => {
       expect(game.scene.ui.getHandler()).toBeInstanceOf(ModifierSelectUiHandler);
@@ -85,7 +85,7 @@ describe("Shop modifications", async () => {
   it("should have Eviolite and Mini Black Hole available in Daily", async () => {
     await game.dailyMode.startBattle();
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to("BattleEndPhase");
     game.onNextPrompt("SelectModifierPhase", UiMode.MODIFIER_SELECT, () => {
       expect(game.scene.ui.getHandler()).toBeInstanceOf(ModifierSelectUiHandler);

--- a/test/items/dire-hit.test.ts
+++ b/test/items/dire-hit.test.ts
@@ -60,7 +60,7 @@ describe("Items - Dire Hit", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     await game.phaseInterceptor.to(BattleEndPhase);
 

--- a/test/items/double-battle-chance-booster.test.ts
+++ b/test/items/double-battle-chance-booster.test.ts
@@ -57,7 +57,7 @@ describe("Items - Double Battle Chance Boosters", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     await game.phaseInterceptor.to("BattleEndPhase");
 

--- a/test/items/temp-stat-stage-booster.test.ts
+++ b/test/items/temp-stat-stage-booster.test.ts
@@ -125,7 +125,7 @@ describe("Items - Temporary Stat Stage Boosters", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     await game.phaseInterceptor.to("BattleEndPhase");
 

--- a/test/moves/fake-out.test.ts
+++ b/test/moves/fake-out.test.ts
@@ -92,7 +92,7 @@ describe("Moves - Fake Out", () => {
 
     expect(enemy1.hp).toBeLessThan(enemy1.getMaxHp());
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     game.move.select(MoveId.FAKE_OUT);

--- a/test/moves/geomancy.test.ts
+++ b/test/moves/geomancy.test.ts
@@ -64,7 +64,7 @@ describe("Moves - Geomancy", () => {
     game.move.select(MoveId.GEOMANCY);
 
     await game.phaseInterceptor.to("MoveEndPhase", false);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     await game.toNextWave();
 

--- a/test/moves/gigaton-hammer.test.ts
+++ b/test/moves/gigaton-hammer.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Gigaton Hammer", () => {
 
     expect(enemy1.hp).toBeLessThan(enemy1.getMaxHp());
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     game.move.select(MoveId.GIGATON_HAMMER);
@@ -66,7 +66,7 @@ describe("Moves - Gigaton Hammer", () => {
 
     expect(enemy1.hp).toBeLessThan(enemy1.getMaxHp());
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     game.move.select(MoveId.GIGATON_HAMMER);

--- a/test/moves/jaw-lock.test.ts
+++ b/test/moves/jaw-lock.test.ts
@@ -101,7 +101,7 @@ describe("Moves - Jaw Lock", () => {
 
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
   });

--- a/test/moves/multi-target.test.ts
+++ b/test/moves/multi-target.test.ts
@@ -53,7 +53,7 @@ describe("Multi-target damage reduction", () => {
     const tackle1 = enemy1.getMaxHp() - enemy1.hp;
     enemy1.hp = enemy1.getMaxHp();
 
-    await game.killPokemon(enemy2);
+    await game.faintPokemon(enemy2);
     await game.toNextTurn();
 
     game.move.select(MoveId.DAZZLING_GLEAM);
@@ -93,7 +93,7 @@ describe("Multi-target damage reduction", () => {
     player2.hp = player2.getMaxHp();
     enemy1.hp = enemy1.getMaxHp();
 
-    await game.killPokemon(enemy2);
+    await game.faintPokemon(enemy2);
     await game.toNextTurn();
 
     game.move.select(MoveId.EARTHQUAKE);
@@ -112,7 +112,7 @@ describe("Multi-target damage reduction", () => {
     expect(damageEnemy1Turn1).toBe(damageEnemy1Turn2);
     expect(damagePlayer2Turn1).toBe(damagePlayer2Turn2);
 
-    await game.killPokemon(player2);
+    await game.faintPokemon(player2);
     await game.toNextTurn();
 
     game.move.select(MoveId.EARTHQUAKE);

--- a/test/moves/parting-shot.test.ts
+++ b/test/moves/parting-shot.test.ts
@@ -170,7 +170,7 @@ describe("Moves - Parting Shot", () => {
       game.move.select(MoveId.SPLASH);
 
       // intentionally kill party pokemon, switch to second slot (now 1 party mon is fainted)
-      await game.killPokemon(game.scene.getPlayerParty()[0]);
+      await game.faintPokemon(game.scene.getPlayerParty()[0]);
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
       await game.phaseInterceptor.run(MessagePhase);
       game.doSelectPartyPokemon(1);

--- a/test/moves/relic-song.test.ts
+++ b/test/moves/relic-song.test.ts
@@ -69,7 +69,7 @@ describe("Moves - Relic Song", () => {
     const meloetta = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     expect(meloetta.formIndex).toBe(1);

--- a/test/moves/toxic-spikes.test.ts
+++ b/test/moves/toxic-spikes.test.ts
@@ -125,7 +125,7 @@ describe("Moves - Toxic Spikes", () => {
     game.move.select(MoveId.TOXIC_SPIKES);
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     await game.reload.reloadSession();

--- a/test/phases/evolution-phase.test.ts
+++ b/test/phases/evolution-phase.test.ts
@@ -45,7 +45,7 @@ describe("Evolution Phase", () => {
     vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([]); // Do not attempt to learn level-up moves
 
     game.move.use(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     expect(pokemon.level).toBeGreaterThan(32);
@@ -70,7 +70,7 @@ describe("Evolution Phase", () => {
     });
 
     game.move.use(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     // Repeatedly press "Cancel" to cancel evolution and say "No" to pausing evolutions
     const pressCancelInterval = setInterval(() => game.scene.ui.processInput(Button.CANCEL));
@@ -94,7 +94,7 @@ describe("Evolution Phase", () => {
     vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([]); // Do not attempt to learn level-up moves
 
     game.move.use(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to("EvolutionPhase", false);
 
     // Cancel the evolution
@@ -111,7 +111,7 @@ describe("Evolution Phase", () => {
     expect(pokemon.calculateBaseStats()).toStrictEqual([45, 49, 49, 65, 65, 45]);
 
     game.move.use(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.toNextWave();
 
     // Should not have a second EvolutionPhase after pausing

--- a/test/phases/form-change-phase.test.ts
+++ b/test/phases/form-change-phase.test.ts
@@ -142,7 +142,7 @@ describe("Form Change Phase", () => {
     expect(rillaboom.getFormKey()).toBe("gigantamax");
 
     game.move.use(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to("SelectModifierPhase");
 
     // Navigate UI: Access "Check Party" menu from modifier selection

--- a/test/phases/learn-move-phase.test.ts
+++ b/test/phases/learn-move-phase.test.ts
@@ -30,7 +30,7 @@ describe("Learn Move Phase", () => {
     const pokemon = game.scene.getPlayerPokemon()!;
     const newMovePos = pokemon?.getMoveset().length;
     game.move.select(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
     await game.phaseInterceptor.to(LearnMovePhase);
     const levelMove = pokemon.getLevelMoves(5)[0];
     const levelReq = levelMove[0];

--- a/test/pokemon/evolution.test.ts
+++ b/test/pokemon/evolution.test.ts
@@ -201,7 +201,7 @@ describe("Evolution", () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     game.move.use(MoveId.SPLASH);
-    await game.doKillOpponents();
+    await game.doFaintOpponents();
 
     // Mock the next wave's Pokemon pool
     vi.spyOn(game.scene.arena as any, "pokemonPool", "get").mockReturnValue({

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -318,7 +318,7 @@ export class GameManager {
   }
 
   /** Faint all opponents currently on the field */
-  async doKillOpponents() {
+  async doFaintOpponents() {
     await this.faintPokemon(this.scene.currentBattle.enemyParty[0]);
     if (this.scene.currentBattle.double) {
       await this.faintPokemon(this.scene.currentBattle.enemyParty[1]);

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -319,9 +319,9 @@ export class GameManager {
 
   /** Faint all opponents currently on the field */
   async doKillOpponents() {
-    await this.killPokemon(this.scene.currentBattle.enemyParty[0]);
+    await this.faintPokemon(this.scene.currentBattle.enemyParty[0]);
     if (this.scene.currentBattle.double) {
-      await this.killPokemon(this.scene.currentBattle.enemyParty[1]);
+      await this.faintPokemon(this.scene.currentBattle.enemyParty[1]);
     }
   }
 
@@ -453,7 +453,16 @@ export class GameManager {
     return updateUserInfo();
   }
 
-  async killPokemon(pokemon: PlayerPokemon | EnemyPokemon) {
+  /**
+   * Faints the given Pokemon.
+   * @param pokemon The {@linkcode Pokemon} to faint
+   * @returns A promise that resolves when the Pokemon is fainted
+   * @example
+   *    const enemyPkm = gameManager.field.getEnemyPokemon;
+   *    game.move.select(MoveId.SPLASH);
+   *    await gameManager.faintPokemon(enemyPkm);
+   */
+  async faintPokemon(pokemon: PlayerPokemon | EnemyPokemon) {
     return new Promise<void>(async (resolve, reject) => {
       pokemon.hp = 0;
       this.scene.phaseManager.pushPhase(new FaintPhase(pokemon.getBattlerIndex(), true));

--- a/test/ui/battle-info.test.ts
+++ b/test/ui/battle-info.test.ts
@@ -46,7 +46,7 @@ describe("UI - Battle Info", () => {
       await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
 
       game.move.select(MoveId.SPLASH);
-      await game.doKillOpponents();
+      await game.doFaintOpponents();
       await game.phaseInterceptor.to(ExpPhase, true);
 
       expect(Math.pow).not.toHaveBeenCalledWith(2, expGainsSpeed);


### PR DESCRIPTION
## What are the changes the user will see?

We will give them a more sure feeling that no Pokemon are harmed in our tests

## Why am I making these changes?

We don't kill Pokémon, we just faint them.

## What are the changes from a developer perspective?

- renamed `killedPokemon` to `faintPokemon`
- rename `doKillOpponents` to `doFaintOpponents`

## Screenshots/Videos

n/a

## How to test the changes?

run the automated tests

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
