### PR TITLE
[Bug][UI/UX] Fix visual misalignment in enemy hp bar and type icons

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -55,7 +55,7 @@ export const game = new Phaser.Game({
   dom: {
     createContainer: true,
   },
-  pixelArt: true,
+  antialias: false,
   pipeline: [InvertPostFX] as unknown as Phaser.Types.Core.PipelineConfig,
   scene: [LoadingScene, BattleScene],
   version: pkg.version,


### PR DESCRIPTION
## What are the changes the user will see?
The hp and type icon on enemies will now be properly aligned instead of having a gap.


## Why am I making these changes?
This fixes a visual bug introduced by updating phaser in ##975 where the hp bar and type icons were visually misaligned.


## What are the changes from a developer perspective?

Removed `pixelArt: true` from `src/game.ts` and replaced it with `antiAlias: false`.
The bug happened due to the way sub-pixel rendering changed in phaser v3.85. There is more information here: https://github.com/phaserjs/phaser/discussions/6873.

Setting `pixelArt: true` is equivalent to setting `antiAlias: false` and `roundPixels: true`. However, we actually _don't_ want to round pixels, as we are relying on sub-pixel rendering to properly display hp bars. This is actually perfectly fine, as it is always supported by openGL.
I believe the reason it worked before was because the `roundPixels` setting worked differently for different sorts of objects beforehand.

## Screenshots/Videos
<details><Summary>Before</summary>

![image](https://github.com/user-attachments/assets/5dfe14d5-b7c5-40f1-b846-7d4bbbda7119)
</details>

<details><summary>After</summary>

![image](https://github.com/user-attachments/assets/f36029c1-ee46-48b1-b60c-280e6d0b3566)
</details>


## How to test the changes?
Just spin up a new game and look at the enemy hp bar.

## Checklist

- ~~[ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?~~
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - ~~[ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?~~
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- ~~[ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?~~
  - ~~[ ] If so, please leave a link to it here:~~
- ~~[ ] Have I added the `Localization` tag to this PR?~~

#### If there are no locale changes:
- [x] Have I made sure **not** to commit any changes to the locale repo on this branch?
