### PR TITLE
[Dev] Add `ban-ts-comment` TypeScript-ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,7 @@ const eslintRules = {
   "no-multiple-empty-lines": ["error", { max: 2, maxEOF: 1, maxBOF: 0 }], // Disallows multiple empty lines
   "@typescript-eslint/consistent-type-imports": "error", // Enforces type-only imports wherever possible
   "@typescript-eslint/no-import-type-side-effects": "error", // Typescript turns `import { type X } from Y` into `import {} from Y` but completely removes `import type { X } from Y`
+  "@typescript-eslint/ban-ts-comment": ["error", { "ts-check": false, "ts-expect-error": "allow-with-description" }], // Disallow usage of `@ts-ignore`
 };
 
 export default [

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -469,7 +469,7 @@ export default class BattleScene extends SceneBase {
       true,
     );
 
-    //@ts-ignore (the defined types in the package are incromplete...)
+    // @ts-expect-error - the defined types in the package are incomplete (TODO: fix this?)
     transition.transit({
       mode: "blinds",
       ease: "Cubic.easeInOut",
@@ -1101,8 +1101,8 @@ export default class BattleScene extends SceneBase {
       this.field.remove(this.currentBattle.mysteryEncounter?.introVisuals, true);
     }
 
-    //@ts-ignore  - allowing `null` for currentBattle causes a lot of trouble
-    this.currentBattle = null; // TODO: resolve ts-ignore
+    // @ts-expect-error - allowing `null` for currentBattle causes a lot of trouble
+    this.currentBattle = null; // TODO: refactor so this is gone
 
     // Reset RNG after end of game or save & quit.
     // This needs to happen after clearing this.currentBattle or the seed will be affected by the last wave played

--- a/src/data/data-lists.ts
+++ b/src/data/data-lists.ts
@@ -14,5 +14,5 @@ export const allSpecies: PokemonSpecies[] = [];
 // @ts-expect-error - this forcibly overrides `Map`'s `get` function to not type hint a return of `undefined`
 export const allMoves: DataMap<MoveId, Move> = new Map<MoveId, Move>();
 export const allAbilities: Ability[] = [];
-// @ts-expect-error
+// @ts-expect-error - this forcibly overrides `Map`'s `get` function to not type hint a return of `undefined`
 export const allBiomes: DataMap<BiomeId, Biome> = new Map<BiomeId, Biome>();

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -132,7 +132,7 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
     );
     clownConfig.setPartyTemplates(clownPartyTemplate);
     clownConfig.setDoubleOnly();
-    // @ts-ignore
+    // @ts-expect-error - TODO: change the type of `partyTemplateFunc` or change this `null` assignment
     clownConfig.partyTemplateFunc = null; // Overrides party template func if it exists
 
     // Generate random ability for Blacephalon from pool

--- a/src/data/mystery-encounters/encounters/mysterious-challengers-encounter.ts
+++ b/src/data/mystery-encounters/encounters/mysterious-challengers-encounter.ts
@@ -89,7 +89,7 @@ export const MysteriousChallengersEncounter: MysteryEncounter = MysteryEncounter
     const brutalConfig = allTrainerConfigs[brutalTrainerType].clone();
     brutalConfig.title = allTrainerConfigs[brutalTrainerType].title;
     brutalConfig.setPartyTemplates(e4Template);
-    // @ts-ignore
+    // @ts-expect-error - TODO: change the type of `partyTemplateFunc` or change this `null` assignment
     brutalConfig.partyTemplateFunc = null; // Overrides gym leader party template func
     female = false;
     if (brutalConfig.hasGenders) {

--- a/src/touch-controls.ts
+++ b/src/touch-controls.ts
@@ -1,8 +1,8 @@
 import { globalScene } from "#app/global-scene";
 import { Button } from "#enums/buttons";
-import EventEmitter = Phaser.Events.EventEmitter;
 import { hasTouchscreen } from "./utils";
 import { settings } from "./system/settings/settings-manager";
+import EventEmitter = Phaser.Events.EventEmitter;
 
 const repeatInputDelayMillis = 250;
 
@@ -44,7 +44,7 @@ export default class TouchControl {
     document.querySelectorAll(".apad-button").forEach((element) => this.preventElementZoom(element as HTMLElement));
     // Select all elements with the 'data-key' attribute and bind keys to them
     for (const button of document.querySelectorAll("[data-key]")) {
-      // @ts-ignore - Bind the key to the button using the dataset key
+      // @ts-expect-error - Bind the key to the button using the dataset key
       this.bindKey(button, button.dataset.key);
     }
   }

--- a/test/sprites/pokemon-sprite.test.ts
+++ b/test/sprites/pokemon-sprite.test.ts
@@ -23,10 +23,10 @@ describe("check if every variant's sprite are correctly set", () => {
     masterlist = deepCopy(_masterlist);
     femaleVariant = masterlist.female;
     backVariant = masterlist.back;
-    //@ts-ignore
-    delete masterlist.female; //TODO: resolve ts-ignore
-    //@ts-ignore
-    delete masterlist.back; //TODO: resolve ts-ignore
+    // @ts-expect-error - TODO: remove this?
+    delete masterlist.female;
+    // @ts-expect-error - TODO: remove this?
+    delete masterlist.back;
   });
 
   it("data should not be undefined", () => {

--- a/test/test-utils/gameWrapper.ts
+++ b/test/test-utils/gameWrapper.ts
@@ -97,7 +97,7 @@ export class GameWrapper {
   }
 
   injectMandatory() {
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.game.config = {
       seed: ["test"],
       gameVersion: version,
@@ -120,7 +120,7 @@ export class GameWrapper {
 
     this.scene.sound = {
       play: () => null as any,
-      // @ts-ignore
+      // @ts-expect-error - the test framework intentionally mocks out functionality
       pause: () => null,
       setRate: () => null as any,
       add: () => this.scene.sound as any,
@@ -172,15 +172,15 @@ export class GameWrapper {
     this.scene.scale = this.game.scale;
     this.scene.textures = this.game.textures;
     this.scene.events = this.game.events;
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.manager = new InputManager(this.game, {});
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.manager.keyboard = new KeyboardManager(this.scene);
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.pluginEvents = new EventEmitter();
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.domContainer = {} as HTMLDivElement;
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.spritePipeline = {};
     this.scene.fieldSpritePipeline = {} as any;
     this.scene.load = new MockLoader(this.scene) as any;
@@ -194,7 +194,6 @@ export class GameWrapper {
             // this.frame in Text.js
             source: {} as any,
             setSize: () => null as any,
-            // @ts-ignore
             glTexture: () => ({
               spectorMetadata: {},
             }),
@@ -218,10 +217,10 @@ export class GameWrapper {
     const mockTextureManager = new MockTextureManager(this.scene);
     this.scene.add = mockTextureManager.add;
     this.scene.textures = mockTextureManager as any;
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.sys.displayList = this.scene.add.displayList;
     this.scene.sys.updateList = new UpdateList(this.scene);
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.systems = this.scene.sys;
     this.scene.input = this.game.input as any;
     this.scene.scene = this.scene as any;
@@ -245,7 +244,7 @@ export class GameWrapper {
     };
     this.scene.make = new MockGameObjectCreator(mockTextureManager) as any;
     this.scene.time = new MockClock(this.scene);
-    // @ts-ignore
+    // @ts-expect-error - the test framework intentionally mocks out functionality
     this.scene.remove = vi.fn();
 
     Pokemon.prototype.updateInfo = async () => {};

--- a/test/test-utils/inputsHandler.ts
+++ b/test/test-utils/inputsHandler.ts
@@ -90,8 +90,8 @@ class Fakepad extends Phaser.Input.Gamepad.Gamepad {
   public override index: number;
 
   constructor(pad) {
-    //@ts-ignore
-    super(undefined, { ...pad, buttons: pad.deviceMapping, axes: [] }); //TODO: resolve ts-ignore
+    // @ts-expect-error - TODO: fix this?
+    super(undefined, { ...pad, buttons: pad.deviceMapping, axes: [] });
     this.id = "xbox_360_fakepad";
     this.index = 0;
   }

--- a/test/test-utils/mocks/mocksContainer/mockSprite.ts
+++ b/test/test-utils/mocks/mocksContainer/mockSprite.ts
@@ -17,9 +17,9 @@ export class MockSprite implements MockGameObject {
   constructor(textureManager, x, y, texture) {
     this.textureManager = textureManager;
     this.scene = textureManager.scene;
-    // @ts-ignore
+    // @ts-expect-error - the test framework mocks out most UI elements
     Phaser.GameObjects.Sprite.prototype.setInteractive = this.setInteractive;
-    // @ts-ignore
+    // @ts-expect-error - the test framework mocks out most UI elements
     Phaser.GameObjects.Sprite.prototype.setTexture = this.setTexture;
     Phaser.GameObjects.Sprite.prototype.setSizeToFrame = this.setSizeToFrame;
     Phaser.GameObjects.Sprite.prototype.setFrame = this.setFrame;


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
`@ts-expect-error` should be used instead of `@ts-ignore`.

## What are the changes from a developer perspective?
Added ESLint rule `@typescript-eslint/ban-ts-comment` to disallow usage of `@ts-ignore`.
Uses of `@ts-expect-error` are also required to have a comment explaining their purpose now (min length 3).

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?