### PR TITLE
[AI][Balance] Enemy AI trainers will now tera

### DIFF
--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1702,32 +1702,6 @@ export function getSpeciesFilterRandomPartyMemberFunc(
 }
 
 /**
- * Function to create a {@linkcode PersistentModifier} of applying a single tera on a specific trainer's party
- * Only used in {@linkcode initForPaldeaGymLeader} right now
- *
- * @param party the party
- * @param partySlot the party slot to apply the tera on (currently only the last slot)
- * @param teraType the type that the Pokemon will be tera'd into
- * @returns a PersistentModifier
- */
-// TODO: remove this when trainer teras are reworked
-// function getSpecificTeraModifier(
-//   party: EnemyPokemon[],
-//   partySlot: number,
-//   teraType: ElementalType,
-// ): PersistentModifier[] {
-//   const ret: PersistentModifier[] = [];
-//   ret.push(
-//     modifierTypes
-//       .TERA_SHARD()
-//       .generateType([], [teraType])!
-//       .withIdFromFunc(modifierTypes.TERA_SHARD)
-//       .newModifier(party[partySlot]) as PersistentModifier,
-//   );
-//   return ret;
-// }
-
-/**
  * Function to create a {@linkcode PersistentModifier} of applying random tera types to a trainer's team
  * @param party the party
  * @param count how many random teras will be applied

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1307,10 +1307,13 @@ export class TrainerConfig {
   ): TrainerConfig {
     this.initForGymLeader(signatureSpecies, isMale, ...specialtyTypes);
     this.setBattleBgm("battle_paldea_gym");
-    // TODO: tera
-    // this.setGenModifiersFunc((party) => {
-    //   return getSpecificTeraModifier(party, party.length - 1, specialtyTypes[0]);
-    // });
+    this.genAIFuncs.push((party: EnemyPokemon[]) => {
+      const lastSlot = party.length - 1;
+      if (this.specialtyTypes?.length) {
+        party[lastSlot].teraType = randSeedItem(this.specialtyTypes);
+      }
+      this.trainerAI.setInstantTera(lastSlot);
+    });
 
     return this;
   }

--- a/src/data/trainer-configs/champion-trainer-configs.ts
+++ b/src/data/trainer-configs/champion-trainer-configs.ts
@@ -14,6 +14,7 @@ import {
   SINNOH_CHAMPION_THEME,
 } from "#app/constants/music";
 import { getRandomPartyMemberFunc, TrainerConfig, type TrainerConfigs } from "#app/data/trainer-config";
+import { ElementalType } from "#enums/elemental-type";
 import { PokeballType } from "#enums/pokeball-type";
 import { SpeciesId } from "#enums/species-id";
 import { TrainerSlot } from "#enums/trainer-slot";
@@ -217,7 +218,7 @@ export const championTrainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       4,
       getRandomPartyMemberFunc([SpeciesId.VOLCARONA], TrainerSlot.TRAINER, true, (p) => {
-        // Tera Fire
+        p.teraType = ElementalType.FIRE;
         p.setBoss(true, 2);
         p.generateAndPopulateMoveset();
       }),
@@ -229,18 +230,8 @@ export const championTrainerConfigs: TrainerConfigs = {
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.MASTER_BALL;
       }),
-    ),
-  // TODO: remove this when trainer teras are reworked
-  // .setGenModifiersFunc((party) => {
-  //   const teraPokemon = party[4];
-  //   return [
-  //     modifierTypes
-  //       .TERA_SHARD()
-  //       .generateType([], [ElementalType.FIRE])!
-  //       .withIdFromFunc(modifierTypes.TERA_SHARD)
-  //       .newModifier(teraPokemon) as PersistentModifier,
-  //   ]; //TODO: is the bang correct?
-  // }),
+    )
+    .setInstantTera(4),
   [TrainerType.IRIS]: new TrainerConfig(++t)
     .initForChampion(TrainerVariant.FEMALE, [IRIS_CHAMPION_THEME])
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([SpeciesId.HYDREIGON]))
@@ -307,6 +298,7 @@ export const championTrainerConfigs: TrainerConfigs = {
         TrainerSlot.TRAINER,
         true,
         (p) => {
+          p.teraType = p.species.type1; // Tera Grass/Fire/Water
           p.setBoss(true, 2);
           p.generateAndPopulateMoveset();
         },
@@ -319,29 +311,8 @@ export const championTrainerConfigs: TrainerConfigs = {
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.MASTER_BALL;
       }),
-    ),
-  // TODO: remove this when trainer teras are reworked
-  // .setGenModifiersFunc((party) => {
-  //   const teraPokemon = party[4];
-  //   let teraType: ElementalType;
-  //   switch (teraPokemon.species.speciesId) {
-  //     case SpeciesId.DECIDUEYE:
-  //       teraType = ElementalType.GHOST;
-  //       break;
-  //     case SpeciesId.INCINEROAR:
-  //       teraType = ElementalType.DARK;
-  //       break;
-  //     default:
-  //       teraType = ElementalType.WATER;
-  //   }
-  //   return [
-  //     modifierTypes
-  //       .TERA_SHARD()
-  //       .generateType([], [teraType])!
-  //       .withIdFromFunc(modifierTypes.TERA_SHARD)
-  //       .newModifier(teraPokemon) as PersistentModifier,
-  //   ]; //TODO: is the bang correct?
-  // }),
+    )
+    .setInstantTera(4),
   [TrainerType.LEON]: new TrainerConfig(++t)
     .initForChampion(TrainerVariant.DEFAULT, [GALAR_CHAMPION_THEME])
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([SpeciesId.RILLABOOM, SpeciesId.CINDERACE, SpeciesId.INTELEON]))
@@ -373,7 +344,7 @@ export const championTrainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       4,
       getRandomPartyMemberFunc([SpeciesId.KINGAMBIT], TrainerSlot.TRAINER, true, (p) => {
-        // Tera flying
+        p.teraType = ElementalType.FLYING;
         p.setBoss(true, 2);
         p.generateAndPopulateMoveset();
       }),
@@ -385,18 +356,8 @@ export const championTrainerConfigs: TrainerConfigs = {
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.MASTER_BALL;
       }),
-    ),
-  // TODO: remove this when trainer teras are reworked
-  // .setGenModifiersFunc((party) => {
-  //   const teraPokemon = party[4];
-  //   return [
-  //     modifierTypes
-  //       .TERA_SHARD()
-  //       .generateType([], [ElementalType.FLYING])!
-  //       .withIdFromFunc(modifierTypes.TERA_SHARD)
-  //       .newModifier(teraPokemon) as PersistentModifier,
-  //   ]; //TODO: is the bang correct?
-  // }),
+    )
+    .setInstantTera(4),
   [TrainerType.NEMONA]: new TrainerConfig(++t)
     .initForChampion(TrainerVariant.FEMALE, [NEMONA_CHAMPION_THEME])
     .setPartyMemberFunc(
@@ -416,7 +377,7 @@ export const championTrainerConfigs: TrainerConfigs = {
         TrainerSlot.TRAINER,
         true,
         (p) => {
-          // Tera Grass/Fire/Water based on the starter
+          p.teraType = p.species.type1; // Tera Grass/Fire/Water
           p.setBoss(true, 2);
           p.generateAndPopulateMoveset();
         },
@@ -430,28 +391,6 @@ export const championTrainerConfigs: TrainerConfigs = {
         p.pokeball = PokeballType.MASTER_BALL;
       }),
     ),
-  // TODO: remove this when trainer teras are reworked
-  // .setGenModifiersFunc((party) => {
-  //   const teraPokemon = party[4];
-  //   let teraType: ElementalType;
-  //   switch (teraPokemon.species.speciesId) {
-  //     case SpeciesId.MEOWSCARADA:
-  //       teraType = ElementalType.GRASS;
-  //       break;
-  //     case SpeciesId.SKELEDIRGE:
-  //       teraType = ElementalType.FIRE;
-  //       break;
-  //     default:
-  //       teraType = ElementalType.WATER;
-  //   }
-  //   return [
-  //     modifierTypes
-  //       .TERA_SHARD()
-  //       .generateType([], [teraType])!
-  //       .withIdFromFunc(modifierTypes.TERA_SHARD)
-  //       .newModifier(teraPokemon) as PersistentModifier,
-  //   ]; //TODO: is the bang correct?
-  // }),
   [TrainerType.KIERAN]: new TrainerConfig(++t)
     .initForChampion(TrainerVariant.DEFAULT, [KIERAN_CHAMPION_THEME])
     .setPartyMemberFunc(0, getRandomPartyMemberFunc([SpeciesId.POLIWRATH, SpeciesId.POLITOED]))
@@ -468,6 +407,7 @@ export const championTrainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       4,
       getRandomPartyMemberFunc([SpeciesId.HYDRAPPLE], TrainerSlot.TRAINER, true, (p) => {
+        p.teraType = ElementalType.FIGHTING;
         p.setBoss(true, 2);
         p.generateAndPopulateMoveset();
       }),
@@ -479,5 +419,6 @@ export const championTrainerConfigs: TrainerConfigs = {
         p.generateAndPopulateMoveset();
         p.pokeball = PokeballType.MASTER_BALL;
       }),
-    ),
+    )
+    .setInstantTera(4),
 };

--- a/src/data/trainer-configs/evil-boss-trainer-configs.ts
+++ b/src/data/trainer-configs/evil-boss-trainer-configs.ts
@@ -641,6 +641,7 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
     .setPartyMemberFunc(
       4,
       getRandomPartyMemberFunc([SpeciesId.SYLVEON], TrainerSlot.TRAINER, true, (p) => {
+        // Tera fairy
         p.abilityIndex = 2; // Pixilate
         p.generateAndPopulateMoveset();
         p.gender = Gender.FEMALE;
@@ -655,23 +656,14 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
         p.pokeball = PokeballType.ULTRA_BALL;
         p.generateName();
       }),
-    ),
-  // TODO: remove this when trainer teras are reworked
-  // .setGenModifiersFunc((party) => {
-  //   const teraPokemon = party[4];
-  //   return [
-  //     modifierTypes
-  //       .TERA_SHARD()
-  //       .generateType([], [teraPokemon.species.type1])!
-  //       .withIdFromFunc(modifierTypes.TERA_SHARD)
-  //       .newModifier(teraPokemon) as PersistentModifier,
-  //   ]; //TODO: is the bang correct?
-  // }),
+    )
+    .setInstantTera(4),
   [TrainerType.PENNY_2]: new TrainerConfig(++t)
     .initForEvilTeamLeader(STAR_BOSS_TITLE, PENNY, true, STAR_MUSIC)
     .setPartyMemberFunc(
       0,
       getRandomPartyMemberFunc([SpeciesId.SYLVEON], TrainerSlot.TRAINER, true, (p) => {
+        // Tera fairy
         p.setBoss(true, 2);
         p.abilityIndex = 2; // Pixilate
         p.generateAndPopulateMoveset();
@@ -724,16 +716,6 @@ export const evilBossTrainerConfigs: TrainerConfigs = {
           p.pokeball = PokeballType.ULTRA_BALL;
         },
       ),
-    ),
-  // TODO: remove this when trainer teras are reworked
-  // .setGenModifiersFunc((party) => {
-  //   const teraPokemon = party[0];
-  //   return [
-  //     modifierTypes
-  //       .TERA_SHARD()
-  //       .generateType([], [teraPokemon.species.type1])!
-  //       .withIdFromFunc(modifierTypes.TERA_SHARD)
-  //       .newModifier(teraPokemon) as PersistentModifier,
-  //   ]; //TODO: is the bang correct?
-  // }),
+    )
+    .setInstantTera(0),
 };


### PR DESCRIPTION
## What are the changes the user will see?

* Paldea gym leaders will now tera their ace pokemon again
* Hau will now tera his starter to its primary type (Not sure where dark/ghost/water came from previously, probably a typo)
* Nemona will now tera her starter to its primary type
* Geeta will tera her Kingambit to Flying
* Kieran will now tera his Hydrapple to Fighting
* Penny will now tera her Sylveon to Fairy

The rival and expert breeder were not updated to have instant tera because it is assumed we will want to change both of them later on anyway

## Why am I making these changes?

Closes #986

## What are the changes from a developer perspective?

* Updated `initForPaldeaGymLeader`
* Updated various trainer configs

## Screenshots/Videos

![image](https://github.com/user-attachments/assets/90b1cd47-cc4d-4b74-b549-49d40638e198)


## How to test the changes?

Override to floor 20 and add the trainer you want to test into the town boss pool

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->