### PR TITLE
[Refactor] Update `GameManager` method names

### DIFF
--- a/test/abilities/aftermath.test.ts
+++ b/test/abilities/aftermath.test.ts
@@ -89,7 +89,7 @@ describe("Abilities - Aftermath", () => {
     const [feebas, milotic] = game.scene.getPlayerParty();
 
     game.move.use(MoveId.U_TURN);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     expect(feebas.isOnField()).toBe(false);
@@ -106,7 +106,7 @@ describe("Abilities - Aftermath", () => {
     feebas.hp = 1;
 
     game.move.use(MoveId.GRASS_KNOT);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     expect(feebas.getHeldItems()[0]?.type.id).toBe("REVIVER_SEED");

--- a/test/abilities/anticipation.test.ts
+++ b/test/abilities/anticipation.test.ts
@@ -81,7 +81,7 @@ describe("Abilities - Anticipation", () => {
 
     game.move.use(MoveId.GRAVITY);
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     // Should not have activated Anticipation despite taking super-effective damage

--- a/test/abilities/battle-bond.test.ts
+++ b/test/abilities/battle-bond.test.ts
@@ -48,7 +48,7 @@ describe("Abilities - BATTLE BOND", () => {
     expect(greninja.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toEndOfTurn();
     game.doSelectModifier();
     await game.phaseInterceptor.to("QuietFormChangePhase");
@@ -78,7 +78,7 @@ describe("Abilities - BATTLE BOND", () => {
     expect(waterShuriken.calculateBattlePower).toHaveLastReturnedWith(expectedBattlePower);
     expect(actualMultiHitType).toBe(expectedMultiHitType);
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     // Wave 5: Use Water Shuriken in base form

--- a/test/abilities/commander.test.ts
+++ b/test/abilities/commander.test.ts
@@ -77,7 +77,7 @@ describe("Abilities - Commander", () => {
     const tatsugiri = game.scene.getPlayerField()[0];
 
     game.move.select(MoveId.LIQUIDATION, 0, BattlerIndex.ENEMY);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
 
     await game.phaseInterceptor.to("MovePhase", false);
     expect(game.scene.triggerPokemonBattleAnim).toHaveBeenCalledWith(tatsugiri, PokemonAnimType.COMMANDER_APPLY);
@@ -220,7 +220,7 @@ describe("Abilities - Commander", () => {
     await game.toNextTurn();
 
     expect(tatsugiri.getTag(BattlerTagType.UNDERWATER)).toBeDefined();
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
 
     await game.phaseInterceptor.to("MovePhase", false);
     const dondozo = game.scene.getPlayerField()[1];

--- a/test/abilities/costar.test.ts
+++ b/test/abilities/costar.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - COSTAR", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to(CommandPhase);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.phaseInterceptor.to(MessagePhase);
 
     [leftPokemon, rightPokemon] = game.scene.getPlayerField();
@@ -67,7 +67,7 @@ describe("Abilities - COSTAR", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to(CommandPhase);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.phaseInterceptor.to(MessagePhase);
 
     [leftPokemon, rightPokemon] = game.scene.getPlayerField();

--- a/test/abilities/defiant-competitive.test.ts
+++ b/test/abilities/defiant-competitive.test.ts
@@ -209,12 +209,12 @@ describe.each([
     await game.toNextTurn();
 
     // Turn 2: Switch out
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.move.forceEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
 
     // Turn 3: Switch back into original Sticky Web user
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.move.forceEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
     if (isDefiant) {

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -123,7 +123,7 @@ describe("Abilities - Disguise", () => {
     expect(mimikyu.hp).equals(maxHp - disguiseDamage);
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
 
     await game.toEndOfTurn();
 

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -182,7 +182,7 @@ describe("Abilities - Disguise", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintPokemon(mimikyu1);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
     await game.faintOpponents();

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -141,7 +141,7 @@ describe("Abilities - Disguise", () => {
     expect(mimikyu.formIndex).toBe(bustedForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     expect(mimikyu.formIndex).toBe(bustedForm);
@@ -161,7 +161,7 @@ describe("Abilities - Disguise", () => {
     expect(mimikyu.formIndex).toBe(bustedForm);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     expect(mimikyu.formIndex).toBe(disguisedForm);
@@ -185,7 +185,7 @@ describe("Abilities - Disguise", () => {
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to("PartyHealPhase");
 
     expect(mimikyu1.formIndex).toBe(disguisedForm);

--- a/test/abilities/flash-fire.test.ts
+++ b/test/abilities/flash-fire.test.ts
@@ -93,7 +93,7 @@ describe("Abilities - Flash Fire", () => {
     game.move.select(MoveId.BATON_PASS);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.phaseInterceptor.to(TurnEndPhase);
     const chansey = game.scene.getPlayerPokemon()!;

--- a/test/abilities/flower-gift.test.ts
+++ b/test/abilities/flower-gift.test.ts
@@ -127,10 +127,10 @@ describe("Abilities - Flower Gift", () => {
 
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.to("MovePhase");
 
     expect(cherrim.summonData.abilitySuppressed).toBe(false);
@@ -145,7 +145,7 @@ describe("Abilities - Flower Gift", () => {
 
     expect(cherrim.formIndex).toBe(SUNSHINE_FORM);
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     expect(cherrim.formIndex).toBe(OVERCAST_FORM);
@@ -178,7 +178,7 @@ describe("Abilities - Flower Gift", () => {
 
     // Switch out Primal Groudon to end weather
     game.move.use(MoveId.SPLASH, 0);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.toNextTurn();
 
     expect(cherrim.formIndex).toBe(OVERCAST_FORM);

--- a/test/abilities/forecast.test.ts
+++ b/test/abilities/forecast.test.ts
@@ -123,25 +123,25 @@ describe("Abilities - Forecast", () => {
       expect(castform.formIndex).toBe(SNOWY_FORM);
 
       game.move.select(MoveId.SPLASH);
-      game.doSwitchPokemon(2); // Feebas now 2, Kyogre 1
+      game.switchPokemon(2); // Feebas now 2, Kyogre 1
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(RAINY_FORM);
 
       game.move.select(MoveId.SPLASH);
-      game.doSwitchPokemon(3); // Kyogre now 3, Groudon 1
+      game.switchPokemon(3); // Kyogre now 3, Groudon 1
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SUNNY_FORM);
 
       game.move.select(MoveId.SPLASH);
-      game.doSwitchPokemon(4); // Groudon now 4, Rayquaza 1
+      game.switchPokemon(4); // Groudon now 4, Rayquaza 1
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(NORMAL_FORM);
 
       game.move.select(MoveId.SPLASH);
-      game.doSwitchPokemon(2); // Rayquaza now 2, Feebas 1
+      game.switchPokemon(2); // Rayquaza now 2, Feebas 1
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(NORMAL_FORM);
@@ -153,13 +153,13 @@ describe("Abilities - Forecast", () => {
       expect(castform.formIndex).toBe(SNOWY_FORM);
 
       game.move.select(MoveId.SPLASH);
-      game.doSwitchPokemon(5); // Feebas now 5, Altaria 1
+      game.switchPokemon(5); // Feebas now 5, Altaria 1
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(NORMAL_FORM);
 
       game.move.select(MoveId.SPLASH);
-      game.doSwitchPokemon(5); // Altaria now 5, Feebas 1
+      game.switchPokemon(5); // Altaria now 5, Feebas 1
       await game.toNextTurn();
 
       expect(castform.formIndex).toBe(SNOWY_FORM);
@@ -244,11 +244,11 @@ describe("Abilities - Forecast", () => {
     await game.toNextTurn();
 
     // Second turn - switch out Castform, regains Forecast
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     // Third turn - switch in Castform
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.to("MovePhase");
 
     expect(castform.summonData.abilitySuppressed).toBe(false);
@@ -264,7 +264,7 @@ describe("Abilities - Forecast", () => {
     await game.toNextTurn();
 
     // Second turn - switch in Castform, regains Forecast
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.to("PostSummonPhase");
 
     const castform = game.field.getPlayerPokemon();
@@ -286,7 +286,7 @@ describe("Abilities - Forecast", () => {
 
     expect(castform.formIndex).toBe(RAINY_FORM);
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     expect(castform.formIndex).toBe(NORMAL_FORM);
@@ -302,7 +302,7 @@ describe("Abilities - Forecast", () => {
 
     // Switch out Primal Groudon to end weather
     game.move.use(MoveId.SPLASH, 0);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.toNextTurn();
 
     expect(castform.formIndex).toBe(NORMAL_FORM);

--- a/test/abilities/gulp-missile.test.ts
+++ b/test/abilities/gulp-missile.test.ts
@@ -84,7 +84,7 @@ describe("Abilities - Gulp Missile", () => {
     game.move.select(MoveId.SURF);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn(); // form change is delayed until after end of turn
 
     expect(cramorant.formIndex).toBe(NORMAL_FORM);

--- a/test/abilities/ice-face.test.ts
+++ b/test/abilities/ice-face.test.ts
@@ -214,7 +214,7 @@ describe("Abilities - Ice Face", () => {
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
 
     game.move.select(MoveId.ICE_BEAM);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(TurnInitPhase);

--- a/test/abilities/ice-face.test.ts
+++ b/test/abilities/ice-face.test.ts
@@ -143,9 +143,9 @@ describe("Abilities - Ice Face", () => {
     expect(eiscue.isFullHp()).toBe(true);
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
 
     await game.phaseInterceptor.to(QuietFormChangePhase);
     eiscue = game.scene.getPlayerPokemon()!;
@@ -189,7 +189,7 @@ describe("Abilities - Ice Face", () => {
     expect(eiscue.isFullHp()).toBe(true);
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
 
     await game.phaseInterceptor.to(TurnEndPhase);
     eiscue = game.scene.getPlayerParty()[1];

--- a/test/abilities/intimidate.test.ts
+++ b/test/abilities/intimidate.test.ts
@@ -54,7 +54,7 @@ describe("Abilities - Intimidate", () => {
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-1);
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(-1);
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.run("CommandPhase");
     await game.phaseInterceptor.to("CommandPhase");
 

--- a/test/abilities/libero.test.ts
+++ b/test/abilities/libero.test.ts
@@ -73,9 +73,9 @@ describe("Abilities - Libero", () => {
     expect(leadPokemonType).not.toBe(moveType);
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     leadPokemon = game.scene.getPlayerPokemon()!;

--- a/test/abilities/mimicry.test.ts
+++ b/test/abilities/mimicry.test.ts
@@ -39,7 +39,7 @@ describe("Abilities - Mimicry", () => {
     await game.toNextTurn();
     expect(playerPokemon1.getTypes().includes(ElementalType.FAIRY)).toBe(true);
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     expect(playerPokemon2.getTypes().includes(ElementalType.FAIRY)).toBe(true);

--- a/test/abilities/mirror-armor.test.ts
+++ b/test/abilities/mirror-armor.test.ts
@@ -151,7 +151,7 @@ describe("Abilities - Mirror Armor", () => {
     game.move.use(MoveId.U_TURN);
     await game.move.forceEnemyMove(MoveId.U_TURN);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    game.doSelectPartyPokemon(1, "SwitchPhase");
+    game.selectPartyPokemon(1, "SwitchPhase");
 
     await game.toEndOfTurn();
 

--- a/test/abilities/parental-bond.test.ts
+++ b/test/abilities/parental-bond.test.ts
@@ -417,10 +417,10 @@ describe("Abilities - Parental Bond", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.toNextTurn();
 
     // TODO: Update hit count to 1 once Future Sight is fixed to not activate abilities if user is off the field

--- a/test/abilities/pastel-veil.test.ts
+++ b/test/abilities/pastel-veil.test.ts
@@ -65,7 +65,7 @@ describe("Abilities - Pastel Veil", () => {
 
     await game.phaseInterceptor.to(CommandPhase);
     game.move.select(MoveId.SPLASH);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.phaseInterceptor.to(TurnEndPhase);
 
     expect(magikarp.getStatusEffect(true)).toBe(StatusEffect.NONE);

--- a/test/abilities/perish-body.test.ts
+++ b/test/abilities/perish-body.test.ts
@@ -43,7 +43,7 @@ describe("Abilities - Perish Body", () => {
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     expect(milotic.getTag(BattlerTagType.PERISH_SONG)).toBeUndefined();
@@ -60,7 +60,7 @@ describe("Abilities - Perish Body", () => {
     game.move.select(MoveId.PECK);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     game.move.select(MoveId.PECK);

--- a/test/abilities/power-construct.test.ts
+++ b/test/abilities/power-construct.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - POWER CONSTRUCT", () => {
     expect(zygarde.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);
@@ -73,7 +73,7 @@ describe("Abilities - POWER CONSTRUCT", () => {
     expect(zygarde.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/protean.test.ts
+++ b/test/abilities/protean.test.ts
@@ -73,9 +73,9 @@ describe("Abilities - Protean", () => {
     expect(leadPokemonType).not.toBe(moveType);
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     leadPokemon = game.scene.getPlayerPokemon()!;

--- a/test/abilities/rattled.test.ts
+++ b/test/abilities/rattled.test.ts
@@ -93,7 +93,7 @@ describe("Abilities - Rattled", () => {
     // Rattled should have activated before the turn starts due to the player Magikarp's Intimidate
     expect(enemy.getStatStage(Stat.SPD)).toBe(1);
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
 
     // advance to before the enemy makes a move
     await game.phaseInterceptor.to("MovePhase", false);
@@ -113,7 +113,7 @@ describe("Abilities - Rattled", () => {
     game.move.use(MoveId.SPLASH);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
 
     await game.toEndOfTurn();
 

--- a/test/abilities/schooling.test.ts
+++ b/test/abilities/schooling.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - SCHOOLING", () => {
     expect(wishiwashi.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/screen-cleaner.test.ts
+++ b/test/abilities/screen-cleaner.test.ts
@@ -41,7 +41,7 @@ describe("Abilities - Screen Cleaner", () => {
     expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeDefined();
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.to(PostSummonPhase);
 
     expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeUndefined();
@@ -58,7 +58,7 @@ describe("Abilities - Screen Cleaner", () => {
     expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeDefined();
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.to(PostSummonPhase);
 
     expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeUndefined();
@@ -75,7 +75,7 @@ describe("Abilities - Screen Cleaner", () => {
     expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeDefined();
 
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.to(PostSummonPhase);
 
     expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeUndefined();

--- a/test/abilities/shields-down.test.ts
+++ b/test/abilities/shields-down.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - SHIELDS DOWN", () => {
     expect(minior.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/speed-boost.test.ts
+++ b/test/abilities/speed-boost.test.ts
@@ -85,7 +85,7 @@ describe("Abilities - Speed Boost", () => {
   it("should not trigger this turn if pokemon was switched into combat via normal switch, but the turn after", async () => {
     await game.classicMode.startBattle([SpeciesId.SHUCKLE, SpeciesId.NINJASK]);
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
     const playerPokemon = game.scene.getPlayerPokemon()!;
     expect(playerPokemon.getStatStage(Stat.SPD)).toBe(0);

--- a/test/abilities/speed-boost.test.ts
+++ b/test/abilities/speed-boost.test.ts
@@ -50,7 +50,7 @@ describe("Abilities - Speed Boost", () => {
     await game.classicMode.startBattle([SpeciesId.SHUCKLE, SpeciesId.NINJASK]);
 
     game.move.select(MoveId.U_TURN);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
     const playerPokemon = game.scene.getPlayerPokemon()!;
     expect(playerPokemon.getStatStage(Stat.SPD)).toBe(0);
@@ -66,13 +66,13 @@ describe("Abilities - Speed Boost", () => {
     const [shuckle, ninjask] = game.scene.getPlayerParty();
 
     game.move.select(MoveId.U_TURN);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
     expect(game.scene.getPlayerPokemon()!).toBe(ninjask);
     expect(ninjask.getStatStage(Stat.SPD)).toBe(0);
 
     game.move.select(MoveId.U_TURN);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
     expect(game.scene.getPlayerPokemon()!).toBe(shuckle);
     expect(shuckle.getStatStage(Stat.SPD)).toBe(0);

--- a/test/abilities/suction-cups.test.ts
+++ b/test/abilities/suction-cups.test.ts
@@ -49,7 +49,7 @@ describe("Abilities - Suction Cups", () => {
 
     game.move.use(MoveId.SPLASH);
     await game.move.forceEnemyMove(MoveId.FALSE_SWIPE);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     expect(feebas.isOnField()).toBe(false);

--- a/test/abilities/sweet-veil.test.ts
+++ b/test/abilities/sweet-veil.test.ts
@@ -85,7 +85,7 @@ describe("Abilities - Sweet Veil", () => {
 
     // Turn 2: Switch into Swirlix with Sweet Veil
     game.move.use(MoveId.SPLASH);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
 
     await game.toEndOfTurn();
 

--- a/test/abilities/synchronize.test.ts
+++ b/test/abilities/synchronize.test.ts
@@ -76,7 +76,7 @@ describe("Abilities - Synchronize", () => {
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toEndOfTurn();
 
     expect(game.field.getPlayerPokemon().getStatusEffect(true)).toBe(StatusEffect.POISON);

--- a/test/abilities/unburden.test.ts
+++ b/test/abilities/unburden.test.ts
@@ -252,7 +252,7 @@ describe("Abilities - Unburden", () => {
     // Turn 2: Switch Meowth to Weezing, activating Neutralizing Gas
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.toEndOfTurn();
 
     expect(getHeldItemCount(treecko)).toBeLessThan(playerHeldItems);
@@ -261,7 +261,7 @@ describe("Abilities - Unburden", () => {
     // Turn 3: Switch Weezing to Meowth, deactivating Neutralizing Gas
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.toEndOfTurn();
 
     expect(getHeldItemCount(treecko)).toBeLessThan(playerHeldItems);
@@ -346,7 +346,7 @@ describe("Abilities - Unburden", () => {
     await game.toNextTurn();
 
     game.doRevivePokemon(1);
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
 

--- a/test/abilities/unburden.test.ts
+++ b/test/abilities/unburden.test.ts
@@ -345,7 +345,7 @@ describe("Abilities - Unburden", () => {
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
 
-    game.doRevivePokemon(1);
+    game.revivePokemon(1);
     game.switchPokemon(1);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();

--- a/test/abilities/unburden.test.ts
+++ b/test/abilities/unburden.test.ts
@@ -280,7 +280,7 @@ describe("Abilities - Unburden", () => {
 
     // Player uses Baton Pass, which also passes the Baton item
     game.move.select(MoveId.BATON_PASS);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     expect(getHeldItemCount(treecko)).toBe(0);
@@ -342,7 +342,7 @@ describe("Abilities - Unburden", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.move.selectEnemyMove(MoveId.THIEF);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     game.revivePokemon(1);
@@ -373,7 +373,7 @@ describe("Abilities - Unburden", () => {
     await game.move.selectEnemyMove(MoveId.THIEF, BattlerIndex.PLAYER);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2]);
-    game.doSelectPartyPokemon(0, "RevivalBlessingPhase");
+    game.selectPartyPokemon(0, "RevivalBlessingPhase");
     await game.toNextTurn();
 
     expect(game.scene.getPlayerField()[0]).toBe(treecko);

--- a/test/abilities/wimp-out.test.ts
+++ b/test/abilities/wimp-out.test.ts
@@ -73,7 +73,7 @@ describe("Abilities - Wimp Out", () => {
     const wimpod = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     expect(wimpod.hp).toEqual(Math.floor(wimpod.getMaxHp() * 0.33 + 1));
@@ -112,7 +112,7 @@ describe("Abilities - Wimp Out", () => {
     await game.classicMode.startBattle([SpeciesId.WIMPOD, SpeciesId.TYRUNT]);
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.toEndOfTurn();
 
@@ -127,7 +127,7 @@ describe("Abilities - Wimp Out", () => {
     await game.classicMode.startBattle([SpeciesId.WIMPOD, SpeciesId.TYRUNT]);
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -153,7 +153,7 @@ describe("Abilities - Wimp Out", () => {
     wimpod.hp *= 0.51;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.phaseInterceptor.to("SwitchSummonPhase", false);
 
     expect(wimpod.summonData.abilitiesApplied).not.toContain(AbilityId.WIMP_OUT);
@@ -168,7 +168,7 @@ describe("Abilities - Wimp Out", () => {
     await game.classicMode.startBattle([SpeciesId.WIMPOD, SpeciesId.TYRUNT]);
 
     game.move.select(MoveId.HEAD_SMASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     confirmSwitch();
@@ -214,7 +214,7 @@ describe("Abilities - Wimp Out", () => {
       wimpod.damageAndUpdate(toDmgValue(wimpod.getMaxHp() * 0.4));
 
       game.move.select(MoveId.DOUBLE_EDGE);
-      game.doSelectPartyPokemon(1);
+      game.selectPartyPokemon(1);
       await game.toEndOfTurn();
 
       expect(game.scene.getPlayerParty()[1].hp).toBeGreaterThan(
@@ -232,7 +232,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.51;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     confirmSwitch();
@@ -257,7 +257,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.51;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     confirmSwitch();
@@ -270,7 +270,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.52;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     confirmSwitch();
@@ -282,7 +282,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.52;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     confirmSwitch();
@@ -294,7 +294,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.52;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     confirmSwitch();
@@ -306,7 +306,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.7;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     confirmSwitch();
@@ -318,7 +318,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.55;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     confirmSwitch();
@@ -374,7 +374,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.51;
 
     game.move.select(MoveId.THUNDER_PUNCH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     confirmSwitch();
@@ -396,7 +396,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.65;
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     confirmSwitch();
@@ -408,7 +408,7 @@ describe("Abilities - Wimp Out", () => {
     vi.spyOn(allMoves.get(MoveId.SLUDGE_BOMB), "chance", "get").mockReturnValue(100);
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     expect(game.scene.getPlayerParty()[1].getStatusEffect(true)).toEqual(StatusEffect.POISON);
@@ -422,7 +422,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.51;
 
     game.move.select(MoveId.ENDURE);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -438,7 +438,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.51;
 
     game.move.select(MoveId.ENDURE);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -454,7 +454,7 @@ describe("Abilities - Wimp Out", () => {
     game.scene.getPlayerPokemon()!.hp *= 0.51;
 
     game.move.select(MoveId.ENDURE);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;

--- a/test/abilities/zen-mode.test.ts
+++ b/test/abilities/zen-mode.test.ts
@@ -98,7 +98,7 @@ describe("Abilities - ZEN MODE", () => {
     expect(darmanitan.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     expect(darmanitan.formIndex).toBe(baseForm);

--- a/test/abilities/zen-mode.test.ts
+++ b/test/abilities/zen-mode.test.ts
@@ -75,7 +75,7 @@ describe("Abilities - ZEN MODE", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintPokemon(darmanitan);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     expect(darmanitan.isFainted()).toBe(true);

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -96,7 +96,7 @@ describe("Abilities - ZERO TO HERO", () => {
     game.doSelectPartyPokemon(1);
     await game.toNextTurn();
 
-    game.doRevivePokemon(1);
+    game.revivePokemon(1);
     game.switchPokemon(1);
     await game.toNextTurn();
 

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -47,7 +47,7 @@ describe("Abilities - ZERO TO HERO", () => {
     expect(palafin2.isFainted()).toBe(true);
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to(TurnEndPhase);
     game.doSelectModifier();
     await game.phaseInterceptor.to(QuietFormChangePhase);

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -63,7 +63,7 @@ describe("Abilities - ZERO TO HERO", () => {
     const palafin = game.scene.getPlayerPokemon()!;
     expect(palafin.formIndex).toBe(baseForm);
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.phaseInterceptor.to(QuietFormChangePhase);
     expect(palafin.formIndex).toBe(heroForm);
   });
@@ -97,7 +97,7 @@ describe("Abilities - ZERO TO HERO", () => {
     await game.toNextTurn();
 
     game.doRevivePokemon(1);
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     expect(palafin.formIndex).toBe(heroForm);

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -76,7 +76,7 @@ describe("Abilities - ZERO TO HERO", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintPokemon(palafin);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
     expect(palafin.formIndex).toBe(baseForm);
   });
@@ -93,7 +93,7 @@ describe("Abilities - ZERO TO HERO", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintPokemon(palafin);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     game.revivePokemon(1);

--- a/test/arena/type-hazard.test.ts
+++ b/test/arena/type-hazard.test.ts
@@ -36,10 +36,10 @@ describe("Arena - Type Hazards", () => {
     game.move.select(MoveId.STEALTH_ROCK);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     const player = game.scene.getPlayerParty()[0];

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -332,7 +332,7 @@ describe("Test Battle Phase", () => {
     game.move.select(moveToUse);
 
     await game.phaseInterceptor.to("BattleEndPhase");
-    game.doRevivePokemon(0); // pretend max revive was picked
+    game.revivePokemon(0); // pretend max revive was picked
     game.doSelectModifier();
 
     game.onNextPrompt(

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -309,7 +309,7 @@ describe("Test Battle Phase", () => {
     game.move.select(moveToUse);
 
     vi.spyOn(game.scene.arena, "trySetWeather");
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
     expect(game.scene.arena.trySetWeather).not.toHaveBeenCalled();
     expect(game.scene.currentBattle.waveIndex).toBeGreaterThan(waveIndex);

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -58,7 +58,7 @@ describe("Double Battles", () => {
     game.doSelectModifier();
 
     const charizard = game.scene.getPlayerParty().findIndex((p) => p.species.speciesId === SpeciesId.CHARIZARD);
-    game.doRevivePokemon(charizard);
+    game.revivePokemon(charizard);
 
     await game.phaseInterceptor.to(TurnInitPhase);
     expect(game.scene.getPlayerField().filter((p) => !p.isFainted())).toHaveLength(2);

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -52,7 +52,7 @@ describe("Double Battles", () => {
       expect(pokemon.isFainted()).toBe(true);
     }
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     await game.phaseInterceptor.to(BattleEndPhase);
     game.doSelectModifier();
@@ -76,7 +76,7 @@ describe("Double Battles", () => {
     // Play through endless, waves 1 to 9, counting number of double battles from waves 2 to 9
     await game.rng.equalSample(DOUBLE_CHANCE, async () => {
       game.move.select(MoveId.SPLASH);
-      await game.doFaintOpponents();
+      await game.faintOpponents();
       await game.toNextWave();
 
       if (game.scene.getEnemyParty().length === 1) {

--- a/test/battle/reload.test.ts
+++ b/test/battle/reload.test.ts
@@ -57,7 +57,7 @@ describe("Reload", () => {
       // Input first option for Map
       game.scene.ui.getHandler().processInput(Button.ACTION);
     });
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
     expect(game.phaseInterceptor.log).toContain("NewBiomeEncounterPhase");
 
@@ -83,7 +83,7 @@ describe("Reload", () => {
 
     // Transition from Wave 10 to Wave 11 in order to trigger biome switch
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
     expect(game.phaseInterceptor.log).toContain("NewBiomeEncounterPhase");
 
@@ -167,7 +167,7 @@ describe("Reload", () => {
     game.move.use(MoveId.SPLASH);
     await game.toNextTurn();
     game.move.use(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     expect(game.field.getPlayerPokemon().getStatusEffect(true)).toBe(StatusEffect.TOXIC);

--- a/test/game-modes/daily-mode.test.ts
+++ b/test/game-modes/daily-mode.test.ts
@@ -74,7 +74,7 @@ describe("Shop modifications", async () => {
   it("should not have Eviolite and Mini Black Hole available in Classic if not unlocked", async () => {
     await game.classicMode.startBattle([SpeciesId.BULBASAUR]);
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to("BattleEndPhase");
     game.onNextPrompt("SelectModifierPhase", UiMode.MODIFIER_SELECT, () => {
       expect(game.scene.ui.getHandler()).toBeInstanceOf(ModifierSelectUiHandler);
@@ -85,7 +85,7 @@ describe("Shop modifications", async () => {
   it("should have Eviolite and Mini Black Hole available in Daily", async () => {
     await game.dailyMode.startBattle();
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to("BattleEndPhase");
     game.onNextPrompt("SelectModifierPhase", UiMode.MODIFIER_SELECT, () => {
       expect(game.scene.ui.getHandler()).toBeInstanceOf(ModifierSelectUiHandler);

--- a/test/items/dire-hit.test.ts
+++ b/test/items/dire-hit.test.ts
@@ -60,7 +60,7 @@ describe("Items - Dire Hit", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     await game.phaseInterceptor.to(BattleEndPhase);
 

--- a/test/items/double-battle-chance-booster.test.ts
+++ b/test/items/double-battle-chance-booster.test.ts
@@ -57,7 +57,7 @@ describe("Items - Double Battle Chance Boosters", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     await game.phaseInterceptor.to("BattleEndPhase");
 

--- a/test/items/multi-lens.test.ts
+++ b/test/items/multi-lens.test.ts
@@ -195,10 +195,10 @@ describe.todo("Items - Multi Lens", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.toNextTurn();
 
     // TODO: Update hit count to 1 once Future Sight is fixed to not activate held items if user is off the field

--- a/test/items/temp-stat-stage-booster.test.ts
+++ b/test/items/temp-stat-stage-booster.test.ts
@@ -125,7 +125,7 @@ describe("Items - Temporary Stat Stage Boosters", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     await game.phaseInterceptor.to("BattleEndPhase");
 

--- a/test/moves/baton-pass.test.ts
+++ b/test/moves/baton-pass.test.ts
@@ -48,7 +48,7 @@ describe("Moves - Baton Pass", () => {
 
     // round 2 - baton pass
     game.move.select(MoveId.BATON_PASS);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     // assert
@@ -99,7 +99,7 @@ describe("Moves - Baton Pass", () => {
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.phaseInterceptor.to("MoveEndPhase");
     expect(player1.findTag((t) => t.tagType === BattlerTagType.SALT_CURED)).toBeTruthy();
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     expect(player2.findTag((t) => t.tagType === BattlerTagType.SALT_CURED)).toBeUndefined();
@@ -123,7 +123,7 @@ describe("Moves - Baton Pass", () => {
     game.move.select(MoveId.BATON_PASS);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toNextTurn();
 
     expect(enemy.getTag(BattlerTagType.FIRE_SPIN)).toBeUndefined();

--- a/test/moves/chilly-reception.test.ts
+++ b/test/moves/chilly-reception.test.ts
@@ -48,7 +48,7 @@ describe("Moves - Chilly Reception", () => {
 
     await game.phaseInterceptor.to("TurnInitPhase", false);
     game.move.select(MoveId.CHILLY_RECEPTION);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.toEndOfTurn();
     expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
@@ -59,7 +59,7 @@ describe("Moves - Chilly Reception", () => {
     await game.classicMode.startBattle([SpeciesId.SLOWKING, SpeciesId.MEOWTH]);
 
     game.move.select(MoveId.CHILLY_RECEPTION);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.toEndOfTurn();
     expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);

--- a/test/moves/fairy-lock.test.ts
+++ b/test/moves/fairy-lock.test.ts
@@ -82,7 +82,7 @@ describe("Moves - Fairy Lock", () => {
     });
 
     game.move.select(MoveId.SPLASH);
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();

--- a/test/moves/fairy-lock.test.ts
+++ b/test/moves/fairy-lock.test.ts
@@ -108,9 +108,9 @@ describe("Moves - Fairy Lock", () => {
     game.move.select(MoveId.SPLASH);
     game.move.select(MoveId.SPLASH);
     await game.move.selectEnemyMove(MoveId.WHIRLWIND, 0);
-    game.doSelectPartyPokemon(2);
+    game.selectPartyPokemon(2);
     await game.move.selectEnemyMove(MoveId.WHIRLWIND, 1);
-    game.doSelectPartyPokemon(2);
+    game.selectPartyPokemon(2);
     await game.toEndOfTurn();
     await game.toNextTurn();
 
@@ -124,7 +124,7 @@ describe("Moves - Fairy Lock", () => {
 
     game.move.select(MoveId.FAIRY_LOCK);
     game.move.select(MoveId.MEMENTO, 1);
-    game.doSelectPartyPokemon(2);
+    game.selectPartyPokemon(2);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
@@ -151,7 +151,7 @@ describe("Moves - Fairy Lock", () => {
     game.move.use(MoveId.MEMENTO, 1, BattlerIndex.PLAYER);
     await game.move.selectEnemyMove(MoveId.MEMENTO, BattlerIndex.PLAYER);
     await game.move.selectEnemyMove(MoveId.MEMENTO, BattlerIndex.PLAYER);
-    game.doSelectPartyPokemon(2);
+    game.selectPartyPokemon(2);
     game.setTurnOrder([BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER]);
 
     // Allow all 3 targets to use Memento

--- a/test/moves/fake-out.test.ts
+++ b/test/moves/fake-out.test.ts
@@ -126,7 +126,7 @@ describe("Moves - Fake Out", () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.MAGIKARP]);
 
     game.move.select(moveId);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.toNextTurn();
 
@@ -151,7 +151,7 @@ describe("Moves - Fake Out", () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.SPLASH);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.toNextTurn();
 

--- a/test/moves/fake-out.test.ts
+++ b/test/moves/fake-out.test.ts
@@ -103,10 +103,10 @@ describe("Moves - Fake Out", () => {
     expect(enemy2.hp).toBeLessThan(enemy2.getMaxHp());
     enemy2.hp = enemy2.getMaxHp();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     game.move.select(MoveId.FAKE_OUT);

--- a/test/moves/fake-out.test.ts
+++ b/test/moves/fake-out.test.ts
@@ -92,7 +92,7 @@ describe("Moves - Fake Out", () => {
 
     expect(enemy1.hp).toBeLessThan(enemy1.getMaxHp());
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     game.move.select(MoveId.FAKE_OUT);

--- a/test/moves/future-sight.test.ts
+++ b/test/moves/future-sight.test.ts
@@ -69,7 +69,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     await passTurns(1);
@@ -216,7 +216,7 @@ describe("Moves - Future Sight", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
 
@@ -238,7 +238,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     game.move.select(MoveId.SPLASH);

--- a/test/moves/geomancy.test.ts
+++ b/test/moves/geomancy.test.ts
@@ -64,7 +64,7 @@ describe("Moves - Geomancy", () => {
     game.move.select(MoveId.GEOMANCY);
 
     await game.phaseInterceptor.to("MoveEndPhase", false);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     await game.toNextWave();
 

--- a/test/moves/gigaton-hammer.test.ts
+++ b/test/moves/gigaton-hammer.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Gigaton Hammer", () => {
 
     expect(enemy1.hp).toBeLessThan(enemy1.getMaxHp());
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     game.move.select(MoveId.GIGATON_HAMMER);
@@ -66,7 +66,7 @@ describe("Moves - Gigaton Hammer", () => {
 
     expect(enemy1.hp).toBeLessThan(enemy1.getMaxHp());
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     game.move.select(MoveId.GIGATON_HAMMER);

--- a/test/moves/glaive-rush.test.ts
+++ b/test/moves/glaive-rush.test.ts
@@ -123,9 +123,9 @@ describe("Moves - Glaive Rush", () => {
     await game.toEndOfTurn();
     expect(player.hp).toBe(player.getMaxHp());
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toEndOfTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toEndOfTurn();
     expect(player.hp).toBe(player.getMaxHp());
   });

--- a/test/moves/gmax-chi-strike.test.ts
+++ b/test/moves/gmax-chi-strike.test.ts
@@ -108,7 +108,7 @@ describe("Moves - G-Max Chi Strike grants a stackable crit boost", () => {
     await game.toNextTurn();
 
     game.move.select(MoveId.BATON_PASS);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     game.move.select(MoveId.G_MAX_CHI_STRIKE);

--- a/test/moves/imprison.test.ts
+++ b/test/moves/imprison.test.ts
@@ -131,7 +131,7 @@ describe("Moves - Imprison", () => {
     await game.move.selectEnemyMove(MoveId.IMPRISON);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
 

--- a/test/moves/jaw-lock.test.ts
+++ b/test/moves/jaw-lock.test.ts
@@ -101,7 +101,7 @@ describe("Moves - Jaw Lock", () => {
 
     await game.phaseInterceptor.to(TurnEndPhase);
 
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
   });

--- a/test/moves/lunar-dance.test.ts
+++ b/test/moves/lunar-dance.test.ts
@@ -48,7 +48,7 @@ describe("Moves - Lunar Dance", () => {
     expect(bulbasaur.hp).toBeLessThan(bulbasaur.getMaxHp());
 
     // Switch out Bulbasaur for Rattata so we can swtich bulbasaur back in with lunar dance
-    game.doSwitchPokemon(2);
+    game.switchPokemon(2);
     game.move.select(MoveId.SPLASH, 1);
     await game.phaseInterceptor.to(CommandPhase);
     await game.toNextTurn();

--- a/test/moves/lunar-dance.test.ts
+++ b/test/moves/lunar-dance.test.ts
@@ -55,7 +55,7 @@ describe("Moves - Lunar Dance", () => {
 
     game.move.select(MoveId.SPLASH, 0);
     game.move.select(MoveId.LUNAR_DANCE);
-    game.doSelectPartyPokemon(2);
+    game.selectPartyPokemon(2);
     await game.phaseInterceptor.to("SwitchPhase", false);
     await game.toNextTurn();
 

--- a/test/moves/parting-shot.test.ts
+++ b/test/moves/parting-shot.test.ts
@@ -74,19 +74,19 @@ describe("Moves - Parting Shot", () => {
       game.move.select(MoveId.MEMENTO);
       await game.phaseInterceptor.to(FaintPhase);
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      game.doSelectPartyPokemon(1);
+      game.selectPartyPokemon(1);
 
       await game.phaseInterceptor.to(TurnInitPhase, false);
       game.move.select(MoveId.MEMENTO);
       await game.phaseInterceptor.to(FaintPhase);
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      game.doSelectPartyPokemon(2);
+      game.selectPartyPokemon(2);
 
       await game.phaseInterceptor.to(TurnInitPhase, false);
       game.move.select(MoveId.MEMENTO);
       await game.phaseInterceptor.to(FaintPhase);
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      game.doSelectPartyPokemon(3);
+      game.selectPartyPokemon(3);
 
       // set up done
       await game.phaseInterceptor.to(TurnInitPhase, false);
@@ -173,7 +173,7 @@ describe("Moves - Parting Shot", () => {
       await game.faintPokemon(game.scene.getPlayerParty()[0]);
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
       await game.phaseInterceptor.run(MessagePhase);
-      game.doSelectPartyPokemon(1);
+      game.selectPartyPokemon(1);
 
       await game.phaseInterceptor.to(TurnInitPhase, false);
       game.move.select(MoveId.PARTING_SHOT);

--- a/test/moves/power-trick.test.ts
+++ b/test/moves/power-trick.test.ts
@@ -78,7 +78,7 @@ describe("Moves - Power Trick", () => {
     player.addTag(BattlerTagType.POWER_TRICK);
 
     game.move.select(MoveId.BATON_PASS);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.phaseInterceptor.to(TurnEndPhase);
 

--- a/test/moves/relic-song.test.ts
+++ b/test/moves/relic-song.test.ts
@@ -69,7 +69,7 @@ describe("Moves - Relic Song", () => {
     const meloetta = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     expect(meloetta.formIndex).toBe(1);

--- a/test/moves/retaliate.test.ts
+++ b/test/moves/retaliate.test.ts
@@ -39,7 +39,7 @@ describe("Moves - Retaliate", () => {
     game.move.select(MoveId.RETALIATE);
     await game.toEndOfTurn();
     expect(retaliate.calculateBattlePower).toHaveLastReturnedWith(70);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.toNextTurn();
     game.move.select(MoveId.RETALIATE);

--- a/test/moves/revival-blessing.test.ts
+++ b/test/moves/revival-blessing.test.ts
@@ -39,7 +39,7 @@ describe("Moves - Revival Blessing", () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.MEMENTO);
-    game.doSelectPartyPokemon(1, "SwitchPhase");
+    game.selectPartyPokemon(1, "SwitchPhase");
     await game.toNextTurn();
 
     const player = game.scene.getPlayerPokemon()!;
@@ -48,7 +48,7 @@ describe("Moves - Revival Blessing", () => {
     game.move.select(MoveId.REVIVAL_BLESSING);
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    game.doSelectPartyPokemon(1, "RevivalBlessingPhase");
+    game.selectPartyPokemon(1, "RevivalBlessingPhase");
 
     await game.phaseInterceptor.to("MoveEndPhase", false);
 
@@ -109,7 +109,7 @@ describe("Moves - Revival Blessing", () => {
 
     expect(feebas.isFainted()).toBe(true);
 
-    game.doSelectPartyPokemon(0, "RevivalBlessingPhase");
+    game.selectPartyPokemon(0, "RevivalBlessingPhase");
     await game.toNextTurn();
 
     expect(feebas.isFainted()).toBe(false);

--- a/test/moves/shed-tail.test.ts
+++ b/test/moves/shed-tail.test.ts
@@ -38,7 +38,7 @@ describe("Moves - Shed Tail", () => {
     const magikarp = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.SHED_TAIL);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
 
     await game.toEndOfTurn();
 

--- a/test/moves/sky-drop.test.ts
+++ b/test/moves/sky-drop.test.ts
@@ -373,7 +373,7 @@ describe("Moves - Sky Drop", () => {
 
     [tatsugiri, enemy1].forEach((p) => expect(p.getTag(BattlerTagType.SKY_DROP)).toBeDefined());
 
-    game.doSelectPartyPokemon(2, "SwitchPhase");
+    game.selectPartyPokemon(2, "SwitchPhase");
     await game.phaseInterceptor.to("MoveEndPhase");
 
     [tatsugiri, enemy1].forEach((p) => expect(p.getTag(BattlerTagType.SKY_DROP)).toBeUndefined());

--- a/test/moves/spikes.test.ts
+++ b/test/moves/spikes.test.ts
@@ -39,10 +39,10 @@ describe("Moves - Spikes", () => {
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     const player = game.scene.getPlayerParty()[0];

--- a/test/moves/syrup-bomb.test.ts
+++ b/test/moves/syrup-bomb.test.ts
@@ -84,7 +84,7 @@ describe("Moves - SYRUP BOMB", () => {
     await game.move.forceHit();
     await game.toNextTurn();
 
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     expect(game.scene.getEnemyPokemon()!.getStatStage(Stat.SPD)).toBe(-1);

--- a/test/moves/toxic-spikes.test.ts
+++ b/test/moves/toxic-spikes.test.ts
@@ -45,7 +45,7 @@ describe("Moves - Toxic Spikes", () => {
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
 
     expect(enemy.hp).toBe(enemy.getMaxHp());
@@ -92,9 +92,9 @@ describe("Moves - Toxic Spikes", () => {
     // that set them up is the one switching in
     game.move.select(MoveId.COURT_CHANGE);
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
-    game.doSwitchPokemon(1);
+    game.switchPokemon(1);
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();

--- a/test/moves/toxic-spikes.test.ts
+++ b/test/moves/toxic-spikes.test.ts
@@ -125,7 +125,7 @@ describe("Moves - Toxic Spikes", () => {
     game.move.select(MoveId.TOXIC_SPIKES);
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     await game.reload.reloadSession();

--- a/test/moves/u-turn.test.ts
+++ b/test/moves/u-turn.test.ts
@@ -41,7 +41,7 @@ describe("Moves - U-turn", () => {
 
     // act
     game.move.select(MoveId.U_TURN);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
 
     // assert
@@ -59,7 +59,7 @@ describe("Moves - U-turn", () => {
 
     // act
     game.move.select(MoveId.U_TURN);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.phaseInterceptor.to("SwitchPhase", false);
 
     // assert
@@ -95,7 +95,7 @@ describe("Moves - U-turn", () => {
 
     // KO the opponent with U-Turn
     game.move.select(MoveId.U_TURN);
-    game.doSelectPartyPokemon(1);
+    game.selectPartyPokemon(1);
     await game.toEndOfTurn();
     expect(enemy.isFainted()).toBe(true);
 

--- a/test/phases/evolution-phase.test.ts
+++ b/test/phases/evolution-phase.test.ts
@@ -45,7 +45,7 @@ describe("Evolution Phase", () => {
     vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([]); // Do not attempt to learn level-up moves
 
     game.move.use(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     expect(pokemon.level).toBeGreaterThan(32);
@@ -70,7 +70,7 @@ describe("Evolution Phase", () => {
     });
 
     game.move.use(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     // Repeatedly press "Cancel" to cancel evolution and say "No" to pausing evolutions
     const pressCancelInterval = setInterval(() => game.scene.ui.processInput(Button.CANCEL));
@@ -94,7 +94,7 @@ describe("Evolution Phase", () => {
     vi.spyOn(pokemon, "getLevelMoves").mockReturnValue([]); // Do not attempt to learn level-up moves
 
     game.move.use(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to("EvolutionPhase", false);
 
     // Cancel the evolution
@@ -111,7 +111,7 @@ describe("Evolution Phase", () => {
     expect(pokemon.calculateBaseStats()).toStrictEqual([45, 49, 49, 65, 65, 45]);
 
     game.move.use(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.toNextWave();
 
     // Should not have a second EvolutionPhase after pausing

--- a/test/phases/form-change-phase.test.ts
+++ b/test/phases/form-change-phase.test.ts
@@ -142,7 +142,7 @@ describe("Form Change Phase", () => {
     expect(rillaboom.getFormKey()).toBe("gigantamax");
 
     game.move.use(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to("SelectModifierPhase");
 
     // Navigate UI: Access "Check Party" menu from modifier selection

--- a/test/phases/learn-move-phase.test.ts
+++ b/test/phases/learn-move-phase.test.ts
@@ -30,7 +30,7 @@ describe("Learn Move Phase", () => {
     const pokemon = game.scene.getPlayerPokemon()!;
     const newMovePos = pokemon?.getMoveset().length;
     game.move.select(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
     await game.phaseInterceptor.to(LearnMovePhase);
     const levelMove = pokemon.getLevelMoves(5)[0];
     const levelReq = levelMove[0];

--- a/test/pokemon/evolution.test.ts
+++ b/test/pokemon/evolution.test.ts
@@ -201,7 +201,7 @@ describe("Evolution", () => {
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
     game.move.use(MoveId.SPLASH);
-    await game.doFaintOpponents();
+    await game.faintOpponents();
 
     // Mock the next wave's Pokemon pool
     vi.spyOn(game.scene.arena as any, "pokemonPool", "get").mockReturnValue({

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -474,20 +474,20 @@ export class GameManager {
    * Command an in-battle switch to another Pokemon via the main battle menu.
    * @param pokemonIndex - The index of the pokemon in your party to switch to
    */
-  switchPokemon(pokemonIndex: number) {
+  switchPokemon(pokemonIndex: number): void {
     this.onNextPrompt("CommandPhase", UiMode.COMMAND, () => {
       (this.scene.ui.getHandler() as CommandUiHandler).setCursor(2);
       (this.scene.ui.getHandler() as CommandUiHandler).processInput(Button.ACTION);
     });
 
-    this.doSelectPartyPokemon(pokemonIndex, "CommandPhase");
+    this.selectPartyPokemon(pokemonIndex, "CommandPhase");
   }
 
   /**
    * Revive pokemon, currently players only.
    * @param pokemonIndex - The index of the pokemon in your party to revive
    */
-  revivePokemon(pokemonIndex: number) {
+  revivePokemon(pokemonIndex: number): void {
     const party = this.scene.getPlayerParty();
     const candidate = new ModifierTypeOption(modifierTypes.MAX_REVIVE(), 0);
     const modifier = candidate.type!.newModifier(party[pokemonIndex]);
@@ -499,11 +499,11 @@ export class GameManager {
    * of the party UI, where you just need to navigate to a party slot and press
    * Action twice - navigating any menus that come up after you select a party member
    * is not supported.
-   * @param slot the index of the pokemon in your party to switch to
-   * @param inPhase Which phase to expect the selection to occur in. Typically
-   * non-command switch actions happen in SwitchPhase.
+   * @param slot - The index of the pokemon in your party to switch to
+   * @param inPhase - (Default `"SwitchPhase"`) Which phase to expect the selection to occur in.
+   *   Typically non-command switch actions happen in `SwitchPhase`.
    */
-  doSelectPartyPokemon(slot: number, inPhase = "SwitchPhase") {
+  selectPartyPokemon(slot: number, inPhase = "SwitchPhase"): void {
     this.onNextPrompt(inPhase, UiMode.PARTY, () => {
       const partyHandler = this.scene.ui.getHandler() as PartyUiHandler;
 

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -472,9 +472,9 @@ export class GameManager {
 
   /**
    * Command an in-battle switch to another Pokemon via the main battle menu.
-   * @param pokemonIndex the index of the pokemon in your party to switch to
+   * @param pokemonIndex - The index of the pokemon in your party to switch to
    */
-  doSwitchPokemon(pokemonIndex: number) {
+  switchPokemon(pokemonIndex: number) {
     this.onNextPrompt("CommandPhase", UiMode.COMMAND, () => {
       (this.scene.ui.getHandler() as CommandUiHandler).setCursor(2);
       (this.scene.ui.getHandler() as CommandUiHandler).processInput(Button.ACTION);

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -485,9 +485,9 @@ export class GameManager {
 
   /**
    * Revive pokemon, currently players only.
-   * @param pokemonIndex the index of the pokemon in your party to revive
+   * @param pokemonIndex - The index of the pokemon in your party to revive
    */
-  doRevivePokemon(pokemonIndex: number) {
+  revivePokemon(pokemonIndex: number) {
     const party = this.scene.getPlayerParty();
     const candidate = new ModifierTypeOption(modifierTypes.MAX_REVIVE(), 0);
     const modifier = candidate.type!.newModifier(party[pokemonIndex]);

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -318,7 +318,7 @@ export class GameManager {
   }
 
   /** Faint all opponents currently on the field */
-  async doFaintOpponents() {
+  async faintOpponents() {
     await this.faintPokemon(this.scene.currentBattle.enemyParty[0]);
     if (this.scene.currentBattle.double) {
       await this.faintPokemon(this.scene.currentBattle.enemyParty[1]);

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -455,16 +455,15 @@ export class GameManager {
 
   /**
    * Faints the given Pokemon.
-   * @param pokemon The {@linkcode Pokemon} to faint
    * @returns A promise that resolves when the Pokemon is fainted
    * @example
-   *    const enemyPkm = gameManager.field.getEnemyPokemon;
-   *    game.move.select(MoveId.SPLASH);
-   *    await gameManager.faintPokemon(enemyPkm);
+   * const enemyPkmn = game.field.getEnemyPokemon();
+   * game.move.select(MoveId.SPLASH);
+   * await game.faintPokemon(enemyPkmn);
    */
-  async faintPokemon(pokemon: PlayerPokemon | EnemyPokemon) {
+  async faintPokemon(pokemon: PlayerPokemon | EnemyPokemon): Promise<void> {
     return new Promise<void>(async (resolve, reject) => {
-      pokemon.hp = 0;
+      pokemon.faint();
       this.scene.phaseManager.pushPhase(new FaintPhase(pokemon.getBattlerIndex(), true));
       await this.phaseInterceptor.to("FaintPhase").catch((e) => reject(e));
       resolve();

--- a/test/ui/battle-info.test.ts
+++ b/test/ui/battle-info.test.ts
@@ -46,7 +46,7 @@ describe("UI - Battle Info", () => {
       await game.classicMode.startBattle([SpeciesId.CHARIZARD]);
 
       game.move.select(MoveId.SPLASH);
-      await game.doFaintOpponents();
+      await game.faintOpponents();
       await game.phaseInterceptor.to(ExpPhase, true);
 
       expect(Math.pow).not.toHaveBeenCalledWith(2, expGainsSpeed);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Standardize/simplify method naming.

## What are the changes from a developer perspective?
- `doFaintOpponents` renamed to `faintOpponents`
- `doSwitchPokemon` renamed to `switchPokemon`
- `doRevivePokemon` renamed to `revivePokemon`
- `doSelectPartyPokemon` renamed to `selectPartyPokemon`
- Minor TSDocs updates for some of the functions

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?