### PR TITLE
[Refactor] Consolidate arena tag functions

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -210,7 +210,7 @@ export default class Battle {
     const moneyAmount = new NumberHolder(globalScene.currentBattle.moneyScattered);
     globalScene.applyModifiers(MoneyMultiplierModifier, true, moneyAmount);
 
-    if (globalScene.arena.findTag(ArenaTagType.HAPPY_HOUR)) {
+    if (globalScene.arena.hasTag(ArenaTagType.HAPPY_HOUR)) {
       moneyAmount.value *= 2;
     }
 

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -210,7 +210,7 @@ export default class Battle {
     const moneyAmount = new NumberHolder(globalScene.currentBattle.moneyScattered);
     globalScene.applyModifiers(MoneyMultiplierModifier, true, moneyAmount);
 
-    if (globalScene.arena.getTag(ArenaTagType.HAPPY_HOUR)) {
+    if (globalScene.arena.findTag(ArenaTagType.HAPPY_HOUR)) {
       moneyAmount.value *= 2;
     }
 

--- a/src/data/abilities/ab-attrs/post-defend-apply-entry-hazard-tag-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-apply-entry-hazard-tag-ab-attr.ts
@@ -18,15 +18,18 @@ export class PostDefendApplyEntryHazardTagAbAttr extends PostDefendAbAttr {
   }
 
   override apply(pokemon: Pokemon, simulated: boolean, attacker: Pokemon, move: Move): boolean {
-    if (this.condition(pokemon, attacker, move)) {
-      const tag = globalScene.arena.findTag(this.tagType) as EntryHazardTag;
-      if (!globalScene.arena.findTag(this.tagType) || tag.layers < tag.maxLayers) {
-        if (!simulated) {
-          globalScene.arena.addTag(this.tagType, pokemon.id, undefined, undefined, pokemon.getOpposingArenaTagSide());
-        }
-        return true;
-      }
+    if (!this.condition(pokemon, attacker, move)) {
+      return false;
     }
+
+    const tag = globalScene.arena.findTag<EntryHazardTag>(this.tagType);
+    if (!tag || tag.layers < tag.maxLayers) {
+      if (!simulated) {
+        globalScene.arena.addTag(this.tagType, pokemon.id, undefined, undefined, pokemon.getOpposingArenaTagSide());
+      }
+      return true;
+    }
+
     return false;
   }
 }

--- a/src/data/abilities/ab-attrs/post-defend-apply-entry-hazard-tag-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-apply-entry-hazard-tag-ab-attr.ts
@@ -19,8 +19,8 @@ export class PostDefendApplyEntryHazardTagAbAttr extends PostDefendAbAttr {
 
   override apply(pokemon: Pokemon, simulated: boolean, attacker: Pokemon, move: Move): boolean {
     if (this.condition(pokemon, attacker, move)) {
-      const tag = globalScene.arena.getTag(this.tagType) as EntryHazardTag;
-      if (!globalScene.arena.getTag(this.tagType) || tag.layers < tag.maxLayers) {
+      const tag = globalScene.arena.findTag(this.tagType) as EntryHazardTag;
+      if (!globalScene.arena.findTag(this.tagType) || tag.layers < tag.maxLayers) {
         if (!simulated) {
           globalScene.arena.addTag(this.tagType, pokemon.id, undefined, undefined, pokemon.getOpposingArenaTagSide());
         }

--- a/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
@@ -28,7 +28,7 @@ export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageC
   }
 
   override apply(pokemon: Pokemon, simulated: boolean): boolean {
-    if (globalScene.arena.findTag(this.tagType, pokemon.getArenaTagSide())) {
+    if (globalScene.arena.hasTag(this.tagType, pokemon.getArenaTagSide())) {
       return super.apply(pokemon, simulated);
     }
     return false;

--- a/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
@@ -28,7 +28,7 @@ export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageC
   }
 
   override apply(pokemon: Pokemon, simulated: boolean): boolean {
-    if (globalScene.arena.getTag(this.tagType, pokemon.getArenaTagSide())) {
+    if (globalScene.arena.findTag(this.tagType, pokemon.getArenaTagSide())) {
       return super.apply(pokemon, simulated);
     }
     return false;

--- a/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
@@ -28,7 +28,7 @@ export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageC
   }
 
   override apply(pokemon: Pokemon, simulated: boolean): boolean {
-    if (globalScene.arena.getTagOnSide(this.tagType, pokemon.getArenaTagSide())) {
+    if (globalScene.arena.getTag(this.tagType, pokemon.getArenaTagSide())) {
       return super.apply(pokemon, simulated);
     }
     return false;

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -303,7 +303,7 @@ export function initAbilities() {
         AttackTypeImmunityAbAttr,
         ElementalType.GROUND,
         (pokemon: Pokemon) =>
-          !pokemon.getTag(BattlerTagType.IGNORE_FLYING) && !globalScene.arena.getTag(ArenaTagType.GRAVITY),
+          !pokemon.getTag(BattlerTagType.IGNORE_FLYING) && !globalScene.arena.findTag(ArenaTagType.GRAVITY),
       )
       .ignorable(),
     new Ability(AbilityId.EFFECT_SPORE, 3)

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -303,7 +303,7 @@ export function initAbilities() {
         AttackTypeImmunityAbAttr,
         ElementalType.GROUND,
         (pokemon: Pokemon) =>
-          !pokemon.getTag(BattlerTagType.IGNORE_FLYING) && !globalScene.arena.findTag(ArenaTagType.GRAVITY),
+          !pokemon.getTag(BattlerTagType.IGNORE_FLYING) && !globalScene.arena.hasTag(ArenaTagType.GRAVITY),
       )
       .ignorable(),
     new Ability(AbilityId.EFFECT_SPORE, 3)

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -1604,7 +1604,7 @@ export function initMoves() {
       .attr(AddBattlerTagAttr, BattlerTagType.FLOATING, true, { failOnOverlap: true, turnCountMin: 5 })
       .condition(
         (user, _target, _move) =>
-          !globalScene.arena.getTag(ArenaTagType.GRAVITY)
+          !globalScene.arena.findTag(ArenaTagType.GRAVITY)
           && [BattlerTagType.FLOATING, BattlerTagType.IGNORE_FLYING, BattlerTagType.INGRAIN].every(
             (tag) => !user.getTag(tag),
           ),
@@ -2928,7 +2928,7 @@ export function initMoves() {
     new AttackMove(MoveId.GRAV_APPLE, ElementalType.GRASS, MoveCategory.PHYSICAL, 80, 100, 10, 100, 0, 8)
       .attr(StatStageChangeAttr, [Stat.DEF], -1)
       .attr(MovePowerMultiplierAttr, (_user, _target, _move) =>
-        globalScene.arena.getTag(ArenaTagType.GRAVITY) ? 1.5 : 1,
+        globalScene.arena.findTag(ArenaTagType.GRAVITY) ? 1.5 : 1,
       )
       .makesContact(false),
     new AttackMove(MoveId.SPIRIT_BREAK, ElementalType.FAIRY, MoveCategory.PHYSICAL, 75, 100, 15, 100, 0, 8)

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -1604,7 +1604,7 @@ export function initMoves() {
       .attr(AddBattlerTagAttr, BattlerTagType.FLOATING, true, { failOnOverlap: true, turnCountMin: 5 })
       .condition(
         (user, _target, _move) =>
-          !globalScene.arena.findTag(ArenaTagType.GRAVITY)
+          !globalScene.arena.hasTag(ArenaTagType.GRAVITY)
           && [BattlerTagType.FLOATING, BattlerTagType.IGNORE_FLYING, BattlerTagType.INGRAIN].every(
             (tag) => !user.getTag(tag),
           ),
@@ -2928,7 +2928,7 @@ export function initMoves() {
     new AttackMove(MoveId.GRAV_APPLE, ElementalType.GRASS, MoveCategory.PHYSICAL, 80, 100, 10, 100, 0, 8)
       .attr(StatStageChangeAttr, [Stat.DEF], -1)
       .attr(MovePowerMultiplierAttr, (_user, _target, _move) =>
-        globalScene.arena.findTag(ArenaTagType.GRAVITY) ? 1.5 : 1,
+        globalScene.arena.hasTag(ArenaTagType.GRAVITY) ? 1.5 : 1,
       )
       .makesContact(false),
     new AttackMove(MoveId.SPIRIT_BREAK, ElementalType.FAIRY, MoveCategory.PHYSICAL, 75, 100, 15, 100, 0, 8)

--- a/src/data/moves/move-attrs/add-arena-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-arena-tag-attr.ts
@@ -83,7 +83,7 @@ export class AddArenaTagAttr extends ChanceBasedMoveEffectAttr {
 
   override getCondition(): MoveConditionFunc | null {
     return this.failOnOverlap
-      ? (user, _target, move) => !globalScene.arena.getTagOnSide(this.tagType, this.getTagSide(user, move))
+      ? (user, _target, move) => !globalScene.arena.getTag(this.tagType, this.getTagSide(user, move))
       : null;
   }
 }

--- a/src/data/moves/move-attrs/add-arena-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-arena-tag-attr.ts
@@ -83,7 +83,7 @@ export class AddArenaTagAttr extends ChanceBasedMoveEffectAttr {
 
   override getCondition(): MoveConditionFunc | null {
     return this.failOnOverlap
-      ? (user, _target, move) => !globalScene.arena.getTag(this.tagType, this.getTagSide(user, move))
+      ? (user, _target, move) => !globalScene.arena.findTag(this.tagType, this.getTagSide(user, move))
       : null;
   }
 }

--- a/src/data/moves/move-attrs/add-arena-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-arena-tag-attr.ts
@@ -83,7 +83,7 @@ export class AddArenaTagAttr extends ChanceBasedMoveEffectAttr {
 
   override getCondition(): MoveConditionFunc | null {
     return this.failOnOverlap
-      ? (user, _target, move) => !globalScene.arena.findTag(this.tagType, this.getTagSide(user, move))
+      ? (user, _target, move) => !globalScene.arena.hasTag(this.tagType, this.getTagSide(user, move))
       : null;
   }
 }

--- a/src/data/moves/move-attrs/add-entry-hazard-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-entry-hazard-tag-attr.ts
@@ -11,7 +11,7 @@ export class AddEntryHazardTagAttr extends AddArenaTagAttr {
   override getCondition(): MoveConditionFunc {
     return (user, _target, move) => {
       const side = this.getTagSide(user, move);
-      const tag = globalScene.arena.getTag(this.tagType, side) as EntryHazardTag;
+      const tag = globalScene.arena.findTag(this.tagType, side) as EntryHazardTag;
       if (!tag) {
         return true;
       }

--- a/src/data/moves/move-attrs/add-entry-hazard-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-entry-hazard-tag-attr.ts
@@ -1,6 +1,6 @@
-import { globalScene } from "#app/global-scene";
-import type { EntryHazardTag } from "../../arena-tag";
 import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import type { EntryHazardTag } from "#app/data/arena-tag";
+import { globalScene } from "#app/global-scene";
 import { AddArenaTagAttr } from "./add-arena-tag-attr";
 
 /**
@@ -11,7 +11,7 @@ export class AddEntryHazardTagAttr extends AddArenaTagAttr {
   override getCondition(): MoveConditionFunc {
     return (user, _target, move) => {
       const side = this.getTagSide(user, move);
-      const tag = globalScene.arena.findTag(this.tagType, side) as EntryHazardTag;
+      const tag = globalScene.arena.findTag<EntryHazardTag>(this.tagType, side);
       if (!tag) {
         return true;
       }

--- a/src/data/moves/move-attrs/add-entry-hazard-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-entry-hazard-tag-attr.ts
@@ -11,7 +11,7 @@ export class AddEntryHazardTagAttr extends AddArenaTagAttr {
   override getCondition(): MoveConditionFunc {
     return (user, _target, move) => {
       const side = this.getTagSide(user, move);
-      const tag = globalScene.arena.getTagOnSide(this.tagType, side) as EntryHazardTag;
+      const tag = globalScene.arena.getTag(this.tagType, side) as EntryHazardTag;
       if (!tag) {
         return true;
       }

--- a/src/data/moves/move-attrs/delayed-attack-attr.ts
+++ b/src/data/moves/move-attrs/delayed-attack-attr.ts
@@ -56,7 +56,7 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
       // Add a Delayed Attack tag to the arena if it doesn't already exist
       globalScene.arena.addTag(ArenaTagType.DELAYED_ATTACK, user.id);
       // Queue an attack on the added (or existing) tag
-      const tag = globalScene.arena.getTag(ArenaTagType.DELAYED_ATTACK) as DelayedAttackTag;
+      const tag = globalScene.arena.findTag(ArenaTagType.DELAYED_ATTACK) as DelayedAttackTag;
       if (tag) {
         tag.addAttack(user, move.id, target.getBattlerIndex());
       }
@@ -75,7 +75,7 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
   /** Delayed attacks fail if another delayed attack is already queued against the target */
   override getCondition(): MoveConditionFunc {
     return (_user, target, _move) => {
-      const delayedAttackTag = globalScene.arena.getTag(ArenaTagType.DELAYED_ATTACK) as DelayedAttackTag;
+      const delayedAttackTag = globalScene.arena.findTag(ArenaTagType.DELAYED_ATTACK) as DelayedAttackTag;
       return !delayedAttackTag?.delayedAttacks.some((attack) => attack.targetIndex === target.getBattlerIndex());
     };
   }

--- a/src/data/moves/move-attrs/delayed-attack-attr.ts
+++ b/src/data/moves/move-attrs/delayed-attack-attr.ts
@@ -29,7 +29,8 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
   }
 
   /**
-   * If used virtually, this queues a message and proceeds normally.
+   * If used virtually, this queues a message and proceeds normally. (TODO: change this)
+   *
    * Otherwise, this adds a delayed attack to the field and cancels other move effects
    * for the current attack.
    */
@@ -56,10 +57,9 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
       // Add a Delayed Attack tag to the arena if it doesn't already exist
       globalScene.arena.addTag(ArenaTagType.DELAYED_ATTACK, user.id);
       // Queue an attack on the added (or existing) tag
-      const tag = globalScene.arena.findTag(ArenaTagType.DELAYED_ATTACK) as DelayedAttackTag;
-      if (tag) {
-        tag.addAttack(user, move.id, target.getBattlerIndex());
-      }
+      const tag = globalScene.arena.findTag<DelayedAttackTag>(ArenaTagType.DELAYED_ATTACK);
+      tag?.addAttack(user, move.id, target.getBattlerIndex());
+
       return true;
     } else {
       globalScene.phaseManager.queueMessagePhase(
@@ -75,7 +75,7 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
   /** Delayed attacks fail if another delayed attack is already queued against the target */
   override getCondition(): MoveConditionFunc {
     return (_user, target, _move) => {
-      const delayedAttackTag = globalScene.arena.findTag(ArenaTagType.DELAYED_ATTACK) as DelayedAttackTag;
+      const delayedAttackTag = globalScene.arena.findTag<DelayedAttackTag>(ArenaTagType.DELAYED_ATTACK);
       return !delayedAttackTag?.delayedAttacks.some((attack) => attack.targetIndex === target.getBattlerIndex());
     };
   }

--- a/src/data/moves/move-attrs/delayed-attack-attr.ts
+++ b/src/data/moves/move-attrs/delayed-attack-attr.ts
@@ -29,10 +29,12 @@ export class DelayedAttackAttr extends OverrideMoveEffectAttr {
   }
 
   /**
-   * If used virtually, this queues a message and proceeds normally. (TODO: change this)
+   * If used virtually, this queues a message and proceeds normally.
    *
    * Otherwise, this adds a delayed attack to the field and cancels other move effects
    * for the current attack.
+   *
+   * @todo Remove the virtual check, this behavior is incorrect and doesn't match mainline
    */
   override apply(user: Pokemon, target: Pokemon, move: Move, overridden: BooleanHolder, virtual: boolean): boolean {
     // Edge case for the move applied on a pokemon that has fainted

--- a/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
@@ -1,10 +1,10 @@
-import type { Pokemon } from "#app/field/pokemon";
-import { globalScene } from "#app/global-scene";
+import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import type { PendingHealTag } from "#app/data/arena-tag";
 import type { Move } from "#app/data/moves/move";
 import { SacrificialAttr } from "#app/data/moves/move-attrs/sacrificial-attr";
-import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
+import type { Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
 import { ArenaTagType } from "#enums/arena-tag-type";
-import type { PendingHealTag } from "#app/data/arena-tag";
 
 /**
  * Attr used for moves that faint the user but revive a different Pokemon
@@ -28,15 +28,13 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
   override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
     globalScene.arena.addTag(ArenaTagType.PENDING_HEAL, 0);
 
-    const tag = globalScene.arena.getTag(ArenaTagType.PENDING_HEAL) as PendingHealTag;
-    if (tag) {
-      tag.queueHeal(user.getBattlerIndex(), {
-        sourceId: user.id,
-        moveId: move.id,
-        restorePP: this.restorePP,
-        healMessageKey: this.moveTriggerMessage,
-      });
-    }
+    const tag = globalScene.arena.findTag<PendingHealTag>(ArenaTagType.PENDING_HEAL);
+    tag?.queueHeal(user.getBattlerIndex(), {
+      sourceId: user.id,
+      moveId: move.id,
+      restorePP: this.restorePP,
+      healMessageKey: this.moveTriggerMessage,
+    });
 
     return super.applyEffect(user, target, move);
   }

--- a/src/data/moves/move-attrs/swap-arena-tags-attr.ts
+++ b/src/data/moves/move-attrs/swap-arena-tags-attr.ts
@@ -42,11 +42,8 @@ export class SwapArenaTagsAttr extends MoveEffectAttr {
   }
 
   override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
-    const tagPlayerTemp = globalScene.arena.findTags(
-      (t) => this.swappableTags.includes(t.tagType),
-      ArenaTagSide.PLAYER,
-    );
-    const tagEnemyTemp = globalScene.arena.findTags((t) => this.swappableTags.includes(t.tagType), ArenaTagSide.ENEMY);
+    const tagPlayerTemp = globalScene.arena.getTags((t) => this.swappableTags.includes(t.tagType), ArenaTagSide.PLAYER);
+    const tagEnemyTemp = globalScene.arena.getTags((t) => this.swappableTags.includes(t.tagType), ArenaTagSide.ENEMY);
 
     if (tagPlayerTemp) {
       for (const swapTagsType of tagPlayerTemp) {

--- a/src/data/moves/move-attrs/swap-arena-tags-attr.ts
+++ b/src/data/moves/move-attrs/swap-arena-tags-attr.ts
@@ -42,14 +42,11 @@ export class SwapArenaTagsAttr extends MoveEffectAttr {
   }
 
   override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
-    const tagPlayerTemp = globalScene.arena.findTagsOnSide(
+    const tagPlayerTemp = globalScene.arena.findTags(
       (t) => this.swappableTags.includes(t.tagType),
       ArenaTagSide.PLAYER,
     );
-    const tagEnemyTemp = globalScene.arena.findTagsOnSide(
-      (t) => this.swappableTags.includes(t.tagType),
-      ArenaTagSide.ENEMY,
-    );
+    const tagEnemyTemp = globalScene.arena.findTags((t) => this.swappableTags.includes(t.tagType), ArenaTagSide.ENEMY);
 
     if (tagPlayerTemp) {
       for (const swapTagsType of tagPlayerTemp) {

--- a/src/data/moves/move-conditions/fail-on-gravity-condition.ts
+++ b/src/data/moves/move-conditions/fail-on-gravity-condition.ts
@@ -3,4 +3,4 @@ import { globalScene } from "#app/global-scene";
 import { ArenaTagType } from "#enums/arena-tag-type";
 
 export const failOnGravityCondition: MoveConditionFunc = (_user, _target, _move) =>
-  !globalScene.arena.getTag(ArenaTagType.GRAVITY);
+  !globalScene.arena.findTag(ArenaTagType.GRAVITY);

--- a/src/data/moves/move-conditions/fail-on-gravity-condition.ts
+++ b/src/data/moves/move-conditions/fail-on-gravity-condition.ts
@@ -3,4 +3,4 @@ import { globalScene } from "#app/global-scene";
 import { ArenaTagType } from "#enums/arena-tag-type";
 
 export const failOnGravityCondition: MoveConditionFunc = (_user, _target, _move) =>
-  !globalScene.arena.findTag(ArenaTagType.GRAVITY);
+  !globalScene.arena.hasTag(ArenaTagType.GRAVITY);

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -767,7 +767,7 @@ export abstract class Move implements Localizable {
       moveAccuracy.value = Math.floor(moveAccuracy.value * FOG_ACCURACY_MULTIPLIER);
     }
 
-    if (!isOhko && globalScene.arena.getTag(ArenaTagType.GRAVITY)) {
+    if (!isOhko && globalScene.arena.findTag(ArenaTagType.GRAVITY)) {
       moveAccuracy.value = Math.floor(moveAccuracy.value * 1.67);
     }
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -767,7 +767,7 @@ export abstract class Move implements Localizable {
       moveAccuracy.value = Math.floor(moveAccuracy.value * FOG_ACCURACY_MULTIPLIER);
     }
 
-    if (!isOhko && globalScene.arena.findTag(ArenaTagType.GRAVITY)) {
+    if (!isOhko && globalScene.arena.hasTag(ArenaTagType.GRAVITY)) {
       moveAccuracy.value = Math.floor(moveAccuracy.value * 1.67);
     }
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -858,7 +858,7 @@ export class Arena {
   getTags<T extends ArenaTag = ArenaTag>(
     tagPredicate: (t: ArenaTag) => boolean,
     side: ArenaTagSide = ArenaTagSide.BOTH,
-  ): T[] {
+  ): T[] | undefined {
     const validSides = new Set<ArenaTagSide>([ArenaTagSide.BOTH, side]);
 
     return this.tags.filter((t) => tagPredicate(t) && (side === ArenaTagSide.BOTH || validSides.has(t.side))) as T[];

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -795,7 +795,7 @@ export class Arena {
     side: ArenaTagSide = ArenaTagSide.BOTH,
     quiet: boolean = false,
   ): boolean {
-    const existingTag = this.getTag(tagType, side);
+    const existingTag = this.findTag(tagType, side);
     if (existingTag) {
       existingTag.onOverlap(this);
 
@@ -824,7 +824,7 @@ export class Arena {
   }
 
   hasTag(tagType: ArenaTagType): boolean {
-    return !!this.getTag(tagType);
+    return !!this.findTag(tagType);
   }
 
   /**
@@ -835,7 +835,7 @@ export class Arena {
    * @param side - (Default `ArenaTagSide.BOTH`) The {@linkcode ArenaTagSide} to look at
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
-  getTag<T extends ArenaTag = ArenaTag>(
+  findTag<T extends ArenaTag = ArenaTag>(
     tagType: ArenaTagType | AbstractConstructor<T>,
     side: ArenaTagSide = ArenaTagSide.BOTH,
   ): T | undefined {
@@ -858,7 +858,7 @@ export class Arena {
    * @param side - (Default `ArenaTagSide.BOTH`) The {@linkcode ArenaTagSide} to look at
    * @returns array of {@linkcode ArenaTag}s from which the Arena's tags return `true` and apply to the given side
    */
-  findTags<T extends ArenaTag = ArenaTag>(
+  getTags<T extends ArenaTag = ArenaTag>(
     tagPredicate: (t: ArenaTag) => boolean,
     side: ArenaTagSide = ArenaTagSide.BOTH,
   ): T[] {
@@ -891,7 +891,7 @@ export class Arena {
   }
 
   removeTagOnSide(tagType: ArenaTagType, side: ArenaTagSide, quiet: boolean = false): boolean {
-    const tag = this.getTag(tagType, side);
+    const tag = this.findTag(tagType, side);
     if (tag) {
       tag.onRemove(this, quiet);
       this.tags.splice(this.tags.indexOf(tag), 1);

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -823,8 +823,16 @@ export class Arena {
     return true;
   }
 
-  hasTag(tagType: ArenaTagType): boolean {
-    return !!this.findTag(tagType);
+  /**
+   * Checks if an {@linkcode ArenaTag} exists on the specified side of the Arena.
+   * @param tagType - The {@linkcode ArenaTagType} to check for
+   * @param side - (Default `ArenaTagSide.BOTH`) The {@linkcode ArenaTagSide} to look at
+   * @returns Whether the `ArenaTag` exists
+   */
+  hasTag(tagType: ArenaTagType, side: ArenaTagSide = ArenaTagSide.BOTH): boolean {
+    return this.tags.some(
+      (t) => t.tagType === tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
+    );
   }
 
   /**

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -795,7 +795,7 @@ export class Arena {
     side: ArenaTagSide = ArenaTagSide.BOTH,
     quiet: boolean = false,
   ): boolean {
-    const existingTag = this.getTagOnSide(tagType, side);
+    const existingTag = this.getTag(tagType, side);
     if (existingTag) {
       existingTag.onOverlap(this);
 
@@ -823,15 +823,6 @@ export class Arena {
     return true;
   }
 
-  /**
-   * Attempts to get a tag from the Arena via {@linkcode getTagOnSide} that applies to both sides
-   * @param tagType The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
-   * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
-   */
-  getTag(tagType: ArenaTagType | AbstractConstructor<ArenaTag>): ArenaTag | undefined {
-    return this.getTagOnSide(tagType, ArenaTagSide.BOTH);
-  }
-
   hasTag(tagType: ArenaTagType): boolean {
     return !!this.getTag(tagType);
   }
@@ -840,41 +831,40 @@ export class Arena {
    * Attempts to get a tag from the Arena from a specific side (the tag passed in has to either apply to both sides, or the specific side only)
    *
    * eg: `MIST` only applies to the user's side, while `MUD_SPORT` applies to both user and enemy side
-   * @param tagType The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
-   * @param side The {@linkcode ArenaTagSide} to look at
+   * @param tagType - The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
+   * @param side - (Default `ArenaTagSide.BOTH`) The {@linkcode ArenaTagSide} to look at
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
-  getTagOnSide(tagType: ArenaTagType | AbstractConstructor<ArenaTag>, side: ArenaTagSide): ArenaTag | undefined {
-    return typeof tagType === "number"
-      ? this.tags.find(
-          (t) =>
-            t.tagType === tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-        )
-      : this.tags.find(
-          (t) =>
-            t instanceof tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-        );
-  }
-
-  /**
-   * Uses {@linkcode findTagsOnSide} to filter (using the parameter function) for specific tags that apply to both sides
-   * @param tagPredicate a function mapping {@linkcode ArenaTag}s to `boolean`s
-   * @returns array of {@linkcode ArenaTag}s from which the Arena's tags return true and apply to both sides
-   */
-  findTags(tagPredicate: (t: ArenaTag) => boolean): ArenaTag[] {
-    return this.findTagsOnSide(tagPredicate, ArenaTagSide.BOTH);
+  getTag<T extends ArenaTag = ArenaTag>(
+    tagType: ArenaTagType | AbstractConstructor<T>,
+    side: ArenaTagSide = ArenaTagSide.BOTH,
+  ): T | undefined {
+    const ret =
+      typeof tagType === "number"
+        ? this.tags.find(
+            (t) =>
+              t.tagType === tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
+          )
+        : this.tags.find(
+            (t) =>
+              t instanceof tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
+          );
+    return ret as T;
   }
 
   /**
    * Returns specific tags from the arena that pass the `tagPredicate` function passed in as a parameter, and apply to the given side
-   * @param tagPredicate a function mapping {@linkcode ArenaTag}s to `boolean`s
-   * @param side The {@linkcode ArenaTagSide} to look at
+   * @param tagPredicate - A function mapping {@linkcode ArenaTag}s to `boolean`s
+   * @param side - (Default `ArenaTagSide.BOTH`) The {@linkcode ArenaTagSide} to look at
    * @returns array of {@linkcode ArenaTag}s from which the Arena's tags return `true` and apply to the given side
    */
-  findTagsOnSide(tagPredicate: (t: ArenaTag) => boolean, side: ArenaTagSide): ArenaTag[] {
+  findTags<T extends ArenaTag = ArenaTag>(
+    tagPredicate: (t: ArenaTag) => boolean,
+    side: ArenaTagSide = ArenaTagSide.BOTH,
+  ): T[] {
     return this.tags.filter(
       (t) => tagPredicate(t) && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-    );
+    ) as T[];
   }
 
   lapseTags(): void {
@@ -901,7 +891,7 @@ export class Arena {
   }
 
   removeTagOnSide(tagType: ArenaTagType, side: ArenaTagSide, quiet: boolean = false): boolean {
-    const tag = this.getTagOnSide(tagType, side);
+    const tag = this.getTag(tagType, side);
     if (tag) {
       tag.onRemove(this, quiet);
       this.tags.splice(this.tags.indexOf(tag), 1);

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -830,9 +830,9 @@ export class Arena {
    * @returns Whether the `ArenaTag` exists
    */
   hasTag(tagType: ArenaTagType, side: ArenaTagSide = ArenaTagSide.BOTH): boolean {
-    return this.tags.some(
-      (t) => t.tagType === tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-    );
+    const validSides = new Set<ArenaTagSide>([ArenaTagSide.BOTH, side]);
+
+    return this.tags.some((t) => t.tagType === tagType && (side === ArenaTagSide.BOTH || validSides.has(t.side)));
   }
 
   /**
@@ -844,13 +844,13 @@ export class Arena {
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
   findTag<T extends ArenaTag = ArenaTag>(tagType: ArenaTagType, side: ArenaTagSide = ArenaTagSide.BOTH): T | undefined {
-    return this.tags.find(
-      (t) => tagType === t.tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-    ) as T;
+    const validSides = new Set<ArenaTagSide>([ArenaTagSide.BOTH, side]);
+
+    return this.tags.find((t) => tagType === t.tagType && (side === ArenaTagSide.BOTH || validSides.has(t.side))) as T;
   }
 
   /**
-   * Returns specific tags from the arena that pass the `tagPredicate` function passed in as a parameter, and apply to the given side
+   * Returns all tags from the arena that pass the `tagPredicate` function passed in as a parameter, and apply to the given side
    * @param tagPredicate - A function mapping {@linkcode ArenaTag}s to `boolean`s
    * @param side - (Default `ArenaTagSide.BOTH`) The {@linkcode ArenaTagSide} to look at
    * @returns array of {@linkcode ArenaTag}s from which the Arena's tags return `true` and apply to the given side
@@ -859,9 +859,9 @@ export class Arena {
     tagPredicate: (t: ArenaTag) => boolean,
     side: ArenaTagSide = ArenaTagSide.BOTH,
   ): T[] {
-    return this.tags.filter(
-      (t) => tagPredicate(t) && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-    ) as T[];
+    const validSides = new Set<ArenaTagSide>([ArenaTagSide.BOTH, side]);
+
+    return this.tags.filter((t) => tagPredicate(t) && (side === ArenaTagSide.BOTH || validSides.has(t.side))) as T[];
   }
 
   lapseTags(): void {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_NEW_TERRAIN_DURATION, PRIMAL_WEATHER_TYPES } from "#app/constants/game";
+import { DEFAULT_NEW_WEATHER_DURATION } from "#app/constants/weather";
 import type { PostTerrainChangeAbAttr } from "#app/data/abilities/ab-attrs/post-terrain-change-ab-attr";
 import type { PostWeatherChangeAbAttr } from "#app/data/abilities/ab-attrs/post-weather-change-ab-attr";
 import type { TerrainEventTypeChangeAbAttr } from "#app/data/abilities/ab-attrs/terrain-event-type-change-ab-attr";
@@ -11,17 +13,15 @@ import { SpeciesFormChangeRevertWeatherFormTrigger, SpeciesFormChangeWeatherTrig
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { getTerrainClearMessage, getTerrainStartMessage, Terrain } from "#app/data/terrain";
 import { getWeatherClearMessage, getWeatherStartMessage, Weather } from "#app/data/weather";
-import { DEFAULT_NEW_TERRAIN_DURATION, PRIMAL_WEATHER_TYPES } from "#app/constants/game";
-import { DEFAULT_NEW_WEATHER_DURATION } from "#app/constants/weather";
 import { TagAddedEvent, TagRemovedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#app/events/arena";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import Overrides from "#app/overrides";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
-import { type AbstractConstructor, getEnumValues } from "#app/utils/common-utils";
-import { randSeedInt, weightedPick } from "#app/utils/random-utils";
+import { getEnumValues } from "#app/utils/common-utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
+import { randSeedInt, weightedPick } from "#app/utils/random-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -800,7 +800,7 @@ export class Arena {
       existingTag.onOverlap(this);
 
       if (existingTag instanceof EntryHazardTag) {
-        const { tagType, side, turnCount, layers, maxLayers } = existingTag as EntryHazardTag;
+        const { tagType, side, turnCount, layers, maxLayers } = existingTag;
         this.eventTarget.dispatchEvent(new TagAddedEvent(tagType, side, turnCount, layers, maxLayers));
       }
 
@@ -839,25 +839,14 @@ export class Arena {
    * Attempts to get a tag from the Arena from a specific side (the tag passed in has to either apply to both sides, or the specific side only)
    *
    * eg: `MIST` only applies to the user's side, while `MUD_SPORT` applies to both user and enemy side
-   * @param tagType - The {@linkcode ArenaTagType} or {@linkcode ArenaTag} to get
+   * @param tagType - The {@linkcode ArenaTagType} to get
    * @param side - (Default `ArenaTagSide.BOTH`) The {@linkcode ArenaTagSide} to look at
    * @returns either the {@linkcode ArenaTag}, or `undefined` if it isn't there
    */
-  findTag<T extends ArenaTag = ArenaTag>(
-    tagType: ArenaTagType | AbstractConstructor<T>,
-    side: ArenaTagSide = ArenaTagSide.BOTH,
-  ): T | undefined {
-    const ret =
-      typeof tagType === "number"
-        ? this.tags.find(
-            (t) =>
-              t.tagType === tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-          )
-        : this.tags.find(
-            (t) =>
-              t instanceof tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
-          );
-    return ret as T;
+  findTag<T extends ArenaTag = ArenaTag>(tagType: ArenaTagType, side: ArenaTagSide = ArenaTagSide.BOTH): T | undefined {
+    return this.tags.find(
+      (t) => tagType === t.tagType && (side === ArenaTagSide.BOTH || t.side === ArenaTagSide.BOTH || t.side === side),
+    ) as T;
   }
 
   /**

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -4,8 +4,7 @@ import type { PostTerrainChangeAbAttr } from "#app/data/abilities/ab-attrs/post-
 import type { PostWeatherChangeAbAttr } from "#app/data/abilities/ab-attrs/post-weather-change-ab-attr";
 import type { TerrainEventTypeChangeAbAttr } from "#app/data/abilities/ab-attrs/terrain-event-type-change-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import type { ArenaTag } from "#app/data/arena-tag";
-import { EntryHazardTag, getArenaTag } from "#app/data/arena-tag";
+import { getArenaTag, type ArenaTag, type EntryHazardTag } from "#app/data/arena-tag";
 import { getBiomeBgm, IndoorBiomes, type BiomeTierTrainerPools, type PokemonPools } from "#app/data/biome-utils";
 import { allBiomes } from "#app/data/data-lists";
 import type { Move } from "#app/data/moves/move";
@@ -19,6 +18,7 @@ import { globalScene } from "#app/global-scene";
 import Overrides from "#app/overrides";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
+import { EntryHazardArenaTagTypes } from "#app/utils/arena-tag-type-utils";
 import { getEnumValues } from "#app/utils/common-utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
 import { randSeedInt, weightedPick } from "#app/utils/random-utils";
@@ -799,8 +799,8 @@ export class Arena {
     if (existingTag) {
       existingTag.onOverlap(this);
 
-      if (existingTag instanceof EntryHazardTag) {
-        const { tagType, side, turnCount, layers, maxLayers } = existingTag;
+      if (EntryHazardArenaTagTypes.includes(existingTag.tagType)) {
+        const { tagType, side, turnCount, layers, maxLayers } = existingTag as EntryHazardTag;
         this.eventTarget.dispatchEvent(new TagAddedEvent(tagType, side, turnCount, layers, maxLayers));
       }
 
@@ -813,7 +813,9 @@ export class Arena {
       this.tags.push(newTag);
       newTag.onAdd(this, quiet);
 
-      const { layers = 0, maxLayers = 0 } = newTag instanceof EntryHazardTag ? newTag : {};
+      const { layers = 0, maxLayers = 0 } = EntryHazardArenaTagTypes.includes(newTag.tagType)
+        ? (newTag as EntryHazardTag)
+        : {};
 
       this.eventTarget.dispatchEvent(
         new TagAddedEvent(newTag.tagType, newTag.side, newTag.turnCount, layers, maxLayers),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1191,10 +1191,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         break;
       case Stat.SPD:
         const side = this.getArenaTagSide();
-        if (globalScene.arena.getTagOnSide(ArenaTagType.TAILWIND, side)) {
+        if (globalScene.arena.getTag(ArenaTagType.TAILWIND, side)) {
           ret *= 2;
         }
-        if (globalScene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
+        if (globalScene.arena.getTag(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
           ret >>= 2;
         }
 
@@ -1834,7 +1834,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return (
       trappedByAbility.value
       || this.hasTag(...TrappedBattlerTagTypes)
-      || !!globalScene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, side)
+      || !!globalScene.arena.getTag(ArenaTagType.FAIRY_LOCK, side)
     );
   }
 
@@ -3325,7 +3325,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   getCriticalHitResult(source: Pokemon, move: Move, simulated: boolean = true): boolean {
     const defendingSide = this.getArenaTagSide();
-    const noCritTag = globalScene.arena.getTagOnSide(NoCritTag, defendingSide);
+    const noCritTag = globalScene.arena.getTag(NoCritTag, defendingSide);
     if (noCritTag || Overrides.NEVER_CRIT_OVERRIDE || move.hasAttr(FixedDamageAttr)) {
       return false;
     }
@@ -4124,7 +4124,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   isSafeguarded(attacker: Pokemon): boolean {
     const defendingSide = this.getArenaTagSide();
-    if (globalScene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, defendingSide)) {
+    if (globalScene.arena.getTag(ArenaTagType.SAFEGUARD, defendingSide)) {
       const bypassed = new BooleanHolder(false);
       if (attacker) {
         applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, false, bypassed);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -50,7 +50,6 @@ import type { UserFieldStatusEffectImmunityAbAttr } from "#app/data/abilities/ab
 import type { WeightMultiplierAbAttr } from "#app/data/abilities/ab-attrs/weight-multiplier-ab-attr";
 import type { Ability } from "#app/data/abilities/ability";
 import { applyAbAttrs, getAbApplyFunc } from "#app/data/abilities/apply-ab-attrs";
-import { NoCritTag } from "#app/data/arena-tag";
 import type { AutotomizedTag } from "#app/data/battler-tags/autotomized-tag";
 import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { CritBoostStackableTag } from "#app/data/battler-tags/crit-boost-stackable-tag";
@@ -3325,7 +3324,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   getCriticalHitResult(source: Pokemon, move: Move, simulated: boolean = true): boolean {
     const defendingSide = this.getArenaTagSide();
-    const noCritTag = globalScene.arena.findTag(NoCritTag, defendingSide);
+    const noCritTag = globalScene.arena.hasTag(ArenaTagType.NO_CRIT, defendingSide);
     if (noCritTag || Overrides.NEVER_CRIT_OVERRIDE || move.hasAttr(FixedDamageAttr)) {
       return false;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1191,10 +1191,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         break;
       case Stat.SPD:
         const side = this.getArenaTagSide();
-        if (globalScene.arena.findTag(ArenaTagType.TAILWIND, side)) {
+        if (globalScene.arena.hasTag(ArenaTagType.TAILWIND, side)) {
           ret *= 2;
         }
-        if (globalScene.arena.findTag(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
+        if (globalScene.arena.hasTag(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
           ret >>= 2;
         }
 
@@ -1834,7 +1834,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return (
       trappedByAbility.value
       || this.hasTag(...TrappedBattlerTagTypes)
-      || !!globalScene.arena.findTag(ArenaTagType.FAIRY_LOCK, side)
+      || globalScene.arena.hasTag(ArenaTagType.FAIRY_LOCK, side)
     );
   }
 
@@ -4124,7 +4124,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   isSafeguarded(attacker: Pokemon): boolean {
     const defendingSide = this.getArenaTagSide();
-    if (globalScene.arena.findTag(ArenaTagType.SAFEGUARD, defendingSide)) {
+    if (globalScene.arena.hasTag(ArenaTagType.SAFEGUARD, defendingSide)) {
       const bypassed = new BooleanHolder(false);
       if (attacker) {
         applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, false, bypassed);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1191,10 +1191,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         break;
       case Stat.SPD:
         const side = this.getArenaTagSide();
-        if (globalScene.arena.getTag(ArenaTagType.TAILWIND, side)) {
+        if (globalScene.arena.findTag(ArenaTagType.TAILWIND, side)) {
           ret *= 2;
         }
-        if (globalScene.arena.getTag(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
+        if (globalScene.arena.findTag(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
           ret >>= 2;
         }
 
@@ -1834,7 +1834,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return (
       trappedByAbility.value
       || this.hasTag(...TrappedBattlerTagTypes)
-      || !!globalScene.arena.getTag(ArenaTagType.FAIRY_LOCK, side)
+      || !!globalScene.arena.findTag(ArenaTagType.FAIRY_LOCK, side)
     );
   }
 
@@ -3325,7 +3325,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   getCriticalHitResult(source: Pokemon, move: Move, simulated: boolean = true): boolean {
     const defendingSide = this.getArenaTagSide();
-    const noCritTag = globalScene.arena.getTag(NoCritTag, defendingSide);
+    const noCritTag = globalScene.arena.findTag(NoCritTag, defendingSide);
     if (noCritTag || Overrides.NEVER_CRIT_OVERRIDE || move.hasAttr(FixedDamageAttr)) {
       return false;
     }
@@ -4124,7 +4124,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   isSafeguarded(attacker: Pokemon): boolean {
     const defendingSide = this.getArenaTagSide();
-    if (globalScene.arena.getTag(ArenaTagType.SAFEGUARD, defendingSide)) {
+    if (globalScene.arena.findTag(ArenaTagType.SAFEGUARD, defendingSide)) {
       const bypassed = new BooleanHolder(false);
       if (attacker) {
         applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, false, bypassed);

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -551,8 +551,8 @@ export default class Trainer extends Phaser.GameObjects.Container {
         score /= playerField.length;
         if (forSwitch && !p.isOnField()) {
           globalScene.arena
-            .findTagsOnSide((t) => t instanceof EntryHazardTag, ArenaTagSide.ENEMY)
-            .map((t) => (score *= (t as EntryHazardTag).getMatchupScoreMultiplier(p)));
+            .findTags<EntryHazardTag>((t) => t instanceof EntryHazardTag, ArenaTagSide.ENEMY)
+            .map((t) => (score *= t.getMatchupScoreMultiplier(p)));
         }
       }
 

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -1,4 +1,4 @@
-import { EntryHazardTag } from "#app/data/arena-tag";
+import type { EntryHazardTag } from "#app/data/arena-tag";
 import { getLevelForWaveFunc } from "#app/data/exp";
 import { pokemonPreEvolutions } from "#app/data/pokemon-pre-evolutions";
 import type PokemonSpecies from "#app/data/pokemon-species";
@@ -11,16 +11,17 @@ import type { EnemyPokemon } from "#app/field/enemy-pokemon";
 import { globalScene } from "#app/global-scene";
 import type { PersistentModifier } from "#app/modifier/modifier";
 import { getIsInitialized, initI18n } from "#app/plugins/i18n";
-import { randSeedInt, randSeedItem, randSeedWeightedItem } from "#app/utils/random-utils";
+import { EntryHazardArenaTagTypes } from "#app/utils/arena-tag-type-utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
+import { randSeedInt, randSeedItem, randSeedWeightedItem } from "#app/utils/random-utils";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import { SpeciesId } from "#enums/species-id";
+import { TeraAIMode } from "#enums/tera-ai-mode";
 import { TrainerPoolTier } from "#enums/trainer-pool-tier";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { TrainerType } from "#enums/trainer-type";
 import { TrainerVariant } from "#enums/trainer-variant";
-import { TeraAIMode } from "#enums/tera-ai-mode";
 import i18next from "i18next";
 
 export default class Trainer extends Phaser.GameObjects.Container {
@@ -551,8 +552,8 @@ export default class Trainer extends Phaser.GameObjects.Container {
         score /= playerField.length;
         if (forSwitch && !p.isOnField()) {
           globalScene.arena
-            .getTags<EntryHazardTag>((t) => t instanceof EntryHazardTag, ArenaTagSide.ENEMY)
-            .map((t) => (score *= t.getMatchupScoreMultiplier(p)));
+            .getTags<EntryHazardTag>((t) => EntryHazardArenaTagTypes.includes(t.tagType), ArenaTagSide.ENEMY)
+            ?.map((t) => (score *= t.getMatchupScoreMultiplier(p)));
         }
       }
 

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -551,7 +551,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
         score /= playerField.length;
         if (forSwitch && !p.isOnField()) {
           globalScene.arena
-            .findTags<EntryHazardTag>((t) => t instanceof EntryHazardTag, ArenaTagSide.ENEMY)
+            .getTags<EntryHazardTag>((t) => t instanceof EntryHazardTag, ArenaTagSide.ENEMY)
             .map((t) => (score *= t.getMatchupScoreMultiplier(p)));
         }
       }

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -366,7 +366,7 @@ export class CommandPhase extends FieldPhase {
           const trapTag =
             pokemon.getTag<TrappedTag>(...TrappedBattlerTagTypes)
             ?? pokemon.getTag<SkyDropTag>(BattlerTagType.SKY_DROP);
-          const fairyLockTag = arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
+          const fairyLockTag = arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
 
           if (!isSwitch) {
             ui.setMode<CommandUiHandler>(UiMode.COMMAND, this.fieldIndex);

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -366,7 +366,7 @@ export class CommandPhase extends FieldPhase {
           const trapTag =
             pokemon.getTag<TrappedTag>(...TrappedBattlerTagTypes)
             ?? pokemon.getTag<SkyDropTag>(BattlerTagType.SKY_DROP);
-          const fairyLockTag = arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
+          const fairyLockTag = arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER);
 
           if (!isSwitch) {
             ui.setMode<CommandUiHandler>(UiMode.COMMAND, this.fieldIndex);

--- a/src/phases/money-reward-phase.ts
+++ b/src/phases/money-reward-phase.ts
@@ -26,7 +26,7 @@ export class MoneyRewardPhase extends BattlePhase {
 
     globalScene.applyModifiers(MoneyMultiplierModifier, true, moneyAmount);
 
-    if (globalScene.arena.findTag(ArenaTagType.HAPPY_HOUR)) {
+    if (globalScene.arena.hasTag(ArenaTagType.HAPPY_HOUR)) {
       moneyAmount.value *= 2;
     }
 

--- a/src/phases/money-reward-phase.ts
+++ b/src/phases/money-reward-phase.ts
@@ -26,7 +26,7 @@ export class MoneyRewardPhase extends BattlePhase {
 
     globalScene.applyModifiers(MoneyMultiplierModifier, true, moneyAmount);
 
-    if (globalScene.arena.getTag(ArenaTagType.HAPPY_HOUR)) {
+    if (globalScene.arena.findTag(ArenaTagType.HAPPY_HOUR)) {
       moneyAmount.value *= 2;
     }
 

--- a/src/ui/components/arena-flyout.ts
+++ b/src/ui/components/arena-flyout.ts
@@ -279,7 +279,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
           return;
         }
 
-        const isEntryHazardTag = globalScene.arena.getTag(tagAddedEvent.arenaTagType) instanceof EntryHazardTag;
+        const isEntryHazardTag = globalScene.arena.findTag(tagAddedEvent.arenaTagType) instanceof EntryHazardTag;
         let arenaEffectType: ArenaEffectType;
 
         if (tagAddedEvent.arenaTagSide === ArenaTagSide.BOTH) {

--- a/src/ui/components/arena-flyout.ts
+++ b/src/ui/components/arena-flyout.ts
@@ -279,6 +279,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
           return;
         }
 
+        // TODO: fix this
         const isEntryHazardTag = globalScene.arena.findTag(tagAddedEvent.arenaTagType) instanceof EntryHazardTag;
         let arenaEffectType: ArenaEffectType;
 

--- a/src/ui/components/arena-flyout.ts
+++ b/src/ui/components/arena-flyout.ts
@@ -1,8 +1,11 @@
-import { EntryHazardTag } from "#app/data/arena-tag";
 import type { ArenaEvent } from "#app/events/arena";
 import { TagAddedEvent, TagRemovedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#app/events/arena";
+import type { TurnEndEvent } from "#app/events/battle-scene";
 import { globalScene } from "#app/global-scene";
+import { TimeOfDayWidget } from "#app/ui/components/time-of-day-widget";
 import { addTextObject } from "#app/ui/text/text-utils";
+import { addWindow } from "#app/ui/ui-theme";
+import { EntryHazardArenaTagTypes } from "#app/utils/arena-tag-type-utils";
 import { fixedNumber, isNil } from "#app/utils/common-utils";
 import { toCamelCaseString, toTitleCase } from "#app/utils/string-utils";
 import { ArenaEventType } from "#enums/arena-event-type";
@@ -15,9 +18,6 @@ import { WeatherType } from "#enums/weather-type";
 import { WindowVariant } from "#enums/window-variant";
 import type { ParseKeys } from "i18next";
 import i18next from "i18next";
-import type { TurnEndEvent } from "../../events/battle-scene";
-import { addWindow } from "../ui-theme";
-import { TimeOfDayWidget } from "./time-of-day-widget";
 
 /** Enum used to differentiate {@linkcode Arena} effects */
 enum ArenaEffectType {
@@ -279,8 +279,9 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
           return;
         }
 
-        // TODO: fix this
-        const isEntryHazardTag = globalScene.arena.findTag(tagAddedEvent.arenaTagType) instanceof EntryHazardTag;
+        const isEntryHazardTag =
+          EntryHazardArenaTagTypes.includes(tagAddedEvent.arenaTagType)
+          && globalScene.arena.hasTag(tagAddedEvent.arenaTagType);
         let arenaEffectType: ArenaEffectType;
 
         if (tagAddedEvent.arenaTagSide === ArenaTagSide.BOTH) {

--- a/test/abilities/good-as-gold.test.ts
+++ b/test/abilities/good-as-gold.test.ts
@@ -85,7 +85,7 @@ describe("Abilities - Good As Gold", () => {
 
     await game.toEndOfTurn();
     expect(player).toHaveMoveResult(MoveResult.SUCCESS);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY)).toBeDefined();
   });
 
   it("should not negate moves that target all Pokemon", async () => {

--- a/test/abilities/good-as-gold.test.ts
+++ b/test/abilities/good-as-gold.test.ts
@@ -85,7 +85,7 @@ describe("Abilities - Good As Gold", () => {
 
     await game.toEndOfTurn();
     expect(player).toHaveMoveResult(MoveResult.SUCCESS);
-    expect(game.scene.arena.findTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY)).toBeTruthy();
   });
 
   it("should not negate moves that target all Pokemon", async () => {

--- a/test/abilities/good-as-gold.test.ts
+++ b/test/abilities/good-as-gold.test.ts
@@ -85,7 +85,7 @@ describe("Abilities - Good As Gold", () => {
 
     await game.toEndOfTurn();
     expect(player).toHaveMoveResult(MoveResult.SUCCESS);
-    expect(game.scene.arena.getTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.ENEMY)).toBeDefined();
   });
 
   it("should not negate moves that target all Pokemon", async () => {

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -172,8 +172,8 @@ describe("Abilities - Magic Bounce", () => {
     game.move.use(MoveId.SPIKES);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
+    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("should bounce spikes even when the target is protected", async () => {
@@ -182,7 +182,7 @@ describe("Abilities - Magic Bounce", () => {
 
     game.move.use(MoveId.SPIKES);
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
+    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
   });
 
   it("should not bounce spikes when the target is in the semi-invulnerable state", async () => {
@@ -192,7 +192,7 @@ describe("Abilities - Magic Bounce", () => {
     game.move.use(MoveId.SPIKES);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)!["layers"]).toBe(1);
+    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)!["layers"]).toBe(1);
   });
 
   it("should not bounce back curse", async () => {
@@ -353,10 +353,7 @@ describe("Abilities - Magic Bounce", () => {
     await game.toEndOfTurn();
 
     expect(
-      game.scene.arena
-        .getTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)
-        ?.getSourcePokemon()
-        ?.getBattlerIndex(),
+      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
     game.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER, true);
 
@@ -365,10 +362,7 @@ describe("Abilities - Magic Bounce", () => {
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
     expect(
-      game.scene.arena
-        .getTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)
-        ?.getSourcePokemon()
-        ?.getBattlerIndex(),
+      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
   });
 

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -173,7 +173,7 @@ describe("Abilities - Magic Bounce", () => {
     await game.toEndOfTurn();
 
     expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
-    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 
   it("should bounce spikes even when the target is protected", async () => {
@@ -352,18 +352,16 @@ describe("Abilities - Magic Bounce", () => {
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
 
-    expect(
-      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
-    ).toBe(BattlerIndex.ENEMY);
+    const tag1 = game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER);
+    expect(tag1?.getSourcePokemon()?.getBattlerIndex()).toBe(BattlerIndex.ENEMY);
     game.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER, true);
 
     // turn 2
     game.move.use(MoveId.STICKY_WEB, 0);
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
-    expect(
-      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
-    ).toBe(BattlerIndex.ENEMY);
+    const tag2 = game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER);
+    expect(tag2?.getSourcePokemon()?.getBattlerIndex()).toBe(BattlerIndex.ENEMY);
   });
 
   it("should not bounce back status moves that hit through semi-invulnerable states", async () => {

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -172,8 +172,8 @@ describe("Abilities - Magic Bounce", () => {
     game.move.use(MoveId.SPIKES);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
+    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("should bounce spikes even when the target is protected", async () => {
@@ -182,7 +182,7 @@ describe("Abilities - Magic Bounce", () => {
 
     game.move.use(MoveId.SPIKES);
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
+    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
   });
 
   it("should not bounce spikes when the target is in the semi-invulnerable state", async () => {
@@ -192,7 +192,7 @@ describe("Abilities - Magic Bounce", () => {
     game.move.use(MoveId.SPIKES);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)!["layers"]).toBe(1);
+    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)!["layers"]).toBe(1);
   });
 
   it("should not bounce back curse", async () => {
@@ -353,7 +353,7 @@ describe("Abilities - Magic Bounce", () => {
     await game.toEndOfTurn();
 
     expect(
-      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
+      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
     game.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER, true);
 
@@ -362,7 +362,7 @@ describe("Abilities - Magic Bounce", () => {
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
     expect(
-      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
+      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
   });
 

--- a/test/abilities/screen-cleaner.test.ts
+++ b/test/abilities/screen-cleaner.test.ts
@@ -1,4 +1,5 @@
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -31,51 +32,51 @@ describe("Abilities - Screen Cleaner", () => {
     game.override.moveset([MoveId.HAIL]);
     game.override.enemyMoveset([MoveId.AURORA_VEIL, MoveId.AURORA_VEIL, MoveId.AURORA_VEIL, MoveId.AURORA_VEIL]);
 
-    await game.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
+    await game.classicMode.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.HAIL);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.findTag(ArenaTagType.AURORA_VEIL)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.AURORA_VEIL, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await game.toNextTurn();
     game.switchPokemon(1);
     await game.phaseInterceptor.to("PostSummonPhase");
 
-    expect(game.scene.arena.findTag(ArenaTagType.AURORA_VEIL)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.AURORA_VEIL, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 
   it("removes Light Screen", async () => {
-    game.override.enemyMoveset([MoveId.LIGHT_SCREEN, MoveId.LIGHT_SCREEN, MoveId.LIGHT_SCREEN, MoveId.LIGHT_SCREEN]);
+    game.override.enemyMoveset(MoveId.LIGHT_SCREEN);
 
-    await game.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
+    await game.classicMode.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.findTag(ArenaTagType.LIGHT_SCREEN)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await game.toNextTurn();
     game.switchPokemon(1);
     await game.phaseInterceptor.to("PostSummonPhase");
 
-    expect(game.scene.arena.findTag(ArenaTagType.LIGHT_SCREEN)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 
   it("removes Reflect", async () => {
-    game.override.enemyMoveset([MoveId.REFLECT, MoveId.REFLECT, MoveId.REFLECT, MoveId.REFLECT]);
+    game.override.enemyMoveset(MoveId.REFLECT);
 
-    await game.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
+    await game.classicMode.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.findTag(ArenaTagType.REFLECT)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await game.toNextTurn();
     game.switchPokemon(1);
     await game.phaseInterceptor.to("PostSummonPhase");
 
-    expect(game.scene.arena.findTag(ArenaTagType.REFLECT)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 });

--- a/test/abilities/screen-cleaner.test.ts
+++ b/test/abilities/screen-cleaner.test.ts
@@ -36,13 +36,13 @@ describe("Abilities - Screen Cleaner", () => {
     game.move.select(MoveId.HAIL);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.AURORA_VEIL)).toBeDefined();
 
     await game.toNextTurn();
     game.switchPokemon(1);
     await game.phaseInterceptor.to("PostSummonPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.AURORA_VEIL)).toBeUndefined();
   });
 
   it("removes Light Screen", async () => {
@@ -53,13 +53,13 @@ describe("Abilities - Screen Cleaner", () => {
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.LIGHT_SCREEN)).toBeDefined();
 
     await game.toNextTurn();
     game.switchPokemon(1);
     await game.phaseInterceptor.to("PostSummonPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.LIGHT_SCREEN)).toBeUndefined();
   });
 
   it("removes Reflect", async () => {
@@ -70,12 +70,12 @@ describe("Abilities - Screen Cleaner", () => {
     game.move.select(MoveId.SPLASH);
     await game.phaseInterceptor.to("TurnEndPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.REFLECT)).toBeDefined();
 
     await game.toNextTurn();
     game.switchPokemon(1);
     await game.phaseInterceptor.to("PostSummonPhase");
 
-    expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.REFLECT)).toBeUndefined();
   });
 });

--- a/test/arena/arena-gravity.test.ts
+++ b/test/arena/arena-gravity.test.ts
@@ -47,7 +47,7 @@ describe("Arena - Gravity", () => {
     game.move.select(MoveId.GRAVITY);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
 
     // Use non-OHKO move on second turn
     await game.toNextTurn();
@@ -68,7 +68,7 @@ describe("Arena - Gravity", () => {
     game.move.select(MoveId.GRAVITY);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
 
     // Use OHKO move on second turn
     await game.toNextTurn();
@@ -98,7 +98,7 @@ describe("Arena - Gravity", () => {
       game.move.select(MoveId.GRAVITY);
       await game.toEndOfTurn();
 
-      expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+      expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
 
       // Use ground move on 3rd turn
       await game.toNextTurn();
@@ -120,7 +120,7 @@ describe("Arena - Gravity", () => {
       game.move.select(MoveId.GRAVITY);
       await game.toEndOfTurn();
 
-      expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+      expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
 
       // Use electric move on 2nd turn
       await game.toNextTurn();

--- a/test/arena/arena-gravity.test.ts
+++ b/test/arena/arena-gravity.test.ts
@@ -1,7 +1,7 @@
-import { BattlerIndex } from "#enums/battler-index";
 import { allMoves } from "#app/data/data-lists";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -47,7 +47,7 @@ describe("Arena - Gravity", () => {
     game.move.select(MoveId.GRAVITY);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.GRAVITY)).toBeTruthy();
 
     // Use non-OHKO move on second turn
     await game.toNextTurn();
@@ -68,7 +68,7 @@ describe("Arena - Gravity", () => {
     game.move.select(MoveId.GRAVITY);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.GRAVITY)).toBeTruthy();
 
     // Use OHKO move on second turn
     await game.toNextTurn();
@@ -98,7 +98,7 @@ describe("Arena - Gravity", () => {
       game.move.select(MoveId.GRAVITY);
       await game.toEndOfTurn();
 
-      expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
+      expect(game.scene.arena.hasTag(ArenaTagType.GRAVITY)).toBeTruthy();
 
       // Use ground move on 3rd turn
       await game.toNextTurn();
@@ -120,7 +120,7 @@ describe("Arena - Gravity", () => {
       game.move.select(MoveId.GRAVITY);
       await game.toEndOfTurn();
 
-      expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
+      expect(game.scene.arena.hasTag(ArenaTagType.GRAVITY)).toBeTruthy();
 
       // Use electric move on 2nd turn
       await game.toNextTurn();

--- a/test/moves/brick-break.test.ts
+++ b/test/moves/brick-break.test.ts
@@ -52,8 +52,8 @@ describe("Moves - Brick Break", () => {
     game.move.select(MoveId.BRICK_BREAK);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTagOnSide(tagType, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("Reflect should not reduce Brick Break's damage when removed", async () => {
@@ -86,6 +86,6 @@ describe("Moves - Brick Break", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeDefined();
   });
 });

--- a/test/moves/brick-break.test.ts
+++ b/test/moves/brick-break.test.ts
@@ -1,7 +1,7 @@
 import { allMoves } from "#app/data/data-lists";
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { toDmgValue } from "#app/utils/common-utils";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveCategory } from "#enums/move-category";
 import { MoveId } from "#enums/move-id";
@@ -52,8 +52,8 @@ describe("Moves - Brick Break", () => {
     game.move.select(MoveId.BRICK_BREAK);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.findTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 
   it("Reflect should not reduce Brick Break's damage when removed", async () => {
@@ -86,6 +86,6 @@ describe("Moves - Brick Break", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeTruthy();
   });
 });

--- a/test/moves/brick-break.test.ts
+++ b/test/moves/brick-break.test.ts
@@ -52,8 +52,8 @@ describe("Moves - Brick Break", () => {
     game.move.select(MoveId.BRICK_BREAK);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("Reflect should not reduce Brick Break's damage when removed", async () => {
@@ -86,6 +86,6 @@ describe("Moves - Brick Break", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.REFLECT, ArenaTagSide.ENEMY)).toBeDefined();
   });
 });

--- a/test/moves/ceaseless-edge.test.ts
+++ b/test/moves/ceaseless-edge.test.ts
@@ -48,11 +48,11 @@ describe("Moves - Ceaseless Edge", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
-    const tagBefore = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagBefore = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
 
     await game.phaseInterceptor.to("TurnEndPhase");
-    const tagAfter = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagAfter = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagAfter instanceof EntryHazardTag).toBeTruthy();
     expect(tagAfter.layers).toBe(1);
     expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
@@ -66,11 +66,11 @@ describe("Moves - Ceaseless Edge", () => {
     game.move.select(MoveId.CEASELESS_EDGE);
     await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
-    const tagBefore = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagBefore = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
 
     await game.toNextTurn();
-    const tagAfter = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagAfter = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagAfter instanceof EntryHazardTag).toBeTruthy();
     expect(tagAfter.layers).toBe(2);
 

--- a/test/moves/ceaseless-edge.test.ts
+++ b/test/moves/ceaseless-edge.test.ts
@@ -48,12 +48,12 @@ describe("Moves - Ceaseless Edge", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
-    const tagBefore = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
+    const tagBefore = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
+    expect(tagBefore).toBeUndefined();
 
     await game.phaseInterceptor.to("TurnEndPhase");
-    const tagAfter = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(tagAfter instanceof EntryHazardTag).toBeTruthy();
+    const tagAfter = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)!;
+    expect(tagAfter).toBeDefined();
     expect(tagAfter.layers).toBe(1);
     expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
   });

--- a/test/moves/ceaseless-edge.test.ts
+++ b/test/moves/ceaseless-edge.test.ts
@@ -48,11 +48,11 @@ describe("Moves - Ceaseless Edge", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
-    const tagBefore = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagBefore = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
 
     await game.phaseInterceptor.to("TurnEndPhase");
-    const tagAfter = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagAfter = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagAfter instanceof EntryHazardTag).toBeTruthy();
     expect(tagAfter.layers).toBe(1);
     expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
@@ -66,11 +66,11 @@ describe("Moves - Ceaseless Edge", () => {
     game.move.select(MoveId.CEASELESS_EDGE);
     await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
-    const tagBefore = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagBefore = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
 
     await game.toNextTurn();
-    const tagAfter = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagAfter = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagAfter instanceof EntryHazardTag).toBeTruthy();
     expect(tagAfter.layers).toBe(2);
 

--- a/test/moves/ceaseless-edge.test.ts
+++ b/test/moves/ceaseless-edge.test.ts
@@ -1,4 +1,4 @@
-import { EntryHazardTag } from "#app/data/arena-tag";
+import type { EntryHazardTag } from "#app/data/arena-tag";
 import { allMoves } from "#app/data/data-lists";
 import { toDmgValue } from "#app/utils/common-utils";
 import { AbilityId } from "#enums/ability-id";
@@ -48,8 +48,8 @@ describe("Moves - Ceaseless Edge", () => {
 
     await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
-    const tagBefore = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
-    expect(tagBefore).toBeUndefined();
+    const tagBefore = game.scene.arena.hasTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
+    expect(tagBefore).toBeFalsy();
 
     await game.phaseInterceptor.to("TurnEndPhase");
     const tagAfter = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)!;
@@ -66,13 +66,13 @@ describe("Moves - Ceaseless Edge", () => {
     game.move.select(MoveId.CEASELESS_EDGE);
     await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
-    const tagBefore = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
+    const tagBefore = game.scene.arena.hasTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
+    expect(tagBefore).toBeFalsy();
 
     await game.toNextTurn();
-    const tagAfter = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(tagAfter instanceof EntryHazardTag).toBeTruthy();
-    expect(tagAfter.layers).toBe(2);
+    const tagAfter = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.SPIKES, ArenaTagSide.ENEMY);
+    expect(tagAfter).toBeDefined();
+    expect(tagAfter!.layers).toBe(2);
 
     game.forceEnemyToSwitch();
     game.move.select(MoveId.SPLASH);

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -39,18 +39,18 @@ describe("Moves - Court Change", () => {
     game.move.select(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
-    const tag1 = game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
+    const tag1 = game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
     expect(tag1?.tagType).toBe(ArenaTagType.SAFEGUARD);
     expect(tag1?.turnCount).toBe(4);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
 
     game.move.select(MoveId.COURT_CHANGE);
     await game.toNextTurn();
 
-    const tag2 = game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
+    const tag2 = game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
     expect(tag2?.tagType).toBe(ArenaTagType.SAFEGUARD);
     expect(tag2?.turnCount).toBe(3);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
   });
 
   test("should not miss", async () => {
@@ -63,17 +63,13 @@ describe("Moves - Court Change", () => {
     game.move.select(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)?.tagType).toBe(
-      ArenaTagType.SAFEGUARD,
-    );
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)?.tagType).toBe(ArenaTagType.SAFEGUARD);
+    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
 
     game.move.select(MoveId.COURT_CHANGE);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)?.tagType).toBe(
-      ArenaTagType.SAFEGUARD,
-    );
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)?.tagType).toBe(ArenaTagType.SAFEGUARD);
+    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
   });
 });

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -39,18 +39,18 @@ describe("Moves - Court Change", () => {
     game.move.select(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
-    const tag1 = game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
+    const tag1 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
     expect(tag1?.tagType).toBe(ArenaTagType.SAFEGUARD);
     expect(tag1?.turnCount).toBe(4);
-    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
 
     game.move.select(MoveId.COURT_CHANGE);
     await game.toNextTurn();
 
-    const tag2 = game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
+    const tag2 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
     expect(tag2?.tagType).toBe(ArenaTagType.SAFEGUARD);
     expect(tag2?.turnCount).toBe(3);
-    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
   });
 
   test("should not miss", async () => {
@@ -63,13 +63,13 @@ describe("Moves - Court Change", () => {
     game.move.select(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)?.tagType).toBe(ArenaTagType.SAFEGUARD);
-    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)?.tagType).toBe(ArenaTagType.SAFEGUARD);
+    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
 
     game.move.select(MoveId.COURT_CHANGE);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)?.tagType).toBe(ArenaTagType.SAFEGUARD);
-    expect(game.scene.arena.getTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)?.tagType).toBe(ArenaTagType.SAFEGUARD);
+    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
   });
 });

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -39,18 +39,16 @@ describe("Moves - Court Change", () => {
     game.move.select(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
-    const tag1 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER);
-    expect(tag1?.tagType).toBe(ArenaTagType.SAFEGUARD);
-    expect(tag1?.turnCount).toBe(4);
-    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
+    const tag1 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)!;
+    expect(tag1.turnCount).toBe(4);
+    expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeFalsy();
 
     game.move.select(MoveId.COURT_CHANGE);
     await game.toNextTurn();
 
-    const tag2 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY);
-    expect(tag2?.tagType).toBe(ArenaTagType.SAFEGUARD);
-    expect(tag2?.turnCount).toBe(3);
-    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
+    const tag2 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)!;
+    expect(tag2.turnCount).toBe(3);
+    expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeFalsy();
   });
 
   test("should not miss", async () => {
@@ -63,13 +61,13 @@ describe("Moves - Court Change", () => {
     game.move.select(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)?.tagType).toBe(ArenaTagType.SAFEGUARD);
-    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeFalsy();
 
     game.move.select(MoveId.COURT_CHANGE);
     await game.toNextTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)?.tagType).toBe(ArenaTagType.SAFEGUARD);
-    expect(game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeFalsy();
   });
 });

--- a/test/moves/defog.test.ts
+++ b/test/moves/defog.test.ts
@@ -62,7 +62,7 @@ describe("Moves - Defog", () => {
     await game.toEndOfTurn();
 
     [ArenaTagSide.PLAYER, ArenaTagSide.ENEMY].forEach((side) =>
-      expect(game.scene.arena.getTag(tagType, side)).toBeUndefined(),
+      expect(game.scene.arena.findTag(tagType, side)).toBeUndefined(),
     );
   });
 
@@ -83,7 +83,7 @@ describe("Moves - Defog", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 });

--- a/test/moves/defog.test.ts
+++ b/test/moves/defog.test.ts
@@ -62,7 +62,7 @@ describe("Moves - Defog", () => {
     await game.toEndOfTurn();
 
     [ArenaTagSide.PLAYER, ArenaTagSide.ENEMY].forEach((side) =>
-      expect(game.scene.arena.getTagOnSide(tagType, side)).toBeUndefined(),
+      expect(game.scene.arena.getTag(tagType, side)).toBeUndefined(),
     );
   });
 
@@ -83,7 +83,7 @@ describe("Moves - Defog", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(tagType, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 });

--- a/test/moves/defog.test.ts
+++ b/test/moves/defog.test.ts
@@ -1,5 +1,5 @@
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -62,7 +62,7 @@ describe("Moves - Defog", () => {
     await game.toEndOfTurn();
 
     [ArenaTagSide.PLAYER, ArenaTagSide.ENEMY].forEach((side) =>
-      expect(game.scene.arena.findTag(tagType, side)).toBeUndefined(),
+      expect(game.scene.arena.hasTag(tagType, side)).toBeFalsy(),
     );
   });
 
@@ -83,7 +83,7 @@ describe("Moves - Defog", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(tagType, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(tagType, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 });

--- a/test/moves/destiny-bond.test.ts
+++ b/test/moves/destiny-bond.test.ts
@@ -195,7 +195,7 @@ describe("Moves - Destiny Bond", () => {
     expect(playerPokemon?.isFainted()).toBe(true);
 
     // Ceaseless Edge spikes effect should still activate
-    const tagAfter = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagAfter = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagAfter.tagType).toBe(ArenaTagType.SPIKES);
     expect(tagAfter.layers).toBe(1);
   });
@@ -220,7 +220,7 @@ describe("Moves - Destiny Bond", () => {
     expect(playerPokemon1?.isFainted()).toBe(true);
 
     // Pledge secondary effect should still activate
-    const tagAfter = game.scene.arena.getTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
+    const tagAfter = game.scene.arena.findTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
     expect(tagAfter?.tagType).toBe(ArenaTagType.GRASS_WATER_PLEDGE);
   });
 

--- a/test/moves/destiny-bond.test.ts
+++ b/test/moves/destiny-bond.test.ts
@@ -195,7 +195,7 @@ describe("Moves - Destiny Bond", () => {
     expect(playerPokemon?.isFainted()).toBe(true);
 
     // Ceaseless Edge spikes effect should still activate
-    const tagAfter = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const tagAfter = game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagAfter.tagType).toBe(ArenaTagType.SPIKES);
     expect(tagAfter.layers).toBe(1);
   });
@@ -220,7 +220,7 @@ describe("Moves - Destiny Bond", () => {
     expect(playerPokemon1?.isFainted()).toBe(true);
 
     // Pledge secondary effect should still activate
-    const tagAfter = game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
+    const tagAfter = game.scene.arena.getTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
     expect(tagAfter?.tagType).toBe(ArenaTagType.GRASS_WATER_PLEDGE);
   });
 

--- a/test/moves/destiny-bond.test.ts
+++ b/test/moves/destiny-bond.test.ts
@@ -1,16 +1,16 @@
 import type { EntryHazardTag } from "#app/data/arena-tag";
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { allMoves } from "#app/data/data-lists";
+import { PokemonInstantReviveModifier } from "#app/modifier/modifier";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { BattlerIndex } from "#enums/battler-index";
-import { StatusEffect } from "#enums/status-effect";
-import { PokemonInstantReviveModifier } from "#app/modifier/modifier";
 
 describe("Moves - Destiny Bond", () => {
   let phaserGame: Phaser.Game;
@@ -195,8 +195,7 @@ describe("Moves - Destiny Bond", () => {
     expect(playerPokemon?.isFainted()).toBe(true);
 
     // Ceaseless Edge spikes effect should still activate
-    const tagAfter = game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(tagAfter.tagType).toBe(ArenaTagType.SPIKES);
+    const tagAfter = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)!;
     expect(tagAfter.layers).toBe(1);
   });
 
@@ -220,8 +219,7 @@ describe("Moves - Destiny Bond", () => {
     expect(playerPokemon1?.isFainted()).toBe(true);
 
     // Pledge secondary effect should still activate
-    const tagAfter = game.scene.arena.findTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY);
-    expect(tagAfter?.tagType).toBe(ArenaTagType.GRASS_WATER_PLEDGE);
+    expect(game.scene.arena.hasTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeTruthy();
   });
 
   /**

--- a/test/moves/fairy-lock.test.ts
+++ b/test/moves/fairy-lock.test.ts
@@ -43,8 +43,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -72,8 +72,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -101,8 +101,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
@@ -128,8 +128,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -166,8 +166,8 @@ describe("Moves - Fairy Lock", () => {
     expect(enemyPokemon[1].isFainted()).toBe(true);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
     expect(playerPokemon[0].isTrapped()).toBe(true);
   });
 });

--- a/test/moves/fairy-lock.test.ts
+++ b/test/moves/fairy-lock.test.ts
@@ -1,12 +1,12 @@
+import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
-import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { BattlerIndex } from "#enums/battler-index";
 
 describe("Moves - Fairy Lock", () => {
   let phaserGame: Phaser.Game;
@@ -43,8 +43,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await game.toNextTurn();
 
@@ -72,8 +72,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await game.toNextTurn();
 
@@ -101,8 +101,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
@@ -128,8 +128,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await game.toNextTurn();
 
@@ -166,8 +166,8 @@ describe("Moves - Fairy Lock", () => {
     expect(enemyPokemon[1].isFainted()).toBe(true);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeTruthy();
     expect(playerPokemon[0].isTrapped()).toBe(true);
   });
 });

--- a/test/moves/fairy-lock.test.ts
+++ b/test/moves/fairy-lock.test.ts
@@ -43,8 +43,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -72,8 +72,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -101,8 +101,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
     game.move.select(MoveId.SPLASH);
@@ -128,8 +128,8 @@ describe("Moves - Fairy Lock", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.move.selectEnemyMove(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -166,8 +166,8 @@ describe("Moves - Fairy Lock", () => {
     expect(enemyPokemon[1].isFainted()).toBe(true);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FAIRY_LOCK, ArenaTagSide.ENEMY)).toBeDefined();
     expect(playerPokemon[0].isTrapped()).toBe(true);
   });
 });

--- a/test/moves/future-sight.test.ts
+++ b/test/moves/future-sight.test.ts
@@ -1,6 +1,7 @@
 import { allMoves } from "#app/data/data-lists";
 import { MetronomeAttr } from "#app/data/moves/move-attrs/metronome-attr";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
@@ -56,7 +57,7 @@ describe("Moves - Future Sight", () => {
     await game.toNextTurn();
 
     expect(enemy.isFullHp()).toBeTruthy();
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await passTurns(2);
 
@@ -85,7 +86,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await passTurns(2);
 
@@ -101,7 +102,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await passTurns(2);
 
@@ -117,7 +118,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await passTurns(2);
 
@@ -137,7 +138,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT, 1, BattlerIndex.ENEMY_2);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
     enemyPokemon.forEach((p) => expect(p.isFullHp()).toBeTruthy());
 
     await passTurns(2, true);
@@ -157,7 +158,7 @@ describe("Moves - Future Sight", () => {
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
     expect(playerPokemon[1]).toHaveMoveResult(MoveResult.FAIL);
   });
 
@@ -173,7 +174,7 @@ describe("Moves - Future Sight", () => {
     await game.toEndOfTurn();
 
     enemyPokemon.forEach((p) => expect(p.isFullHp()).toBeTruthy());
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await passTurns(2, true);
 
@@ -191,7 +192,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.DELAYED_ATTACK, ArenaTagSide.ENEMY)).toBeTruthy();
 
     await passTurns(1, true);
 

--- a/test/moves/future-sight.test.ts
+++ b/test/moves/future-sight.test.ts
@@ -56,7 +56,7 @@ describe("Moves - Future Sight", () => {
     await game.toNextTurn();
 
     expect(enemy.isFullHp()).toBeTruthy();
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
 
     await passTurns(2);
 
@@ -85,7 +85,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
 
     await passTurns(2);
 
@@ -101,7 +101,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
 
     await passTurns(2);
 
@@ -117,7 +117,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
 
     await passTurns(2);
 
@@ -137,7 +137,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.FUTURE_SIGHT, 1, BattlerIndex.ENEMY_2);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
     enemyPokemon.forEach((p) => expect(p.isFullHp()).toBeTruthy());
 
     await passTurns(2, true);
@@ -157,7 +157,7 @@ describe("Moves - Future Sight", () => {
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
     expect(playerPokemon[1]).toHaveMoveResult(MoveResult.FAIL);
   });
 
@@ -173,7 +173,7 @@ describe("Moves - Future Sight", () => {
     await game.toEndOfTurn();
 
     enemyPokemon.forEach((p) => expect(p.isFullHp()).toBeTruthy());
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
 
     await passTurns(2, true);
 
@@ -191,7 +191,7 @@ describe("Moves - Future Sight", () => {
     game.move.select(MoveId.SPLASH, 1);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.DELAYED_ATTACK)).toBeDefined();
 
     await passTurns(1, true);
 

--- a/test/moves/heal-block.test.ts
+++ b/test/moves/heal-block.test.ts
@@ -61,8 +61,8 @@ describe("Moves - Heal Block", () => {
     game.move.select(MoveId.WISH);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)).toBeDefined();
-    while (game.scene.arena.getTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)) {
+    expect(game.scene.arena.findTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)).toBeDefined();
+    while (game.scene.arena.findTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)) {
       game.move.select(MoveId.SPLASH);
       await game.toEndOfTurn();
     }

--- a/test/moves/heal-block.test.ts
+++ b/test/moves/heal-block.test.ts
@@ -61,8 +61,8 @@ describe("Moves - Heal Block", () => {
     game.move.select(MoveId.WISH);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.WISH, ArenaTagSide.PLAYER)).toBeDefined();
-    while (game.scene.arena.getTagOnSide(ArenaTagType.WISH, ArenaTagSide.PLAYER)) {
+    expect(game.scene.arena.getTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)).toBeDefined();
+    while (game.scene.arena.getTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)) {
       game.move.select(MoveId.SPLASH);
       await game.toEndOfTurn();
     }

--- a/test/moves/heal-block.test.ts
+++ b/test/moves/heal-block.test.ts
@@ -1,12 +1,12 @@
-import { BattlerIndex } from "#enums/battler-index";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import { GameManager } from "#test/test-utils/gameManager";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { WeatherType } from "#enums/weather-type";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -61,8 +61,8 @@ describe("Moves - Heal Block", () => {
     game.move.select(MoveId.WISH);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)).toBeDefined();
-    while (game.scene.arena.findTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)) {
+    expect(game.scene.arena.hasTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)).toBeTruthy();
+    while (game.scene.arena.hasTag(ArenaTagType.WISH, ArenaTagSide.PLAYER)) {
       game.move.select(MoveId.SPLASH);
       await game.toEndOfTurn();
     }

--- a/test/moves/healing-wish-lunar-dance.test.ts
+++ b/test/moves/healing-wish-lunar-dance.test.ts
@@ -120,7 +120,7 @@ describe("Moves - Lunar Dance and Healing Wish", () => {
       expect(bulbasaur.isFainted()).toBeTruthy();
       expect(charmander).toHaveFullHp();
       expect(game.phaseInterceptor.log).not.toContain("PokemonHealPhase");
-      expect(game.scene.arena.getTag(ArenaTagType.PENDING_HEAL)).toBeDefined();
+      expect(game.scene.arena.hasTag(ArenaTagType.PENDING_HEAL)).toBeTruthy();
 
       await game.toNextTurn();
 
@@ -130,7 +130,7 @@ describe("Moves - Lunar Dance and Healing Wish", () => {
       await game.toEndOfTurn();
 
       expect(squirtle).toHaveFullHp();
-      expect(game.scene.arena.getTag(ArenaTagType.PENDING_HEAL)).toBeUndefined();
+      expect(game.scene.arena.hasTag(ArenaTagType.PENDING_HEAL)).toBeFalsy();
 
       // Set Charmander's HP to 1, then switch back to Charmander.
       // HW/LD shouldn't activate again
@@ -162,7 +162,7 @@ describe("Moves - Lunar Dance and Healing Wish", () => {
       expect(bulbasaur.isFainted()).toBeTruthy();
       expect(charmander).toHaveFullHp();
       expect(game.phaseInterceptor.log).not.toContain("PokemonHealPhase");
-      expect(game.scene.arena.getTag(ArenaTagType.PENDING_HEAL)).toBeDefined();
+      expect(game.scene.arena.hasTag(ArenaTagType.PENDING_HEAL)).toBeTruthy();
 
       // Use HW/LD again, sending in Squirtle. HW/LD should activate and heal Squirtle
       game.move.use(moveId);
@@ -224,7 +224,7 @@ describe("Moves - Lunar Dance and Healing Wish", () => {
     expect(bulbasaur.isFainted()).toBeTruthy();
     expect(charmander).toHaveFullHp();
     expect(game.phaseInterceptor.log).not.toContain("PokemonHealPhase");
-    expect(game.scene.arena.getTag(ArenaTagType.PENDING_HEAL)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.PENDING_HEAL)).toBeTruthy();
 
     game.move.use(MoveId.HEALING_WISH);
     game.selectPartyPokemon(2);
@@ -233,7 +233,7 @@ describe("Moves - Lunar Dance and Healing Wish", () => {
     await game.toNextTurn();
     expect(squirtle).toHaveFullHp();
     squirtle.getMoveset().forEach((mv) => expect(mv.ppUsed).toBe(0));
-    expect(game.scene.arena.getTag(ArenaTagType.PENDING_HEAL)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.PENDING_HEAL)).toBeTruthy();
 
     game.switchPokemon(3);
 
@@ -241,6 +241,6 @@ describe("Moves - Lunar Dance and Healing Wish", () => {
     await game.toEndOfTurn();
     expect(pikachu).toHaveFullHp();
     pikachu.getMoveset().forEach((mv) => expect(mv.ppUsed).toBe(1));
-    expect(game.scene.arena.getTag(ArenaTagType.PENDING_HEAL)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.PENDING_HEAL)).toBeFalsy();
   });
 });

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -170,8 +170,8 @@ describe("Moves - Magic Coat", () => {
     game.move.use(MoveId.SPIKES);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
+    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("should not bounce back curse", async () => {
@@ -332,7 +332,7 @@ describe("Moves - Magic Coat", () => {
     await game.toEndOfTurn();
 
     expect(
-      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
+      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
     game.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER, true);
 
@@ -341,7 +341,7 @@ describe("Moves - Magic Coat", () => {
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
     expect(
-      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
+      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
   });
 });

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -170,8 +170,8 @@ describe("Moves - Magic Coat", () => {
     game.move.use(MoveId.SPIKES);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
+    expect(game.scene.arena.getTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("should not bounce back curse", async () => {
@@ -332,10 +332,7 @@ describe("Moves - Magic Coat", () => {
     await game.toEndOfTurn();
 
     expect(
-      game.scene.arena
-        .getTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)
-        ?.getSourcePokemon()
-        ?.getBattlerIndex(),
+      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
     game.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER, true);
 
@@ -344,10 +341,7 @@ describe("Moves - Magic Coat", () => {
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
     expect(
-      game.scene.arena
-        .getTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)
-        ?.getSourcePokemon()
-        ?.getBattlerIndex(),
+      game.scene.arena.getTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
     ).toBe(BattlerIndex.ENEMY);
   });
 });

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -171,7 +171,7 @@ describe("Moves - Magic Coat", () => {
     await game.toEndOfTurn();
 
     expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.PLAYER)?.["layers"]).toBe(1);
-    expect(game.scene.arena.findTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.SPIKES, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 
   it("should not bounce back curse", async () => {
@@ -331,17 +331,16 @@ describe("Moves - Magic Coat", () => {
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
 
-    expect(
-      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
-    ).toBe(BattlerIndex.ENEMY);
+    const tag1 = game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER);
+    expect(tag1?.getSourcePokemon()?.getBattlerIndex()).toBe(BattlerIndex.ENEMY);
     game.scene.arena.removeTagOnSide(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER, true);
 
     // turn 2
     game.move.use(MoveId.STICKY_WEB, 0);
     game.move.use(MoveId.TRICK_ROOM, 1);
     await game.toEndOfTurn();
-    expect(
-      game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER)?.getSourcePokemon()?.getBattlerIndex(),
-    ).toBe(BattlerIndex.ENEMY);
+
+    const tag2 = game.scene.arena.findTag(ArenaTagType.STICKY_WEB, ArenaTagSide.PLAYER);
+    expect(tag2?.getSourcePokemon()?.getBattlerIndex()).toBe(BattlerIndex.ENEMY);
   });
 });

--- a/test/moves/pledge-moves.test.ts
+++ b/test/moves/pledge-moves.test.ts
@@ -102,7 +102,7 @@ describe("Moves - Pledge Moves", () => {
     // if they combined moves, so both should be damaged.
     expect(playerPokemon.hp).toBeLessThan(playerPokemon.getMaxHp());
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    expect(game.scene.arena.findTag(ArenaTagType.FIRE_GRASS_PLEDGE)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FIRE_GRASS_PLEDGE)).toBeFalsy();
   });
 
   it("Grass Pledge - should combine with Fire Pledge to form a 150-power Fire-type attack that creates a 'sea of fire'", async () => {
@@ -132,7 +132,7 @@ describe("Moves - Pledge Moves", () => {
     const baseDmg = baseDmgMock.mock.results[baseDmgMock.mock.results.length - 1].value;
     expect(enemyPokemon[0].getMaxHp() - enemyPokemon[0].hp).toBe(toDmgValue(baseDmg * 1.5));
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.findTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeTruthy();
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
     await game.toNextTurn();
@@ -155,7 +155,7 @@ describe("Moves - Pledge Moves", () => {
     }
 
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.findTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeTruthy();
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
     await game.toNextTurn();
@@ -187,7 +187,7 @@ describe("Moves - Pledge Moves", () => {
     expect(playerPokemon[1].getMoveType).toHaveLastReturnedWith(ElementalType.WATER);
     expect(firePledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.findTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeTruthy();
 
     await game.toNextTurn();
 
@@ -228,7 +228,7 @@ describe("Moves - Pledge Moves", () => {
     expect(waterPledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp());
 
-    expect(game.scene.arena.findTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeTruthy();
     enemyPokemon.forEach((p, i) => expect(p.getEffectiveStat(Stat.SPD)).toBe(Math.floor(enemyStartingSpd[i] / 4)));
   });
 
@@ -265,7 +265,7 @@ describe("Moves - Pledge Moves", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeTruthy();
 
     game.move.select(MoveId.IRON_HEAD, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.SPLASH, 1);

--- a/test/moves/pledge-moves.test.ts
+++ b/test/moves/pledge-moves.test.ts
@@ -102,7 +102,7 @@ describe("Moves - Pledge Moves", () => {
     // if they combined moves, so both should be damaged.
     expect(playerPokemon.hp).toBeLessThan(playerPokemon.getMaxHp());
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
-    expect(game.scene.arena.getTag(ArenaTagType.FIRE_GRASS_PLEDGE)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FIRE_GRASS_PLEDGE)).toBeUndefined();
   });
 
   it("Grass Pledge - should combine with Fire Pledge to form a 150-power Fire-type attack that creates a 'sea of fire'", async () => {
@@ -132,7 +132,7 @@ describe("Moves - Pledge Moves", () => {
     const baseDmg = baseDmgMock.mock.results[baseDmgMock.mock.results.length - 1].value;
     expect(enemyPokemon[0].getMaxHp() - enemyPokemon[0].hp).toBe(toDmgValue(baseDmg * 1.5));
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
     await game.toNextTurn();
@@ -155,7 +155,7 @@ describe("Moves - Pledge Moves", () => {
     }
 
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
     await game.toNextTurn();
@@ -187,7 +187,7 @@ describe("Moves - Pledge Moves", () => {
     expect(playerPokemon[1].getMoveType).toHaveLastReturnedWith(ElementalType.WATER);
     expect(firePledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -228,7 +228,7 @@ describe("Moves - Pledge Moves", () => {
     expect(waterPledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp());
 
-    expect(game.scene.arena.getTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
     enemyPokemon.forEach((p, i) => expect(p.getEffectiveStat(Stat.SPD)).toBe(Math.floor(enemyStartingSpd[i] / 4)));
   });
 
@@ -265,7 +265,7 @@ describe("Moves - Pledge Moves", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.IRON_HEAD, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.SPLASH, 1);

--- a/test/moves/pledge-moves.test.ts
+++ b/test/moves/pledge-moves.test.ts
@@ -132,7 +132,7 @@ describe("Moves - Pledge Moves", () => {
     const baseDmg = baseDmgMock.mock.results[baseDmgMock.mock.results.length - 1].value;
     expect(enemyPokemon[0].getMaxHp() - enemyPokemon[0].hp).toBe(toDmgValue(baseDmg * 1.5));
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
     await game.toNextTurn();
@@ -155,7 +155,7 @@ describe("Moves - Pledge Moves", () => {
     }
 
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.FIRE_GRASS_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
     await game.toNextTurn();
@@ -187,7 +187,7 @@ describe("Moves - Pledge Moves", () => {
     expect(playerPokemon[1].getMoveType).toHaveLastReturnedWith(ElementalType.WATER);
     expect(firePledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp()); // PLAYER should not have attacked
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
 
     await game.toNextTurn();
 
@@ -228,7 +228,7 @@ describe("Moves - Pledge Moves", () => {
     expect(waterPledge.calculateBattlePower).toHaveLastReturnedWith(150);
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp());
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.GRASS_WATER_PLEDGE, ArenaTagSide.ENEMY)).toBeDefined();
     enemyPokemon.forEach((p, i) => expect(p.getEffectiveStat(Stat.SPD)).toBe(Math.floor(enemyStartingSpd[i] / 4)));
   });
 
@@ -265,7 +265,7 @@ describe("Moves - Pledge Moves", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.IRON_HEAD, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.SPLASH, 1);

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -66,7 +66,7 @@ describe("Moves - Protect", () => {
     await game.toEndOfTurn();
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-    expect(game.scene.arena.getTagOnSide(EntryHazardTag, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(EntryHazardTag, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   test("should protect the user from status moves", async () => {

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -66,7 +66,7 @@ describe("Moves - Protect", () => {
     await game.toEndOfTurn();
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-    expect(game.scene.arena.getTag(EntryHazardTag, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(EntryHazardTag, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   test("should protect the user from status moves", async () => {

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -66,7 +66,7 @@ describe("Moves - Protect", () => {
     await game.toEndOfTurn();
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
-    expect(game.scene.arena.findTag(EntryHazardTag, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTags((t) => t instanceof EntryHazardTag, ArenaTagSide.ENEMY)).toEqual([]);
   });
 
   test("should protect the user from status moves", async () => {

--- a/test/moves/rapid-spin.test.ts
+++ b/test/moves/rapid-spin.test.ts
@@ -78,7 +78,7 @@ describe("Moves - Rapid Spin", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTagOnSide(tagType, ArenaTagSide.PLAYER)).toBeUndefined();
-    expect(game.scene.arena.getTagOnSide(tagType, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.getTag(tagType, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.getTag(tagType, ArenaTagSide.ENEMY)).toBeDefined();
   });
 });

--- a/test/moves/rapid-spin.test.ts
+++ b/test/moves/rapid-spin.test.ts
@@ -78,7 +78,7 @@ describe("Moves - Rapid Spin", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTag(tagType, ArenaTagSide.PLAYER)).toBeUndefined();
-    expect(game.scene.arena.getTag(tagType, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.findTag(tagType, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.findTag(tagType, ArenaTagSide.ENEMY)).toBeDefined();
   });
 });

--- a/test/moves/rapid-spin.test.ts
+++ b/test/moves/rapid-spin.test.ts
@@ -1,7 +1,7 @@
-import { BattlerIndex } from "#enums/battler-index";
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -78,7 +78,7 @@ describe("Moves - Rapid Spin", () => {
 
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.findTag(tagType, ArenaTagSide.PLAYER)).toBeUndefined();
-    expect(game.scene.arena.findTag(tagType, ArenaTagSide.ENEMY)).toBeDefined();
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.PLAYER)).toBeFalsy();
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.ENEMY)).toBeTruthy();
   });
 });

--- a/test/moves/secret-power.test.ts
+++ b/test/moves/secret-power.test.ts
@@ -75,7 +75,7 @@ describe("Moves - Secret Power", () => {
     const sereneGraceAttr = allAbilities[AbilityId.SERENE_GRACE].getAttrs(AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER)[0];
     vi.spyOn(sereneGraceAttr, "apply");
 
-    let rainbowEffect = game.scene.arena.getTagOnSide(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER);
+    let rainbowEffect = game.scene.arena.getTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER);
     expect(rainbowEffect).toBeDefined();
 
     rainbowEffect = rainbowEffect!;

--- a/test/moves/secret-power.test.ts
+++ b/test/moves/secret-power.test.ts
@@ -75,7 +75,7 @@ describe("Moves - Secret Power", () => {
     const sereneGraceAttr = allAbilities[AbilityId.SERENE_GRACE].getAttrs(AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER)[0];
     vi.spyOn(sereneGraceAttr, "apply");
 
-    let rainbowEffect = game.scene.arena.getTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER);
+    let rainbowEffect = game.scene.arena.findTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER);
     expect(rainbowEffect).toBeDefined();
 
     rainbowEffect = rainbowEffect!;

--- a/test/moves/secret-power.test.ts
+++ b/test/moves/secret-power.test.ts
@@ -1,17 +1,17 @@
+import { allAbilities, allMoves } from "#app/data/data-lists";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { BiomeId } from "#enums/biome-id";
 import { MoveId } from "#enums/move-id";
-import { Stat } from "#enums/stat";
-import { allAbilities, allMoves } from "#app/data/data-lists";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { StatusEffect } from "#enums/status-effect";
-import { BattlerIndex } from "#enums/battler-index";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 describe("Moves - Secret Power", () => {
   let phaserGame: Phaser.Game;
@@ -75,10 +75,9 @@ describe("Moves - Secret Power", () => {
     const sereneGraceAttr = allAbilities[AbilityId.SERENE_GRACE].getAttrs(AbAttrFlag.MOVE_EFFECT_CHANCE_MULTIPLIER)[0];
     vi.spyOn(sereneGraceAttr, "apply");
 
-    let rainbowEffect = game.scene.arena.findTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER);
+    const rainbowEffect = game.scene.arena.findTag(ArenaTagType.WATER_FIRE_PLEDGE, ArenaTagSide.PLAYER)!;
     expect(rainbowEffect).toBeDefined();
 
-    rainbowEffect = rainbowEffect!;
     vi.spyOn(rainbowEffect, "apply");
 
     game.move.select(MoveId.SECRET_POWER, 0, BattlerIndex.ENEMY);

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -190,7 +190,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.findTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER)).toBeTruthy();
   });
 
   it("shouldn't block the opponent from setting hazards", async () => {
@@ -206,7 +206,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.findTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeTruthy();
   });
 
   it("shouldn't block moves that target both sides of the field", async () => {
@@ -225,8 +225,8 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     pokemon.forEach((p) => expect(p.getMoveEffectiveness).not.toHaveReturnedWith(0));
-    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
-    expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TRICK_ROOM)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.GRAVITY)).toBeTruthy();
   });
 
   it("should protect the user from flinching", async () => {

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -190,7 +190,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER)).toBeDefined();
   });
 
   it("shouldn't block the opponent from setting hazards", async () => {
@@ -206,7 +206,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.getTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeDefined();
   });
 
   it("shouldn't block moves that target both sides of the field", async () => {
@@ -225,8 +225,8 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     pokemon.forEach((p) => expect(p.getMoveEffectiveness).not.toHaveReturnedWith(0));
-    expect(game.scene.arena.getTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.GRAVITY)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.GRAVITY)).toBeDefined();
   });
 
   it("should protect the user from flinching", async () => {

--- a/test/moves/substitute.test.ts
+++ b/test/moves/substitute.test.ts
@@ -190,7 +190,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN, ArenaTagSide.PLAYER)).toBeDefined();
   });
 
   it("shouldn't block the opponent from setting hazards", async () => {
@@ -206,7 +206,7 @@ describe("Moves - Substitute", () => {
     await game.toNextTurn();
 
     expect(leadPokemon.getMoveEffectiveness).not.toHaveReturnedWith(0);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.STEALTH_ROCK, ArenaTagSide.PLAYER)).toBeDefined();
   });
 
   it("shouldn't block moves that target both sides of the field", async () => {

--- a/test/moves/tailwind.test.ts
+++ b/test/moves/tailwind.test.ts
@@ -52,7 +52,7 @@ describe("Moves - Tailwind", () => {
 
     expect(magikarp.getEffectiveStat(Stat.SPD)).toBe(magikarpSpd * 2);
     expect(meowth.getEffectiveStat(Stat.SPD)).toBe(meowthSpd * 2);
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
   });
 
   it("lasts for 4 turns", async () => {
@@ -62,20 +62,20 @@ describe("Moves - Tailwind", () => {
 
     game.move.select(MoveId.TAILWIND);
     await game.toNextTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
   });
 
   it("does not affect the opposing side", async () => {
@@ -91,8 +91,8 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).equal(allySpd);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
 
     game.move.select(MoveId.TAILWIND);
 
@@ -100,8 +100,8 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).toBe(allySpd * 2);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("modifies turn order on the turn it is set", async () => {

--- a/test/moves/tailwind.test.ts
+++ b/test/moves/tailwind.test.ts
@@ -52,7 +52,7 @@ describe("Moves - Tailwind", () => {
 
     expect(magikarp.getEffectiveStat(Stat.SPD)).toBe(magikarpSpd * 2);
     expect(meowth.getEffectiveStat(Stat.SPD)).toBe(meowthSpd * 2);
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeTruthy();
   });
 
   it("lasts for 4 turns", async () => {
@@ -62,20 +62,20 @@ describe("Moves - Tailwind", () => {
 
     game.move.select(MoveId.TAILWIND);
     await game.toNextTurn();
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeTruthy();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeTruthy();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeTruthy();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeFalsy();
   });
 
   it("does not affect the opposing side", async () => {
@@ -91,8 +91,8 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).equal(allySpd);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeFalsy();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeFalsy();
 
     game.move.select(MoveId.TAILWIND);
 
@@ -100,8 +100,8 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).toBe(allySpd * 2);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.findTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeFalsy();
   });
 
   it("modifies turn order on the turn it is set", async () => {

--- a/test/moves/tailwind.test.ts
+++ b/test/moves/tailwind.test.ts
@@ -52,7 +52,7 @@ describe("Moves - Tailwind", () => {
 
     expect(magikarp.getEffectiveStat(Stat.SPD)).toBe(magikarpSpd * 2);
     expect(meowth.getEffectiveStat(Stat.SPD)).toBe(meowthSpd * 2);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
   });
 
   it("lasts for 4 turns", async () => {
@@ -62,20 +62,20 @@ describe("Moves - Tailwind", () => {
 
     game.move.select(MoveId.TAILWIND);
     await game.toNextTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
   });
 
   it("does not affect the opposing side", async () => {
@@ -91,8 +91,8 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).equal(allySpd);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
 
     game.move.select(MoveId.TAILWIND);
 
@@ -100,8 +100,8 @@ describe("Moves - Tailwind", () => {
 
     expect(ally.getEffectiveStat(Stat.SPD)).toBe(allySpd * 2);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
-    expect(game.scene.arena.getTagOnSide(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.PLAYER)).toBeDefined();
+    expect(game.scene.arena.getTag(ArenaTagType.TAILWIND, ArenaTagSide.ENEMY)).toBeUndefined();
   });
 
   it("modifies turn order on the turn it is set", async () => {

--- a/test/moves/tidy-up.test.ts
+++ b/test/moves/tidy-up.test.ts
@@ -1,4 +1,5 @@
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
@@ -24,68 +25,39 @@ describe("Moves - Tidy Up", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleType("single");
-    game.override.enemySpecies(SpeciesId.MAGIKARP);
-    game.override.enemyAbility(AbilityId.BALL_FETCH);
-    game.override.enemyMoveset(MoveId.SPLASH);
-    game.override.starterSpecies(SpeciesId.FEEBAS);
-    game.override.ability(AbilityId.BALL_FETCH);
-    game.override.moveset([MoveId.TIDY_UP]);
-    game.override.startingLevel(50);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.STURDY)
+      .enemyMoveset(MoveId.SPLASH)
+      .starterSpecies(SpeciesId.FEEBAS)
+      .ability(AbilityId.STURDY)
+      .moveset([MoveId.TIDY_UP])
+      .startingLevel(50);
   });
 
-  it("spikes are cleared", async () => {
-    game.override.moveset([MoveId.SPIKES, MoveId.TIDY_UP]);
-    game.override.enemyMoveset([MoveId.SPIKES, MoveId.SPIKES, MoveId.SPIKES, MoveId.SPIKES]);
+  it.each([
+    { hazardName: "Spikes", moveId: MoveId.SPIKES, tagType: ArenaTagType.SPIKES },
+    { hazardName: "Stealth Rocks", moveId: MoveId.STEALTH_ROCK, tagType: ArenaTagType.STEALTH_ROCK },
+    { hazardName: "Toxic Spikes", moveId: MoveId.TOXIC_SPIKES, tagType: ArenaTagType.TOXIC_SPIKES },
+    { hazardName: "Sticky Webs", moveId: MoveId.STICKY_WEB, tagType: ArenaTagType.STICKY_WEB },
+    { hazardName: "Sharp Steel", moveId: MoveId.G_MAX_STEELSURGE, tagType: ArenaTagType.SHARP_STEEL },
+  ])("clears $hazardName", async ({ moveId, tagType }) => {
+    game.override.enemyMoveset(moveId);
     await game.classicMode.startBattle();
 
-    game.move.select(MoveId.SPIKES);
+    game.move.use(moveId);
     await game.phaseInterceptor.to("TurnEndPhase");
-    game.move.select(MoveId.TIDY_UP);
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.PLAYER)).toBeTruthy();
+    expect(game.scene.arena.hasTag(tagType, ArenaTagSide.ENEMY)).toBeTruthy();
+    game.move.use(MoveId.TIDY_UP);
     await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.findTag(ArenaTagType.SPIKES)).toBeUndefined();
-  }, 20000);
+    expect(game.scene.arena.hasTag(tagType)).toBeFalsy();
+  });
 
-  it("stealth rocks are cleared", async () => {
-    game.override.moveset([MoveId.STEALTH_ROCK, MoveId.TIDY_UP]);
-    game.override.enemyMoveset([MoveId.STEALTH_ROCK, MoveId.STEALTH_ROCK, MoveId.STEALTH_ROCK, MoveId.STEALTH_ROCK]);
-    await game.classicMode.startBattle();
-
-    game.move.select(MoveId.STEALTH_ROCK);
-    await game.phaseInterceptor.to("TurnEndPhase");
-    game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.findTag(ArenaTagType.STEALTH_ROCK)).toBeUndefined();
-  }, 20000);
-
-  it("toxic spikes are cleared", async () => {
-    game.override.moveset([MoveId.TOXIC_SPIKES, MoveId.TIDY_UP]);
-    game.override.enemyMoveset([MoveId.TOXIC_SPIKES, MoveId.TOXIC_SPIKES, MoveId.TOXIC_SPIKES, MoveId.TOXIC_SPIKES]);
-    await game.classicMode.startBattle();
-
-    game.move.select(MoveId.TOXIC_SPIKES);
-    await game.phaseInterceptor.to("TurnEndPhase");
-    game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES)).toBeUndefined();
-  }, 20000);
-
-  it("sticky webs are cleared", async () => {
-    game.override.moveset([MoveId.STICKY_WEB, MoveId.TIDY_UP]);
-    game.override.enemyMoveset([MoveId.STICKY_WEB, MoveId.STICKY_WEB, MoveId.STICKY_WEB, MoveId.STICKY_WEB]);
-
-    await game.classicMode.startBattle();
-
-    game.move.select(MoveId.STICKY_WEB);
-    await game.phaseInterceptor.to("TurnEndPhase");
-    game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.findTag(ArenaTagType.STICKY_WEB)).toBeUndefined();
-  }, 20000);
-
-  it("substitutes are cleared", async () => {
+  it("clears Substitutes", async () => {
     game.override.moveset([MoveId.SUBSTITUTE, MoveId.TIDY_UP]);
-    game.override.enemyMoveset([MoveId.SUBSTITUTE, MoveId.SUBSTITUTE, MoveId.SUBSTITUTE, MoveId.SUBSTITUTE]);
+    game.override.enemyMoveset(MoveId.SUBSTITUTE);
 
     await game.classicMode.startBattle();
 
@@ -99,7 +71,7 @@ describe("Moves - Tidy Up", () => {
       expect(p).toBeDefined();
       expect(p!.getTag(BattlerTagType.SUBSTITUTE)).toBeUndefined();
     });
-  }, 20000);
+  });
 
   it("user's stats are raised with no traps set", async () => {
     await game.classicMode.startBattle();
@@ -114,5 +86,5 @@ describe("Moves - Tidy Up", () => {
 
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(1);
     expect(playerPokemon.getStatStage(Stat.SPD)).toBe(1);
-  }, 20000);
+  });
 });

--- a/test/moves/tidy-up.test.ts
+++ b/test/moves/tidy-up.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.getTag(ArenaTagType.SPIKES)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.SPIKES)).toBeUndefined();
   }, 20000);
 
   it("stealth rocks are cleared", async () => {
@@ -55,7 +55,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.getTag(ArenaTagType.STEALTH_ROCK)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.STEALTH_ROCK)).toBeUndefined();
   }, 20000);
 
   it("toxic spikes are cleared", async () => {
@@ -67,7 +67,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES)).toBeUndefined();
   }, 20000);
 
   it("sticky webs are cleared", async () => {
@@ -80,7 +80,7 @@ describe("Moves - Tidy Up", () => {
     await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
     await game.phaseInterceptor.to("MoveEndPhase");
-    expect(game.scene.arena.getTag(ArenaTagType.STICKY_WEB)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.STICKY_WEB)).toBeUndefined();
   }, 20000);
 
   it("substitutes are cleared", async () => {

--- a/test/moves/toxic-spikes.test.ts
+++ b/test/moves/toxic-spikes.test.ts
@@ -1,8 +1,8 @@
-import { BattlerIndex } from "#enums/battler-index";
 import type { EntryHazardTag } from "#app/data/arena-tag";
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
@@ -112,9 +112,10 @@ describe("Moves - Toxic Spikes", () => {
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
-    const arenaTags = game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
-    expect(arenaTags.layers).toBe(1);
+    const arenaTag = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY)!;
+    expect(arenaTag).toBeDefined();
+    expect(arenaTag.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
+    expect(arenaTag.layers).toBe(1);
   });
 
   it("should persist through reload", async () => {

--- a/test/moves/toxic-spikes.test.ts
+++ b/test/moves/toxic-spikes.test.ts
@@ -131,9 +131,10 @@ describe("Moves - Toxic Spikes", () => {
 
     await game.reload.reloadSession();
 
-    const arenaTags = game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
-    expect(arenaTags.layers).toBe(1);
+    const arenaTag = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY)!;
+    expect(arenaTag).toBeDefined();
+    expect(arenaTag.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
+    expect(arenaTag.layers).toBe(1);
   });
 
   it("should apply even if the target is fainted", async () => {
@@ -148,8 +149,9 @@ describe("Moves - Toxic Spikes", () => {
     expect(enemyPokemon.isFainted()).toBe(true);
     await game.toNextTurn();
 
-    const arenaTags = game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
-    expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
-    expect(arenaTags.layers).toBe(1);
+    const arenaTag = game.scene.arena.findTag<EntryHazardTag>(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY)!;
+    expect(arenaTag).toBeDefined();
+    expect(arenaTag.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
+    expect(arenaTag.layers).toBe(1);
   });
 });

--- a/test/moves/toxic-spikes.test.ts
+++ b/test/moves/toxic-spikes.test.ts
@@ -112,7 +112,7 @@ describe("Moves - Toxic Spikes", () => {
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
-    const arenaTags = game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const arenaTags = game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
     expect(arenaTags.layers).toBe(1);
   });
@@ -130,7 +130,7 @@ describe("Moves - Toxic Spikes", () => {
 
     await game.reload.reloadSession();
 
-    const arenaTags = game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const arenaTags = game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
     expect(arenaTags.layers).toBe(1);
   });
@@ -147,7 +147,7 @@ describe("Moves - Toxic Spikes", () => {
     expect(enemyPokemon.isFainted()).toBe(true);
     await game.toNextTurn();
 
-    const arenaTags = game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const arenaTags = game.scene.arena.findTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
     expect(arenaTags.layers).toBe(1);
   });

--- a/test/moves/toxic-spikes.test.ts
+++ b/test/moves/toxic-spikes.test.ts
@@ -112,7 +112,7 @@ describe("Moves - Toxic Spikes", () => {
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
-    const arenaTags = game.scene.arena.getTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const arenaTags = game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
     expect(arenaTags.layers).toBe(1);
   });
@@ -130,7 +130,7 @@ describe("Moves - Toxic Spikes", () => {
 
     await game.reload.reloadSession();
 
-    const arenaTags = game.scene.arena.getTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const arenaTags = game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
     expect(arenaTags.layers).toBe(1);
   });
@@ -147,7 +147,7 @@ describe("Moves - Toxic Spikes", () => {
     expect(enemyPokemon.isFainted()).toBe(true);
     await game.toNextTurn();
 
-    const arenaTags = game.scene.arena.getTagOnSide(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
+    const arenaTags = game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(arenaTags.tagType).toBe(ArenaTagType.TOXIC_SPIKES);
     expect(arenaTags.layers).toBe(1);
   });

--- a/test/moves/trick-room.test.ts
+++ b/test/moves/trick-room.test.ts
@@ -72,7 +72,7 @@ describe("Moves - Trick Room", () => {
 
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
-    expect(game.scene.arena.hasTag(ArenaTagType.TRICK_ROOM)).toBeTruthy();
+    expect(game.scene.arena.hasTag(ArenaTagType.TRICK_ROOM)).toBeFalsy();
   });
 
   it("should not reverse move priority order", async () => {

--- a/test/moves/trick-room.test.ts
+++ b/test/moves/trick-room.test.ts
@@ -55,7 +55,7 @@ describe("Moves - Trick Room", () => {
 
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     expect(game.field.getTurnOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-    expect(game.scene.arena.getTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
   });
 
   it("should cancel an active Trick Room if used again", async () => {
@@ -72,7 +72,7 @@ describe("Moves - Trick Room", () => {
 
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
-    expect(game.scene.arena.getTag(ArenaTagType.TRICK_ROOM)).toBeUndefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeUndefined();
   });
 
   it("should not reverse move priority order", async () => {
@@ -85,7 +85,7 @@ describe("Moves - Trick Room", () => {
     await game.toEndOfTurn();
 
     expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    expect(game.scene.arena.getTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
   });
 
   it("should not reverse effects which cause Pokemon to move first/last within a priority bracket", async () => {
@@ -105,6 +105,6 @@ describe("Moves - Trick Room", () => {
     await game.toEndOfTurn();
 
     expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    expect(game.scene.arena.getTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
+    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
   });
 });

--- a/test/moves/trick-room.test.ts
+++ b/test/moves/trick-room.test.ts
@@ -55,7 +55,7 @@ describe("Moves - Trick Room", () => {
 
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     expect(game.field.getTurnOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TRICK_ROOM)).toBeTruthy();
   });
 
   it("should cancel an active Trick Room if used again", async () => {
@@ -72,7 +72,7 @@ describe("Moves - Trick Room", () => {
 
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
-    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeUndefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TRICK_ROOM)).toBeTruthy();
   });
 
   it("should not reverse move priority order", async () => {
@@ -85,7 +85,7 @@ describe("Moves - Trick Room", () => {
     await game.toEndOfTurn();
 
     expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TRICK_ROOM)).toBeTruthy();
   });
 
   it("should not reverse effects which cause Pokemon to move first/last within a priority bracket", async () => {
@@ -105,6 +105,6 @@ describe("Moves - Trick Room", () => {
     await game.toEndOfTurn();
 
     expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    expect(game.scene.arena.findTag(ArenaTagType.TRICK_ROOM)).toBeDefined();
+    expect(game.scene.arena.hasTag(ArenaTagType.TRICK_ROOM)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Reduce code redundancy, reduce import pollution.

## What are the changes from a developer perspective?
- `Arena#getTagOnSide` and `Arena#findTagsOnSide` consolidated into `Arena#findTag` and `Arena#getTags`.
- Added TSDocs to `Arena#hasTag`.
- Replaced some instances of `findTag` with `hasTag` where it was being used as a boolean.
- `Arena#findTag` no longer accepts class constructors as a parameter.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)