### PR TITLE
[Test] Fix flaky Ice Face test

### DIFF
--- a/test/abilities/ice-face.test.ts
+++ b/test/abilities/ice-face.test.ts
@@ -1,10 +1,5 @@
-import { BattlerIndex } from "#enums/battler-index";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -30,50 +25,46 @@ describe("Abilities - Ice Face", () => {
 
   beforeEach(() => {
     game = new GameManager(phaserGame);
-    game.override.battleType("single");
-    game.override.enemySpecies(SpeciesId.EISCUE);
-    game.override.enemyAbility(AbilityId.ICE_FACE);
-    game.override.moveset([MoveId.TACKLE, MoveId.ICE_BEAM, MoveId.TOXIC_THREAD, MoveId.HAIL]);
+    game.override.battleType("single").enemySpecies(SpeciesId.EISCUE).enemyAbility(AbilityId.ICE_FACE);
   });
 
   it("takes no damage from physical move and transforms to Noice", async () => {
     await game.classicMode.startBattle([SpeciesId.HITMONLEE]);
 
-    game.move.select(MoveId.TACKLE);
+    game.move.use(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
 
-    expect(eiscue.isFullHp()).toBe(true);
+    expect(eiscue).toHaveFullHp();
     expect(eiscue.formIndex).toBe(noiceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
   });
 
   it("takes no damage from the first hit of multihit physical move and transforms to Noice", async () => {
-    game.override.moveset([MoveId.SURGING_STRIKES]);
     game.override.enemyLevel(1);
     await game.classicMode.startBattle([SpeciesId.HITMONLEE]);
 
-    game.move.select(MoveId.SURGING_STRIKES);
+    game.move.use(MoveId.SURGING_STRIKES);
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeDefined();
 
     // First hit
-    await game.phaseInterceptor.to(MoveEffectPhase);
-    expect(eiscue.isFullHp()).toBe(true);
+    await game.phaseInterceptor.to("MoveEffectPhase");
+    expect(eiscue).toHaveFullHp();
     expect(eiscue.formIndex).toBe(icefaceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
 
     // Second hit
-    await game.phaseInterceptor.to(MoveEffectPhase);
-    expect(eiscue.hp).lessThan(eiscue.getMaxHp());
+    await game.phaseInterceptor.to("MoveEffectPhase");
+    expect(eiscue).not.toHaveFullHp();
     expect(eiscue.formIndex).toBe(noiceForm);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-    expect(eiscue.hp).lessThan(eiscue.getMaxHp());
+    expect(eiscue).not.toHaveFullHp();
     expect(eiscue.formIndex).toBe(noiceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
   });
@@ -81,47 +72,46 @@ describe("Abilities - Ice Face", () => {
   it("takes damage from special moves", async () => {
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
 
-    game.move.select(MoveId.ICE_BEAM);
+    game.move.use(MoveId.ICE_BEAM);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBe(undefined);
     expect(eiscue.formIndex).toBe(icefaceForm);
-    expect(eiscue.hp).toBeLessThan(eiscue.getMaxHp());
+    expect(eiscue).not.toHaveFullHp();
   });
 
   it("takes effects from status moves", async () => {
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
 
-    game.move.select(MoveId.TOXIC_THREAD);
+    game.move.use(MoveId.TOXIC_THREAD);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBe(undefined);
     expect(eiscue.formIndex).toBe(icefaceForm);
   });
 
   it("transforms to Ice Face when Hail or Snow starts", async () => {
-    game.override.moveset([MoveId.QUICK_ATTACK]);
     game.override.enemyMoveset([MoveId.HAIL, MoveId.HAIL, MoveId.HAIL, MoveId.HAIL]);
 
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
 
-    game.move.select(MoveId.QUICK_ATTACK);
+    game.move.use(MoveId.QUICK_ATTACK);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
 
-    expect(eiscue.isFullHp()).toBe(true);
+    expect(eiscue).toHaveFullHp();
     expect(eiscue.formIndex).toBe(noiceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBeNull();
     expect(eiscue.formIndex).toBe(icefaceForm);
@@ -129,26 +119,25 @@ describe("Abilities - Ice Face", () => {
 
   it("transforms to Ice Face when summoned on arena with active Snow or Hail", async () => {
     game.override.enemyMoveset([MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE, MoveId.TACKLE]);
-    game.override.moveset([MoveId.SNOWSCAPE]);
 
     await game.classicMode.startBattle([SpeciesId.EISCUE, SpeciesId.NINJASK]);
 
-    game.move.select(MoveId.SNOWSCAPE);
+    game.move.use(MoveId.SNOWSCAPE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
-    let eiscue = game.scene.getPlayerPokemon()!;
+    await game.phaseInterceptor.to("TurnEndPhase");
+    let eiscue = game.field.getPlayerPokemon();
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
     expect(eiscue.formIndex).toBe(noiceForm);
-    expect(eiscue.isFullHp()).toBe(true);
+    expect(eiscue).toHaveFullHp();
 
     await game.toNextTurn();
     game.switchPokemon(1);
     await game.toNextTurn();
     game.switchPokemon(1);
 
-    await game.phaseInterceptor.to(QuietFormChangePhase);
-    eiscue = game.scene.getPlayerPokemon()!;
+    await game.phaseInterceptor.to("QuietFormChangePhase");
+    eiscue = game.field.getPlayerPokemon();
 
     expect(eiscue.formIndex).toBe(icefaceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBe(undefined);
@@ -160,15 +149,15 @@ describe("Abilities - Ice Face", () => {
 
     await game.classicMode.startBattle([SpeciesId.EISCUE]);
 
-    game.move.select(MoveId.HAIL);
-    const eiscue = game.scene.getPlayerPokemon()!;
+    game.move.use(MoveId.HAIL);
+    const eiscue = game.field.getPlayerPokemon();
 
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
     expect(eiscue.formIndex).toBe(noiceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(eiscue.formIndex).toBe(noiceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
@@ -179,19 +168,19 @@ describe("Abilities - Ice Face", () => {
 
     await game.classicMode.startBattle([SpeciesId.EISCUE, SpeciesId.MAGIKARP]);
 
-    game.move.select(MoveId.ICE_BEAM);
+    game.move.use(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
-    let eiscue = game.scene.getPlayerPokemon()!;
+    await game.phaseInterceptor.to("TurnEndPhase");
+    let eiscue = game.field.getPlayerPokemon();
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
     expect(eiscue.formIndex).toBe(noiceForm);
-    expect(eiscue.isFullHp()).toBe(true);
+    expect(eiscue).toHaveFullHp();
 
     await game.toNextTurn();
     game.switchPokemon(1);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     eiscue = game.scene.getPlayerParty()[1];
 
     expect(eiscue.formIndex).toBe(noiceForm);
@@ -208,16 +197,16 @@ describe("Abilities - Ice Face", () => {
 
     await game.classicMode.startBattle([SpeciesId.EISCUE]);
 
-    const eiscue = game.scene.getPlayerPokemon()!;
+    const eiscue = game.field.getPlayerPokemon();
 
     expect(eiscue.formIndex).toBe(noiceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).toBeUndefined();
 
-    game.move.select(MoveId.ICE_BEAM);
+    game.move.use(MoveId.ICE_BEAM);
     await game.faintOpponents();
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.doSelectModifier();
-    await game.phaseInterceptor.to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
 
     expect(eiscue.formIndex).toBe(icefaceForm);
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBe(undefined);
@@ -227,23 +216,21 @@ describe("Abilities - Ice Face", () => {
     game.override.enemyMoveset(MoveId.SUBSTITUTE).moveset(MoveId.POWER_TRIP);
     await game.classicMode.startBattle();
 
-    game.move.select(MoveId.POWER_TRIP);
+    game.move.use(MoveId.POWER_TRIP);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toNextTurn();
 
-    expect(game.scene.getEnemyPokemon()!.formIndex).toBe(icefaceForm);
+    expect(game.field.getEnemyPokemon().formIndex).toBe(icefaceForm);
   });
 
   it("cannot be suppressed", async () => {
-    game.override.moveset([MoveId.GASTRO_ACID]);
-
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
 
-    game.move.select(MoveId.GASTRO_ACID);
+    game.move.use(MoveId.GASTRO_ACID);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBe(undefined);
     expect(eiscue.formIndex).toBe(icefaceForm);
@@ -251,15 +238,13 @@ describe("Abilities - Ice Face", () => {
   });
 
   it("cannot be swapped with another ability", async () => {
-    game.override.moveset([MoveId.SKILL_SWAP]);
-
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
 
-    game.move.select(MoveId.SKILL_SWAP);
+    game.move.use(MoveId.SKILL_SWAP);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBe(undefined);
     expect(eiscue.formIndex).toBe(icefaceForm);
@@ -271,14 +256,14 @@ describe("Abilities - Ice Face", () => {
 
     await game.classicMode.startBattle([SpeciesId.MAGIKARP]);
 
-    game.move.select(MoveId.SIMPLE_BEAM);
+    game.move.use(MoveId.SIMPLE_BEAM);
 
-    await game.phaseInterceptor.to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
 
-    const eiscue = game.scene.getEnemyPokemon()!;
+    const eiscue = game.field.getEnemyPokemon();
 
     expect(eiscue.getTag(BattlerTagType.ICE_FACE)).not.toBe(undefined);
     expect(eiscue.formIndex).toBe(icefaceForm);
-    expect(game.scene.getPlayerPokemon()!.hasAbility(AbilityId.TRACE)).toBe(true);
+    expect(game.field.getPlayerPokemon().hasAbility(AbilityId.TRACE)).toBe(true);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

An Ice Face test is producing false negatives in some PRs' Actions

## What are the changes from a developer perspective?

- The player Pokemon now uses Splash instead of Ice Beam in the "preserve form on switch" test. This may have caused the enemy Magikarp to faint unexpectedly in some runs.
- Updated all tests in the Ice Face suite to use new test utilities

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

`npm run test ice-face`

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?