### PR TITLE
[Dev] Add enemy pokemon level to encounter logging

### DIFF
--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -427,6 +427,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
     console.log(
       `Pokemon: ${getPokemonNameWithAffix(enemyPokemon)}`,
       `| Species ID: ${enemyPokemon.species.speciesId}`,
+      `| Level: ${enemyPokemon.level}`,
       `| Nature: ${getNatureName(enemyPokemon.nature, true, true, true)}`,
     );
     console.log(`Stats (IVs): ${stats}`);

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -216,6 +216,7 @@ export class EncounterPhase extends BattlePhase {
       console.log(
         `Pokemon: ${getPokemonNameWithAffix(enemyPokemon)}`,
         `| Species ID: ${enemyPokemon.species.speciesId}`,
+        `| Level: ${enemyPokemon.level}`,
         `| Nature: ${getNatureName(enemyPokemon.nature, true, true, true)}`,
       );
       console.log(`Stats (IVs): ${stats}`);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To aid in development of battles.

## What are the changes from a developer perspective?
Added logging of enemy Pokémon levels in `EncounterPhase` and `encounter-phase-utils.ts`.

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/e533f4de-a5c3-4973-a595-69a0f05d418e)

## How to test the changes?
Open the browser devtools and observe the console log when starting a new wave.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Have I provided screenshots/videos of the changes (if applicable)?