### PR TITLE
[Refactor] Reduce test imports

### DIFF
--- a/test/abilities/battery.test.ts
+++ b/test/abilities/battery.test.ts
@@ -1,7 +1,5 @@
 import { allMoves } from "#app/data/data-lists";
 import { AbilityId } from "#enums/ability-id";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -43,7 +41,7 @@ describe("Abilities - Battery", () => {
 
     game.move.select(MoveId.DAZZLING_GLEAM);
     game.move.select(MoveId.SPLASH, 1);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(basePower * batteryMultiplier);
   });
@@ -58,7 +56,7 @@ describe("Abilities - Battery", () => {
 
     game.move.select(MoveId.BREAKING_SWIPE);
     game.move.select(MoveId.SPLASH, 1);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(basePower);
   });
@@ -73,7 +71,7 @@ describe("Abilities - Battery", () => {
 
     game.move.select(MoveId.DAZZLING_GLEAM);
     game.move.select(MoveId.SPLASH, 1);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(basePower);
   });

--- a/test/abilities/costar.test.ts
+++ b/test/abilities/costar.test.ts
@@ -1,9 +1,7 @@
-import { Stat } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { CommandPhase } from "#app/phases/command-phase";
-import { MessagePhase } from "#app/phases/message-phase";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
@@ -38,7 +36,7 @@ describe("Abilities - COSTAR", () => {
     let [leftPokemon, rightPokemon] = game.scene.getPlayerField();
 
     game.move.select(MoveId.NASTY_PLOT);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -46,9 +44,9 @@ describe("Abilities - COSTAR", () => {
     expect(rightPokemon.getStatStage(Stat.SPATK)).toBe(0);
 
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.switchPokemon(2);
-    await game.phaseInterceptor.to(MessagePhase);
+    await game.phaseInterceptor.to("MessagePhase");
 
     [leftPokemon, rightPokemon] = game.scene.getPlayerField();
     expect(leftPokemon.getStatStage(Stat.SPATK)).toBe(2);
@@ -66,9 +64,9 @@ describe("Abilities - COSTAR", () => {
     expect(leftPokemon.getStatStage(Stat.ATK)).toBe(-2);
 
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.switchPokemon(2);
-    await game.phaseInterceptor.to(MessagePhase);
+    await game.phaseInterceptor.to("MessagePhase");
 
     [leftPokemon, rightPokemon] = game.scene.getPlayerField();
     expect(leftPokemon.getStatStage(Stat.ATK)).toBe(-2);

--- a/test/abilities/flash-fire.test.ts
+++ b/test/abilities/flash-fire.test.ts
@@ -1,10 +1,8 @@
+import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { SpeciesId } from "#enums/species-id";
-import { MovePhase } from "#app/phases/move-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
@@ -42,7 +40,7 @@ describe("Abilities - Flash Fire", () => {
     const blissey = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(blissey.hp).toBe(blissey.getMaxHp());
   }, 20000);
 
@@ -53,7 +51,7 @@ describe("Abilities - Flash Fire", () => {
     const blissey = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.PROTECT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(blissey!.getTag(BattlerTagType.FIRE_BOOST)).toBeUndefined();
   }, 20000);
 
@@ -65,10 +63,10 @@ describe("Abilities - Flash Fire", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.move.forceHit();
-    await game.phaseInterceptor.to(MovePhase, false);
+    await game.phaseInterceptor.to("MovePhase", false);
     await game.move.forceHit();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(blissey!.getTag(BattlerTagType.FIRE_BOOST)).toBeDefined();
   }, 20000);
 
@@ -81,7 +79,7 @@ describe("Abilities - Flash Fire", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(blissey!.getTag(BattlerTagType.FIRE_BOOST)).toBeDefined();
   }, 20000);
 
@@ -95,7 +93,7 @@ describe("Abilities - Flash Fire", () => {
 
     game.selectPartyPokemon(1);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const chansey = game.scene.getPlayerPokemon()!;
     expect(game.scene.getPlayerPokemon()!.species.speciesId).toBe(SpeciesId.CHANSEY);
     expect(chansey!.getTag(BattlerTagType.FIRE_BOOST)).toBeUndefined();
@@ -112,7 +110,7 @@ describe("Abilities - Flash Fire", () => {
     // first turn
     game.move.select(MoveId.EMBER);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const originalDmg = initialHP - blissey.hp;
 
     expect(blissey.hp > 0);
@@ -120,7 +118,7 @@ describe("Abilities - Flash Fire", () => {
 
     // second turn
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const flashFireDmg = initialHP - blissey.hp;
 
     expect(flashFireDmg).toBeGreaterThan(originalDmg);
@@ -141,7 +139,7 @@ describe("Abilities - Flash Fire", () => {
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     await game.phaseInterceptor.to("MoveEffectPhase");
     await game.move.forceMiss();
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const originalDmg = initialHP - blissey.hp;
 
     expect(blissey.hp > 0);
@@ -149,7 +147,7 @@ describe("Abilities - Flash Fire", () => {
 
     // second turn
     game.move.select(MoveId.FIRE_PLEDGE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const flashFireDmg = initialHP - blissey.hp;
 
     expect(flashFireDmg).toBeGreaterThan(originalDmg);

--- a/test/abilities/heatproof.test.ts
+++ b/test/abilities/heatproof.test.ts
@@ -1,9 +1,8 @@
-import { SpeciesId } from "#enums/species-id";
-import { StatusEffect } from "#enums/status-effect";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { toDmgValue } from "#app/utils/common-utils";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -45,14 +44,14 @@ describe("Abilities - Heatproof", () => {
     enemy.hp = initialHP;
 
     game.move.select(MoveId.FLAMETHROWER);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const heatproofDamage = initialHP - enemy.hp;
 
     enemy.hp = initialHP;
     game.override.enemyAbility(AbilityId.BALL_FETCH);
 
     game.move.select(MoveId.FLAMETHROWER);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const regularDamage = initialHP - enemy.hp;
 
     expect(heatproofDamage).toBeLessThanOrEqual(regularDamage / 2 + 1);

--- a/test/abilities/imposter.test.ts
+++ b/test/abilities/imposter.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { Stat, BATTLE_STATS, EFFECTIVE_STATS } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { BATTLE_STATS, EFFECTIVE_STATS, Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 // TODO: Add more tests once Imposter is fully implemented
 describe("Abilities - Imposter", () => {
@@ -39,7 +38,7 @@ describe("Abilities - Imposter", () => {
     await game.classicMode.startBattle([SpeciesId.DITTO]);
 
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -86,7 +85,7 @@ describe("Abilities - Imposter", () => {
     const avgSpAtk = Math.floor((player.getStat(Stat.SPATK, false) + enemy.getStat(Stat.SPATK, false)) / 2);
 
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.ATK, false)).toBe(avgAtk);
     expect(enemy.getStat(Stat.ATK, false)).toBe(avgAtk);
@@ -102,7 +101,7 @@ describe("Abilities - Imposter", () => {
     const player = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     player.getMoveset().forEach((move) => {
       // Should set correct maximum PP without touching `ppUp`

--- a/test/abilities/intimidate.test.ts
+++ b/test/abilities/intimidate.test.ts
@@ -1,12 +1,11 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { UiMode } from "#enums/ui-mode";
-import { Stat } from "#enums/stat";
-import { getMovePosition } from "#test/test-utils/gameManagerUtils";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import { getMovePosition } from "#test/test-utils/gameManagerUtils";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Abilities - Intimidate", () => {
   let phaserGame: Phaser.Game;
@@ -35,17 +34,7 @@ describe("Abilities - Intimidate", () => {
   });
 
   it("should lower ATK stat stage by 1 of enemy Pokemon on entry and player switch", async () => {
-    await game.classicMode.runToSummon([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA]);
-    game.onNextPrompt(
-      "CheckSwitchPhase",
-      UiMode.CONFIRM,
-      () => {
-        game.setMode(UiMode.MESSAGE);
-        game.endPhase();
-      },
-      () => game.isCurrentPhase("CommandPhase") || game.isCurrentPhase("TurnInitPhase"),
-    );
-    await game.phaseInterceptor.to("CommandPhase", false);
+    await game.classicMode.startBattle([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA]);
 
     let playerPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -55,8 +44,7 @@ describe("Abilities - Intimidate", () => {
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(-1);
 
     game.switchPokemon(1);
-    await game.phaseInterceptor.run("CommandPhase");
-    await game.phaseInterceptor.to("CommandPhase");
+    await game.toNextTurn();
 
     playerPokemon = game.scene.getPlayerPokemon()!;
     expect(playerPokemon.species.speciesId).toBe(SpeciesId.POOCHYENA);
@@ -66,17 +54,7 @@ describe("Abilities - Intimidate", () => {
 
   it("should lower ATK stat stage by 1 for every enemy Pokemon in a double battle on entry", async () => {
     game.override.battleType("double").startingWave(3);
-    await game.classicMode.runToSummon([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA]);
-    game.onNextPrompt(
-      "CheckSwitchPhase",
-      UiMode.CONFIRM,
-      () => {
-        game.setMode(UiMode.MESSAGE);
-        game.endPhase();
-      },
-      () => game.isCurrentPhase("CommandPhase") || game.isCurrentPhase("TurnInitPhase"),
-    );
-    await game.phaseInterceptor.to("CommandPhase", false);
+    await game.classicMode.startBattle([SpeciesId.MIGHTYENA, SpeciesId.POOCHYENA]);
 
     const playerField = game.scene.getPlayerField()!;
     const enemyField = game.scene.getEnemyField()!;

--- a/test/abilities/intrepid-sword.test.ts
+++ b/test/abilities/intrepid-sword.test.ts
@@ -1,8 +1,7 @@
-import { Stat } from "#enums/stat";
-import { GameManager } from "#test/test-utils/gameManager";
-import { CommandPhase } from "#app/phases/command-phase";
 import { AbilityId } from "#enums/ability-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -34,7 +33,7 @@ describe("Abilities - Intrepid Sword", () => {
     const playerPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    await game.phaseInterceptor.to(CommandPhase, false);
+    await game.phaseInterceptor.to("CommandPhase", false);
 
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(1);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(1);

--- a/test/abilities/magic-guard.test.ts
+++ b/test/abilities/magic-guard.test.ts
@@ -1,7 +1,6 @@
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { getStatusEffectCatchRateMultiplier } from "#app/data/status-effect";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
@@ -55,7 +54,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -76,7 +75,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -97,7 +96,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -116,7 +115,7 @@ describe("Abilities - Magic Guard", () => {
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -141,7 +140,7 @@ describe("Abilities - Magic Guard", () => {
     const toxicStartCounter = enemyPokemon.status!.toxicTurnCount;
     //should be 0
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -165,7 +164,7 @@ describe("Abilities - Magic Guard", () => {
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -187,7 +186,7 @@ describe("Abilities - Magic Guard", () => {
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -212,7 +211,7 @@ describe("Abilities - Magic Guard", () => {
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -234,7 +233,7 @@ describe("Abilities - Magic Guard", () => {
     game.move.select(MoveId.HIGH_JUMP_KICK);
     await game.move.forceMiss();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -251,7 +250,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.TAKE_DOWN);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -268,7 +267,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.STRUGGLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -286,7 +285,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.STEEL_BEAM);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -301,7 +300,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.CHARM);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
   });
 */
 
@@ -313,7 +312,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.BELLY_DRUM);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -335,7 +334,7 @@ describe("Abilities - Magic Guard", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -359,7 +358,7 @@ describe("Abilities - Magic Guard", () => {
     enemyPokemon.hp = 1;
 
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -382,7 +381,7 @@ describe("Abilities - Magic Guard", () => {
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -405,7 +404,7 @@ describe("Abilities - Magic Guard", () => {
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
     game.move.select(MoveId.ABSORB);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:
@@ -424,7 +423,7 @@ describe("Abilities - Magic Guard", () => {
     await game.startBattle([SpeciesId.MAGIKARP]);
     const leadPokemon = game.scene.getPlayerPokemon()!;
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     /**
      * Expect:

--- a/test/abilities/moxie.test.ts
+++ b/test/abilities/moxie.test.ts
@@ -1,14 +1,11 @@
-import { Stat } from "#enums/stat";
-import { GameManager } from "#test/test-utils/gameManager";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { BattlerIndex } from "#enums/battler-index";
-import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { VictoryPhase } from "#app/phases/victory-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 
 describe("Abilities - Moxie", () => {
   let phaserGame: Phaser.Game;
@@ -45,7 +42,7 @@ describe("Abilities - Moxie", () => {
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(0);
 
     game.move.select(moveToUse);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(VictoryPhase);
+    await game.phaseInterceptor.to("VictoryPhase");
 
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(1);
   }, 20000);
@@ -66,7 +63,7 @@ describe("Abilities - Moxie", () => {
 
       game.move.select(moveToUse, BattlerIndex.PLAYER_2);
 
-      await game.phaseInterceptor.to(TurnEndPhase);
+      await game.phaseInterceptor.to("TurnEndPhase");
 
       expect(firstPokemon.getStatStage(Stat.ATK)).toBe(1);
     },

--- a/test/abilities/no-guard.test.ts
+++ b/test/abilities/no-guard.test.ts
@@ -1,13 +1,12 @@
+import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
 import { HitCheckResult } from "#enums/hit-check-result";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Abilities - No Guard", () => {
   let phaserGame: Phaser.Game;
@@ -43,12 +42,12 @@ describe("Abilities - No Guard", () => {
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
 
     const moveEffectPhase = game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase;
     vi.spyOn(moveEffectPhase, "hitCheck");
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(moveEffectPhase.hitCheck).toHaveReturnedWith([HitCheckResult.HIT, 1]);
   });

--- a/test/abilities/pastel-veil.test.ts
+++ b/test/abilities/pastel-veil.test.ts
@@ -1,7 +1,5 @@
-import { BattlerIndex } from "#enums/battler-index";
 import { AbilityId } from "#enums/ability-id";
-import { CommandPhase } from "#app/phases/command-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
@@ -44,7 +42,7 @@ describe("Abilities - Pastel Veil", () => {
     game.move.select(MoveId.SPLASH);
     game.move.select(MoveId.TOXIC_THREAD, 1, BattlerIndex.PLAYER);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(magikarp.getStatusEffect(true)).toBe(StatusEffect.NONE);
   });
@@ -60,13 +58,13 @@ describe("Abilities - Pastel Veil", () => {
     game.move.select(MoveId.SPLASH);
     game.move.select(MoveId.TOXIC_THREAD, 1, BattlerIndex.PLAYER);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(magikarp.getStatusEffect(true)).toBe(StatusEffect.POISON);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH);
     game.switchPokemon(2);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(magikarp.getStatusEffect(true)).toBe(StatusEffect.NONE);
   });

--- a/test/abilities/power-construct.test.ts
+++ b/test/abilities/power-construct.test.ts
@@ -1,5 +1,3 @@
-import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -48,9 +46,9 @@ describe("Abilities - POWER CONSTRUCT", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintOpponents();
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.doSelectModifier();
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
     expect(zygarde.formIndex).toBe(baseForm);
   });
@@ -74,9 +72,9 @@ describe("Abilities - POWER CONSTRUCT", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintOpponents();
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.doSelectModifier();
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
     expect(zygarde.formIndex).toBe(baseForm);
   });

--- a/test/abilities/power-spot.test.ts
+++ b/test/abilities/power-spot.test.ts
@@ -1,7 +1,5 @@
 import { allMoves } from "#app/data/data-lists";
 import { AbilityId } from "#enums/ability-id";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -42,7 +40,7 @@ describe("Abilities - Power Spot", () => {
     await game.startBattle([SpeciesId.REGIELEKI, SpeciesId.STONJOURNER]);
     game.move.select(MoveId.DAZZLING_GLEAM);
     game.move.select(MoveId.SPLASH, 1);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(basePower * powerSpotMultiplier);
   });
@@ -56,7 +54,7 @@ describe("Abilities - Power Spot", () => {
     await game.startBattle([SpeciesId.REGIELEKI, SpeciesId.STONJOURNER]);
     game.move.select(MoveId.BREAKING_SWIPE);
     game.move.select(MoveId.SPLASH, 1);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(basePower * powerSpotMultiplier);
   });
@@ -70,7 +68,7 @@ describe("Abilities - Power Spot", () => {
     await game.startBattle([SpeciesId.STONJOURNER, SpeciesId.REGIELEKI]);
     game.move.select(MoveId.BREAKING_SWIPE);
     game.move.select(MoveId.SPLASH, 1);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(basePower);
   });

--- a/test/abilities/sand-veil.test.ts
+++ b/test/abilities/sand-veil.test.ts
@@ -1,8 +1,5 @@
 import type { StatMultiplierAbAttr } from "#app/data/abilities/ab-attrs/stat-multiplier-ab-attr";
 import { allAbilities } from "#app/data/data-lists";
-import { CommandPhase } from "#app/phases/command-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
@@ -61,13 +58,13 @@ describe("Abilities - Sand Veil", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
 
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
 
-    await game.phaseInterceptor.to(MoveEndPhase, false);
+    await game.phaseInterceptor.to("MoveEndPhase", false);
 
     expect(leadPokemon[0].isFullHp()).toBe(true);
     expect(leadPokemon[1].hp).toBeLessThan(leadPokemon[1].getMaxHp());

--- a/test/abilities/sap-sipper.test.ts
+++ b/test/abilities/sap-sipper.test.ts
@@ -1,17 +1,15 @@
-import { Stat } from "#enums/stat";
-import { TerrainType } from "#enums/terrain-type";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import { allMoves } from "#app/data/data-lists";
+import { MetronomeAttr } from "#app/data/moves/move-attrs/metronome-attr";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+import { TerrainType } from "#enums/terrain-type";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { allMoves } from "#app/data/data-lists";
-import { MetronomeAttr } from "#app/data/moves/move-attrs/metronome-attr";
-import { StatusEffect } from "#enums/status-effect";
 
 // See also: TypeImmunityAbAttr
 describe("Abilities - Sap Sipper", () => {
@@ -51,7 +49,7 @@ describe("Abilities - Sap Sipper", () => {
 
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(initialEnemyHp - enemyPokemon.hp).toBe(0);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(1);
@@ -68,7 +66,7 @@ describe("Abilities - Sap Sipper", () => {
 
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getStatusEffect()).toBe(StatusEffect.NONE);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(1);
@@ -83,7 +81,7 @@ describe("Abilities - Sap Sipper", () => {
 
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(game.scene.arena.hasTerrain(TerrainType.GRASSY)).toBe(true);
     expect(game.scene.getEnemyPokemon()!.getStatStage(Stat.ATK)).toBe(0);
@@ -101,7 +99,7 @@ describe("Abilities - Sap Sipper", () => {
 
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(initialEnemyHp - enemyPokemon.hp).toBe(0);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(1);
@@ -118,11 +116,11 @@ describe("Abilities - Sap Sipper", () => {
 
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(playerPokemon.getTag(BattlerTagType.SPIKY_SHIELD)).toBeDefined();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(0);
     expect(game.phaseInterceptor.log).not.toContain("ShowAbilityPhase");
@@ -145,7 +143,7 @@ describe("Abilities - Sap Sipper", () => {
 
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(initialEnemyHp - enemyPokemon.hp).toBe(0);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(1);

--- a/test/abilities/schooling.test.ts
+++ b/test/abilities/schooling.test.ts
@@ -1,5 +1,3 @@
-import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -48,9 +46,9 @@ describe("Abilities - SCHOOLING", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintOpponents();
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.doSelectModifier();
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
     expect(wishiwashi.formIndex).toBe(soloForm);
   });

--- a/test/abilities/screen-cleaner.test.ts
+++ b/test/abilities/screen-cleaner.test.ts
@@ -1,7 +1,5 @@
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { PostSummonPhase } from "#app/phases/post-summon-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -36,13 +34,13 @@ describe("Abilities - Screen Cleaner", () => {
     await game.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.HAIL);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeDefined();
 
     await game.toNextTurn();
     game.switchPokemon(1);
-    await game.phaseInterceptor.to(PostSummonPhase);
+    await game.phaseInterceptor.to("PostSummonPhase");
 
     expect(game.scene.arena.getTag(ArenaTagType.AURORA_VEIL)).toBeUndefined();
   });
@@ -53,13 +51,13 @@ describe("Abilities - Screen Cleaner", () => {
     await game.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeDefined();
 
     await game.toNextTurn();
     game.switchPokemon(1);
-    await game.phaseInterceptor.to(PostSummonPhase);
+    await game.phaseInterceptor.to("PostSummonPhase");
 
     expect(game.scene.arena.getTag(ArenaTagType.LIGHT_SCREEN)).toBeUndefined();
   });
@@ -70,13 +68,13 @@ describe("Abilities - Screen Cleaner", () => {
     await game.startBattle([SpeciesId.MAGIKARP, SpeciesId.MAGIKARP]);
 
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeDefined();
 
     await game.toNextTurn();
     game.switchPokemon(1);
-    await game.phaseInterceptor.to(PostSummonPhase);
+    await game.phaseInterceptor.to("PostSummonPhase");
 
     expect(game.scene.arena.getTag(ArenaTagType.REFLECT)).toBeUndefined();
   });

--- a/test/abilities/shield-dust.test.ts
+++ b/test/abilities/shield-dust.test.ts
@@ -1,7 +1,7 @@
 import type { IgnoreMoveEffectsAbAttr } from "#app/data/abilities/ab-attrs/ignore-move-effects-ab-attr";
 import type { MoveEffectChanceMultiplierAbAttr } from "#app/data/abilities/ab-attrs/move-effect-chance-multiplier-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { NumberHolder } from "#app/utils/common-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
@@ -46,7 +46,7 @@ describe("Abilities - Shield Dust", () => {
     game.move.select(MoveId.AIR_SLASH);
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
 
     // Shield Dust negates secondary effect
     const phase = game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase;

--- a/test/abilities/shields-down.test.ts
+++ b/test/abilities/shields-down.test.ts
@@ -1,5 +1,3 @@
-import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -48,9 +46,9 @@ describe("Abilities - SHIELDS DOWN", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintOpponents();
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.doSelectModifier();
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
     expect(minior.formIndex).toBe(meteorForm);
   });

--- a/test/abilities/speed-boost.test.ts
+++ b/test/abilities/speed-boost.test.ts
@@ -1,4 +1,4 @@
-import { AttemptRunPhase } from "#app/phases/attempt-run-phase";
+import type { AttemptRunPhase } from "#app/phases/attempt-run-phase";
 import type { CommandPhase } from "#app/phases/command-phase";
 import { AbilityId } from "#enums/ability-id";
 import { BattleCommand } from "#enums/battle-command";
@@ -102,7 +102,7 @@ describe("Abilities - Speed Boost", () => {
     commandPhase.handleCommand(BattleCommand.RUN, 0);
     const runPhase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
     runPhase.forceFailEscape = true;
-    await game.phaseInterceptor.to(AttemptRunPhase);
+    await game.phaseInterceptor.to("AttemptRunPhase");
     await game.toNextTurn();
 
     const playerPokemon = game.scene.getPlayerPokemon()!;

--- a/test/abilities/sturdy.test.ts
+++ b/test/abilities/sturdy.test.ts
@@ -1,6 +1,4 @@
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -38,7 +36,7 @@ describe("Abilities - Sturdy", () => {
   test("Sturdy activates when user is at full HP", async () => {
     await game.startBattle();
     game.move.select(MoveId.CLOSE_COMBAT);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     expect(game.scene.getEnemyParty()[0].hp).toBe(1);
   });
 
@@ -49,7 +47,7 @@ describe("Abilities - Sturdy", () => {
     enemyPokemon.hp = enemyPokemon.getMaxHp() - 1;
 
     game.move.select(MoveId.CLOSE_COMBAT);
-    await game.phaseInterceptor.to(DamageAnimPhase);
+    await game.phaseInterceptor.to("DamageAnimPhase");
 
     expect(enemyPokemon.hp).toBe(0);
     expect(enemyPokemon.isFainted()).toBe(true);
@@ -58,7 +56,7 @@ describe("Abilities - Sturdy", () => {
   test("Sturdy pokemon should be immune to OHKO moves", async () => {
     await game.startBattle();
     game.move.select(MoveId.FISSURE);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
     expect(enemyPokemon.isFullHp()).toBe(true);
@@ -69,7 +67,7 @@ describe("Abilities - Sturdy", () => {
 
     await game.startBattle();
     game.move.select(MoveId.CLOSE_COMBAT);
-    await game.phaseInterceptor.to(DamageAnimPhase);
+    await game.phaseInterceptor.to("DamageAnimPhase");
 
     const enemyPokemon: EnemyPokemon = game.scene.getEnemyParty()[0];
     expect(enemyPokemon.hp).toBe(0);

--- a/test/abilities/unseen-fist.test.ts
+++ b/test/abilities/unseen-fist.test.ts
@@ -1,12 +1,10 @@
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { BerryPhase } from "#app/phases/berry-phase";
 
 describe("Abilities - Unseen Fist", () => {
   let phaserGame: Phaser.Game;
@@ -60,7 +58,7 @@ describe("Abilities - Unseen Fist", () => {
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.getTag(BattlerTagType.SUBSTITUTE)).toBeUndefined();
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
@@ -87,7 +85,7 @@ async function testUnseenFistHitResult(
   const enemyStartingHp = enemyPokemon.hp;
 
   game.move.select(attackMoveId);
-  await game.phaseInterceptor.to(TurnEndPhase, false);
+  await game.phaseInterceptor.to("TurnEndPhase", false);
 
   if (shouldSucceed) {
     expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);

--- a/test/abilities/volt_absorb.test.ts
+++ b/test/abilities/volt_absorb.test.ts
@@ -1,13 +1,12 @@
-import { Stat } from "#enums/stat";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { BattlerIndex } from "#enums/battler-index";
 
 // See also: TypeImmunityAbAttr
 describe("Abilities - Volt Absorb", () => {
@@ -46,7 +45,7 @@ describe("Abilities - Volt Absorb", () => {
 
     game.move.select(moveToUse);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(playerPokemon.getStatStage(Stat.SPDEF)).toBe(1);
     expect(playerPokemon.getTag(BattlerTagType.CHARGED)).toBeDefined();

--- a/test/abilities/wind-power.test.ts
+++ b/test/abilities/wind-power.test.ts
@@ -1,6 +1,5 @@
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -37,7 +36,7 @@ describe("Abilities - Wind Power", () => {
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeUndefined();
 
     game.move.select(MoveId.PETAL_BLIZZARD);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeDefined();
   });
@@ -52,7 +51,7 @@ describe("Abilities - Wind Power", () => {
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeUndefined();
 
     game.move.select(MoveId.TAILWIND);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeDefined();
   });
@@ -70,7 +69,7 @@ describe("Abilities - Wind Power", () => {
 
     game.move.select(MoveId.TAILWIND);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeDefined();
     expect(magikarp.getTag(BattlerTagType.CHARGED)).toBeUndefined();
@@ -86,7 +85,7 @@ describe("Abilities - Wind Power", () => {
 
     game.move.select(MoveId.SANDSTORM);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(shiftry.getTag(BattlerTagType.CHARGED)).toBeUndefined();
   });

--- a/test/abilities/wonder-skin.test.ts
+++ b/test/abilities/wonder-skin.test.ts
@@ -1,5 +1,4 @@
 import { allAbilities, allMoves } from "#app/data/data-lists";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -38,7 +37,7 @@ describe("Abilities - Wonder Skin", () => {
 
     await game.startBattle([SpeciesId.PIKACHU]);
     game.move.select(MoveId.CHARM);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(50);
   });
@@ -50,7 +49,7 @@ describe("Abilities - Wonder Skin", () => {
 
     await game.startBattle([SpeciesId.PIKACHU]);
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100);
   });
@@ -66,7 +65,7 @@ describe("Abilities - Wonder Skin", () => {
 
       await game.startBattle([SpeciesId.PIKACHU]);
       game.move.select(MoveId.CHARM);
-      await game.phaseInterceptor.to(MoveEffectPhase);
+      await game.phaseInterceptor.to("MoveEffectPhase");
 
       expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100);
     });

--- a/test/abilities/zero-to-hero.test.ts
+++ b/test/abilities/zero-to-hero.test.ts
@@ -1,5 +1,3 @@
-import { QuietFormChangePhase } from "#app/phases/quiet-form-change-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -48,10 +46,10 @@ describe("Abilities - ZERO TO HERO", () => {
 
     game.move.select(MoveId.SPLASH);
     await game.faintOpponents();
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.doSelectModifier();
-    await game.phaseInterceptor.to(QuietFormChangePhase);
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
+    await game.phaseInterceptor.to("QuietFormChangePhase");
 
     expect(palafin1.formIndex).toBe(baseForm);
     expect(palafin2.formIndex).toBe(baseForm);
@@ -64,7 +62,7 @@ describe("Abilities - ZERO TO HERO", () => {
     expect(palafin.formIndex).toBe(baseForm);
 
     game.switchPokemon(1);
-    await game.phaseInterceptor.to(QuietFormChangePhase);
+    await game.phaseInterceptor.to("QuietFormChangePhase");
     expect(palafin.formIndex).toBe(heroForm);
   });
 

--- a/test/arena/weather-fog.test.ts
+++ b/test/arena/weather-fog.test.ts
@@ -1,13 +1,12 @@
+import { FOG_ACCURACY_MULTIPLIER } from "#app/constants/game";
 import { allMoves } from "#app/data/data-lists";
 import { AbilityId } from "#enums/ability-id";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { FOG_ACCURACY_MULTIPLIER } from "#app/constants/game";
 
 describe("Weather - Fog", () => {
   let phaserGame: Phaser.Game;
@@ -41,7 +40,7 @@ describe("Weather - Fog", () => {
 
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100 * FOG_ACCURACY_MULTIPLIER);
   });
@@ -53,7 +52,7 @@ describe("Weather - Fog", () => {
     game.override.ability(AbilityId.AIR_LOCK);
     await game.classicMode.startBattle([SpeciesId.FEEBAS]);
     game.move.select(MoveId.TACKLE);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattleAccuracy).toHaveReturnedWith(100);
   });

--- a/test/arena/weather-strong_winds.test.ts
+++ b/test/arena/weather-strong_winds.test.ts
@@ -1,9 +1,8 @@
 import { allMoves } from "#app/data/data-lists";
-import { StatusEffect } from "#enums/status-effect";
-import { TurnStartPhase } from "#app/phases/turn-start-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -40,7 +39,7 @@ describe("Weather - Strong Winds", () => {
 
     game.move.select(MoveId.THUNDERBOLT);
 
-    await game.phaseInterceptor.to(TurnStartPhase);
+    await game.phaseInterceptor.to("TurnStartPhase");
     expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.THUNDERBOLT).type, pikachu)).toBe(0.5);
   });
 
@@ -51,7 +50,7 @@ describe("Weather - Strong Winds", () => {
 
     game.move.select(MoveId.THUNDERBOLT);
 
-    await game.phaseInterceptor.to(TurnStartPhase);
+    await game.phaseInterceptor.to("TurnStartPhase");
     expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.THUNDERBOLT).type, pikachu)).toBe(1);
   });
 
@@ -62,7 +61,7 @@ describe("Weather - Strong Winds", () => {
 
     game.move.select(MoveId.ICE_BEAM);
 
-    await game.phaseInterceptor.to(TurnStartPhase);
+    await game.phaseInterceptor.to("TurnStartPhase");
     expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.ICE_BEAM).type, pikachu)).toBe(1);
   });
 
@@ -73,7 +72,7 @@ describe("Weather - Strong Winds", () => {
 
     game.move.select(MoveId.ROCK_SLIDE);
 
-    await game.phaseInterceptor.to(TurnStartPhase);
+    await game.phaseInterceptor.to("TurnStartPhase");
     expect(enemy.getAttackTypeEffectiveness(allMoves.get(MoveId.ROCK_SLIDE).type, pikachu)).toBe(1);
   });
 

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -37,6 +37,7 @@ describe("Test Phase Interceptor", () => {
   });
 
   it("test phase interceptor with prompt", async () => {
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase");
 
     game.onNextPrompt("SelectGenderPhase", UiMode.OPTION_SELECT, () => {
@@ -44,8 +45,9 @@ describe("Test Phase Interceptor", () => {
       game.endPhase();
     });
 
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("SelectGenderPhase");
-
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("TitlePhase");
     await game.waitMode(UiMode.TITLE);
 
@@ -54,6 +56,7 @@ describe("Test Phase Interceptor", () => {
   });
 
   it("test phase interceptor with prompt with preparation for a future prompt", async () => {
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase");
 
     game.onNextPrompt("SelectGenderPhase", UiMode.OPTION_SELECT, () => {
@@ -65,8 +68,9 @@ describe("Test Phase Interceptor", () => {
       game.setMode(UiMode.MESSAGE);
       game.endPhase();
     });
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("SelectGenderPhase");
-
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("TitlePhase");
     await game.waitMode(UiMode.TITLE);
 
@@ -81,18 +85,23 @@ describe("Test Phase Interceptor", () => {
   });
 
   it("wrong phase", async () => {
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase");
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase").catch((e) => {
       expect(e).toBe("Wrong phase: this is SelectGenderPhase and not LoginPhase");
     });
   });
 
   it("wrong phase but skip", async () => {
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase");
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase", () => game.isCurrentPhase("SelectGenderPhase"));
   });
 
   it("good run", async () => {
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase");
     game.onNextPrompt(
       "SelectGenderPhase",
@@ -103,11 +112,14 @@ describe("Test Phase Interceptor", () => {
       },
       () => game.isCurrentPhase("TitlePhase"),
     );
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("SelectGenderPhase", () => game.isCurrentPhase("TitlePhase"));
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("TitlePhase");
   });
 
   it("good run from select gender to title", async () => {
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase");
     game.onNextPrompt(
       "SelectGenderPhase",
@@ -122,6 +134,7 @@ describe("Test Phase Interceptor", () => {
   });
 
   it("good run to SummonPhase phase", async () => {
+    // @ts-expect-error - this is specifically testing the phase interceptor class
     await game.phaseInterceptor.run("LoginPhase");
     game.onNextPrompt(
       "SelectGenderPhase",

--- a/test/battle/double-battle.test.ts
+++ b/test/battle/double-battle.test.ts
@@ -1,16 +1,14 @@
-import { BattlerIndex } from "#enums/battler-index";
 import { getGameMode } from "#app/game-mode";
-import { GameModes } from "#enums/game-modes";
-import { BattleEndPhase } from "#app/phases/battle-end-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
+import { GameModes } from "#enums/game-modes";
 import { MoveId } from "#enums/move-id";
+import { PhaseId } from "#enums/phase-id";
 import { SpeciesId } from "#enums/species-id";
+import { TrainerType } from "#enums/trainer-type";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { TrainerType } from "#enums/trainer-type";
-import { PhaseId } from "#enums/phase-id";
 
 describe("Double Battles", () => {
   const DOUBLE_CHANCE = 8; // Normal chance of double battle is 1/8
@@ -54,13 +52,13 @@ describe("Double Battles", () => {
 
     await game.faintOpponents();
 
-    await game.phaseInterceptor.to(BattleEndPhase);
+    await game.phaseInterceptor.to("BattleEndPhase");
     game.doSelectModifier();
 
     const charizard = game.scene.getPlayerParty().findIndex((p) => p.species.speciesId === SpeciesId.CHARIZARD);
     game.revivePokemon(charizard);
 
-    await game.phaseInterceptor.to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
     expect(game.scene.getPlayerField().filter((p) => !p.isFainted())).toHaveLength(2);
   }, 20000);
 

--- a/test/battle/escape-calculations.test.ts
+++ b/test/battle/escape-calculations.test.ts
@@ -1,4 +1,4 @@
-import { AttemptRunPhase } from "#app/phases/attempt-run-phase";
+import type { AttemptRunPhase } from "#app/phases/attempt-run-phase";
 import type { CommandPhase } from "#app/phases/command-phase";
 import { NumberHolder } from "#app/utils/common-utils";
 import { AbilityId } from "#enums/ability-id";
@@ -43,7 +43,7 @@ describe("Escape chance calculations", () => {
     const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
     commandPhase.handleCommand(BattleCommand.RUN, 0);
 
-    await game.phaseInterceptor.to(AttemptRunPhase, false);
+    await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
     const escapePercentage = new NumberHolder(0);
 
@@ -112,7 +112,7 @@ describe("Escape chance calculations", () => {
     const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
     commandPhase.handleCommand(BattleCommand.RUN, 0);
 
-    await game.phaseInterceptor.to(AttemptRunPhase, false);
+    await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
     const escapePercentage = new NumberHolder(0);
 
@@ -187,7 +187,7 @@ describe("Escape chance calculations", () => {
     const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
     commandPhase.handleCommand(BattleCommand.RUN, 0);
 
-    await game.phaseInterceptor.to(AttemptRunPhase, false);
+    await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
     const escapePercentage = new NumberHolder(0);
 
@@ -270,7 +270,7 @@ describe("Escape chance calculations", () => {
     const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
     commandPhase.handleCommand(BattleCommand.RUN, 0);
 
-    await game.phaseInterceptor.to(AttemptRunPhase, false);
+    await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
     const escapePercentage = new NumberHolder(0);
 

--- a/test/items/dire-hit.test.ts
+++ b/test/items/dire-hit.test.ts
@@ -1,18 +1,15 @@
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import { TempCritBoosterModifier } from "#app/modifier/modifier";
+import { CommandPhase } from "#app/phases/command-phase";
+import { NewBattlePhase } from "#app/phases/new-battle-phase";
+import type { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { Button } from "#enums/buttons";
 import { MoveId } from "#enums/move-id";
+import { ShopCursorTarget } from "#enums/shop-cursor-target";
 import { SpeciesId } from "#enums/species-id";
+import { UiMode } from "#enums/ui-mode";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phase from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { BattleEndPhase } from "#app/phases/battle-end-phase";
-import { TempCritBoosterModifier } from "#app/modifier/modifier";
-import { UiMode } from "#enums/ui-mode";
-import type { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { Button } from "#enums/buttons";
-import { CommandPhase } from "#app/phases/command-phase";
-import { NewBattlePhase } from "#app/phases/new-battle-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
-import { ShopCursorTarget } from "#enums/shop-cursor-target";
 
 describe("Items - Dire Hit", () => {
   let phaserGame: Phaser.Game;
@@ -48,7 +45,7 @@ describe("Items - Dire Hit", () => {
 
     game.move.select(MoveId.POUND);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getCritStage).toHaveReturnedWith(1);
   }, 20000);
@@ -62,7 +59,7 @@ describe("Items - Dire Hit", () => {
 
     await game.faintOpponents();
 
-    await game.phaseInterceptor.to(BattleEndPhase);
+    await game.phaseInterceptor.to("BattleEndPhase");
 
     const modifier = game.scene.findModifier((m) => m instanceof TempCritBoosterModifier) as TempCritBoosterModifier;
     expect(modifier.getBattleCount()).toBe(4);
@@ -82,7 +79,7 @@ describe("Items - Dire Hit", () => {
       true,
     );
 
-    await game.phaseInterceptor.to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
 
     // Making sure only one booster is in the modifier list even after picking up another
     let count = 0;

--- a/test/items/leek.test.ts
+++ b/test/items/leek.test.ts
@@ -1,4 +1,3 @@
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -38,7 +37,7 @@ describe.todo("Items - Leek", () => {
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyMember.getCritStage).toHaveReturnedWith(2);
   }, 20000);
@@ -52,7 +51,7 @@ describe.todo("Items - Leek", () => {
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyMember.getCritStage).toHaveReturnedWith(2);
   }, 20000);
@@ -66,7 +65,7 @@ describe.todo("Items - Leek", () => {
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyMember.getCritStage).toHaveReturnedWith(2);
   }, 20000);
@@ -80,7 +79,7 @@ describe.todo("Items - Leek", () => {
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyMember.getCritStage).toHaveReturnedWith(0);
   }, 20000);

--- a/test/items/leftovers.test.ts
+++ b/test/items/leftovers.test.ts
@@ -1,5 +1,3 @@
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -47,13 +45,13 @@ describe("Items - Leftovers", () => {
     game.move.select(MoveId.SPLASH);
 
     // We should have less hp after the attack
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
 
     const leadHpAfterDamage = leadPokemon.hp;
 
     // Check if leftovers heal us
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(leadPokemon.hp).toBeGreaterThan(leadHpAfterDamage);
   }, 20000);
 });

--- a/test/items/scope-lens.test.ts
+++ b/test/items/scope-lens.test.ts
@@ -1,4 +1,3 @@
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -38,7 +37,7 @@ describe.todo("Items - Scope Lens", () => {
 
     game.move.select(MoveId.POUND);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.getCritStage).toHaveReturnedWith(1);
   }, 20000);

--- a/test/items/temp-stat-stage-booster.test.ts
+++ b/test/items/temp-stat-stage-booster.test.ts
@@ -1,16 +1,15 @@
-import { BATTLE_STATS, Stat } from "#enums/stat";
-import { GameManager } from "#test/test-utils/gameManager";
+import { TempStatStageBoosterModifier } from "#app/modifier/modifier";
+import type { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { AbilityId } from "#enums/ability-id";
+import { Button } from "#enums/buttons";
+import { MoveId } from "#enums/move-id";
+import { ShopCursorTarget } from "#enums/shop-cursor-target";
 import { SpeciesId } from "#enums/species-id";
+import { BATTLE_STATS, Stat } from "#enums/stat";
+import { UiMode } from "#enums/ui-mode";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phase from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { MoveId } from "#enums/move-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { AbilityId } from "#enums/ability-id";
-import { TempStatStageBoosterModifier } from "#app/modifier/modifier";
-import { UiMode } from "#enums/ui-mode";
-import { Button } from "#enums/buttons";
-import type { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { ShopCursorTarget } from "#enums/shop-cursor-target";
 
 describe("Items - Temporary Stat Stage Boosters", () => {
   let phaserGame: Phaser.Game;
@@ -47,7 +46,7 @@ describe("Items - Temporary Stat Stage Boosters", () => {
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.runFrom("EnemyCommandPhase").to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(partyMember.getStatStageMultiplier).toHaveReturnedWith(1.3);
   }, 20000);
@@ -64,11 +63,11 @@ describe("Items - Temporary Stat Stage Boosters", () => {
     // Raise ACC by +2 stat stages
     game.move.select(MoveId.HONE_CLAWS);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // ACC at +3 stat stages yields a x2 multiplier
     expect(partyMember.getAccuracyMultiplier).toHaveReturnedWith(2);
@@ -84,11 +83,11 @@ describe("Items - Temporary Stat Stage Boosters", () => {
     // Raise ATK by +1 stat stage
     game.move.select(MoveId.HONE_CLAWS);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // ATK at +1 stat stage yields a x1.5 multiplier, add 0.3 from X_ATTACK
     expect(partyMember.getStatStageMultiplier).toHaveReturnedWith(1.8);
@@ -112,7 +111,7 @@ describe("Items - Temporary Stat Stage Boosters", () => {
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(partyMember.getAccuracyMultiplier).toHaveReturnedWith(3);
     expect(partyMember.getStatStageMultiplier).toHaveReturnedWith(4);

--- a/test/moves/after-you.test.ts
+++ b/test/moves/after-you.test.ts
@@ -1,8 +1,8 @@
-import { BattlerIndex } from "#enums/battler-index";
+import type { MovePhase } from "#app/phases/move-phase";
 import { AbilityId } from "#enums/ability-id";
-import { MoveResult } from "#enums/move-result";
-import { MovePhase } from "#app/phases/move-phase";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
@@ -41,7 +41,7 @@ describe("Moves - After You", () => {
     game.move.select(MoveId.SPLASH, 1);
 
     await game.phaseInterceptor.to("MoveEffectPhase");
-    await game.phaseInterceptor.to(MovePhase, false);
+    await game.phaseInterceptor.to("MovePhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as MovePhase;
     expect(phase.pokemon).toBe(game.scene.getPlayerField()[1]);
     await game.phaseInterceptor.to("MoveEndPhase");
@@ -56,7 +56,7 @@ describe("Moves - After You", () => {
 
     await game.phaseInterceptor.to("MoveEndPhase");
     await game.phaseInterceptor.to("MoveEndPhase");
-    await game.phaseInterceptor.to(MovePhase);
+    await game.phaseInterceptor.to("MovePhase");
 
     expect(game.scene.getPlayerField()[1]).toHaveMoveResult(MoveResult.FAIL);
   });

--- a/test/moves/aromatherapy.test.ts
+++ b/test/moves/aromatherapy.test.ts
@@ -1,11 +1,10 @@
-import { StatusEffect } from "#enums/status-effect";
-import { CommandPhase } from "#app/phases/command-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Aromatherapy", () => {
   let phaserGame: Phaser.Game;
@@ -40,7 +39,7 @@ describe("Moves - Aromatherapy", () => {
     vi.spyOn(partyPokemon, "resetStatus");
 
     game.move.select(MoveId.AROMATHERAPY, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -62,7 +61,7 @@ describe("Moves - Aromatherapy", () => {
     vi.spyOn(rightOpp, "resetStatus");
 
     game.move.select(MoveId.AROMATHERAPY, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -86,7 +85,7 @@ describe("Moves - Aromatherapy", () => {
     vi.spyOn(partyPokemon, "resetStatus");
 
     game.move.select(MoveId.AROMATHERAPY, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 

--- a/test/moves/astonish.test.ts
+++ b/test/moves/astonish.test.ts
@@ -1,10 +1,6 @@
 import { allMoves } from "#app/data/data-lists";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { CommandPhase } from "#app/phases/command-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -47,20 +43,20 @@ describe("Moves - Astonish", () => {
 
     game.move.select(MoveId.ASTONISH);
 
-    await game.phaseInterceptor.to(MoveEndPhase, false);
+    await game.phaseInterceptor.to("MoveEndPhase", false);
 
     expect(enemyPokemon.getTag(BattlerTagType.FLINCHED)).toBeDefined();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
     expect(enemyPokemon.getTag(BattlerTagType.FLINCHED)).toBeUndefined();
 
-    await game.phaseInterceptor.to(CommandPhase, false);
+    await game.phaseInterceptor.to("CommandPhase", false);
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(leadPokemon.hp).toBeLessThan(leadPokemon.getMaxHp());
   });

--- a/test/moves/beak-blast.test.ts
+++ b/test/moves/beak-blast.test.ts
@@ -1,11 +1,8 @@
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { StatusEffect } from "#enums/status-effect";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { MovePhase } from "#app/phases/move-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -45,10 +42,10 @@ describe("Moves - Beak Blast", () => {
 
     game.move.select(MoveId.BEAK_BLAST);
 
-    await game.phaseInterceptor.to(MovePhase, false);
+    await game.phaseInterceptor.to("MovePhase", false);
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeDefined();
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.getStatusEffect(true)).toBe(StatusEffect.BURN);
   });
 
@@ -62,10 +59,10 @@ describe("Moves - Beak Blast", () => {
 
     game.move.select(MoveId.BEAK_BLAST);
 
-    await game.phaseInterceptor.to(MovePhase, false);
+    await game.phaseInterceptor.to("MovePhase", false);
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeDefined();
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.getStatusEffect(true)).toBe(StatusEffect.BURN);
   });
 
@@ -79,10 +76,10 @@ describe("Moves - Beak Blast", () => {
 
     game.move.select(MoveId.BEAK_BLAST);
 
-    await game.phaseInterceptor.to(MovePhase, false);
+    await game.phaseInterceptor.to("MovePhase", false);
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeDefined();
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.getStatusEffect(true)).not.toBe(StatusEffect.BURN);
   });
 
@@ -94,7 +91,7 @@ describe("Moves - Beak Blast", () => {
 
     game.move.select(MoveId.BEAK_BLAST);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(leadPokemon.turnData.hitCount).toBe(2);
   });
 
@@ -108,10 +105,10 @@ describe("Moves - Beak Blast", () => {
 
     game.move.select(MoveId.BEAK_BLAST);
 
-    await game.phaseInterceptor.to(MovePhase, false);
+    await game.phaseInterceptor.to("MovePhase", false);
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeDefined();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
     expect(leadPokemon.getTag(BattlerTagType.BEAK_BLAST_CHARGING)).toBeUndefined();
   });

--- a/test/moves/beat-up.test.ts
+++ b/test/moves/beat-up.test.ts
@@ -2,7 +2,6 @@ import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -50,14 +49,14 @@ describe("Moves - Beat Up", () => {
 
     game.move.select(MoveId.BEAT_UP);
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(playerPokemon.turnData.hitCount).toBe(6);
     expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
 
     while (playerPokemon.turnData.hitsLeft > 0) {
       enemyStartingHp = enemyPokemon.hp;
-      await game.phaseInterceptor.to(MoveEffectPhase);
+      await game.phaseInterceptor.to("MoveEffectPhase");
       expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
     }
   });
@@ -78,7 +77,7 @@ describe("Moves - Beat Up", () => {
 
     game.move.select(MoveId.BEAT_UP);
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(playerPokemon.turnData.hitCount).toBe(5);
   });

--- a/test/moves/belly-drum.test.ts
+++ b/test/moves/belly-drum.test.ts
@@ -1,12 +1,11 @@
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { toDmgValue } from "#app/utils/common-utils";
+import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
-import { AbilityId } from "#enums/ability-id";
 
 // RATIO : HP Cost of Move
 const RATIO = 2;
@@ -48,7 +47,7 @@ describe("Moves - BELLY DRUM", () => {
     const hpLost = toDmgValue(leadPokemon.getMaxHp() / RATIO);
 
     game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
@@ -65,7 +64,7 @@ describe("Moves - BELLY DRUM", () => {
     leadPokemon.setStatStage(Stat.SPATK, 6);
 
     game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
@@ -80,7 +79,7 @@ describe("Moves - BELLY DRUM", () => {
     leadPokemon.setStatStage(Stat.ATK, 6);
 
     game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
@@ -94,7 +93,7 @@ describe("Moves - BELLY DRUM", () => {
     leadPokemon.hp = hpLost - PREDAMAGE;
 
     game.move.select(MoveId.BELLY_DRUM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(hpLost - PREDAMAGE);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(0);

--- a/test/moves/ceaseless-edge.test.ts
+++ b/test/moves/ceaseless-edge.test.ts
@@ -1,15 +1,13 @@
 import { EntryHazardTag } from "#app/data/arena-tag";
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { allMoves } from "#app/data/data-lists";
+import { toDmgValue } from "#app/utils/common-utils";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { toDmgValue } from "#app/utils/common-utils";
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("Moves - Ceaseless Edge", () => {
@@ -48,12 +46,12 @@ describe("Moves - Ceaseless Edge", () => {
 
     game.move.select(MoveId.CEASELESS_EDGE);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
     const tagBefore = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const tagAfter = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagAfter instanceof EntryHazardTag).toBeTruthy();
     expect(tagAfter.layers).toBe(1);
@@ -66,7 +64,7 @@ describe("Moves - Ceaseless Edge", () => {
     await game.classicMode.startBattle([SpeciesId.ILLUMISE]);
 
     game.move.select(MoveId.CEASELESS_EDGE);
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Spikes should not have any layers before move effect is applied
     const tagBefore = game.scene.arena.getTagOnSide(ArenaTagType.SPIKES, ArenaTagSide.ENEMY) as EntryHazardTag;
     expect(tagBefore instanceof EntryHazardTag).toBeFalsy();
@@ -78,7 +76,7 @@ describe("Moves - Ceaseless Edge", () => {
 
     game.forceEnemyToSwitch();
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase, false);
+    await game.phaseInterceptor.to("TurnEndPhase", false);
 
     const switchedInPokemon = game.field.getEnemyPokemon();
     expect(switchedInPokemon.getInverseHp()).toBe(toDmgValue(switchedInPokemon.getMaxHp() / 6));

--- a/test/moves/clangorous-soul.test.ts
+++ b/test/moves/clangorous-soul.test.ts
@@ -1,10 +1,9 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 /** HP Cost of Move */
 const RATIO = 3;
@@ -44,7 +43,7 @@ describe("Moves - Clangorous Soul", () => {
     const hpLost = Math.floor(leadPokemon.getMaxHp() / RATIO);
 
     game.move.select(MoveId.CLANGOROUS_SOUL);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(1);
@@ -67,7 +66,7 @@ describe("Moves - Clangorous Soul", () => {
     leadPokemon.setStatStage(Stat.SPDEF, 4);
 
     game.move.select(MoveId.CLANGOROUS_SOUL);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
@@ -89,7 +88,7 @@ describe("Moves - Clangorous Soul", () => {
     leadPokemon.setStatStage(Stat.SPD, 6);
 
     game.move.select(MoveId.CLANGOROUS_SOUL);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
@@ -107,7 +106,7 @@ describe("Moves - Clangorous Soul", () => {
     leadPokemon.hp = hpLost - PREDAMAGE;
 
     game.move.select(MoveId.CLANGOROUS_SOUL);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(hpLost - PREDAMAGE);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(0);

--- a/test/moves/crafty-shield.test.ts
+++ b/test/moves/crafty-shield.test.ts
@@ -1,13 +1,11 @@
+import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { AbilityId } from "#enums/ability-id";
-import { MoveId } from "#enums/move-id";
-import { Stat } from "#enums/stat";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { CommandPhase } from "#app/phases/command-phase";
 
 describe("Moves - Crafty Shield", () => {
   let phaserGame: Phaser.Game;
@@ -45,11 +43,11 @@ describe("Moves - Crafty Shield", () => {
 
     game.move.select(MoveId.CRAFTY_SHIELD);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
 
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     leadPokemon.forEach((p) => expect(p.getStatStage(Stat.ATK)).toBe(0));
   });
@@ -63,11 +61,11 @@ describe("Moves - Crafty Shield", () => {
 
     game.move.select(MoveId.CRAFTY_SHIELD);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
 
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(leadPokemon.some((p) => p.hp < p.getMaxHp())).toBeTruthy();
   });
@@ -82,11 +80,11 @@ describe("Moves - Crafty Shield", () => {
 
     game.move.select(MoveId.CRAFTY_SHIELD);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
 
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     leadPokemon.forEach((p) => expect(p.getTag(BattlerTagType.CURSED)).toBeUndefined());
   });
@@ -98,11 +96,11 @@ describe("Moves - Crafty Shield", () => {
 
     game.move.select(MoveId.CRAFTY_SHIELD);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
 
     game.move.select(MoveId.SWORDS_DANCE, 1);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(leadPokemon[0].getStatStage(Stat.ATK)).toBe(0);
     expect(leadPokemon[1].getStatStage(Stat.ATK)).toBe(2);

--- a/test/moves/double-team.test.ts
+++ b/test/moves/double-team.test.ts
@@ -1,8 +1,7 @@
-import { Stat } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -42,7 +41,7 @@ describe("Moves - Double Team", () => {
     expect(ally.getStatStage(Stat.EVA)).toBe(0);
 
     game.move.select(MoveId.DOUBLE_TEAM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     await game.toNextTurn();
 
     expect(ally.getStatStage(Stat.EVA)).toBe(1);

--- a/test/moves/fillet-away.test.ts
+++ b/test/moves/fillet-away.test.ts
@@ -1,4 +1,3 @@
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { toDmgValue } from "#app/utils/common-utils";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -45,7 +44,7 @@ describe("Moves - FILLET AWAY", () => {
     const hpLost = toDmgValue(leadPokemon.getMaxHp() / RATIO);
 
     game.move.select(MoveId.FILLET_AWAY);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(2);
@@ -64,7 +63,7 @@ describe("Moves - FILLET AWAY", () => {
     leadPokemon.setStatStage(Stat.SPATK, 3);
 
     game.move.select(MoveId.FILLET_AWAY);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp() - hpLost);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
@@ -82,7 +81,7 @@ describe("Moves - FILLET AWAY", () => {
     leadPokemon.setStatStage(Stat.SPD, 6);
 
     game.move.select(MoveId.FILLET_AWAY);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(leadPokemon.getMaxHp());
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(6);
@@ -98,7 +97,7 @@ describe("Moves - FILLET AWAY", () => {
     leadPokemon.hp = hpLost - PREDAMAGE;
 
     game.move.select(MoveId.FILLET_AWAY);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.hp).toBe(hpLost - PREDAMAGE);
     expect(leadPokemon.getStatStage(Stat.ATK)).toBe(0);

--- a/test/moves/flail.test.ts
+++ b/test/moves/flail.test.ts
@@ -1,14 +1,13 @@
+import { allMoves } from "#app/data/data-lists";
+import type { Move } from "#app/data/moves/move";
+import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
-import { allMoves } from "#app/data/data-lists";
-import type { Move } from "#app/data/moves/move";
-import { BattlerIndex } from "#enums/battler-index";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Flail", () => {
   let phaserGame: Phaser.Game;
@@ -62,9 +61,9 @@ describe("Moves - Flail", () => {
     game.move.select(MoveId.FLAIL, 0);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(flail.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(flail.calculateBattlePower).toHaveLastReturnedWith(expectedBp);
   });
 });

--- a/test/moves/flower-shield.test.ts
+++ b/test/moves/flower-shield.test.ts
@@ -1,10 +1,9 @@
-import { Stat } from "#enums/stat";
-import { ElementalType } from "#enums/elemental-type";
-import { BiomeId } from "#enums/biome-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BiomeId } from "#enums/biome-id";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -43,7 +42,7 @@ describe("Moves - Flower Shield", () => {
     expect(cherrim.getStatStage(Stat.DEF)).toBe(0);
 
     game.move.select(MoveId.FLOWER_SHIELD);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(magikarp.getStatStage(Stat.DEF)).toBe(0);
     expect(cherrim.getStatStage(Stat.DEF)).toBe(1);
@@ -63,7 +62,7 @@ describe("Moves - Flower Shield", () => {
 
     game.move.select(MoveId.FLOWER_SHIELD);
     game.move.select(MoveId.SPLASH, 1);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     grassPokemons.forEach((p) => expect(p.getStatStage(Stat.DEF)).toBe(1));
     nonGrassPokemons.forEach((p) => expect(p.getStatStage(Stat.DEF)).toBe(0));
@@ -86,7 +85,7 @@ describe("Moves - Flower Shield", () => {
     expect(paras.isSemiInvulnerable()).toBeFalsy();
 
     game.move.select(MoveId.FLOWER_SHIELD);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(paras.isSemiInvulnerable()).toBeTruthy();
     expect(paras.getStatStage(Stat.DEF)).toBe(0);
@@ -104,7 +103,7 @@ describe("Moves - Flower Shield", () => {
     expect(ally.getStatStage(Stat.DEF)).toBe(0);
 
     game.move.select(MoveId.FLOWER_SHIELD);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemy.getStatStage(Stat.DEF)).toBe(0);
     expect(ally.getStatStage(Stat.DEF)).toBe(0);

--- a/test/moves/focus-punch.test.ts
+++ b/test/moves/focus-punch.test.ts
@@ -1,8 +1,5 @@
-import { BerryPhase } from "#app/phases/berry-phase";
-import { MessagePhase } from "#app/phases/message-phase";
 import { MoveHeaderPhase } from "#app/phases/move-header-phase";
 import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
-import { TurnStartPhase } from "#app/phases/turn-start-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -47,12 +44,12 @@ describe("Moves - Focus Punch", () => {
 
     game.move.select(MoveId.FOCUS_PUNCH);
 
-    await game.phaseInterceptor.to(MessagePhase);
+    await game.phaseInterceptor.to("MessagePhase");
 
     expect(enemyPokemon.hp).toBe(enemyStartingHp);
     expect(leadPokemon.getMoveHistory().length).toBe(0);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.hp).toBeLessThan(enemyStartingHp);
     expect(leadPokemon.getMoveHistory().length).toBe(1);
@@ -71,12 +68,12 @@ describe("Moves - Focus Punch", () => {
 
     game.move.select(MoveId.FOCUS_PUNCH);
 
-    await game.phaseInterceptor.to(MessagePhase);
+    await game.phaseInterceptor.to("MessagePhase");
 
     expect(enemyPokemon.hp).toBe(enemyStartingHp);
     expect(leadPokemon.getMoveHistory().length).toBe(0);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.hp).toBe(enemyStartingHp);
     expect(leadPokemon.getMoveHistory().length).toBe(1);
@@ -93,11 +90,11 @@ describe("Moves - Focus Punch", () => {
 
     game.move.select(MoveId.FOCUS_PUNCH);
 
-    await game.phaseInterceptor.to(MessagePhase); // Header message
+    await game.phaseInterceptor.to("MessagePhase"); // Header message
 
     expect(leadPokemon.getMoveHistory().length).toBe(0);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(leadPokemon.getMoveHistory().length).toBe(1);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
@@ -112,7 +109,7 @@ describe("Moves - Focus Punch", () => {
     game.forceEnemyToSwitch();
     game.move.select(MoveId.FOCUS_PUNCH);
 
-    await game.phaseInterceptor.to(TurnStartPhase);
+    await game.phaseInterceptor.to("TurnStartPhase");
 
     expect(game.scene.phaseManager.getCurrentPhase() instanceof SwitchSummonPhase).toBeTruthy();
     expect(game.scene.phaseManager["phaseQueue"].find((phase) => phase instanceof MoveHeaderPhase)).toBeDefined();

--- a/test/moves/follow-me.test.ts
+++ b/test/moves/follow-me.test.ts
@@ -1,9 +1,8 @@
-import { Stat } from "#enums/stat";
-import { BattlerIndex } from "#enums/battler-index";
 import { AbilityId } from "#enums/ability-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
@@ -46,7 +45,7 @@ describe("Moves - Follow Me", () => {
     await game.move.selectEnemyMove(MoveId.TACKLE, BattlerIndex.PLAYER_2);
     await game.move.selectEnemyMove(MoveId.TACKLE, BattlerIndex.PLAYER_2);
 
-    await game.phaseInterceptor.to(TurnEndPhase, false);
+    await game.phaseInterceptor.to("TurnEndPhase", false);
 
     expect(playerPokemon[0].hp).toBeLessThan(playerPokemon[0].getMaxHp());
     expect(playerPokemon[1].hp).toBe(playerPokemon[1].getMaxHp());
@@ -64,7 +63,7 @@ describe("Moves - Follow Me", () => {
     await game.move.selectEnemyMove(MoveId.TACKLE, BattlerIndex.PLAYER);
     await game.move.selectEnemyMove(MoveId.TACKLE, BattlerIndex.PLAYER_2);
 
-    await game.phaseInterceptor.to(TurnEndPhase, false);
+    await game.phaseInterceptor.to("TurnEndPhase", false);
 
     playerPokemon.sort((a, b) => a.getEffectiveStat(Stat.SPD) - b.getEffectiveStat(Stat.SPD));
 
@@ -87,7 +86,7 @@ describe("Moves - Follow Me", () => {
     await game.move.selectEnemyMove(MoveId.FOLLOW_ME);
     await game.move.selectEnemyMove(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase, false);
+    await game.phaseInterceptor.to("TurnEndPhase", false);
 
     // If redirection was bypassed, both enemies should be damaged
     expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
@@ -107,7 +106,7 @@ describe("Moves - Follow Me", () => {
     await game.move.selectEnemyMove(MoveId.FOLLOW_ME);
     await game.move.selectEnemyMove(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase, false);
+    await game.phaseInterceptor.to("TurnEndPhase", false);
 
     // If redirection was bypassed, both enemies should be damaged
     expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());

--- a/test/moves/foresight.test.ts
+++ b/test/moves/foresight.test.ts
@@ -1,6 +1,5 @@
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -48,7 +47,7 @@ describe("Moves - Foresight", () => {
     enemy.hp = enemy.getMaxHp();
 
     game.move.select(MoveId.MACH_PUNCH);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
   });
@@ -63,7 +62,7 @@ describe("Moves - Foresight", () => {
     game.move.select(MoveId.FORESIGHT);
     await game.toNextTurn();
     game.move.select(MoveId.QUICK_ATTACK);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(pokemon.getAccuracyMultiplier).toHaveReturnedWith(1);
   });

--- a/test/moves/freezy-frost.test.ts
+++ b/test/moves/freezy-frost.test.ts
@@ -1,12 +1,11 @@
-import { Stat } from "#enums/stat";
+import { allMoves } from "#app/data/data-lists";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { allMoves } from "#app/data/data-lists";
-import { CommandPhase } from "#app/phases/command-phase";
 
 describe("Moves - Freezy Frost", () => {
   let phaserGame: Phaser.Game;
@@ -77,7 +76,7 @@ describe("Moves - Freezy Frost", () => {
     const [leftOpp, rightOpp] = game.scene.getEnemyField();
 
     game.move.select(MoveId.HOWL, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -87,7 +86,7 @@ describe("Moves - Freezy Frost", () => {
     expect(rightOpp.getStatStage(Stat.ATK)).toBe(2);
 
     game.move.select(MoveId.FREEZY_FROST, 0, leftOpp.getBattlerIndex());
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 

--- a/test/moves/fusion-flare-bolt.test.ts
+++ b/test/moves/fusion-flare-bolt.test.ts
@@ -1,16 +1,13 @@
-import { Stat } from "#enums/stat";
-import { BattlerIndex } from "#enums/battler-index";
 import { allMoves } from "#app/data/data-lists";
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { MovePhase } from "#app/phases/move-phase";
+import type { Move } from "#app/data/moves/move";
+import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Move } from "#app/data/moves/move";
 
 describe("Moves - Fusion Flare and Fusion Bolt", () => {
   let phaserGame: Phaser.Game;
@@ -56,14 +53,14 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
     // Force user party to act before enemy party
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(100);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
   }, 20000);
 
@@ -76,14 +73,14 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
     // Force user party to act before enemy party
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
   }, 20000);
 
@@ -96,19 +93,19 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
     // Force first enemy to act (and fail) in between party
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(100);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     // Skip enemy move; because the enemy is at full HP, Rest should fail
-    await game.phaseInterceptor.runFrom(MovePhase).to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
   }, 20000);
 
@@ -122,18 +119,18 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
     // Force first enemy to act in between party
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(100);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     // Skip enemy move
-    await game.phaseInterceptor.runFrom(MovePhase).to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
   }, 20000);
 
@@ -146,14 +143,14 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
     // Force user party to act before enemy party
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
   }, 20000);
 
@@ -190,24 +187,24 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
     // Force first enemy to act in between party
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
   }, 20000);
 
@@ -244,24 +241,24 @@ describe("Moves - Fusion Flare and Fusion Bolt", () => {
     // Force first enemy to act in between party
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(100);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionBolt.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionBolt.calculateBattlePower).toHaveLastReturnedWith(200);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     expect((game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase).move.moveId).toBe(fusionFlare.id);
-    await game.phaseInterceptor.to(DamageAnimPhase, false);
+    await game.phaseInterceptor.to("DamageAnimPhase", false);
     expect(fusionFlare.calculateBattlePower).toHaveLastReturnedWith(200);
   }, 20000);
 });

--- a/test/moves/fusion-flare.test.ts
+++ b/test/moves/fusion-flare.test.ts
@@ -1,4 +1,3 @@
-import { TurnStartPhase } from "#app/phases/turn-start-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
@@ -42,7 +41,7 @@ describe("Moves - Fusion Flare", () => {
 
     game.move.select(fusionFlare);
 
-    await game.phaseInterceptor.to(TurnStartPhase, false);
+    await game.phaseInterceptor.to("TurnStartPhase", false);
 
     // Inflict freeze quietly and check if it was properly inflicted
     partyMember.trySetStatus(StatusEffect.FREEZE, false);

--- a/test/moves/growth.test.ts
+++ b/test/moves/growth.test.ts
@@ -1,12 +1,10 @@
-import { Stat } from "#enums/stat";
-import { GameManager } from "#test/test-utils/gameManager";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 
 describe("Moves - Growth", () => {
   let phaserGame: Phaser.Game;
@@ -39,7 +37,7 @@ describe("Moves - Growth", () => {
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(0);
 
     game.move.select(MoveId.GROWTH);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(1);
   }, 20000);

--- a/test/moves/guard-split.test.ts
+++ b/test/moves/guard-split.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { Stat } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Guard Split", () => {
   let phaserGame: Phaser.Game;
@@ -43,7 +42,7 @@ describe("Moves - Guard Split", () => {
     const avgSpDef = Math.floor((player.getStat(Stat.SPDEF, false) + enemy.getStat(Stat.SPDEF, false)) / 2);
 
     game.move.select(MoveId.GUARD_SPLIT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.DEF, false)).toBe(avgDef);
     expect(enemy.getStat(Stat.DEF, false)).toBe(avgDef);
@@ -63,10 +62,10 @@ describe("Moves - Guard Split", () => {
     const avgSpDef = Math.floor((player.getStat(Stat.SPDEF, false) + enemy.getStat(Stat.SPDEF, false)) / 2);
 
     game.move.select(MoveId.GUARD_SPLIT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     game.move.select(MoveId.GUARD_SPLIT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.DEF, false)).toBe(avgDef);
     expect(enemy.getStat(Stat.DEF, false)).toBe(avgDef);

--- a/test/moves/guard-swap.test.ts
+++ b/test/moves/guard-swap.test.ts
@@ -1,12 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { Stat, BATTLE_STATS } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { BATTLE_STATS, Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Guard Swap", () => {
   let phaserGame: Phaser.Game;
@@ -43,14 +41,14 @@ describe("Moves - Guard Swap", () => {
 
     game.move.select(MoveId.GUARD_SWAP);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     for (const s of BATTLE_STATS) {
       expect(player.getStatStage(s)).toBe(0);
       expect(enemy.getStatStage(s)).toBe(1);
     }
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     for (const s of BATTLE_STATS) {
       if (s === Stat.DEF || s === Stat.SPDEF) {

--- a/test/moves/hard-press.test.ts
+++ b/test/moves/hard-press.test.ts
@@ -1,5 +1,4 @@
 import { allMoves } from "#app/data/data-lists";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -38,7 +37,7 @@ describe("Moves - Hard Press", () => {
     await game.startBattle([SpeciesId.PIKACHU]);
 
     game.move.select(MoveId.HARD_PRESS);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(100);
   });
@@ -51,7 +50,7 @@ describe("Moves - Hard Press", () => {
     vi.spyOn(enemy, "getHpRatio").mockReturnValue(targetHpRatio);
 
     game.move.select(MoveId.HARD_PRESS);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(50);
   });
@@ -64,7 +63,7 @@ describe("Moves - Hard Press", () => {
     vi.spyOn(enemy, "getHpRatio").mockReturnValue(targetHpRatio);
 
     game.move.select(MoveId.HARD_PRESS);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(1);
   });
@@ -77,7 +76,7 @@ describe("Moves - Hard Press", () => {
     vi.spyOn(enemy, "getHpRatio").mockReturnValue(targetHpRatio);
 
     game.move.select(MoveId.HARD_PRESS);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(moveToCheck.calculateBattlePower).toHaveReturnedWith(1);
   });

--- a/test/moves/haze.test.ts
+++ b/test/moves/haze.test.ts
@@ -1,11 +1,10 @@
-import { Stat } from "#enums/stat";
-import { GameManager } from "#test/test-utils/gameManager";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 
 describe("Moves - Haze", () => {
   describe("integration tests", () => {
@@ -44,16 +43,16 @@ describe("Moves - Haze", () => {
       expect(enemy.getStatStage(Stat.ATK)).toBe(0);
 
       game.move.select(MoveId.SWORDS_DANCE);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       game.move.select(MoveId.CHARM);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(user.getStatStage(Stat.ATK)).toBe(2);
       expect(enemy.getStatStage(Stat.ATK)).toBe(-2);
 
       game.move.select(MoveId.HAZE);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(user.getStatStage(Stat.ATK)).toBe(0);
       expect(enemy.getStatStage(Stat.ATK)).toBe(0);

--- a/test/moves/heal-bell.test.ts
+++ b/test/moves/heal-bell.test.ts
@@ -1,11 +1,10 @@
-import { StatusEffect } from "#enums/status-effect";
-import { CommandPhase } from "#app/phases/command-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Heal Bell", () => {
   let phaserGame: Phaser.Game;
@@ -40,7 +39,7 @@ describe("Moves - Heal Bell", () => {
     vi.spyOn(partyPokemon, "resetStatus");
 
     game.move.select(MoveId.HEAL_BELL, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -62,7 +61,7 @@ describe("Moves - Heal Bell", () => {
     vi.spyOn(rightOpp, "resetStatus");
 
     game.move.select(MoveId.HEAL_BELL, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -86,7 +85,7 @@ describe("Moves - Heal Bell", () => {
     vi.spyOn(partyPokemon, "resetStatus");
 
     game.move.select(MoveId.HEAL_BELL, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 

--- a/test/moves/heart-swap.test.ts
+++ b/test/moves/heart-swap.test.ts
@@ -1,12 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { BATTLE_STATS } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { BATTLE_STATS } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Heart Swap", () => {
   let phaserGame: Phaser.Game;
@@ -43,14 +41,14 @@ describe("Moves - Heart Swap", () => {
 
     game.move.select(MoveId.HEART_SWAP);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     for (const s of BATTLE_STATS) {
       expect(player.getStatStage(s)).toBe(0);
       expect(enemy.getStatStage(s)).toBe(1);
     }
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     for (const s of BATTLE_STATS) {
       expect(enemy.getStatStage(s)).toBe(0);

--- a/test/moves/hyper-beam.test.ts
+++ b/test/moves/hyper-beam.test.ts
@@ -3,8 +3,6 @@ import { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -45,7 +43,7 @@ describe("Moves - Hyper Beam", () => {
 
     game.move.select(MoveId.HYPER_BEAM);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
     expect(leadPokemon.getTag(BattlerTagType.RECHARGING)).toBeDefined();
@@ -53,14 +51,14 @@ describe("Moves - Hyper Beam", () => {
     const enemyPostAttackHp = enemyPokemon.hp;
 
     /** Game should progress without a new command from the player */
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(enemyPokemon.hp).toBe(enemyPostAttackHp);
     expect(leadPokemon.getTag(BattlerTagType.RECHARGING)).toBeUndefined();
 
     game.move.select(MoveId.TACKLE);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.hp).toBeLessThan(enemyPostAttackHp);
   });

--- a/test/moves/jaw-lock.test.ts
+++ b/test/moves/jaw-lock.test.ts
@@ -1,13 +1,9 @@
-import { BattlerIndex } from "#enums/battler-index";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { FaintPhase } from "#app/phases/faint-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { GameManager } from "#test/test-utils/gameManager";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -48,12 +44,12 @@ describe("Moves - Jaw Lock", () => {
     game.move.select(MoveId.JAW_LOCK);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
     expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
     expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
@@ -69,17 +65,17 @@ describe("Moves - Jaw Lock", () => {
     game.move.select(MoveId.JAW_LOCK);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
     expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
     expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
 
-    await game.phaseInterceptor.to(FaintPhase);
+    await game.phaseInterceptor.to("FaintPhase");
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
     expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
@@ -94,12 +90,12 @@ describe("Moves - Jaw Lock", () => {
     game.move.select(MoveId.JAW_LOCK);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(leadPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
     expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeDefined();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     await game.faintOpponents();
 
@@ -118,7 +114,7 @@ describe("Moves - Jaw Lock", () => {
     game.move.select(MoveId.SPLASH, 1);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(playerPokemon[0].getTag(BattlerTagType.TRAPPED)).toBeDefined();
     expect(enemyPokemon[0].getTag(BattlerTagType.TRAPPED)).toBeDefined();
@@ -128,7 +124,7 @@ describe("Moves - Jaw Lock", () => {
     game.move.select(MoveId.JAW_LOCK, 0, BattlerIndex.ENEMY_2);
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemyPokemon[1].getTag(BattlerTagType.TRAPPED)).toBeUndefined();
     expect(playerPokemon[0].getTag(BattlerTagType.TRAPPED)).toBeDefined();
@@ -145,7 +141,7 @@ describe("Moves - Jaw Lock", () => {
 
     game.move.select(MoveId.JAW_LOCK);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(playerPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();
     expect(enemyPokemon.getTag(BattlerTagType.TRAPPED)).toBeUndefined();

--- a/test/moves/lunar-blessing.test.ts
+++ b/test/moves/lunar-blessing.test.ts
@@ -1,8 +1,7 @@
-import { StatusEffect } from "#enums/status-effect";
-import { CommandPhase } from "#app/phases/command-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -48,7 +47,7 @@ describe("Moves - Lunar Blessing", () => {
     vi.spyOn(rightPlayer, "heal");
 
     game.move.select(MoveId.LUNAR_BLESSING, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -68,7 +67,7 @@ describe("Moves - Lunar Blessing", () => {
     vi.spyOn(rightPlayer, "resetStatus");
 
     game.move.select(MoveId.LUNAR_BLESSING, 0);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 

--- a/test/moves/magnet-rise.test.ts
+++ b/test/moves/magnet-rise.test.ts
@@ -1,5 +1,3 @@
-import { CommandPhase } from "#app/phases/command-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -37,7 +35,7 @@ describe("Moves - Magnet Rise", () => {
 
     const startingHp = game.scene.getPlayerParty()[0].hp;
     game.move.select(moveToUse);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const finalHp = game.scene.getPlayerParty()[0].hp;
     const hpLost = finalHp - startingHp;
     expect(hpLost).toBe(0);
@@ -48,12 +46,12 @@ describe("Moves - Magnet Rise", () => {
 
     const startingHp = game.scene.getPlayerParty()[0].hp;
     game.move.select(moveToUse);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     let finalHp = game.scene.getPlayerParty()[0].hp;
     let hpLost = finalHp - startingHp;
     expect(hpLost).toBe(0);
     game.move.select(MoveId.GRAVITY);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     finalHp = game.scene.getPlayerParty()[0].hp;
     hpLost = finalHp - startingHp;
     expect(hpLost).not.toBe(0);

--- a/test/moves/make-it-rain.test.ts
+++ b/test/moves/make-it-rain.test.ts
@@ -1,12 +1,10 @@
-import { Stat } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 
 describe("Moves - Make It Rain", () => {
   let phaserGame: Phaser.Game;
@@ -41,7 +39,7 @@ describe("Moves - Make It Rain", () => {
     game.move.select(MoveId.MAKE_IT_RAIN);
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
   });
@@ -57,7 +55,7 @@ describe("Moves - Make It Rain", () => {
 
     game.move.select(MoveId.MAKE_IT_RAIN);
 
-    await game.phaseInterceptor.to(StatStageChangePhase);
+    await game.phaseInterceptor.to("StatStageChangePhase");
 
     expect(enemyPokemon.isFainted()).toBe(true);
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
@@ -74,7 +72,7 @@ describe("Moves - Make It Rain", () => {
     game.move.select(MoveId.MAKE_IT_RAIN);
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(StatStageChangePhase);
+    await game.phaseInterceptor.to("StatStageChangePhase");
 
     enemyPokemon.forEach((p) => expect(p.isFainted()).toBe(true));
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
@@ -91,7 +89,7 @@ describe("Moves - Make It Rain", () => {
     // Make Make It Rain miss the first target
     await game.move.forceMiss(true);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);
   });

--- a/test/moves/mat-block.test.ts
+++ b/test/moves/mat-block.test.ts
@@ -1,13 +1,10 @@
-import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { CommandPhase } from "#app/phases/command-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
 
 describe("Moves - Mat Block", () => {
   let phaserGame: Phaser.Game;
@@ -45,11 +42,11 @@ describe("Moves - Mat Block", () => {
 
     game.move.select(MoveId.MAT_BLOCK);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
 
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     leadPokemon.forEach((p) => expect(p.hp).toBe(p.getMaxHp()));
   });
@@ -63,11 +60,11 @@ describe("Moves - Mat Block", () => {
 
     game.move.select(MoveId.MAT_BLOCK);
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
 
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     leadPokemon.forEach((p) => expect(p.getStatStage(Stat.ATK)).toBe(-2));
   });
@@ -78,19 +75,19 @@ describe("Moves - Mat Block", () => {
     const leadPokemon = game.scene.getPlayerField();
 
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const leadStartingHp = leadPokemon.map((p) => p.hp);
 
-    await game.phaseInterceptor.to(CommandPhase, false);
+    await game.phaseInterceptor.to("CommandPhase", false);
     game.move.select(MoveId.MAT_BLOCK);
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.MAT_BLOCK, 1);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(leadPokemon.some((p, i) => p.hp < leadStartingHp[i])).toBeTruthy();
   });

--- a/test/moves/miracle-eye.test.ts
+++ b/test/moves/miracle-eye.test.ts
@@ -1,7 +1,6 @@
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -44,7 +43,7 @@ describe("Moves - Miracle Eye", () => {
     await game.toNextTurn();
     game.move.select(MoveId.CONFUSION);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     expect(enemy.hp).toBeLessThan(enemy.getMaxHp());
   });

--- a/test/moves/parting-shot.test.ts
+++ b/test/moves/parting-shot.test.ts
@@ -1,4 +1,3 @@
-import { MessagePhase } from "#app/phases/message-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
@@ -169,7 +168,7 @@ describe("Moves - Parting Shot", () => {
       // intentionally kill party pokemon, switch to second slot (now 1 party mon is fainted)
       await game.faintPokemon(game.scene.getPlayerParty()[0]);
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      await game.phaseInterceptor.run(MessagePhase);
+      await game.phaseInterceptor.to("MessagePhase");
       game.selectPartyPokemon(1);
 
       await game.phaseInterceptor.to("TurnInitPhase", false);

--- a/test/moves/parting-shot.test.ts
+++ b/test/moves/parting-shot.test.ts
@@ -1,14 +1,11 @@
+import { MessagePhase } from "#app/phases/message-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, test } from "vitest";
-import { GameManager } from "#test/test-utils/gameManager";
-import { Stat } from "#enums/stat";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { FaintPhase } from "#app/phases/faint-phase";
-import { MessagePhase } from "#app/phases/message-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 
 describe("Moves - Parting Shot", () => {
   let phaserGame: Phaser.Game;
@@ -42,7 +39,7 @@ describe("Moves - Parting Shot", () => {
 
     game.move.select(MoveId.PARTING_SHOT);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
     expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
@@ -57,7 +54,7 @@ describe("Moves - Parting Shot", () => {
 
     game.move.select(MoveId.PARTING_SHOT);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
     expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
@@ -72,24 +69,24 @@ describe("Moves - Parting Shot", () => {
 
       // use Memento 3 times to debuff enemy
       game.move.select(MoveId.MEMENTO);
-      await game.phaseInterceptor.to(FaintPhase);
+      await game.phaseInterceptor.to("FaintPhase");
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
       game.selectPartyPokemon(1);
 
-      await game.phaseInterceptor.to(TurnInitPhase, false);
+      await game.phaseInterceptor.to("TurnInitPhase", false);
       game.move.select(MoveId.MEMENTO);
-      await game.phaseInterceptor.to(FaintPhase);
+      await game.phaseInterceptor.to("FaintPhase");
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
       game.selectPartyPokemon(2);
 
-      await game.phaseInterceptor.to(TurnInitPhase, false);
+      await game.phaseInterceptor.to("TurnInitPhase", false);
       game.move.select(MoveId.MEMENTO);
-      await game.phaseInterceptor.to(FaintPhase);
+      await game.phaseInterceptor.to("FaintPhase");
       expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
       game.selectPartyPokemon(3);
 
       // set up done
-      await game.phaseInterceptor.to(TurnInitPhase, false);
+      await game.phaseInterceptor.to("TurnInitPhase", false);
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon).toBeDefined();
 
@@ -99,7 +96,7 @@ describe("Moves - Parting Shot", () => {
       // now parting shot should fail
       game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-6);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-6);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
@@ -118,7 +115,7 @@ describe("Moves - Parting Shot", () => {
 
       game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
@@ -137,7 +134,7 @@ describe("Moves - Parting Shot", () => {
 
       game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
@@ -155,7 +152,7 @@ describe("Moves - Parting Shot", () => {
 
       game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-1);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-1);
       expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
@@ -175,10 +172,10 @@ describe("Moves - Parting Shot", () => {
       await game.phaseInterceptor.run(MessagePhase);
       game.selectPartyPokemon(1);
 
-      await game.phaseInterceptor.to(TurnInitPhase, false);
+      await game.phaseInterceptor.to("TurnInitPhase", false);
       game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to(BerryPhase, false);
+      await game.phaseInterceptor.to("BerryPhase", false);
       const enemyPokemon = game.scene.getEnemyPokemon()!;
       expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
       expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);

--- a/test/moves/powder.test.ts
+++ b/test/moves/powder.test.ts
@@ -1,16 +1,14 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { AbilityId } from "#enums/ability-id";
-import { MoveId } from "#enums/move-id";
-import { SpeciesId } from "#enums/species-id";
-import { BerryPhase } from "#app/phases/berry-phase";
 import { PokemonMove } from "#app/field/pokemon-move";
-import { MoveResult } from "#enums/move-result";
-import { ElementalType } from "#enums/elemental-type";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { StatusEffect } from "#enums/status-effect";
+import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
+import { ElementalType } from "#enums/elemental-type";
+import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
+import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Powder", () => {
   let phaserGame: Phaser.Game;
@@ -49,7 +47,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
     expect(enemyPokemon.moveset[0]!.ppUsed).toBe(1);
@@ -58,7 +56,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.SUCCESS);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
     expect(enemyPokemon.moveset[0]!.ppUsed).toBe(2);
@@ -73,7 +71,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.SUCCESS);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
   });
@@ -87,7 +85,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.SUCCESS);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
   });
@@ -101,7 +99,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
   });
@@ -115,7 +113,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
   });
@@ -129,7 +127,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon.getStatusEffect(true)).not.toBe(StatusEffect.FREEZE);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
@@ -144,7 +142,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
     expect(enemyPokemon.summonData?.types).not.toBe(ElementalType.FIRE);
@@ -168,10 +166,10 @@ describe("Moves - Powder", () => {
     game.move.select(MoveId.FIERY_DANCE, 0, BattlerIndex.ENEMY);
     game.move.select(MoveId.POWDER, 1, BattlerIndex.ENEMY);
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
     const enemyStartingHp = enemyPokemon.hp;
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     // player should not take damage
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
@@ -192,7 +190,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
     expect(playerPokemon).toHaveUsedMove(MoveId.POWDER);
@@ -207,7 +205,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
   });
@@ -221,7 +219,7 @@ describe("Moves - Powder", () => {
 
     game.move.select(MoveId.POWDER);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
   });
@@ -238,7 +236,7 @@ describe("Moves - Powder", () => {
     await game.move.selectEnemyMove(MoveId.FIRE_PLEDGE, BattlerIndex.PLAYER);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY_2, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
   });
@@ -255,7 +253,7 @@ describe("Moves - Powder", () => {
     await game.move.selectEnemyMove(MoveId.WATER_PLEDGE, BattlerIndex.PLAYER);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
   });
@@ -272,7 +270,7 @@ describe("Moves - Powder", () => {
     await game.move.selectEnemyMove(MoveId.WATER_PLEDGE, BattlerIndex.PLAYER);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY_2, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.SUCCESS);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
   });

--- a/test/moves/power-split.test.ts
+++ b/test/moves/power-split.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { Stat } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Power Split", () => {
   let phaserGame: Phaser.Game;
@@ -43,7 +42,7 @@ describe("Moves - Power Split", () => {
     const avgSpAtk = Math.floor((player.getStat(Stat.SPATK, false) + enemy.getStat(Stat.SPATK, false)) / 2);
 
     game.move.select(MoveId.POWER_SPLIT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.ATK, false)).toBe(avgAtk);
     expect(enemy.getStat(Stat.ATK, false)).toBe(avgAtk);
@@ -63,10 +62,10 @@ describe("Moves - Power Split", () => {
     const avgSpAtk = Math.floor((player.getStat(Stat.SPATK, false) + enemy.getStat(Stat.SPATK, false)) / 2);
 
     game.move.select(MoveId.POWER_SPLIT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     game.move.select(MoveId.POWER_SPLIT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.ATK, false)).toBe(avgAtk);
     expect(enemy.getStat(Stat.ATK, false)).toBe(avgAtk);

--- a/test/moves/power-swap.test.ts
+++ b/test/moves/power-swap.test.ts
@@ -1,12 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { Stat, BATTLE_STATS } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { BATTLE_STATS, Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Power Swap", () => {
   let phaserGame: Phaser.Game;
@@ -43,14 +41,14 @@ describe("Moves - Power Swap", () => {
 
     game.move.select(MoveId.POWER_SWAP);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     for (const s of BATTLE_STATS) {
       expect(player.getStatStage(s)).toBe(0);
       expect(enemy.getStatStage(s)).toBe(1);
     }
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     for (const s of BATTLE_STATS) {
       if (s === Stat.ATK || s === Stat.SPATK) {

--- a/test/moves/power-trick.test.ts
+++ b/test/moves/power-trick.test.ts
@@ -1,12 +1,11 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { MoveId } from "#enums/move-id";
-import { Stat } from "#enums/stat";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Power Trick", () => {
   let phaserGame: Phaser.Game;
@@ -43,7 +42,7 @@ describe("Moves - Power Trick", () => {
 
     game.move.select(MoveId.POWER_TRICK);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.ATK, false)).toBe(baseDEF);
     expect(player.getStat(Stat.DEF, false)).toBe(baseATK);
@@ -59,11 +58,11 @@ describe("Moves - Power Trick", () => {
 
     game.move.select(MoveId.POWER_TRICK);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     game.move.select(MoveId.POWER_TRICK);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.ATK, false)).toBe(baseATK);
     expect(player.getStat(Stat.DEF, false)).toBe(baseDEF);
@@ -80,7 +79,7 @@ describe("Moves - Power Trick", () => {
     game.move.select(MoveId.BATON_PASS);
     game.selectPartyPokemon(1);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const switchedPlayer = game.scene.getPlayerPokemon()!;
     const baseATK = switchedPlayer.getStat(Stat.ATK);
@@ -100,7 +99,7 @@ describe("Moves - Power Trick", () => {
 
     game.move.select(MoveId.TRANSFORM);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const enemy = game.scene.getEnemyPokemon()!;
     const baseATK = enemy.getStat(Stat.ATK);

--- a/test/moves/purify.test.ts
+++ b/test/moves/purify.test.ts
@@ -1,8 +1,7 @@
-import { BattlerIndex } from "#enums/battler-index";
 import { Status } from "#app/data/status-effect";
-import type { PlayerPokemon } from "#app/field/player-pokemon";
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
+import type { PlayerPokemon } from "#app/field/player-pokemon";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
@@ -48,7 +47,7 @@ describe("Moves - Purify", () => {
 
     game.move.select(MoveId.PURIFY);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(enemyPokemon.getStatusEffect()).toBe(StatusEffect.NONE);
     expect(playerPokemon.isFullHp()).toBe(true);
@@ -64,7 +63,7 @@ describe("Moves - Purify", () => {
 
     game.move.select(MoveId.PURIFY);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     expect(playerPokemon.hp).toBe(playerInitialHp);
   });

--- a/test/moves/roost.test.ts
+++ b/test/moves/roost.test.ts
@@ -1,10 +1,8 @@
 import { BattlerIndex } from "#enums/battler-index";
-import { ElementalType } from "#enums/elemental-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
@@ -52,7 +50,7 @@ describe("Moves - Roost", () => {
     const playerPokemonStartingHP = playerPokemon.hp;
     game.move.select(MoveId.ROOST);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be normal type, and NOT flying type
     let playerPokemonTypes = playerPokemon.getTypes();
@@ -60,7 +58,7 @@ describe("Moves - Roost", () => {
     expect(playerPokemonTypes.length === 1).toBeTruthy();
     expect(playerPokemon.isGrounded()).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // Lose HP, still normal type
     playerPokemonTypes = playerPokemon.getTypes();
@@ -76,7 +74,7 @@ describe("Moves - Roost", () => {
     const playerPokemonStartingHP = playerPokemon.hp;
     game.move.select(MoveId.ROOST);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be normal type, and NOT flying type
     let playerPokemonTypes = playerPokemon.getTypes();
@@ -84,7 +82,7 @@ describe("Moves - Roost", () => {
     expect(playerPokemonTypes[0] === ElementalType.FLYING).toBeFalsy();
     expect(playerPokemon.isGrounded()).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // Should have lost HP and is now back to being pure flying
     playerPokemonTypes = playerPokemon.getTypes();
@@ -100,7 +98,7 @@ describe("Moves - Roost", () => {
     const playerPokemonStartingHP = playerPokemon.hp;
     game.move.select(MoveId.ROOST);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be pure fighting type and grounded
     let playerPokemonTypes = playerPokemon.getTypes();
@@ -108,7 +106,7 @@ describe("Moves - Roost", () => {
     expect(playerPokemonTypes.length === 1).toBeTruthy();
     expect(playerPokemon.isGrounded()).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // Should have lost HP and is now back to being fighting/flying
     playerPokemonTypes = playerPokemon.getTypes();
@@ -125,7 +123,7 @@ describe("Moves - Roost", () => {
     const playerPokemonStartingHP = playerPokemon.hp;
     game.move.select(MoveId.ROOST);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be pure eletric type and grounded
     let playerPokemonTypes = playerPokemon.getTypes();
@@ -133,7 +131,7 @@ describe("Moves - Roost", () => {
     expect(playerPokemonTypes.length === 1).toBeTruthy();
     expect(playerPokemon.isGrounded()).toBeFalsy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // Should have lost HP and is now back to being electric/flying
     playerPokemonTypes = playerPokemon.getTypes();
@@ -149,17 +147,17 @@ describe("Moves - Roost", () => {
     const playerPokemonStartingHP = playerPokemon.hp;
     game.move.select(MoveId.BURN_UP);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be pure flying type after burn up
     let playerPokemonTypes = playerPokemon.getTypes();
     expect(playerPokemonTypes[0] === ElementalType.FLYING).toBeTruthy();
     expect(playerPokemonTypes.length === 1).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.ROOST);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be typeless type after roost and is grounded
     playerPokemonTypes = playerPokemon.getTypes();
@@ -168,7 +166,7 @@ describe("Moves - Roost", () => {
     expect(playerPokemonTypes.length === 1).toBeTruthy();
     expect(playerPokemon.isGrounded()).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // Should go back to being pure flying and have taken damage from earthquake, and is ungrounded again
     playerPokemonTypes = playerPokemon.getTypes();
@@ -185,17 +183,17 @@ describe("Moves - Roost", () => {
     const playerPokemonStartingHP = playerPokemon.hp;
     game.move.select(MoveId.DOUBLE_SHOCK);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be pure flying type after burn up
     let playerPokemonTypes = playerPokemon.getTypes();
     expect(playerPokemonTypes[0] === ElementalType.FLYING).toBeTruthy();
     expect(playerPokemonTypes.length === 1).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.ROOST);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     // Should only be typeless type after roost and is grounded
     playerPokemonTypes = playerPokemon.getTypes();
@@ -204,7 +202,7 @@ describe("Moves - Roost", () => {
     expect(playerPokemonTypes.length === 1).toBeTruthy();
     expect(playerPokemon.isGrounded()).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // Should go back to being pure flying and have taken damage from earthquake, and is ungrounded again
     playerPokemonTypes = playerPokemon.getTypes();
@@ -224,14 +222,14 @@ describe("Moves - Roost", () => {
     await game.classicMode.startBattle([SpeciesId.MOLTRES]);
     const playerPokemon = game.scene.getPlayerPokemon()!;
     game.move.select(MoveId.ROOST);
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
     let playerPokemonTypes = playerPokemon.getTypes();
     expect(playerPokemonTypes[0] === ElementalType.FIRE).toBeTruthy();
     expect(playerPokemonTypes.length === 1).toBeTruthy();
     expect(playerPokemon.isGrounded()).toBeTruthy();
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     // Should be fire/flying/ghost
     playerPokemonTypes = playerPokemon.getTypes();

--- a/test/moves/scale-shot.test.ts
+++ b/test/moves/scale-shot.test.ts
@@ -1,16 +1,12 @@
-import { BattlerIndex } from "#enums/battler-index";
 import { allMoves } from "#app/data/data-lists";
-import { DamageAnimPhase } from "#app/phases/damage-anim-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Moves - Scale Shot", () => {
   let phaserGame: Phaser.Game;
@@ -47,16 +43,16 @@ describe("Moves - Scale Shot", () => {
 
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to(MoveEffectPhase);
-    await game.phaseInterceptor.to(DamageAnimPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
+    await game.phaseInterceptor.to("DamageAnimPhase");
 
     //check that stats haven't changed after one or two hits have occurred
-    await game.phaseInterceptor.to(MoveEffectPhase);
+    await game.phaseInterceptor.to("MoveEffectPhase");
     expect(minccino.getStatStage(Stat.DEF)).toBe(0);
     expect(minccino.getStatStage(Stat.SPD)).toBe(0);
 
     //check that stats changed on last hit
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     expect(minccino.getStatStage(Stat.DEF)).toBe(-1);
     expect(minccino.getStatStage(Stat.SPD)).toBe(1);
   });
@@ -73,7 +69,7 @@ describe("Moves - Scale Shot", () => {
     const minccino = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.SCALE_SHOT);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     //effect not nullified by sheer force
     expect(minccino.getStatStage(Stat.DEF)).toBe(-1);

--- a/test/moves/shell-trap.test.ts
+++ b/test/moves/shell-trap.test.ts
@@ -1,6 +1,4 @@
 import { allMoves } from "#app/data/data-lists";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
 import type { MovePhase } from "#app/phases/move-phase";
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
@@ -49,13 +47,13 @@ describe("Moves - Shell Trap", () => {
 
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2]);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     const movePhase = game.scene.phaseManager.getCurrentPhase();
     expect(movePhase?.is<MovePhase>(PhaseId.MOVE)).toBeTruthy();
     expect((movePhase as MovePhase).pokemon).toBe(playerPokemon[1]);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     enemyPokemon.forEach((p) => expect(p.hp).toBeLessThan(p.getMaxHp()));
   });
 
@@ -72,13 +70,13 @@ describe("Moves - Shell Trap", () => {
 
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2]);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     const movePhase = game.scene.phaseManager.getCurrentPhase();
     expect(movePhase?.is<MovePhase>(PhaseId.MOVE)).toBeTruthy();
     expect((movePhase as MovePhase).pokemon).not.toBe(playerPokemon[1]);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     enemyPokemon.forEach((p) => expect(p.hp).toBe(p.getMaxHp()));
   });
 
@@ -95,13 +93,13 @@ describe("Moves - Shell Trap", () => {
 
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2]);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     const movePhase = game.scene.phaseManager.getCurrentPhase();
     expect(movePhase?.is<MovePhase>(PhaseId.MOVE)).toBeTruthy();
     expect((movePhase as MovePhase).pokemon).not.toBe(playerPokemon[1]);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     enemyPokemon.forEach((p) => expect(p.hp).toBe(p.getMaxHp()));
   });
 
@@ -116,7 +114,7 @@ describe("Moves - Shell Trap", () => {
     game.move.select(MoveId.SHELL_TRAP);
     game.move.select(MoveId.BULLDOZE, 1);
 
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     const movePhase = game.scene.phaseManager.getCurrentPhase();
     expect(movePhase?.is<MovePhase>(PhaseId.MOVE)).toBeTruthy();
@@ -124,7 +122,7 @@ describe("Moves - Shell Trap", () => {
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
     enemyPokemon.forEach((p, i) => expect(p.hp).toBe(enemyStartingHp[i]));
   });
 
@@ -139,7 +137,7 @@ describe("Moves - Shell Trap", () => {
 
     game.move.select(MoveId.SHELL_TRAP);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(playerPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());

--- a/test/moves/sparkly-swirl.test.ts
+++ b/test/moves/sparkly-swirl.test.ts
@@ -1,9 +1,8 @@
 import { allMoves } from "#app/data/data-lists";
-import { StatusEffect } from "#enums/status-effect";
-import { CommandPhase } from "#app/phases/command-phase";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -44,7 +43,7 @@ describe("Moves - Sparkly Swirl", () => {
     vi.spyOn(partyPokemon, "resetStatus");
 
     game.move.select(MoveId.SPARKLY_SWIRL, 0, leftOpp.getBattlerIndex());
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
@@ -66,7 +65,7 @@ describe("Moves - Sparkly Swirl", () => {
     vi.spyOn(rightOpp, "resetStatus");
 
     game.move.select(MoveId.SPARKLY_SWIRL, 0, leftOpp.getBattlerIndex());
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 

--- a/test/moves/speed-swap.test.ts
+++ b/test/moves/speed-swap.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { Stat } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Speed Swap", () => {
   let phaserGame: Phaser.Game;
@@ -43,7 +42,7 @@ describe("Moves - Speed Swap", () => {
     const enemySpd = enemy.getStat(Stat.SPD, false);
 
     game.move.select(MoveId.SPEED_SWAP);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.SPD, false)).toBe(enemySpd);
     expect(enemy.getStat(Stat.SPD, false)).toBe(playerSpd);

--- a/test/moves/spit-up.test.ts
+++ b/test/moves/spit-up.test.ts
@@ -1,7 +1,5 @@
 import type { StockpilingTag } from "#app/data/battler-tags/stockpiling-tag";
 import { allMoves } from "#app/data/data-lists";
-import { MovePhase } from "#app/phases/move-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
@@ -57,7 +55,7 @@ describe("Moves - Spit Up", () => {
       expect(stockpilingTag.stockpiledCount).toBe(stacksToSetup);
 
       game.move.select(MoveId.SPIT_UP);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(spitUp.calculateBattlePower).toHaveBeenCalledOnce();
       expect(spitUp.calculateBattlePower).toHaveReturnedWith(expectedPower);
@@ -80,7 +78,7 @@ describe("Moves - Spit Up", () => {
       expect(stockpilingTag.stockpiledCount).toBe(stacksToSetup);
 
       game.move.select(MoveId.SPIT_UP);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(spitUp.calculateBattlePower).toHaveBeenCalledOnce();
       expect(spitUp.calculateBattlePower).toHaveReturnedWith(expectedPower);
@@ -104,7 +102,7 @@ describe("Moves - Spit Up", () => {
       expect(stockpilingTag.stockpiledCount).toBe(stacksToSetup);
 
       game.move.select(MoveId.SPIT_UP);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(spitUp.calculateBattlePower).toHaveBeenCalledOnce();
       expect(spitUp.calculateBattlePower).toHaveReturnedWith(expectedPower);
@@ -122,7 +120,7 @@ describe("Moves - Spit Up", () => {
     expect(stockpilingTag).toBeUndefined();
 
     game.move.select(MoveId.SPIT_UP);
-    await game.phaseInterceptor.to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
 
     expect(pokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(spitUp.calculateBattlePower).not.toHaveBeenCalled();
@@ -139,12 +137,12 @@ describe("Moves - Spit Up", () => {
       expect(stockpilingTag).toBeDefined();
 
       game.move.select(MoveId.SPIT_UP);
-      await game.phaseInterceptor.to(MovePhase);
+      await game.phaseInterceptor.to("MovePhase");
 
       expect(pokemon.getStatStage(Stat.DEF)).toBe(1);
       expect(pokemon.getStatStage(Stat.SPDEF)).toBe(1);
 
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(pokemon).toHaveMoveResult(MoveResult.SUCCESS);
 
@@ -172,7 +170,7 @@ describe("Moves - Spit Up", () => {
       };
 
       game.move.select(MoveId.SPIT_UP);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(pokemon).toHaveMoveResult(MoveResult.SUCCESS);
 

--- a/test/moves/spotlight.test.ts
+++ b/test/moves/spotlight.test.ts
@@ -1,5 +1,4 @@
 import { BattlerIndex } from "#enums/battler-index";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -42,7 +41,7 @@ describe("Moves - Spotlight", () => {
     await game.move.selectEnemyMove(MoveId.SPLASH);
     await game.move.selectEnemyMove(MoveId.SPLASH);
 
-    await game.phaseInterceptor.to(TurnEndPhase, false);
+    await game.phaseInterceptor.to("TurnEndPhase", false);
 
     expect(enemyPokemon[0].hp).toBeLessThan(enemyPokemon[0].getMaxHp());
     expect(enemyPokemon[1].hp).toBe(enemyPokemon[1].getMaxHp());

--- a/test/moves/stockpile.test.ts
+++ b/test/moves/stockpile.test.ts
@@ -1,6 +1,4 @@
 import type { StockpilingTag } from "#app/data/battler-tags/stockpiling-tag";
-import { CommandPhase } from "#app/phases/command-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
@@ -53,11 +51,11 @@ describe("Moves - Stockpile", () => {
       // use Stockpile four times
       for (let i = 0; i < 4; i++) {
         if (i !== 0) {
-          await game.phaseInterceptor.to(CommandPhase);
+          await game.phaseInterceptor.to("CommandPhase");
         }
 
         game.move.select(MoveId.STOCKPILE);
-        await game.phaseInterceptor.to(TurnInitPhase);
+        await game.phaseInterceptor.to("TurnInitPhase");
 
         const stockpilingTag = user.getTag<StockpilingTag>(BattlerTagType.STOCKPILING)!;
 
@@ -91,7 +89,7 @@ describe("Moves - Stockpile", () => {
       expect(user.getStatStage(Stat.SPDEF)).toBe(6);
 
       game.move.select(MoveId.STOCKPILE);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       const stockpilingTag = user.getTag<StockpilingTag>(BattlerTagType.STOCKPILING)!;
       expect(stockpilingTag).toBeDefined();
@@ -100,10 +98,10 @@ describe("Moves - Stockpile", () => {
       expect(user.getStatStage(Stat.SPDEF)).toBe(6);
 
       // do it again, just for good measure
-      await game.phaseInterceptor.to(CommandPhase);
+      await game.phaseInterceptor.to("CommandPhase");
 
       game.move.select(MoveId.STOCKPILE);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       const stockpilingTagAgain = user.getTag<StockpilingTag>(BattlerTagType.STOCKPILING)!;
       expect(stockpilingTagAgain).toBeDefined();

--- a/test/moves/swallow.test.ts
+++ b/test/moves/swallow.test.ts
@@ -1,6 +1,4 @@
 import type { StockpilingTag } from "#app/data/battler-tags/stockpiling-tag";
-import { MovePhase } from "#app/phases/move-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
@@ -57,7 +55,7 @@ describe("Moves - Swallow", () => {
       vi.spyOn(pokemon, "heal");
 
       game.move.select(MoveId.SWALLOW);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(pokemon.heal).toHaveBeenCalledOnce();
       expect(pokemon.heal).toHaveReturnedWith(expectedHeal);
@@ -85,7 +83,7 @@ describe("Moves - Swallow", () => {
       vi.spyOn(pokemon, "heal");
 
       game.move.select(MoveId.SWALLOW);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(pokemon.heal).toHaveBeenCalledOnce();
       expect(pokemon.heal).toHaveReturnedWith(expectedHeal);
@@ -114,7 +112,7 @@ describe("Moves - Swallow", () => {
       vi.spyOn(pokemon, "heal");
 
       game.move.select(MoveId.SWALLOW);
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(pokemon.heal).toHaveBeenCalledOnce();
       expect(pokemon.heal).toHaveReturnedWith(expect.closeTo(expectedHeal));
@@ -132,7 +130,7 @@ describe("Moves - Swallow", () => {
     expect(stockpilingTag).toBeUndefined();
 
     game.move.select(MoveId.SWALLOW);
-    await game.phaseInterceptor.to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
 
     expect(pokemon).toHaveMoveResult(MoveResult.FAIL);
   });
@@ -148,12 +146,12 @@ describe("Moves - Swallow", () => {
       expect(stockpilingTag).toBeDefined();
 
       game.move.select(MoveId.SWALLOW);
-      await game.phaseInterceptor.to(MovePhase);
+      await game.phaseInterceptor.to("MovePhase");
 
       expect(pokemon.getStatStage(Stat.DEF)).toBe(1);
       expect(pokemon.getStatStage(Stat.SPDEF)).toBe(1);
 
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(pokemon).toHaveMoveResult(MoveResult.SUCCESS);
 
@@ -180,7 +178,7 @@ describe("Moves - Swallow", () => {
 
       game.move.select(MoveId.SWALLOW);
 
-      await game.phaseInterceptor.to(TurnInitPhase);
+      await game.phaseInterceptor.to("TurnInitPhase");
 
       expect(pokemon).toHaveMoveResult(MoveResult.SUCCESS);
 

--- a/test/moves/tackle.test.ts
+++ b/test/moves/tackle.test.ts
@@ -1,8 +1,6 @@
-import { Stat } from "#enums/stat";
-import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -39,7 +37,7 @@ describe("Moves - Tackle", () => {
     await game.startBattle([SpeciesId.MIGHTYENA]);
     const hpOpponent = game.scene.currentBattle.enemyParty[0].hp;
     game.move.select(moveToUse);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const hpLost = hpOpponent - game.scene.currentBattle.enemyParty[0].hp;
     expect(hpLost).toBe(0);
   }, 20000);
@@ -53,7 +51,7 @@ describe("Moves - Tackle", () => {
     const hpOpponent = game.scene.currentBattle.enemyParty[0].hp;
 
     game.move.select(moveToUse);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     const hpLost = hpOpponent - game.scene.currentBattle.enemyParty[0].hp;
     expect(hpLost).toBeGreaterThan(0);
     expect(hpLost).toBeLessThan(4);

--- a/test/moves/tail-whip.test.ts
+++ b/test/moves/tail-whip.test.ts
@@ -1,12 +1,10 @@
-import { Stat } from "#enums/stat";
-import { GameManager } from "#test/test-utils/gameManager";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 
 describe("Moves - Tail whip", () => {
   let phaserGame: Phaser.Game;
@@ -42,7 +40,7 @@ describe("Moves - Tail whip", () => {
     expect(enemyPokemon.getStatStage(Stat.DEF)).toBe(0);
 
     game.move.select(moveToUse);
-    await game.phaseInterceptor.runFrom(EnemyCommandPhase).to(TurnInitPhase);
+    await game.phaseInterceptor.to("TurnInitPhase");
 
     expect(enemyPokemon.getStatStage(Stat.DEF)).toBe(-1);
   }, 20000);

--- a/test/moves/tailwind.test.ts
+++ b/test/moves/tailwind.test.ts
@@ -1,14 +1,13 @@
-import { Stat } from "#enums/stat";
+import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { AbilityId } from "#enums/ability-id";
-import { BattlerIndex } from "#enums/battler-index";
 
 describe("Moves - Tailwind", () => {
   let phaserGame: Phaser.Game;
@@ -49,7 +48,7 @@ describe("Moves - Tailwind", () => {
     game.move.select(MoveId.TAILWIND);
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(magikarp.getEffectiveStat(Stat.SPD)).toBe(magikarpSpd * 2);
     expect(meowth.getEffectiveStat(Stat.SPD)).toBe(meowthSpd * 2);
@@ -97,7 +96,7 @@ describe("Moves - Tailwind", () => {
 
     game.move.select(MoveId.TAILWIND);
 
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(ally.getEffectiveStat(Stat.SPD)).toBe(allySpd * 2);
     expect(enemy.getEffectiveStat(Stat.SPD)).equal(enemySpd);

--- a/test/moves/thousand_arrows.test.ts
+++ b/test/moves/thousand_arrows.test.ts
@@ -1,7 +1,5 @@
 import { AbilityId } from "#enums/ability-id";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { BerryPhase } from "#app/phases/berry-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -39,11 +37,11 @@ describe("Moves - Thousand Arrows", () => {
 
     game.move.select(MoveId.THOUSAND_ARROWS);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Enemy should not be grounded before move effect is applied
     expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeUndefined();
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
@@ -59,11 +57,11 @@ describe("Moves - Thousand Arrows", () => {
 
     game.move.select(MoveId.THOUSAND_ARROWS);
 
-    await game.phaseInterceptor.to(MoveEffectPhase, false);
+    await game.phaseInterceptor.to("MoveEffectPhase", false);
     // Enemy should not be grounded before move effect is applied
     expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeUndefined();
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();
     expect(enemyPokemon.hp).toBeLessThan(enemyPokemon.getMaxHp());
@@ -80,7 +78,7 @@ describe("Moves - Thousand Arrows", () => {
 
     game.move.select(MoveId.THOUSAND_ARROWS);
 
-    await game.phaseInterceptor.to(BerryPhase, false);
+    await game.phaseInterceptor.to("BerryPhase", false);
 
     expect(enemyPokemon.getTag(BattlerTagType.FLOATING)).toBeUndefined();
     expect(enemyPokemon.getTag(BattlerTagType.IGNORE_FLYING)).toBeDefined();

--- a/test/moves/tidy-up.test.ts
+++ b/test/moves/tidy-up.test.ts
@@ -1,14 +1,12 @@
-import { Stat } from "#enums/stat";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { MoveEndPhase } from "#app/phases/move-end-phase";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { BattlerTagType } from "#enums/battler-tag-type";
 
 describe("Moves - Tidy Up", () => {
   let phaserGame: Phaser.Game;
@@ -42,9 +40,9 @@ describe("Moves - Tidy Up", () => {
     await game.classicMode.startBattle();
 
     game.move.select(MoveId.SPIKES);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     expect(game.scene.arena.getTag(ArenaTagType.SPIKES)).toBeUndefined();
   }, 20000);
 
@@ -54,9 +52,9 @@ describe("Moves - Tidy Up", () => {
     await game.classicMode.startBattle();
 
     game.move.select(MoveId.STEALTH_ROCK);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     expect(game.scene.arena.getTag(ArenaTagType.STEALTH_ROCK)).toBeUndefined();
   }, 20000);
 
@@ -66,9 +64,9 @@ describe("Moves - Tidy Up", () => {
     await game.classicMode.startBattle();
 
     game.move.select(MoveId.TOXIC_SPIKES);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     expect(game.scene.arena.getTag(ArenaTagType.TOXIC_SPIKES)).toBeUndefined();
   }, 20000);
 
@@ -79,9 +77,9 @@ describe("Moves - Tidy Up", () => {
     await game.classicMode.startBattle();
 
     game.move.select(MoveId.STICKY_WEB);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
     expect(game.scene.arena.getTag(ArenaTagType.STICKY_WEB)).toBeUndefined();
   }, 20000);
 
@@ -92,9 +90,9 @@ describe("Moves - Tidy Up", () => {
     await game.classicMode.startBattle();
 
     game.move.select(MoveId.SUBSTITUTE);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to(MoveEndPhase);
+    await game.phaseInterceptor.to("MoveEndPhase");
 
     const pokemon = [game.scene.getPlayerPokemon()!, game.scene.getEnemyPokemon()!];
     pokemon.forEach((p) => {
@@ -112,7 +110,7 @@ describe("Moves - Tidy Up", () => {
     expect(playerPokemon.getStatStage(Stat.SPD)).toBe(0);
 
     game.move.select(MoveId.TIDY_UP);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(playerPokemon.getStatStage(Stat.ATK)).toBe(1);
     expect(playerPokemon.getStatStage(Stat.SPD)).toBe(1);

--- a/test/moves/torment.test.ts
+++ b/test/moves/torment.test.ts
@@ -1,12 +1,11 @@
-import { MoveId } from "#enums/move-id";
-import { SpeciesId } from "#enums/species-id";
 import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
+import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { MoveResult } from "#enums/move-result";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
 
 describe("Moves - Torment", () => {
   let phaserGame: Phaser.Game;
@@ -55,7 +54,7 @@ describe("Moves - Torment", () => {
     // Third turn, Tackle can be used.
     game.move.select(MoveId.TACKLE);
     await game.move.selectEnemyMove(MoveId.SPLASH);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
     expect(playerPokemon).toHaveUsedMove(MoveId.TACKLE);
   });
 });

--- a/test/moves/transform.test.ts
+++ b/test/moves/transform.test.ts
@@ -1,11 +1,10 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
-import { TurnEndPhase } from "#app/phases/turn-end-phase";
-import { MoveId } from "#enums/move-id";
-import { Stat, BATTLE_STATS, EFFECTIVE_STATS } from "#enums/stat";
 import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { BATTLE_STATS, EFFECTIVE_STATS, Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 // TODO: Add more tests once Transform is fully implemented
 describe("Moves - Transform", () => {
@@ -39,7 +38,7 @@ describe("Moves - Transform", () => {
     await game.classicMode.startBattle([SpeciesId.DITTO]);
 
     game.move.select(MoveId.TRANSFORM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     const player = game.scene.getPlayerPokemon()!;
     const enemy = game.scene.getEnemyPokemon()!;
@@ -86,7 +85,7 @@ describe("Moves - Transform", () => {
     const avgSpAtk = Math.floor((player.getStat(Stat.SPATK, false) + enemy.getStat(Stat.SPATK, false)) / 2);
 
     game.move.select(MoveId.TRANSFORM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     expect(player.getStat(Stat.ATK, false)).toBe(avgAtk);
     expect(enemy.getStat(Stat.ATK, false)).toBe(avgAtk);
@@ -102,7 +101,7 @@ describe("Moves - Transform", () => {
     const player = game.scene.getPlayerPokemon()!;
 
     game.move.select(MoveId.TRANSFORM);
-    await game.phaseInterceptor.to(TurnEndPhase);
+    await game.phaseInterceptor.to("TurnEndPhase");
 
     player.getMoveset().forEach((move) => {
       // Should set correct maximum PP without touching `ppUp`

--- a/test/mystery-encounter/encounter-test-utils.ts
+++ b/test/mystery-encounter/encounter-test-utils.ts
@@ -106,7 +106,7 @@ export async function runSelectMysteryEncounterOption(
   );
 
   if (game.isCurrentPhase(MessagePhase)) {
-    await game.phaseInterceptor.run(MessagePhase);
+    await game.phaseInterceptor.to("MessagePhase");
   }
 
   // dispose of intro messages

--- a/test/mystery-encounter/encounter-test-utils.ts
+++ b/test/mystery-encounter/encounter-test-utils.ts
@@ -2,7 +2,6 @@ import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encount
 import { CommandPhase } from "#app/phases/command-phase";
 import { MessagePhase } from "#app/phases/message-phase";
 import { MysteryEncounterBattlePhase } from "#app/phases/mystery-encounter-phases/battle-phase";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { MysteryEncounterOptionSelectedPhase } from "#app/phases/mystery-encounter-phases/option-selected-phase";
 import { MysteryEncounterRewardsPhase } from "#app/phases/mystery-encounter-phases/rewards-phase";
 import { PostKnockoutPhase } from "#app/phases/post-knockout-phase";
@@ -84,9 +83,9 @@ export async function runMysteryEncounterToEnd(
       uiHandler.processInput(Button.ACTION);
     });
 
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
   } else {
-    await game.phaseInterceptor.to(MysteryEncounterRewardsPhase);
+    await game.phaseInterceptor.to("MysteryEncounterRewardsPhase");
   }
 }
 
@@ -121,7 +120,7 @@ export async function runSelectMysteryEncounterOption(
     () => game.isCurrentPhase(MysteryEncounterOptionSelectedPhase),
   );
 
-  await game.phaseInterceptor.to(MysteryEncounterPhase, true);
+  await game.phaseInterceptor.to("MysteryEncounterPhase", true);
 
   // select the desired option
   const uiHandler = game.scene.ui.getHandler<MysteryEncounterUiHandler>();
@@ -202,5 +201,5 @@ export async function skipBattleRunMysteryEncounterRewardsPhase(game: GameManage
   game.scene.phaseManager.pushPhase(new PostKnockoutPhase(0));
   game.phaseInterceptor.superEndPhase();
   game.setMode(UiMode.MESSAGE);
-  await game.phaseInterceptor.to(MysteryEncounterRewardsPhase, runRewardsPhase);
+  await game.phaseInterceptor.to("MysteryEncounterRewardsPhase", runRewardsPhase);
 }

--- a/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
+++ b/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
@@ -1,25 +1,25 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import type BattleScene from "#app/battle-scene";
 import { HumanTransitableBiomes } from "#app/data/biome-utils";
+import { ATrainersTestEncounter } from "#app/data/mystery-encounters/encounters/a-trainers-test-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { CommandPhase } from "#app/phases/command-phase";
+import { PartyHealPhase } from "#app/phases/party-heal-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { BiomeId } from "#enums/biome-id";
+import { EggTier } from "#enums/egg-type";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { TrainerType } from "#enums/trainer-type";
 import {
   runMysteryEncounterToEnd,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
-import type BattleScene from "#app/battle-scene";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { ATrainersTestEncounter } from "#app/data/mystery-encounters/encounters/a-trainers-test-encounter";
-import { EggTier } from "#enums/egg-type";
-import { CommandPhase } from "#app/phases/command-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { PartyHealPhase } from "#app/phases/party-heal-phase";
-import { TrainerType } from "#enums/trainer-type";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/aTrainersTest";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -125,7 +125,7 @@ describe("A Trainer's Test - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const eggsAfter = scene.gameData.eggs;
@@ -173,7 +173,7 @@ describe("A Trainer's Test - Mystery Encounter", () => {
       const eggsBeforeLength = eggsBefore.length;
 
       await runMysteryEncounterToEnd(game, 2);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const eggsAfter = scene.gameData.eggs;

--- a/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
+++ b/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
@@ -150,7 +150,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.ABSOLUTE_AVARICE, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       for (const partyPokemon of scene.getPlayerParty()) {

--- a/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -1,24 +1,23 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
-import { HumanTransitableBiomes } from "#app/data/biome-utils";
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
 import type BattleScene from "#app/battle-scene";
+import { HumanTransitableBiomes } from "#app/data/biome-utils";
+import { AnOfferYouCantRefuseEncounter } from "#app/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { PlayerPokemon } from "#app/field/player-pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
-import { AnOfferYouCantRefuseEncounter } from "#app/data/mystery-encounters/encounters/an-offer-you-cant-refuse-encounter";
+import { getPokemonSpecies } from "#app/utils/pokemon-utils";
+import { AbilityId } from "#enums/ability-id";
+import { BiomeId } from "#enums/biome-id";
+import { MoveId } from "#enums/move-id";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { SpeciesId } from "#enums/species-id";
+import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { getPokemonSpecies } from "#app/utils/pokemon-utils";
-import { MoveId } from "#enums/move-id";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import i18next from "i18next";
-import { AbilityId } from "#enums/ability-id";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/anOfferYouCantRefuse";
 /** Gyarados for Indimidate */
@@ -200,7 +199,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
       const expBefore = gyarados.exp;
 
       await runMysteryEncounterToEnd(game, 2);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       expect(gyarados.exp).toBe(
         expBefore + Math.floor((getPokemonSpecies(SpeciesId.LIEPARD).baseExp * defaultWave) / 5 + 1),
@@ -216,7 +215,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
       const expBefore = abra.exp;
 
       await runMysteryEncounterToEnd(game, 2);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       expect(abra.exp).toBe(
         expBefore + Math.floor((getPokemonSpecies(SpeciesId.LIEPARD).baseExp * defaultWave) / 5 + 1),

--- a/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -1,26 +1,26 @@
+import type BattleScene from "#app/battle-scene";
+import { BerriesAboundEncounter } from "#app/data/mystery-encounters/encounters/berries-abound-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterDialogueUtils from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import type { BerryModifier } from "#app/modifier/modifier";
+import { CommandPhase } from "#app/phases/command-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { AbilityId } from "#enums/ability-id";
 import { BiomeId } from "#enums/biome-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { UiMode } from "#enums/ui-mode";
 import {
   runMysteryEncounterToEnd,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
-import type BattleScene from "#app/battle-scene";
-import { UiMode } from "#enums/ui-mode";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import type { BerryModifier } from "#app/modifier/modifier";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { BerriesAboundEncounter } from "#app/data/mystery-encounters/encounters/berries-abound-encounter";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import * as EncounterDialogueUtils from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
-import { CommandPhase } from "#app/phases/command-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { AbilityId } from "#enums/ability-id";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/berriesAbound";
 const defaultParty = [SpeciesId.PYUKUMUKU, SpeciesId.MAGIKARP, SpeciesId.PIKACHU];
@@ -133,7 +133,7 @@ describe("Berries Abound - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const berriesAfter = scene.findModifiers((m) => m.isBerryModifier()) as BerryModifier[];
@@ -146,7 +146,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.BERRIES_ABOUND, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 
@@ -231,7 +231,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       });
 
       await runMysteryEncounterToEnd(game, 2);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 

--- a/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -148,7 +148,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -233,7 +233,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
+++ b/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
@@ -371,7 +371,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       game.onNextPrompt("MysteryEncounterRewardsPhase", UiMode.OPTION_SELECT, () => {
         game.phaseInterceptor.superEndPhase();
       });
-      await game.phaseInterceptor.run(MysteryEncounterRewardsPhase);
+      await game.phaseInterceptor.to("MysteryEncounterRewardsPhase");
 
       expect(selectOptionSpy).toHaveBeenCalledTimes(1);
       const optionData = selectOptionSpy.mock.calls[0][0];
@@ -422,7 +422,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2);
 
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -441,7 +441,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2);
 
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -463,7 +463,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2);
 
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -487,7 +487,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2);
 
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -563,7 +563,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 3, { pokemonNo: 1, optionNo: 1 });
 
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
+++ b/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
@@ -1,30 +1,30 @@
+import type BattleScene from "#app/battle-scene";
+import { BugTypeSuperfanEncounter } from "#app/data/mystery-encounters/encounters/bug-type-superfan-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as encounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { PokemonMove } from "#app/field/pokemon-move";
+import { ContactHeldItemTransferChanceModifier } from "#app/modifier/modifier";
+import { CommandPhase } from "#app/phases/command-phase";
+import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
+import { MysteryEncounterRewardsPhase } from "#app/phases/mystery-encounter-phases/rewards-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
 import { BiomeId } from "#enums/biome-id";
+import { MoveId } from "#enums/move-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TrainerType } from "#enums/trainer-type";
+import { UiMode } from "#enums/ui-mode";
 import {
   runMysteryEncounterToEnd,
   runSelectMysteryEncounterOption,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
-import { MoveId } from "#enums/move-id";
-import type BattleScene from "#app/battle-scene";
-import { PokemonMove } from "#app/field/pokemon-move";
-import { UiMode } from "#enums/ui-mode";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { TrainerType } from "#enums/trainer-type";
-import { MysteryEncounterRewardsPhase } from "#app/phases/mystery-encounter-phases/rewards-phase";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { ContactHeldItemTransferChanceModifier } from "#app/modifier/modifier";
-import { CommandPhase } from "#app/phases/command-phase";
-import { BugTypeSuperfanEncounter } from "#app/data/mystery-encounters/encounters/bug-type-superfan-encounter";
-import * as encounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/bugTypeSuperfan";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.WEEDLE];
@@ -400,7 +400,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
 
     it("should NOT be selectable if the player doesn't have any Bug types", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.BUG_TYPE_SUPERFAN, [SpeciesId.ABRA]);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -535,7 +535,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
     it("should NOT be selectable if the player doesn't have any Bug items", async () => {
       game.scene.modifiers = [];
       await game.runToMysteryEncounter(MysteryEncounterType.BUG_TYPE_SUPERFAN, defaultParty);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       game.scene.modifiers = [];
       const encounterPhase = scene.phaseManager.getCurrentPhase();

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -215,7 +215,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
       const abilityToTrain = scene.currentBattle.mysteryEncounter?.misc.ability;
 
       game.onNextPrompt("PostMysteryEncounterPhase", UiMode.MESSAGE, () => {

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -12,7 +12,6 @@ import { modifierTypes } from "#app/modifier/modifier-types";
 import { CommandPhase } from "#app/phases/command-phase";
 import type { MovePhase } from "#app/phases/move-phase";
 import { PostMysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/post-mystery-encounter-phase";
-import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import type { ConfirmUiHandler } from "#app/ui/handlers/confirm-ui-handler";
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
@@ -214,7 +213,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
       const abilityToTrain = scene.currentBattle.mysteryEncounter?.misc.ability;
@@ -229,7 +228,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       const partyUiHandler = game.scene.ui.handlers[UiMode.PARTY] as PartyUiHandler;
       vi.spyOn(partyUiHandler, "show");
       game.endPhase();
-      await game.phaseInterceptor.to(PostMysteryEncounterPhase);
+      await game.phaseInterceptor.to("PostMysteryEncounterPhase");
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(PostMysteryEncounterPhase.name);
 
       // Wait for Yes/No confirmation to appear
@@ -242,7 +241,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       // Click "Select" on Pokemon
       partyUiHandler.processInput(Button.ACTION);
       // Stop next battle before it runs
-      await game.phaseInterceptor.to(NewBattlePhase, false);
+      await game.phaseInterceptor.to("NewBattlePhase", false);
 
       const leadPokemon = scene.getPlayerParty()[0];
       expect(leadPokemon.customPokemonData?.ability).toBe(abilityToTrain);

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -128,7 +128,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -126,7 +126,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       partyLead.calculateStats();
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 
@@ -215,7 +215,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
       const partyCountBefore = scene.getPlayerParty().length;
       scene.getPlayerParty().forEach((p) => (p.moveset = []));
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
+++ b/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
@@ -1,19 +1,9 @@
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import {
-  runMysteryEncounterToEnd,
-  runSelectMysteryEncounterOption,
-} from "#test/mystery-encounter/encounter-test-utils";
 import type BattleScene from "#app/battle-scene";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { DelibirdyEncounter } from "#app/data/mystery-encounters/encounters/delibirdy-encounter";
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
 import type { MoneyRequirement } from "#app/data/mystery-encounters/mystery-encounter-requirements";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { generateModifierType } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import {
   type BerryModifier,
   HealingBoosterModifier,
@@ -23,10 +13,20 @@ import {
   PokemonNatureWeightModifier,
   type PreserveBerryModifier,
 } from "#app/modifier/modifier";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { generateModifierType } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { modifierTypes } from "#app/modifier/modifier-types";
+import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { BerryType } from "#enums/berry-type";
+import { BiomeId } from "#enums/biome-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { SpeciesId } from "#enums/species-id";
+import {
+  runMysteryEncounterToEnd,
+  runSelectMysteryEncounterOption,
+} from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/delibirdy";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -147,7 +147,7 @@ describe("Delibird-y - Mystery Encounter", () => {
     it("should be disabled if player does not have enough money", async () => {
       scene.money = 0;
       await game.runToMysteryEncounter(MysteryEncounterType.DELIBIRDY, defaultParty);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -302,7 +302,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
 
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -435,7 +435,7 @@ describe("Delibird-y - Mystery Encounter", () => {
       scene.addModifier(modifier, true, false, false, true);
       await scene.updateModifiers(true);
 
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
+++ b/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
@@ -1,19 +1,19 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
 import type BattleScene from "#app/battle-scene";
-import { UiMode } from "#enums/ui-mode";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { DepartmentStoreSaleEncounter } from "#app/data/mystery-encounters/encounters/department-store-sale-encounter";
 import { CivilizationEncounterBiomes } from "#app/data/biome-utils";
+import { DepartmentStoreSaleEncounter } from "#app/data/mystery-encounters/encounters/department-store-sale-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { BiomeId } from "#enums/biome-id";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { SpeciesId } from "#enums/species-id";
+import { UiMode } from "#enums/ui-mode";
+import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/departmentStoreSale";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -93,7 +93,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 1);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -130,7 +130,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 2);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -170,7 +170,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 3);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -210,7 +210,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 4);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/field-trip-encounter.test.ts
+++ b/test/mystery-encounter/encounters/field-trip-encounter.test.ts
@@ -1,20 +1,19 @@
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
 import type BattleScene from "#app/battle-scene";
+import { FieldTripEncounter } from "#app/data/mystery-encounters/encounters/field-trip-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { BiomeId } from "#enums/biome-id";
+import { MoveId } from "#enums/move-id";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
-import { FieldTripEncounter } from "#app/data/mystery-encounters/encounters/field-trip-encounter";
-import { MoveId } from "#enums/move-id";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
 import i18next from "i18next";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/fieldTrip";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -87,7 +86,7 @@ describe("Field Trip - Mystery Encounter", () => {
     it("Should give no reward on incorrect option", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIELD_TRIP, defaultParty);
       await runMysteryEncounterToEnd(game, 1, { pokemonNo: 1, optionNo: 2 });
-      await game.phaseInterceptor.to(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -99,7 +98,7 @@ describe("Field Trip - Mystery Encounter", () => {
     it("Should give proper rewards on correct Physical move option", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIELD_TRIP, defaultParty);
       await runMysteryEncounterToEnd(game, 1, { pokemonNo: 1, optionNo: 1 });
-      await game.phaseInterceptor.to(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -148,7 +147,7 @@ describe("Field Trip - Mystery Encounter", () => {
     it("Should give no reward on incorrect option", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIELD_TRIP, defaultParty);
       await runMysteryEncounterToEnd(game, 2, { pokemonNo: 1, optionNo: 1 });
-      await game.phaseInterceptor.to(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -160,7 +159,7 @@ describe("Field Trip - Mystery Encounter", () => {
     it("Should give proper rewards on correct Special move option", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIELD_TRIP, defaultParty);
       await runMysteryEncounterToEnd(game, 2, { pokemonNo: 1, optionNo: 2 });
-      await game.phaseInterceptor.to(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -209,7 +208,7 @@ describe("Field Trip - Mystery Encounter", () => {
     it("Should give no reward on incorrect option", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIELD_TRIP, defaultParty);
       await runMysteryEncounterToEnd(game, 3, { pokemonNo: 1, optionNo: 1 });
-      await game.phaseInterceptor.to(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -222,7 +221,7 @@ describe("Field Trip - Mystery Encounter", () => {
       vi.spyOn(i18next, "t");
       await game.runToMysteryEncounter(MysteryEncounterType.FIELD_TRIP, defaultParty);
       await runMysteryEncounterToEnd(game, 3, { pokemonNo: 1, optionNo: 3 });
-      await game.phaseInterceptor.to(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
@@ -180,7 +180,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIERY_FALLOUT, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const leadPokemonId = scene.getPlayerParty()?.[0].id;
@@ -269,7 +269,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
     it("should give attack type boosting item to lead pokemon", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIERY_FALLOUT, defaultParty);
       await runMysteryEncounterToEnd(game, 3);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const leadPokemonItems = scene.getPlayerParty()?.[0].getHeldItems();
@@ -288,7 +288,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
 
     it("should be disabled if not enough FIRE types are in party", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIERY_FALLOUT, [SpeciesId.MAGIKARP]);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -122,7 +122,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
 
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -182,7 +182,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
 
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -1,27 +1,27 @@
+import type BattleScene from "#app/battle-scene";
+import { FightOrFlightEncounter } from "#app/data/mystery-encounters/encounters/fight-or-flight-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { PokemonMove } from "#app/field/pokemon-move";
+import { CommandPhase } from "#app/phases/command-phase";
+import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
 import { BiomeId } from "#enums/biome-id";
+import { MoveId } from "#enums/move-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { UiMode } from "#enums/ui-mode";
 import {
   runMysteryEncounterToEnd,
   runSelectMysteryEncounterOption,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
-import { MoveId } from "#enums/move-id";
-import type BattleScene from "#app/battle-scene";
-import { PokemonMove } from "#app/field/pokemon-move";
-import { UiMode } from "#enums/ui-mode";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { FightOrFlightEncounter } from "#app/data/mystery-encounters/encounters/fight-or-flight-encounter";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { CommandPhase } from "#app/phases/command-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/fightOrFlight";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -120,7 +120,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -153,7 +153,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
     it("should NOT be selectable if the player doesn't have a Stealing move", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIGHT_OR_FLIGHT, defaultParty);
       scene.getPlayerParty().forEach((p) => (p.moveset = []));
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -180,7 +180,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
       const item = game.scene.currentBattle.mysteryEncounter!.misc;
 
       await runMysteryEncounterToEnd(game, 2);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
@@ -183,7 +183,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -213,7 +213,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -244,7 +244,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -275,7 +275,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
@@ -1,29 +1,29 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import type BattleScene from "#app/battle-scene";
 import { HumanTransitableBiomes } from "#app/data/biome-utils";
+import { FunAndGamesEncounter } from "#app/data/mystery-encounters/encounters/fun-and-games-encounter";
+import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { CommandPhase } from "#app/phases/command-phase";
+import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import { BattleCommand } from "#enums/battle-command";
 import { BiomeId } from "#enums/biome-id";
+import { MoveId } from "#enums/move-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { Nature } from "#enums/nature";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { UiMode } from "#enums/ui-mode";
 import {
   runMysteryEncounterToEnd,
   runSelectMysteryEncounterOption,
 } from "#test/mystery-encounter/encounter-test-utils";
-import type BattleScene from "#app/battle-scene";
-import { UiMode } from "#enums/ui-mode";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { Nature } from "#enums/nature";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { CommandPhase } from "#app/phases/command-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { FunAndGamesEncounter } from "#app/data/mystery-encounters/encounters/fun-and-games-encounter";
-import { MoveId } from "#enums/move-id";
-import { BattleCommand } from "#enums/battle-command";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/funAndGames";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -118,7 +118,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
     it("should NOT be selectable if the player doesn't have enough money", async () => {
       game.scene.money = 0;
       await game.runToMysteryEncounter(MysteryEncounterType.FUN_AND_GAMES, defaultParty);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -152,15 +152,15 @@ describe("Fun And Games! - Mystery Encounter", () => {
 
       // Turn 1
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(BattleCommand.FIGHT, 0, false);
-      await game.phaseInterceptor.to(CommandPhase);
+      await game.phaseInterceptor.to("CommandPhase");
 
       // Turn 2
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(BattleCommand.FIGHT, 0, false);
-      await game.phaseInterceptor.to(CommandPhase);
+      await game.phaseInterceptor.to("CommandPhase");
 
       // Turn 3
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(BattleCommand.FIGHT, 0, false);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
@@ -179,7 +179,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       // Skip minigame
       scene.currentBattle.mysteryEncounter!.misc.turnsRemaining = 0;
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(BattleCommand.FIGHT, 0, false);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
@@ -209,7 +209,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       wobbuffet.hp = Math.floor(0.2 * wobbuffet.getMaxHp());
       scene.currentBattle.mysteryEncounter!.misc.turnsRemaining = 0;
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(BattleCommand.FIGHT, 0, false);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
@@ -240,7 +240,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       wobbuffet.hp = Math.floor(0.1 * wobbuffet.getMaxHp());
       scene.currentBattle.mysteryEncounter!.misc.turnsRemaining = 0;
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(BattleCommand.FIGHT, 0, false);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
@@ -271,7 +271,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       wobbuffet.hp = 1;
       scene.currentBattle.mysteryEncounter!.misc.turnsRemaining = 0;
       (game.scene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(BattleCommand.FIGHT, 0, false);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);

--- a/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
+++ b/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
@@ -1,24 +1,24 @@
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
 import type BattleScene from "#app/battle-scene";
+import { CivilizationEncounterBiomes } from "#app/data/biome-utils";
+import { GlobalTradeSystemEncounter } from "#app/data/mystery-encounters/encounters/global-trade-system-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { generateModifierType } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { PokemonNatureWeightModifier } from "#app/modifier/modifier";
+import { modifierTypes } from "#app/modifier/modifier-types";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
+import * as RandomUtils from "#app/utils/random-utils";
+import { BiomeId } from "#enums/biome-id";
+import { ModifierTier } from "#enums/modifier-tier";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
-import { PokemonNatureWeightModifier } from "#app/modifier/modifier";
-import { generateModifierType } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { modifierTypes } from "#app/modifier/modifier-types";
-import { GlobalTradeSystemEncounter } from "#app/data/mystery-encounters/encounters/global-trade-system-encounter";
-import { CivilizationEncounterBiomes } from "#app/data/biome-utils";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { ModifierTier } from "#enums/modifier-tier";
-import * as RandomUtils from "#app/utils/random-utils";
+import { runMysteryEncounterToEnd } from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/globalTradeSystem";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -226,7 +226,7 @@ describe("Global Trade System - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 3, { pokemonNo: 1, optionNo: 1 });
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
+++ b/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
@@ -1,23 +1,22 @@
+import type BattleScene from "#app/battle-scene";
 import { LostAtSeaEncounter } from "#app/data/mystery-encounters/encounters/lost-at-sea-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
 import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
 import { BiomeId } from "#enums/biome-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   runMysteryEncounterToEnd,
   runSelectMysteryEncounterOption,
 } from "#test/mystery-encounter/encounter-test-utils";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import type BattleScene from "#app/battle-scene";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { PartyExpPhase } from "#app/phases/party-exp-phase";
 import i18next from "i18next";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/lostAtSea";
 /** Blastoise for surf. Pidgeot for fly. Abra for none. */
@@ -118,7 +117,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
       const expBefore = blastoise!.exp;
 
       await runMysteryEncounterToEnd(game, 1);
-      await game.phaseInterceptor.to(PartyExpPhase);
+      await game.phaseInterceptor.to("PartyExpPhase");
 
       expect(blastoise?.exp).toBe(expBefore + Math.floor((laprasSpecies.baseExp * defaultWave) / 5 + 1));
     });
@@ -135,7 +134,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
 
     it("should be disabled if no surfable PKM is in party", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.LOST_AT_SEA, [SpeciesId.ARCANINE]);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -183,7 +182,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
       const expBefore = pidgeot!.exp;
 
       await runMysteryEncounterToEnd(game, 2);
-      await game.phaseInterceptor.to(PartyExpPhase);
+      await game.phaseInterceptor.to("PartyExpPhase");
 
       expect(pidgeot!.exp).toBe(expBefore + Math.floor((laprasBaseExp * defaultWave) / 5 + 1));
     });
@@ -200,7 +199,7 @@ describe("Lost at Sea - Mystery Encounter", () => {
 
     it("should be disabled if no flyable PKM is in party", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.LOST_AT_SEA, [SpeciesId.ARCANINE]);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
+++ b/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
@@ -1,28 +1,28 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import type BattleScene from "#app/battle-scene";
 import { HumanTransitableBiomes } from "#app/data/biome-utils";
+import { MysteriousChallengersEncounter } from "#app/data/mystery-encounters/encounters/mysterious-challengers-encounter";
+import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import { TrainerConfig, TrainerPartyCompoundTemplate, TrainerPartyTemplate } from "#app/data/trainer-config";
+import { CommandPhase } from "#app/phases/command-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
 import { BiomeId } from "#enums/biome-id";
+import { ModifierTier } from "#enums/modifier-tier";
+import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { PartyMemberStrength } from "#enums/party-member-strength";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { UiMode } from "#enums/ui-mode";
 import {
   runMysteryEncounterToEnd,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
-import type BattleScene from "#app/battle-scene";
-import { UiMode } from "#enums/ui-mode";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { ModifierTier } from "#enums/modifier-tier";
-import { MysteriousChallengersEncounter } from "#app/data/mystery-encounters/encounters/mysterious-challengers-encounter";
-import { TrainerConfig, TrainerPartyCompoundTemplate, TrainerPartyTemplate } from "#app/data/trainer-config";
-import { PartyMemberStrength } from "#enums/party-member-strength";
-import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { CommandPhase } from "#app/phases/command-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/mysteriousChallengers";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -159,7 +159,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.MYSTERIOUS_CHALLENGERS, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 
@@ -203,7 +203,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.MYSTERIOUS_CHALLENGERS, defaultParty);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 
@@ -260,7 +260,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.MYSTERIOUS_CHALLENGERS, defaultParty);
       await runMysteryEncounterToEnd(game, 3, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 

--- a/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
+++ b/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
@@ -161,7 +161,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -205,7 +205,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -262,7 +262,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -1,22 +1,22 @@
+import type BattleScene from "#app/battle-scene";
+import { CivilizationEncounterBiomes } from "#app/data/biome-utils";
+import { PartTimerEncounter } from "#app/data/mystery-encounters/encounters/part-timer-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { PokemonMove } from "#app/field/pokemon-move";
+import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { BiomeId } from "#enums/biome-id";
+import { MoveId } from "#enums/move-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import {
   runMysteryEncounterToEnd,
   runSelectMysteryEncounterOption,
 } from "#test/mystery-encounter/encounter-test-utils";
-import type BattleScene from "#app/battle-scene";
-import { CivilizationEncounterBiomes } from "#app/data/biome-utils";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { PartTimerEncounter } from "#app/data/mystery-encounters/encounters/part-timer-encounter";
-import { PokemonMove } from "#app/field/pokemon-move";
-import { MoveId } from "#enums/move-id";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
+import { GameManager } from "#test/test-utils/gameManager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/partTimer";
 // Pyukumuku for lowest speed, Regieleki for highest speed, Feebas for lowest "bulk", Melmetal for highest "bulk"
@@ -233,7 +233,7 @@ describe("Part-Timer - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.PART_TIMER, defaultParty);
       // Mock movesets
       scene.getPlayerParty().forEach((p) => (p.moveset = []));
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/safari-zone.test.ts
+++ b/test/mystery-encounter/encounters/safari-zone.test.ts
@@ -1,26 +1,26 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  runMysteryEncounterToEnd,
-  runSelectMysteryEncounterOption,
-} from "#test/mystery-encounter/encounter-test-utils";
 import type BattleScene from "#app/battle-scene";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import {
   getSafariSpeciesSpawn,
   SafariZoneEncounter,
 } from "#app/data/mystery-encounters/encounters/safari-zone-encounter";
+import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
 import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { getSpecialSpeciesList } from "#app/utils/pokemon-utils";
+import { BiomeId } from "#enums/biome-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesGroups } from "#enums/pokemon-species-groups";
+import { SpeciesId } from "#enums/species-id";
+import {
+  runMysteryEncounterToEnd,
+  runSelectMysteryEncounterOption,
+} from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
+import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/safariZone";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -111,7 +111,7 @@ describe("Safari Zone - Mystery Encounter", () => {
     it("should NOT be selectable if the player doesn't have enough money", async () => {
       game.scene.money = 0;
       await game.runToMysteryEncounter(MysteryEncounterType.SAFARI_ZONE, defaultParty);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -306,7 +306,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -1,23 +1,23 @@
 import type BattleScene from "#app/battle-scene";
 import { TeleportingHijinksEncounter } from "#app/data/mystery-encounters/encounters/teleporting-hijinks-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
-import { AbilityId } from "#enums/ability-id";
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
 import { CommandPhase } from "#app/phases/command-phase";
 import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { GameManager } from "#test/test-utils/gameManager";
 import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { UiMode } from "#enums/ui-mode";
+import { AbilityId } from "#enums/ability-id";
+import { BiomeId } from "#enums/biome-id";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { SpeciesId } from "#enums/species-id";
+import { UiMode } from "#enums/ui-mode";
 import {
   runMysteryEncounterToEnd,
   runSelectMysteryEncounterOption,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
 import i18next from "i18next";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -151,7 +151,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
     it("should NOT be selectable if the player doesn't have enough money", async () => {
       game.scene.money = 0;
       await game.runToMysteryEncounter(MysteryEncounterType.TELEPORTING_HIJINKS, defaultParty);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -223,7 +223,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
 
     it("should NOT be selectable if the player doesn't the right type pokemon", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TELEPORTING_HIJINKS, [SpeciesId.BLASTOISE]);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -304,7 +304,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TELEPORTING_HIJINKS, defaultParty);
       await runMysteryEncounterToEnd(game, 3, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 

--- a/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
@@ -1,27 +1,26 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import type BattleScene from "#app/battle-scene";
+import { FRIENDSHIP_GAIN_PER_LEVEL_UP } from "#app/constants/friendship";
 import { HumanTransitableBiomes } from "#app/data/biome-utils";
+import { TheExpertPokemonBreederEncounter } from "#app/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter";
+import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import { CommandPhase } from "#app/phases/command-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
 import { BiomeId } from "#enums/biome-id";
+import { EggTier } from "#enums/egg-type";
+import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TrainerType } from "#enums/trainer-type";
 import {
   runMysteryEncounterToEnd,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
-import type BattleScene from "#app/battle-scene";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
-import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { CommandPhase } from "#app/phases/command-phase";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { TheExpertPokemonBreederEncounter } from "#app/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter";
-import { TrainerType } from "#enums/trainer-type";
-import { EggTier } from "#enums/egg-type";
-import { PostMysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/post-mystery-encounter-phase";
-import { FRIENDSHIP_GAIN_PER_LEVEL_UP } from "#app/constants/friendship";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/theExpertPokemonBreeder";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -175,7 +174,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const eggsAfter = scene.gameData.eggs;
@@ -188,7 +187,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
 
       game.phaseInterceptor.superEndPhase();
       game.phaseInterceptor.shift();
-      await game.phaseInterceptor.to(PostMysteryEncounterPhase);
+      await game.phaseInterceptor.to("PostMysteryEncounterPhase");
 
       const friendshipAfter = scene.currentBattle.mysteryEncounter!.misc.pokemon1.friendship;
       // 20 from ME + extra from winning battle
@@ -259,7 +258,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const eggsAfter = scene.gameData.eggs;
@@ -272,7 +271,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
 
       game.phaseInterceptor.superEndPhase();
       game.phaseInterceptor.shift();
-      await game.phaseInterceptor.to(PostMysteryEncounterPhase);
+      await game.phaseInterceptor.to("PostMysteryEncounterPhase");
 
       const friendshipAfter = scene.currentBattle.mysteryEncounter!.misc.pokemon2.friendship;
       expect(friendshipAfter).toBe(friendshipBefore + 20 + FRIENDSHIP_GAIN_PER_LEVEL_UP); // 20 from ME + extra for friendship gained from winning battle
@@ -342,7 +341,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 3, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const eggsAfter = scene.gameData.eggs;
@@ -355,7 +354,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
 
       game.phaseInterceptor.superEndPhase();
       game.phaseInterceptor.shift();
-      await game.phaseInterceptor.to(PostMysteryEncounterPhase);
+      await game.phaseInterceptor.to("PostMysteryEncounterPhase");
 
       const friendshipAfter = scene.currentBattle.mysteryEncounter!.misc.pokemon3.friendship;
       expect(friendshipAfter).toBe(friendshipBefore + 20 + FRIENDSHIP_GAIN_PER_LEVEL_UP); // 20 + extra for friendship gained from winning battle

--- a/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
@@ -1,27 +1,27 @@
-import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
-import { BiomeId } from "#enums/biome-id";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import {
-  runMysteryEncounterToEnd,
-  runSelectMysteryEncounterOption,
-} from "#test/mystery-encounter/encounter-test-utils";
 import type BattleScene from "#app/battle-scene";
-import { PlayerPokemon } from "#app/field/player-pokemon";
 import { HumanTransitableBiomes } from "#app/data/biome-utils";
 import {
   getSalesmanSpeciesOffer,
   ThePokemonSalesmanEncounter,
 } from "#app/data/mystery-encounters/encounters/the-pokemon-salesman-encounter";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
+import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { PlayerPokemon } from "#app/field/player-pokemon";
 import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { getSpecialSpeciesList } from "#app/utils/pokemon-utils";
+import { BiomeId } from "#enums/biome-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesGroups } from "#enums/pokemon-species-groups";
+import { SpeciesId } from "#enums/species-id";
+import {
+  runMysteryEncounterToEnd,
+  runSelectMysteryEncounterOption,
+} from "#test/mystery-encounter/encounter-test-utils";
+import { GameManager } from "#test/test-utils/gameManager";
+import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/thePokemonSalesman";
 const defaultParty = [SpeciesId.LAPRAS, SpeciesId.GENGAR, SpeciesId.ABRA];
@@ -172,7 +172,7 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
     it("should be disabled if player does not have enough money", async () => {
       scene.money = 0;
       await game.runToMysteryEncounter(MysteryEncounterType.THE_POKEMON_SALESMAN, defaultParty);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -226,7 +226,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.THE_STRONG_STUFF, defaultParty);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 

--- a/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -228,7 +228,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
@@ -4,7 +4,6 @@ import { TheWinstrateChallengeEncounter } from "#app/data/mystery-encounters/enc
 import MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
 import { CommandPhase } from "#app/phases/command-phase";
-import { MysteryEncounterRewardsPhase } from "#app/phases/mystery-encounter-phases/rewards-phase";
 import { PartyHealPhase } from "#app/phases/party-heal-phase";
 import { PostKnockoutPhase } from "#app/phases/post-knockout-phase";
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
@@ -292,7 +291,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
 
       // Should have Macho Brace in the rewards
       await skipBattleToNextBattle(game, true);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 
@@ -366,8 +365,8 @@ async function skipBattleToNextBattle(game: GameManager, isFinalBattle: boolean 
   game.scene.phaseManager.pushPhase(new PostKnockoutPhase(0));
   game.phaseInterceptor.superEndPhase();
   if (isFinalBattle) {
-    await game.phaseInterceptor.to(MysteryEncounterRewardsPhase);
+    await game.phaseInterceptor.to("MysteryEncounterRewardsPhase");
   } else {
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
   }
 }

--- a/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
@@ -293,7 +293,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
       await skipBattleToNextBattle(game, true);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -335,7 +335,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.THE_WINSTRATE_CHALLENGE, defaultParty);
       await runMysteryEncounterToEnd(game, 2);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -195,7 +195,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -123,7 +123,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
     it("should give 2 Leftovers, 2 Shell Bell, and Black Sludge", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TRASH_TO_TREASURE, defaultParty);
       await runMysteryEncounterToEnd(game, 1);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const leftovers = scene.findModifier((m) => m.isTurnHealModifier());
@@ -193,7 +193,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TRASH_TO_TREASURE, defaultParty);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -196,7 +196,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
         scene.removeModifier(mod);
       });
       await scene.updateModifiers(true);
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);
@@ -256,7 +256,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
     it("should NOT be selectable if the player doesn't have an Attracting move", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.UNCOMMON_BREED, defaultParty);
       scene.getPlayerParty().forEach((p) => (p.moveset = []));
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
       expect(encounterPhase?.constructor.name).toBe(MysteryEncounterPhase.name);

--- a/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -147,7 +147,7 @@ describe("Weird Dream - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(
@@ -202,7 +202,7 @@ describe("Weird Dream - Mystery Encounter", () => {
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
-      await game.phaseInterceptor.run(SelectModifierPhase);
+      await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
       const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -1,25 +1,25 @@
+import type BattleScene from "#app/battle-scene";
+import { WeirdDreamEncounter } from "#app/data/mystery-encounters/encounters/weird-dream-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
+import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { CommandPhase } from "#app/phases/command-phase";
+import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
 import { BiomeId } from "#enums/biome-id";
+import { Button } from "#enums/buttons";
+import { ModifierTier } from "#enums/modifier-tier";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { GameManager } from "#test/test-utils/gameManager";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { UiMode } from "#enums/ui-mode";
 import {
   runMysteryEncounterToEnd,
   skipBattleRunMysteryEncounterRewardsPhase,
 } from "#test/mystery-encounter/encounter-test-utils";
-import type BattleScene from "#app/battle-scene";
-import { UiMode } from "#enums/ui-mode";
-import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
-import { WeirdDreamEncounter } from "#app/data/mystery-encounters/encounters/weird-dream-encounter";
-import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { CommandPhase } from "#app/phases/command-phase";
-import { ModifierTier } from "#enums/modifier-tier";
-import { Button } from "#enums/buttons";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const namespace = "mysteryEncounters/weirdDream";
 const defaultParty = [SpeciesId.MAGBY, SpeciesId.HAUNTER, SpeciesId.ABRA];
@@ -122,7 +122,7 @@ describe("Weird Dream - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 1);
       clearInterval(pressCancelInterval);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
 
       const pokemonAfter = scene.getPlayerParty();
@@ -145,7 +145,7 @@ describe("Weird Dream - Mystery Encounter", () => {
     it("should have 1 Memory Mushroom, 5 Ultra Balls, and 3 Mints in rewards", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.WEIRD_DREAM, defaultParty);
       await runMysteryEncounterToEnd(game, 1);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 
@@ -200,7 +200,7 @@ describe("Weird Dream - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.WEIRD_DREAM, defaultParty);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
-      await game.phaseInterceptor.to(SelectModifierPhase, false);
+      await game.phaseInterceptor.to("SelectModifierPhase", false);
       expect(scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(SelectModifierPhase.name);
       await game.phaseInterceptor.run(SelectModifierPhase);
 

--- a/test/mystery-encounter/mystery-encounter.test.ts
+++ b/test/mystery-encounter/mystery-encounter.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, beforeAll, beforeEach, expect, describe, it } from "vitest";
-import { GameManager } from "#test/test-utils/gameManager";
-import Phaser from "phaser";
-import { SpeciesId } from "#enums/species-id";
+import type BattleScene from "#app/battle-scene";
 import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import type BattleScene from "#app/battle-scene";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Mystery Encounters", () => {
   let phaserGame: Phaser.Game;
@@ -34,7 +34,7 @@ describe("Mystery Encounters", () => {
       SpeciesId.VOLCARONA,
     ]);
 
-    await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+    await game.phaseInterceptor.to("MysteryEncounterPhase", false);
     expect(game.scene.phaseManager.getCurrentPhase()!.constructor.name).toBe(MysteryEncounterPhase.name);
   });
 

--- a/test/phases/form-change-phase.test.ts
+++ b/test/phases/form-change-phase.test.ts
@@ -1,15 +1,15 @@
+import { generateModifierType } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
+import { modifierTypes } from "#app/modifier/modifier-types";
 import { AbilityId } from "#enums/ability-id";
+import { Button } from "#enums/buttons";
+import { ElementalType } from "#enums/elemental-type";
+import { FormChangeItem } from "#enums/form-change-item";
 import { MoveId } from "#enums/move-id";
+import { SpeciesFormKey } from "#enums/species-form-key";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { ElementalType } from "#enums/elemental-type";
-import { generateModifierType } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { modifierTypes } from "#app/modifier/modifier-types";
-import { Button } from "#enums/buttons";
-import { FormChangeItem } from "#enums/form-change-item";
-import { SpeciesFormKey } from "#enums/species-form-key";
 
 describe("Form Change Phase", () => {
   let phaserGame: Phaser.Game;
@@ -158,13 +158,13 @@ describe("Form Change Phase", () => {
     await new Promise<void>((r) => setTimeout(r, 10));
     game.scene.ui.processInput(Button.ACTION);
     game.scene.ui.processInput(Button.ACTION);
-    await game.phaseInterceptor.run("FormChangePhase");
+    await game.phaseInterceptor.to("FormChangePhase");
     expect(rillaboom.getFormKey()).toBe("");
 
     // Navigate UI: Reactivate Max Mushrooms
     game.scene.ui.processInput(Button.ACTION);
     game.scene.ui.processInput(Button.ACTION);
-    await game.phaseInterceptor.run("FormChangePhase");
+    await game.phaseInterceptor.to("FormChangePhase");
     expect(rillaboom.getFormKey()).toBe("gigantamax");
 
     // Navigate UI: Exit "Check Party" menu

--- a/test/phases/learn-move-phase.test.ts
+++ b/test/phases/learn-move-phase.test.ts
@@ -1,9 +1,8 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import Phaser from "phaser";
-import { GameManager } from "#test/test-utils/gameManager";
-import { SpeciesId } from "#enums/species-id";
 import { MoveId } from "#enums/move-id";
-import { LearnMovePhase } from "#app/phases/learn-move-phase";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/gameManager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Learn Move Phase", () => {
   let phaserGame: Phaser.Game;
@@ -31,7 +30,7 @@ describe("Learn Move Phase", () => {
     const newMovePos = pokemon?.getMoveset().length;
     game.move.select(MoveId.SPLASH);
     await game.faintOpponents();
-    await game.phaseInterceptor.to(LearnMovePhase);
+    await game.phaseInterceptor.to("LearnMovePhase");
     const levelMove = pokemon.getLevelMoves(5)[0];
     const levelReq = levelMove[0];
     const levelMoveId = levelMove[1];

--- a/test/phases/mystery-encounter-phase.test.ts
+++ b/test/phases/mystery-encounter-phase.test.ts
@@ -55,7 +55,7 @@ describe("Mystery Encounter Phases", () => {
         // End phase early for test
         game.phaseInterceptor.superEndPhase();
       });
-      await game.phaseInterceptor.run(MysteryEncounterPhase);
+      await game.phaseInterceptor.to("MysteryEncounterPhase");
 
       expect(game.scene.mysteryEncounterSaveData.encounteredEvents.length).toBeGreaterThan(0);
       expect(game.scene.mysteryEncounterSaveData.encounteredEvents[0].type).toEqual(
@@ -79,7 +79,7 @@ describe("Mystery Encounter Phases", () => {
         handler.processInput(Button.ACTION);
       });
 
-      await game.phaseInterceptor.run(MysteryEncounterPhase);
+      await game.phaseInterceptor.to("MysteryEncounterPhase");
 
       // Select option 1 for encounter
       const handler = game.scene.ui.getHandler() as MysteryEncounterUiHandler;

--- a/test/phases/mystery-encounter-phase.test.ts
+++ b/test/phases/mystery-encounter-phase.test.ts
@@ -1,16 +1,16 @@
-import { afterEach, beforeAll, beforeEach, expect, describe, it, vi } from "vitest";
-import { GameManager } from "#test/test-utils/gameManager";
-import Phaser from "phaser";
-import { SpeciesId } from "#enums/species-id";
-import { MysteryEncounterOptionSelectedPhase } from "#app/phases/mystery-encounter-phases/option-selected-phase";
 import { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { UiMode } from "#enums/ui-mode";
-import { Button } from "#enums/buttons";
-import type { MysteryEncounterUiHandler } from "#app/ui/handlers/mystery-encounter-ui-handler";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { MysteryEncounterOptionSelectedPhase } from "#app/phases/mystery-encounter-phases/option-selected-phase";
 import type { MessageUiHandler } from "#app/ui/handlers/message-ui-handler";
+import type { MysteryEncounterUiHandler } from "#app/ui/handlers/mystery-encounter-ui-handler";
+import { Button } from "#enums/buttons";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { SpeciesId } from "#enums/species-id";
+import { UiMode } from "#enums/ui-mode";
+import { GameManager } from "#test/test-utils/gameManager";
 import i18next from "i18next";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("Mystery Encounter Phases", () => {
   let phaserGame: Phaser.Game;
@@ -41,7 +41,7 @@ describe("Mystery Encounter Phases", () => {
         SpeciesId.VOLCARONA,
       ]);
 
-      await game.phaseInterceptor.to(MysteryEncounterPhase, false);
+      await game.phaseInterceptor.to("MysteryEncounterPhase", false);
       expect(game.scene.phaseManager.getCurrentPhase()?.constructor.name).toBe(MysteryEncounterPhase.name);
     });
 

--- a/test/phases/phases.test.ts
+++ b/test/phases/phases.test.ts
@@ -31,7 +31,7 @@ describe("Phases", () => {
     it("should start the login phase", async () => {
       const loginPhase = new LoginPhase();
       scene.phaseManager.unshiftPhase(loginPhase);
-      await game.phaseInterceptor.to(LoginPhase);
+      await game.phaseInterceptor.to("LoginPhase");
       expect(scene.ui.getMode()).to.equal(UiMode.MESSAGE);
     });
   });
@@ -40,7 +40,7 @@ describe("Phases", () => {
     it("should start the title phase", async () => {
       const titlePhase = new TitlePhase();
       scene.phaseManager.unshiftPhase(titlePhase);
-      await game.phaseInterceptor.to(TitlePhase);
+      await game.phaseInterceptor.to("TitlePhase");
       expect(scene.ui.getMode()).to.equal(UiMode.TITLE);
     });
   });
@@ -49,7 +49,7 @@ describe("Phases", () => {
     it("should start the unavailable phase", async () => {
       const unavailablePhase = new UnavailablePhase();
       scene.phaseManager.unshiftPhase(unavailablePhase);
-      await game.phaseInterceptor.to(UnavailablePhase);
+      await game.phaseInterceptor.to("UnavailablePhase");
       expect(scene.ui.getMode()).to.equal(UiMode.UNAVAILABLE);
     }, 20000);
   });

--- a/test/phases/select-modifier-phase.test.ts
+++ b/test/phases/select-modifier-phase.test.ts
@@ -1,20 +1,20 @@
 import type BattleScene from "#app/battle-scene";
-import { getPokemonSpecies } from "#app/utils/pokemon-utils";
-import { settings } from "#app/system/settings/settings-manager";
-import { ShopCursorTarget } from "#enums/shop-cursor-target";
 import { PlayerPokemon } from "#app/field/player-pokemon";
-import { ModifierTier } from "#enums/modifier-tier";
 import type { CustomModifierSettings } from "#app/modifier/modifier-type";
 import { ModifierTypeOption } from "#app/modifier/modifier-type";
 import { modifierTypes } from "#app/modifier/modifier-types";
 import { SelectModifierPhase } from "#app/phases/select-modifier-phase";
+import { settings } from "#app/system/settings/settings-manager";
 import { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
-import { UiMode } from "#enums/ui-mode";
+import { getPokemonSpecies } from "#app/utils/pokemon-utils";
 import { shiftCharCodes } from "#app/utils/string-utils";
 import { AbilityId } from "#enums/ability-id";
 import { Button } from "#enums/buttons";
+import { ModifierTier } from "#enums/modifier-tier";
 import { MoveId } from "#enums/move-id";
+import { ShopCursorTarget } from "#enums/shop-cursor-target";
 import { SpeciesId } from "#enums/species-id";
+import { UiMode } from "#enums/ui-mode";
 import { GameManager } from "#test/test-utils/gameManager";
 import { initSceneWithoutEncounterPhase } from "#test/test-utils/gameManagerUtils";
 import Phaser from "phaser";
@@ -52,7 +52,7 @@ describe("SelectModifierPhase", () => {
     initSceneWithoutEncounterPhase(scene, [SpeciesId.ABRA, SpeciesId.VOLCARONA]);
     const selectModifierPhase = new SelectModifierPhase();
     scene.phaseManager.unshiftPhase(selectModifierPhase);
-    await game.phaseInterceptor.to(SelectModifierPhase);
+    await game.phaseInterceptor.to("SelectModifierPhase");
 
     expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
   });

--- a/test/phases/select-modifier-phase.test.ts
+++ b/test/phases/select-modifier-phase.test.ts
@@ -247,7 +247,7 @@ describe("SelectModifierPhase", () => {
     const selectModifierPhase = new SelectModifierPhase({ customModifierSettings: customModifiers });
     scene.phaseManager.unshiftPhase(selectModifierPhase);
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.run(SelectModifierPhase);
+    await game.phaseInterceptor.to("SelectModifierPhase");
 
     expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
     const modifierSelectHandler = scene.ui.handlers.find(
@@ -271,7 +271,7 @@ describe("SelectModifierPhase", () => {
     const selectModifierPhase = new SelectModifierPhase({ customModifierSettings: customModifiers });
     scene.phaseManager.unshiftPhase(selectModifierPhase);
     game.move.select(MoveId.SPLASH);
-    await game.phaseInterceptor.run(SelectModifierPhase);
+    await game.phaseInterceptor.to("SelectModifierPhase");
 
     expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
     const modifierSelectHandler = scene.ui.handlers.find(

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -20,7 +20,6 @@ import { EncounterPhase } from "#app/phases/encounter-phase";
 import { FaintPhase } from "#app/phases/faint-phase";
 import { LoginPhase } from "#app/phases/login-phase";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
-import { TitlePhase } from "#app/phases/title-phase";
 import { settings } from "#app/system/settings/settings-manager";
 import type { TurnCommand } from "#app/turn-command-manager";
 import type { UiHandler } from "#app/ui/handlers/abstract-ui-handler";
@@ -192,7 +191,7 @@ export class GameManager {
   async runToTitle(): Promise<void> {
     await this.phaseInterceptor.whenAboutToRun(LoginPhase);
     this.phaseInterceptor.pop();
-    await this.phaseInterceptor.run(TitlePhase);
+    await this.phaseInterceptor.to("TitlePhase");
 
     settings.update("general", "gameSpeed", 5);
     settings.update("display", "enableMoveAnimations", false);
@@ -275,7 +274,7 @@ export class GameManager {
       true,
     );
 
-    await this.phaseInterceptor.run("EncounterPhase");
+    await this.phaseInterceptor.to("EncounterPhase");
     if (!isNullOrUndefined(encounterType)) {
       expect(this.scene.currentBattle?.mysteryEncounter?.encounterType).toBe(encounterType);
     }

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -189,7 +189,7 @@ export class GameManager {
    * @returns A promise that resolves when the title phase is reached.
    */
   async runToTitle(): Promise<void> {
-    await this.phaseInterceptor.whenAboutToRun(LoginPhase);
+    await this.phaseInterceptor.to("LoginPhase", false);
     this.phaseInterceptor.pop();
     await this.phaseInterceptor.to("TitlePhase");
 
@@ -207,10 +207,8 @@ export class GameManager {
 
   /**
    * Helper function to run to the final boss encounter as it's a bit tricky due to extra dialogue
+   *
    * Also handles Major/Minor bosses from endless modes
-   * @param game - The game manager
-   * @param species
-   * @param mode
    */
   async runToFinalBossEncounter(species: SpeciesId[], mode: GameModes) {
     console.log("===to final boss encounter===");

--- a/test/test-utils/helpers/challengeModeHelper.ts
+++ b/test/test-utils/helpers/challengeModeHelper.ts
@@ -1,17 +1,17 @@
-import { BattleStyle } from "#enums/battle-style";
-import type { SpeciesId } from "#enums/species-id";
+import type { Challenge } from "#app/data/challenge";
 import overrides from "#app/overrides";
+import { CommandPhase } from "#app/phases/command-phase";
 import { EncounterPhase } from "#app/phases/encounter-phase";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
+import { TurnInitPhase } from "#app/phases/turn-init-phase";
+import { settings } from "#app/system/settings/settings-manager";
+import { BattleStyle } from "#enums/battle-style";
+import type { Challenges } from "#enums/challenges";
+import type { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
 import { generateStarter } from "#test/test-utils/gameManagerUtils";
 import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
-import type { Challenge } from "#app/data/challenge";
-import { CommandPhase } from "#app/phases/command-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
-import type { Challenges } from "#enums/challenges";
 import { copyChallenge } from "data/challenge";
-import { settings } from "#app/system/settings/settings-manager";
 
 /**
  * Helper to handle Challenge mode specifics
@@ -86,7 +86,7 @@ export class ChallengeModeHelper extends GameManagerHelper {
       );
     }
 
-    await this.game.phaseInterceptor.to(CommandPhase);
+    await this.game.phaseInterceptor.to("CommandPhase");
     console.log("==================[New Turn]==================");
   }
 }

--- a/test/test-utils/helpers/challengeModeHelper.ts
+++ b/test/test-utils/helpers/challengeModeHelper.ts
@@ -50,7 +50,7 @@ export class ChallengeModeHelper extends GameManagerHelper {
       selectStarterPhase.initBattle(starters);
     });
 
-    await this.game.phaseInterceptor.run(EncounterPhase);
+    await this.game.phaseInterceptor.to("EncounterPhase");
     if (overrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }

--- a/test/test-utils/helpers/classicModeHelper.ts
+++ b/test/test-utils/helpers/classicModeHelper.ts
@@ -1,16 +1,16 @@
-import { BattleStyle } from "#enums/battle-style";
-import type { SpeciesId } from "#enums/species-id";
 import { getGameMode } from "#app/game-mode";
-import { GameModes } from "#enums/game-modes";
 import overrides from "#app/overrides";
 import { CommandPhase } from "#app/phases/command-phase";
 import { EncounterPhase } from "#app/phases/encounter-phase";
 import { SelectStarterPhase } from "#app/phases/select-starter-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
+import { settings } from "#app/system/settings/settings-manager";
+import { BattleStyle } from "#enums/battle-style";
+import { GameModes } from "#enums/game-modes";
+import type { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
 import { generateStarter } from "#test/test-utils/gameManagerUtils";
 import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
-import { settings } from "#app/system/settings/settings-manager";
 
 /**
  * Helper to handle classic mode specifics
@@ -36,7 +36,7 @@ export class ClassicModeHelper extends GameManagerHelper {
       selectStarterPhase.initBattle(starters);
     });
 
-    await this.game.phaseInterceptor.to(EncounterPhase);
+    await this.game.phaseInterceptor.to("EncounterPhase");
     if (overrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
     }
@@ -72,7 +72,7 @@ export class ClassicModeHelper extends GameManagerHelper {
       );
     }
 
-    await this.game.phaseInterceptor.to(CommandPhase);
+    await this.game.phaseInterceptor.to("CommandPhase");
     console.log("==================[New Turn]==================");
   }
 }

--- a/test/test-utils/helpers/dailyModeHelper.ts
+++ b/test/test-utils/helpers/dailyModeHelper.ts
@@ -1,14 +1,13 @@
-import { BattleStyle } from "#enums/battle-style";
-import { Button } from "#enums/buttons";
 import overrides from "#app/overrides";
 import { CommandPhase } from "#app/phases/command-phase";
-import { EncounterPhase } from "#app/phases/encounter-phase";
 import { TitlePhase } from "#app/phases/title-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
+import { settings } from "#app/system/settings/settings-manager";
 import type { SaveSlotSelectUiHandler } from "#app/ui/handlers/save-slot-select-ui-handler";
+import { BattleStyle } from "#enums/battle-style";
+import { Button } from "#enums/buttons";
 import { UiMode } from "#enums/ui-mode";
 import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
-import { settings } from "#app/system/settings/settings-manager";
 
 /**
  * Helper to handle daily mode specifics
@@ -35,7 +34,7 @@ export class DailyModeHelper extends GameManagerHelper {
       uihandler.processInput(Button.ACTION); // select first slot. that's fine
     });
 
-    await this.game.phaseInterceptor.to(EncounterPhase);
+    await this.game.phaseInterceptor.to("EncounterPhase");
 
     if (overrides.ENEMY_HELD_ITEMS_OVERRIDE.length === 0 && this.game.override.removeEnemyStartingItems) {
       this.game.removeEnemyHeldItems();
@@ -71,7 +70,7 @@ export class DailyModeHelper extends GameManagerHelper {
       );
     }
 
-    await this.game.phaseInterceptor.to(CommandPhase);
+    await this.game.phaseInterceptor.to("CommandPhase");
     console.log("==================[New Turn]==================");
   }
 }

--- a/test/test-utils/helpers/moveHelper.ts
+++ b/test/test-utils/helpers/moveHelper.ts
@@ -5,7 +5,7 @@ import { PokemonMove } from "#app/field/pokemon-move";
 import Overrides from "#app/overrides";
 import type { CommandPhase } from "#app/phases/command-phase";
 import type { EnemyCommandPhase } from "#app/phases/enemy-command-phase";
-import { MoveEffectPhase } from "#app/phases/move-effect-phase";
+import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import type { SelectTargetPhase } from "#app/phases/select-target-phase";
 import type { FightUiHandler } from "#app/ui/handlers/fight-ui-handler";
 import type { TargetSelectUiHandler } from "#app/ui/handlers/target-select-ui-handler";
@@ -27,7 +27,7 @@ export class MoveHelper extends GameManagerHelper {
    * accuracy to -1, guaranteeing a hit.
    */
   public async forceHit(): Promise<void> {
-    await this.game.phaseInterceptor.to(MoveEffectPhase, false);
+    await this.game.phaseInterceptor.to("MoveEffectPhase", false);
     const moveEffectPhase = this.game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase;
     vi.spyOn(moveEffectPhase.move.getMove(), "calculateBattleAccuracy").mockReturnValue(-1);
   }
@@ -38,7 +38,7 @@ export class MoveHelper extends GameManagerHelper {
    * @param firstTargetOnly - Whether the move should force miss on the first target only, in the case of multi-target moves.
    */
   public async forceMiss(firstTargetOnly: boolean = false): Promise<void> {
-    await this.game.phaseInterceptor.to(MoveEffectPhase, false);
+    await this.game.phaseInterceptor.to("MoveEffectPhase", false);
     const moveEffectPhase = this.game.scene.phaseManager.getCurrentPhase() as MoveEffectPhase;
     const accuracy = vi.spyOn(moveEffectPhase.move.getMove(), "calculateBattleAccuracy");
 

--- a/test/test-utils/helpers/reloadHelper.ts
+++ b/test/test-utils/helpers/reloadHelper.ts
@@ -1,13 +1,13 @@
-import { TitlePhase } from "#app/phases/title-phase";
-import { UiMode } from "#enums/ui-mode";
-import { vi } from "vitest";
-import { BattleStyle } from "#enums/battle-style";
-import { CommandPhase } from "#app/phases/command-phase";
-import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import type { SessionSaveData } from "#app/@types/SessionData";
+import { CommandPhase } from "#app/phases/command-phase";
+import { TitlePhase } from "#app/phases/title-phase";
+import { TurnInitPhase } from "#app/phases/turn-init-phase";
+import { settings } from "#app/system/settings/settings-manager";
+import { BattleStyle } from "#enums/battle-style";
+import { UiMode } from "#enums/ui-mode";
 import type { GameManager } from "#test/test-utils/gameManager";
 import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
-import { settings } from "#app/system/settings/settings-manager";
+import { vi } from "vitest";
 
 /**
  * Helper to allow reloading sessions in unit tests.
@@ -73,7 +73,7 @@ export class ReloadHelper extends GameManagerHelper {
       );
     }
 
-    await this.game.phaseInterceptor.to(CommandPhase);
+    await this.game.phaseInterceptor.to("CommandPhase");
     console.log("==================[New Turn]==================");
   }
 }

--- a/test/test-utils/phaseInterceptor.ts
+++ b/test/test-utils/phaseInterceptor.ts
@@ -213,6 +213,7 @@ export class PhaseInterceptor {
    * Method to set the starting phase.
    * @param phaseFrom - The phase to start from.
    * @returns The instance of the PhaseInterceptor.
+   * @deprecated Is this necessary any more?
    */
   protected runFrom(phaseFrom: PhaseInterceptorPhase): PhaseInterceptor {
     this.phaseFrom = phaseFrom;
@@ -295,6 +296,7 @@ export class PhaseInterceptor {
     });
   }
 
+  /** @deprecated Use `to("Phase", false)`? */
   protected whenAboutToRun(
     phaseTarget: PhaseInterceptorPhase,
     _skipFn?: (className: PhaseClass) => boolean,

--- a/test/test-utils/phaseInterceptor.ts
+++ b/test/test-utils/phaseInterceptor.ts
@@ -295,7 +295,10 @@ export class PhaseInterceptor {
     });
   }
 
-  whenAboutToRun(phaseTarget: PhaseInterceptorPhase, _skipFn?: (className: PhaseClass) => boolean): Promise<void> {
+  protected whenAboutToRun(
+    phaseTarget: PhaseInterceptorPhase,
+    _skipFn?: (className: PhaseClass) => boolean,
+  ): Promise<void> {
     const targetName = this.getPhaseName(phaseTarget);
     return new Promise(async (resolve, _reject) => {
       ErrorInterceptor.getInstance().add(this);

--- a/test/test-utils/phaseInterceptor.ts
+++ b/test/test-utils/phaseInterceptor.ts
@@ -225,7 +225,7 @@ export class PhaseInterceptor {
    * @param runTarget - Whether or not to run the target phase.
    * @returns A promise that resolves when the transition is complete.
    */
-  async to(phaseTo: PhaseInterceptorPhase, runTarget: boolean = true): Promise<void> {
+  async to(phaseTo: PhaseString, runTarget: boolean = true): Promise<void> {
     return new Promise(async (resolve, reject) => {
       ErrorInterceptor.getInstance().add(this);
       if (this.phaseFrom) {

--- a/test/test-utils/phaseInterceptor.ts
+++ b/test/test-utils/phaseInterceptor.ts
@@ -214,7 +214,7 @@ export class PhaseInterceptor {
    * @param phaseFrom - The phase to start from.
    * @returns The instance of the PhaseInterceptor.
    */
-  runFrom(phaseFrom: PhaseInterceptorPhase): PhaseInterceptor {
+  protected runFrom(phaseFrom: PhaseInterceptorPhase): PhaseInterceptor {
     this.phaseFrom = phaseFrom;
     return this;
   }
@@ -225,7 +225,7 @@ export class PhaseInterceptor {
    * @param runTarget - Whether or not to run the target phase.
    * @returns A promise that resolves when the transition is complete.
    */
-  async to(phaseTo: PhaseString, runTarget: boolean = true): Promise<void> {
+  public async to(phaseTo: PhaseString, runTarget: boolean = true): Promise<void> {
     return new Promise(async (resolve, reject) => {
       ErrorInterceptor.getInstance().add(this);
       if (this.phaseFrom) {
@@ -262,7 +262,7 @@ export class PhaseInterceptor {
    * @param skipFn - Optional skip function.
    * @returns A promise that resolves when the phase is run.
    */
-  async run(phaseTarget: PhaseInterceptorPhase, skipFn?: (className: PhaseClass) => boolean): Promise<void> {
+  protected async run(phaseTarget: PhaseInterceptorPhase, skipFn?: (className: PhaseClass) => boolean): Promise<void> {
     const targetName = this.getPhaseName(phaseTarget);
     await new Promise<void>((resolve, reject) => {
       ErrorInterceptor.getInstance().add(this);

--- a/test/ui/battle-info.test.ts
+++ b/test/ui/battle-info.test.ts
@@ -1,8 +1,7 @@
-import { ExpGainsSpeed } from "#enums/exp-gains-speed";
-import { SpeciesId } from "#enums/species-id";
-import { ExpPhase } from "#app/phases/exp-phase";
 import { AbilityId } from "#enums/ability-id";
+import { ExpGainsSpeed } from "#enums/exp-gains-speed";
 import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -47,7 +46,7 @@ describe("UI - Battle Info", () => {
 
       game.move.select(MoveId.SPLASH);
       await game.faintOpponents();
-      await game.phaseInterceptor.to(ExpPhase, true);
+      await game.phaseInterceptor.to("ExpPhase", true);
 
       expect(Math.pow).not.toHaveBeenCalledWith(2, expGainsSpeed);
     },

--- a/test/ui/starter-select.test.ts
+++ b/test/ui/starter-select.test.ts
@@ -1,6 +1,5 @@
 import { allSpecies } from "#app/data/data-lists";
 import { EncounterPhase } from "#app/phases/encounter-phase";
-import { SelectStarterPhase } from "#app/phases/select-starter-phase";
 import type { TitlePhase } from "#app/phases/title-phase";
 import type { OptionSelectUiHandler } from "#app/ui/handlers/option-select-ui-handler";
 import type { SaveSlotSelectUiHandler } from "#app/ui/handlers/save-slot-select-ui-handler";
@@ -54,7 +53,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -112,7 +111,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -173,7 +172,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -233,7 +232,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -291,7 +290,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.CYCLE_SHINY);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -350,7 +349,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -408,7 +407,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -465,7 +464,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {
@@ -527,7 +526,7 @@ describe("UI - Starter select", () => {
       handler.processInput(Button.ACTION);
       game.phaseInterceptor.unlock();
     });
-    await game.phaseInterceptor.run(SelectStarterPhase);
+    await game.phaseInterceptor.to("SelectStarterPhase");
     let options: OptionSelectItem[] = [];
     let optionSelectUiHandler: OptionSelectUiHandler | undefined;
     await new Promise<void>((resolve) => {

--- a/test/ui/starter-select.test.ts
+++ b/test/ui/starter-select.test.ts
@@ -1,5 +1,4 @@
 import { allSpecies } from "#app/data/data-lists";
-import { EncounterPhase } from "#app/phases/encounter-phase";
 import type { TitlePhase } from "#app/phases/title-phase";
 import type { OptionSelectUiHandler } from "#app/ui/handlers/option-select-ui-handler";
 import type { SaveSlotSelectUiHandler } from "#app/ui/handlers/save-slot-select-ui-handler";
@@ -85,7 +84,7 @@ describe("UI - Starter select", () => {
         resolve();
       });
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
 
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
     expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
@@ -143,7 +142,7 @@ describe("UI - Starter select", () => {
         resolve();
       });
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
 
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
     expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
@@ -204,7 +203,7 @@ describe("UI - Starter select", () => {
         resolve();
       });
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
 
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
     expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
@@ -264,7 +263,7 @@ describe("UI - Starter select", () => {
         resolve();
       });
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
 
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
     expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
@@ -322,7 +321,7 @@ describe("UI - Starter select", () => {
         resolve();
       });
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
 
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
     expect(game.scene.getPlayerParty()[0].shiny).toBe(false);
@@ -381,7 +380,7 @@ describe("UI - Starter select", () => {
         resolve();
       });
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
 
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
     expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
@@ -439,7 +438,7 @@ describe("UI - Starter select", () => {
         resolve();
       });
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
 
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.BULBASAUR);
     expect(game.scene.getPlayerParty()[0].shiny).toBe(true);
@@ -503,7 +502,7 @@ describe("UI - Starter select", () => {
       const saveSlotSelectUiHandler = game.scene.ui.getHandler() as SaveSlotSelectUiHandler;
       saveSlotSelectUiHandler.processInput(Button.ACTION);
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.CATERPIE);
   }, 20000);
 
@@ -566,7 +565,7 @@ describe("UI - Starter select", () => {
       const saveSlotSelectUiHandler = game.scene.ui.getHandler() as SaveSlotSelectUiHandler;
       saveSlotSelectUiHandler.processInput(Button.ACTION);
     });
-    await game.phaseInterceptor.whenAboutToRun(EncounterPhase);
+    await game.phaseInterceptor.to("EncounterPhase", false);
     expect(game.scene.getPlayerParty()[0].species.speciesId).toBe(SpeciesId.NIDORAN_M);
   }, 20000);
 });

--- a/test/ui/type-hints.test.ts
+++ b/test/ui/type-hints.test.ts
@@ -1,15 +1,14 @@
+import { FightUiHandler } from "#app/ui/handlers/fight-ui-handler";
 import { Button } from "#enums/buttons";
+import { TypeEffectivenessColor } from "#enums/color";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { CommandPhase } from "#app/phases/command-phase";
-import { FightUiHandler } from "#app/ui/handlers/fight-ui-handler";
 import { UiMode } from "#enums/ui-mode";
 import { GameManager } from "#test/test-utils/gameManager";
-import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { MockText } from "#test/test-utils/mocks/mocksContainer/mockText";
 import i18next from "i18next";
-import { TypeEffectivenessColor } from "#enums/color";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("UI - Type Hints", () => {
   let phaserGame: Phaser.Game;
@@ -60,7 +59,7 @@ describe("UI - Type Hints", () => {
       expect.soft(dragonClawText.color).toBe(TypeEffectivenessColor.NO_EFFECT);
       ui.getHandler().processInput(Button.ACTION);
     });
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
   });
 
   it("check status move color", async () => {
@@ -85,6 +84,6 @@ describe("UI - Type Hints", () => {
       expect.soft(growlText.color).toBe(undefined);
       ui.getHandler().processInput(Button.ACTION);
     });
-    await game.phaseInterceptor.to(CommandPhase);
+    await game.phaseInterceptor.to("CommandPhase");
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
A bunch of tests unnecessarily import Phase classes and/or use outdated functions.

## What are the changes from a developer perspective?
- `PhaseInterceptor#to` no longer accepts class constructors as input, only accepting strings instead.
- `run`, `runFrom` and `whenAboutToRun` marked as `protected`.
- `runFrom` and `whenAboutToRun` marked as `@deprecated`.

Relevant changes in `phaseInterceptor.ts`

## How to test the changes?
`npm run test[:silent]`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?