### PR TITLE
[Refactor] Rename `isNullOrUndefined` to `isNil` and add TSDoc

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -128,7 +128,7 @@ import {
   BooleanHolder,
   fixedNumber,
   getEnumValues,
-  isNullOrUndefined,
+  isNil,
   NumberHolder,
 } from "#app/utils/common-utils";
 import { getModifierPoolForType } from "#app/utils/modifier-pool-utils";
@@ -1213,7 +1213,7 @@ export default class BattleScene extends SceneBase {
 
     const playerField = this.getPlayerField();
 
-    if (this.gameMode.isFixedBattle(newWaveIndex) && isNullOrUndefined(trainerData)) {
+    if (this.gameMode.isFixedBattle(newWaveIndex) && isNil(trainerData)) {
       battleConfig = this.gameMode.getFixedBattle(newWaveIndex);
       newDouble = battleConfig.double;
       newBattleType = battleConfig.battleType;
@@ -1253,7 +1253,7 @@ export default class BattleScene extends SceneBase {
           : randSeedInt(2)
             ? TrainerVariant.FEMALE
             : TrainerVariant.DEFAULT;
-        newTrainer = !isNullOrUndefined(trainerData) ? trainerData.toTrainer() : new Trainer(trainerType, variant);
+        newTrainer = !isNil(trainerData) ? trainerData.toTrainer() : new Trainer(trainerType, variant);
         this.field.add(newTrainer);
       }
 
@@ -1281,7 +1281,7 @@ export default class BattleScene extends SceneBase {
       newDouble = false;
     }
 
-    if (!isNullOrUndefined(Overrides.BATTLE_TYPE_OVERRIDE)) {
+    if (!isNil(Overrides.BATTLE_TYPE_OVERRIDE)) {
       let doubleOverrideForWave: "single" | "double" | null = null;
 
       switch (Overrides.BATTLE_TYPE_OVERRIDE) {
@@ -2094,7 +2094,7 @@ export default class BattleScene extends SceneBase {
             } else {
               args.push(1);
             }
-          } else if (modifier instanceof RememberMoveModifier && !isNullOrUndefined(cost)) {
+          } else if (modifier instanceof RememberMoveModifier && !isNil(cost)) {
             args.push(cost);
           }
 
@@ -2912,7 +2912,7 @@ export default class BattleScene extends SceneBase {
         sessionEncounterRate
         + Math.min(currentRunDiffFromAvg * ME_ANTI_VARIANCE_WEIGHT_MODIFIER, ME_MAX_SPAWN_WEIGHT / 2);
 
-      const successRate = isNullOrUndefined(Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE)
+      const successRate = isNil(Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE)
         ? favoredEncounterRate
         : Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE!;
 
@@ -2920,7 +2920,7 @@ export default class BattleScene extends SceneBase {
       const canSpawn =
         encounteredEvents.length === 0
         || waveIndex - encounteredEvents[encounteredEvents.length - 1].waveIndex > 3
-        || !isNullOrUndefined(Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE);
+        || !isNil(Overrides.MYSTERY_ENCOUNTER_RATE_OVERRIDE);
 
       if (canSpawn) {
         let roll = ME_MAX_SPAWN_WEIGHT;
@@ -2948,7 +2948,7 @@ export default class BattleScene extends SceneBase {
     // Loading override or session encounter
     let encounter: MysteryEncounter | null;
     if (
-      !isNullOrUndefined(Overrides.MYSTERY_ENCOUNTER_OVERRIDE)
+      !isNil(Overrides.MYSTERY_ENCOUNTER_OVERRIDE)
       && allMysteryEncounters.hasOwnProperty(Overrides.MYSTERY_ENCOUNTER_OVERRIDE)
     ) {
       encounter = allMysteryEncounters[Overrides.MYSTERY_ENCOUNTER_OVERRIDE];
@@ -2959,7 +2959,7 @@ export default class BattleScene extends SceneBase {
       encounter = allMysteryEncounters[encounterType ?? -1];
       return encounter;
     } else {
-      encounter = !isNullOrUndefined(encounterType) ? allMysteryEncounters[encounterType] : null;
+      encounter = !isNil(encounterType) ? allMysteryEncounters[encounterType] : null;
     }
 
     // Check for queued encounters first
@@ -3017,7 +3017,7 @@ export default class BattleScene extends SceneBase {
             ? MysteryEncounterTier.ULTRA
             : MysteryEncounterTier.EPIC;
 
-    if (!isNullOrUndefined(Overrides.MYSTERY_ENCOUNTER_TIER_OVERRIDE)) {
+    if (!isNil(Overrides.MYSTERY_ENCOUNTER_TIER_OVERRIDE)) {
       tier = Overrides.MYSTERY_ENCOUNTER_TIER_OVERRIDE;
     }
 

--- a/src/data/abilities/ab-attrs/low-hp-move-type-attack-multiplier-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/low-hp-move-type-attack-multiplier-ab-attr.ts
@@ -1,11 +1,11 @@
+import type { Move } from "#app/data/moves/move";
+import type { Pokemon } from "#app/field/pokemon";
+import { isNil, type NumberHolder } from "#app/utils/common-utils";
 import type { ElementalType } from "#enums/elemental-type";
-import { StatMultiplierAbAttr } from "./stat-multiplier-ab-attr";
+import { MoveCategory } from "#enums/move-category";
 import type { BattleStat } from "#enums/stat";
 import { Stat } from "#enums/stat";
-import type { Pokemon } from "#app/field/pokemon";
-import type { Move } from "#app/data/moves/move";
-import { isNullOrUndefined, type NumberHolder } from "#app/utils/common-utils";
-import { MoveCategory } from "#enums/move-category";
+import { StatMultiplierAbAttr } from "./stat-multiplier-ab-attr";
 
 /**
  * Ability attribute that multiplies the ability holder's attack/special attack stat (depends on the move's category) by 1.5 if it uses a move of a specific type at less than 1/3 HP
@@ -41,8 +41,7 @@ export class LowHpMoveTypeAttackMultiplierAbAttr extends StatMultiplierAbAttr {
     move: Move,
     target: Pokemon,
   ): boolean {
-    const category =
-      !isNullOrUndefined(move) && !isNullOrUndefined(target) ? pokemon.getMoveCategory(target, move) : move?.category;
+    const category = !isNil(move) && !isNil(target) ? pokemon.getMoveCategory(target, move) : move?.category;
     this.stat = category === MoveCategory.SPECIAL ? Stat.SPATK : Stat.ATK;
     return super.apply(pokemon, simulated, stat, statValue, move, target);
   }

--- a/src/data/abilities/ab-attrs/protect-stat-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/protect-stat-ab-attr.ts
@@ -1,10 +1,10 @@
 import type { Pokemon } from "#app/field/pokemon";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { isNullOrUndefined, type BooleanHolder } from "#app/utils/common-utils";
+import { isNil, type BooleanHolder } from "#app/utils/common-utils";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { getStatKey, type BattleStat } from "#enums/stat";
 import i18next from "i18next";
 import { PreStatStageChangeAbAttr } from "./pre-stat-stage-change-ab-attr";
-import { AbAttrFlag } from "#enums/ab-attr-flag";
 
 /**
  * Protect one or all {@linkcode BattleStat} from reductions caused by other Pokémon's moves and Abilities
@@ -22,7 +22,7 @@ export class ProtectStatAbAttr extends PreStatStageChangeAbAttr {
   }
 
   override apply(_pokemon: Pokemon, _simulated: boolean, stat: BattleStat, cancelled: BooleanHolder): boolean {
-    if (isNullOrUndefined(this.protectedStat) || stat === this.protectedStat) {
+    if (isNil(this.protectedStat) || stat === this.protectedStat) {
       cancelled.value = true;
       return true;
     }

--- a/src/data/animations/anim-config.ts
+++ b/src/data/animations/anim-config.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { getFrameMs, isNullOrUndefined } from "#app/utils/common-utils";
+import { getFrameMs, isNil } from "#app/utils/common-utils";
 import { AnimBlendType } from "#enums/anim-blend-type";
 import { AnimFocus } from "#enums/anim-focus";
 import { AnimFrameTarget } from "#enums/anim-frame-target";
@@ -433,7 +433,7 @@ export class AnimTimedAddBgEvent extends AnimTimedBgEvent {
     moveAnim.bgSprite.setAlpha(this.opacity / 255);
     globalScene.field.add(moveAnim.bgSprite);
     const fieldPokemon = globalScene.getEnemyPokemon(false) ?? globalScene.getPlayerPokemon(false);
-    if (!isNullOrUndefined(priority)) {
+    if (!isNil(priority)) {
       globalScene.field.moveTo(moveAnim.bgSprite as Phaser.GameObjects.GameObject, priority);
     } else if (fieldPokemon?.isOnField()) {
       globalScene.field.moveBelow(moveAnim.bgSprite as Phaser.GameObjects.GameObject, fieldPokemon);

--- a/src/data/animations/battle-anims.ts
+++ b/src/data/animations/battle-anims.ts
@@ -3,7 +3,7 @@ import type { SubstituteTag } from "#app/data/battler-tags/substitute-tag";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { settings } from "#app/system/settings/settings-manager";
-import { getEnumValues, getFrameMs, isNullOrUndefined, type nil } from "#app/utils/common-utils";
+import { getEnumValues, getFrameMs, isNil, type nil } from "#app/utils/common-utils";
 import { AnimBlendType } from "#enums/anim-blend-type";
 import { AnimFocus } from "#enums/anim-focus";
 import { AnimFrameTarget } from "#enums/anim-frame-target";
@@ -613,7 +613,7 @@ export abstract class BattleAnim {
 
           const graphicIndex = graphicFrameCount++;
           const moveSprite = sprites[graphicIndex];
-          if (!isNullOrUndefined(frame.priority)) {
+          if (!isNil(frame.priority)) {
             const setSpritePriority = (priority: number) => {
               if (existingFieldSprites.length > priority) {
                 // Move to specified priority index

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -15,7 +15,7 @@ import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
-import { BooleanHolder, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils/common-utils";
+import { BooleanHolder, isNil, NumberHolder, toDmgValue } from "#app/utils/common-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -884,7 +884,7 @@ export class DelayedAttackTag extends ArenaTag {
     this.delayedAttacks.forEach((attack) => {
       attack.turnCount--;
 
-      if (!isNullOrUndefined(globalScene.getPokemonById(attack.sourceId)) && attack.turnCount <= 0) {
+      if (!isNil(globalScene.getPokemonById(attack.sourceId)) && attack.turnCount <= 0) {
         const target = globalScene.getField(true).find((p) => attack.targetIndex === p.getBattlerIndex());
         if (target) {
           globalScene.phaseManager.unshiftPhase(
@@ -900,7 +900,7 @@ export class DelayedAttackTag extends ArenaTag {
     });
 
     this.delayedAttacks = this.delayedAttacks.filter(
-      (attack) => !isNullOrUndefined(globalScene.getPokemonById(attack.sourceId)) && attack.turnCount > 0,
+      (attack) => !isNil(globalScene.getPokemonById(attack.sourceId)) && attack.turnCount > 0,
     );
     return this.delayedAttacks.length > 0;
   }
@@ -1014,7 +1014,7 @@ export class PendingHealTag extends ArenaTag {
       targetEffects.splice(targetEffects.indexOf(healEffect), 1);
     }
 
-    return !isNullOrUndefined(healEffect);
+    return !isNil(healEffect);
   }
 
   /**

--- a/src/data/battler-tags/confused-tag.ts
+++ b/src/data/battler-tags/confused-tag.ts
@@ -2,9 +2,10 @@ import { BattlerTag } from "#app/data/battler-tags/battler-tag";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import Overrides from "#app/overrides";
 import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import type { MovePhase } from "#app/phases/move-phase";
-import { isNullOrUndefined, toDmgValue } from "#app/utils/common-utils";
+import { isNil, toDmgValue } from "#app/utils/common-utils";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -13,7 +14,6 @@ import type { MoveId } from "#enums/move-id";
 import { Stat } from "#enums/stat";
 import { TerrainType } from "#enums/terrain-type";
 import i18next from "i18next";
-import Overrides from "#app/overrides";
 
 /**
  * Tag representing the {@link https://bulbapedia.bulbagarden.net/wiki/Confusion_(status_condition) Confusion} status condition
@@ -57,7 +57,7 @@ export class ConfusedTag extends BattlerTag {
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     const ret =
       (lapseType !== BattlerTagLapseType.CUSTOM && super.lapse(pokemon, lapseType))
-      || !isNullOrUndefined(Overrides.STATUS_ACTIVATION_OVERRIDE);
+      || !isNil(Overrides.STATUS_ACTIVATION_OVERRIDE);
 
     if (ret) {
       globalScene.phaseManager.queueMessagePhase(

--- a/src/data/custom-pokemon-data.ts
+++ b/src/data/custom-pokemon-data.ts
@@ -1,6 +1,6 @@
+import { isNil } from "#app/utils/common-utils";
 import type { AbilityId } from "#enums/ability-id";
 import type { ElementalType } from "#enums/elemental-type";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import type { Nature } from "#enums/nature";
 
 /**
@@ -15,7 +15,7 @@ export class CustomPokemonData {
   public types: ElementalType[];
 
   constructor(data?: CustomPokemonData | Partial<CustomPokemonData>) {
-    if (!isNullOrUndefined(data)) {
+    if (!isNil(data)) {
       Object.assign(this, data);
     }
 

--- a/src/data/init/init-encounter-anims.ts
+++ b/src/data/init/init-encounter-anims.ts
@@ -1,8 +1,8 @@
 import { AnimConfig } from "#app/data/animations/anim-config";
-import { encounterAnims } from "../animations/encounter-anims";
 import { globalScene } from "#app/global-scene";
-import { getEnumKeys, isNullOrUndefined } from "#app/utils/common-utils";
+import { getEnumKeys, isNil } from "#app/utils/common-utils";
 import { EncounterAnim } from "#enums/encounter-anims";
+import { encounterAnims } from "../animations/encounter-anims";
 
 /**
  * Fetches animation configs to be used in a Mystery Encounter
@@ -13,7 +13,7 @@ export async function initEncounterAnims(encounterAnim: EncounterAnim | Encounte
   const encounterAnimNames = getEnumKeys(EncounterAnim);
   const encounterAnimFetches: Promise<Map<EncounterAnim, AnimConfig>>[] = [];
   for (const anim of anims) {
-    if (encounterAnims.has(anim) && !isNullOrUndefined(encounterAnims.get(anim))) {
+    if (encounterAnims.has(anim) && !isNil(encounterAnims.get(anim))) {
       continue;
     }
     encounterAnimFetches.push(

--- a/src/data/init/init-encounter-anims.ts
+++ b/src/data/init/init-encounter-anims.ts
@@ -1,8 +1,8 @@
 import { AnimConfig } from "#app/data/animations/anim-config";
+import { encounterAnims } from "#app/data/animations/encounter-anims";
 import { globalScene } from "#app/global-scene";
 import { getEnumKeys, isNil } from "#app/utils/common-utils";
 import { EncounterAnim } from "#enums/encounter-anims";
-import { encounterAnims } from "../animations/encounter-anims";
 
 /**
  * Fetches animation configs to be used in a Mystery Encounter

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -238,9 +238,9 @@ import { userSleptOrComatoseCondition } from "#app/data/moves/move-conditions/us
 import { getNonVolatileStatusEffects } from "#app/data/status-effect";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { ConditionalProtectArenaTagTypes } from "#app/utils/arena-tag-type-utils";
 import { SemiInvulnerableBattlerTagTypes, TrappedBattlerTagTypes } from "#app/utils/battler-tag-type-utils";
+import { isNil } from "#app/utils/common-utils";
 import { crashDamageFunc } from "#app/utils/move-utils";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagRelativeSide } from "#enums/arena-tag-relative-side";
@@ -1868,8 +1868,8 @@ export function initMoves() {
       )
       .condition(
         (_user, target, _move) =>
-          isNullOrUndefined(target.getTag(BattlerTagType.INGRAIN))
-          && isNullOrUndefined(target.getTag(BattlerTagType.IGNORE_FLYING)),
+          isNil(target.getTag(BattlerTagType.INGRAIN))
+          && isNil(target.getTag(BattlerTagType.IGNORE_FLYING)),
       )
       .attr(AddBattlerTagAttr, BattlerTagType.TELEKINESIS, false, { failOnOverlap: true, turnCountMin: 3 })
       .attr(AddBattlerTagAttr, BattlerTagType.FLOATING, false, { failOnOverlap: true, turnCountMin: 3 })
@@ -2671,7 +2671,7 @@ export function initMoves() {
         MovePowerMultiplierAttr,
         (user, _target, _move) => {
           const result = user.getLastXMoves(2)[1]?.result;
-          if (isNullOrUndefined(result)) {
+          if (isNil(result)) {
             return 1;
           }
           return [MoveResult.MISS, MoveResult.FAIL].includes(result) ? 2 : 1;

--- a/src/data/moves/move-attrs/quash-attr.ts
+++ b/src/data/moves/move-attrs/quash-attr.ts
@@ -1,7 +1,7 @@
 import type { MoveConditionFunc } from "#app/@types/MoveConditionFunc";
 import { AddBattlerTagAttr } from "#app/data/moves/move-attrs/add-battler-tag-attr";
 import { globalScene } from "#app/global-scene";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { BattlerTagType } from "#enums/battler-tag-type";
 
 export class QuashAttr extends AddBattlerTagAttr {
@@ -12,7 +12,7 @@ export class QuashAttr extends AddBattlerTagAttr {
   override getCondition(): MoveConditionFunc | null {
     return (_user, target, _move) => {
       const { turnManager } = globalScene.currentBattle;
-      return !target.getTag(BattlerTagType.QUASHED) && !isNullOrUndefined(turnManager.findCommandFromPokemon(target));
+      return !target.getTag(BattlerTagType.QUASHED) && !isNil(turnManager.findCommandFromPokemon(target));
     };
   }
 }

--- a/src/data/moves/move-attrs/weather-instant-charge-attr.ts
+++ b/src/data/moves/move-attrs/weather-instant-charge-attr.ts
@@ -1,7 +1,7 @@
-import type { WeatherType } from "#enums/weather-type";
-import { globalScene } from "#app/global-scene";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { InstantChargeAttr } from "#app/data/moves/move-attrs/instant-charge-attr";
+import { globalScene } from "#app/global-scene";
+import { isNil } from "#app/utils/common-utils";
+import type { WeatherType } from "#enums/weather-type";
 
 /**
  * Attribute that allows charge moves to resolve in 1 turn while specific {@linkcode WeatherType | Weather}
@@ -13,7 +13,7 @@ export class WeatherInstantChargeAttr extends InstantChargeAttr {
     super((_user, _move) => {
       const currentWeather = globalScene.arena.weather;
 
-      if (isNullOrUndefined(currentWeather?.weatherType)) {
+      if (isNil(currentWeather?.weatherType)) {
         return false;
       } else {
         return !currentWeather?.isEffectSuppressed() && weatherTypes.includes(currentWeather?.weatherType);

--- a/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
+++ b/src/data/mystery-encounters/encounters/bug-type-superfan-encounter.ts
@@ -1,3 +1,16 @@
+import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
+import { GAME_WIDTH } from "#app/constants/ui";
+import { allMoves } from "#app/data/data-lists";
+import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
+import {
+  AttackTypeBoosterHeldItemTypeRequirement,
+  CombinationPokemonRequirement,
+  HeldItemRequirement,
+  TypeRequirement,
+} from "#app/data/mystery-encounters/mystery-encounter-requirements";
+import { getEncounterText, showEncounterDialogue } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import type { EnemyPartyConfig } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import {
   generateModifierType,
@@ -8,37 +21,13 @@ import {
   selectPokemonForOption,
   setEncounterRewards,
 } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { transitionMysteryEncounterIntroVisuals } from "../utils/encounter-visuals-utils";
+import { getSpriteKeysFromSpecies } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
 import { getRandomPartyMemberFunc, TrainerPartyCompoundTemplate, TrainerPartyTemplate } from "#app/data/trainer-config";
-import { TrainerSlot } from "#enums/trainer-slot";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { PartyMemberStrength } from "#enums/party-member-strength";
-import { globalScene } from "#app/global-scene";
-import { isNullOrUndefined } from "#app/utils/common-utils";
-import { randSeedInt, randSeedShuffle } from "#app/utils/random-utils";
-import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { TrainerType } from "#enums/trainer-type";
-import { SpeciesId } from "#enums/species-id";
+import { allTrainerConfigs } from "#app/data/trainer-configs/all-trainer-configs";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
 import type { Pokemon } from "#app/field/pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
-import { getEncounterText, showEncounterDialogue } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
-import { LearnMovePhase } from "#app/phases/learn-move-phase";
-import { MoveId } from "#enums/move-id";
-import type { OptionSelectItem } from "#app/ui/interfaces/option-select-config";
-import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import {
-  AttackTypeBoosterHeldItemTypeRequirement,
-  CombinationPokemonRequirement,
-  HeldItemRequirement,
-  TypeRequirement,
-} from "#app/data/mystery-encounters/mystery-encounter-requirements";
-import { ElementalType } from "#enums/elemental-type";
-import type { AttackTypeBoosterModifierType, ModifierTypeOption } from "#app/modifier/modifier-type";
-import { modifierTypes } from "#app/modifier/modifier-types";
+import { globalScene } from "#app/global-scene";
 import type { PokemonHeldItemModifier } from "#app/modifier/modifier";
 import {
   BypassSpeedChanceModifier,
@@ -46,14 +35,25 @@ import {
   GigantamaxAccessModifier,
   MegaEvolutionAccessModifier,
 } from "#app/modifier/modifier";
-import i18next from "i18next";
+import type { AttackTypeBoosterModifierType, ModifierTypeOption } from "#app/modifier/modifier-type";
+import { modifierTypes } from "#app/modifier/modifier-types";
+import { LearnMovePhase } from "#app/phases/learn-move-phase";
 import { MoveInfoOverlay } from "#app/ui/components/move-info-overlay";
-import { allMoves } from "#app/data/data-lists";
+import type { OptionSelectItem } from "#app/ui/interfaces/option-select-config";
+import { isNil } from "#app/utils/common-utils";
+import { randSeedInt, randSeedShuffle } from "#app/utils/random-utils";
+import { ElementalType } from "#enums/elemental-type";
 import { ModifierTier } from "#enums/modifier-tier";
-import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
-import { getSpriteKeysFromSpecies } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
-import { allTrainerConfigs } from "#app/data/trainer-configs/all-trainer-configs";
-import { GAME_WIDTH } from "#app/constants/ui";
+import { MoveId } from "#enums/move-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { PartyMemberStrength } from "#enums/party-member-strength";
+import { SpeciesId } from "#enums/species-id";
+import { TrainerSlot } from "#enums/trainer-slot";
+import { TrainerType } from "#enums/trainer-type";
+import i18next from "i18next";
+import { transitionMysteryEncounterIntroVisuals } from "../utils/encounter-visuals-utils";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/bugTypeSuperfan";
@@ -568,7 +568,7 @@ function getTrainerConfigForWave(waveIndex: number) {
       .setPartyMemberFunc(
         4,
         getRandomPartyMemberFunc([pool3Mon.species], TrainerSlot.TRAINER, true, (p) => {
-          if (!isNullOrUndefined(pool3Mon.formIndex)) {
+          if (!isNil(pool3Mon.formIndex)) {
             p.formIndex = pool3Mon.formIndex;
             p.generateAndPopulateMoveset();
             p.generateName();
@@ -600,7 +600,7 @@ function getTrainerConfigForWave(waveIndex: number) {
       .setPartyMemberFunc(
         3,
         getRandomPartyMemberFunc([pool3Mon.species], TrainerSlot.TRAINER, true, (p) => {
-          if (!isNullOrUndefined(pool3Mon.formIndex)) {
+          if (!isNil(pool3Mon.formIndex)) {
             p.formIndex = pool3Mon.formIndex;
             p.generateAndPopulateMoveset();
             p.generateName();
@@ -610,7 +610,7 @@ function getTrainerConfigForWave(waveIndex: number) {
       .setPartyMemberFunc(
         4,
         getRandomPartyMemberFunc([pool3Mon2.species], TrainerSlot.TRAINER, true, (p) => {
-          if (!isNullOrUndefined(pool3Mon2.formIndex)) {
+          if (!isNil(pool3Mon2.formIndex)) {
             p.formIndex = pool3Mon2.formIndex;
             p.generateAndPopulateMoveset();
             p.generateName();
@@ -645,7 +645,7 @@ function getTrainerConfigForWave(waveIndex: number) {
       .setPartyMemberFunc(
         3,
         getRandomPartyMemberFunc([pool3Mon.species], TrainerSlot.TRAINER, true, (p) => {
-          if (!isNullOrUndefined(pool3Mon.formIndex)) {
+          if (!isNil(pool3Mon.formIndex)) {
             p.formIndex = pool3Mon.formIndex;
             p.generateAndPopulateMoveset();
             p.generateName();
@@ -684,7 +684,7 @@ function getTrainerConfigForWave(waveIndex: number) {
       .setPartyMemberFunc(
         2,
         getRandomPartyMemberFunc([pool3Mon.species], TrainerSlot.TRAINER, true, (p) => {
-          if (!isNullOrUndefined(pool3Mon.formIndex)) {
+          if (!isNil(pool3Mon.formIndex)) {
             p.formIndex = pool3Mon.formIndex;
             p.generateAndPopulateMoveset();
             p.generateName();
@@ -694,7 +694,7 @@ function getTrainerConfigForWave(waveIndex: number) {
       .setPartyMemberFunc(
         3,
         getRandomPartyMemberFunc([pool3Mon2.species], TrainerSlot.TRAINER, true, (p) => {
-          if (!isNullOrUndefined(pool3Mon2.formIndex)) {
+          if (!isNil(pool3Mon2.formIndex)) {
             p.formIndex = pool3Mon2.formIndex;
             p.generateAndPopulateMoveset();
             p.generateName();

--- a/src/data/mystery-encounters/encounters/dark-deal-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dark-deal-encounter.ts
@@ -15,7 +15,7 @@ import { globalScene } from "#app/global-scene";
 import type { PokemonHeldItemModifier } from "#app/modifier/modifier";
 import { modifierTypes } from "#app/modifier/modifier-types";
 import { ModifierRewardPhase } from "#app/phases/modifier-reward-phase";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { getPokemonSpecies, getSpecialSpeciesList } from "#app/utils/pokemon-utils";
 import { randSeedInt } from "#app/utils/random-utils";
 import { Challenges } from "#enums/challenges";
@@ -136,7 +136,7 @@ export const DarkDealEncounter: MysteryEncounter = MysteryEncounterBuilder.withE
             };
           }),
         };
-        if (!isNullOrUndefined(bossSpecies.forms) && bossSpecies.forms.length > 0) {
+        if (!isNil(bossSpecies.forms) && bossSpecies.forms.length > 0) {
           pokemonConfig.formIndex = 0;
         }
         const config: EnemyPartyConfig = {

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -1,52 +1,52 @@
+import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
+import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui";
+import { allSpecies } from "#app/data/data-lists";
+import { getGenderSymbol } from "#app/data/gender";
+import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
+import { getEncounterText, showEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import {
   leaveEncounterWithoutBattle,
   selectPokemonForOption,
   setEncounterRewards,
 } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { TrainerSlot } from "#enums/trainer-slot";
-import { ModifierTier } from "#enums/modifier-tier";
-import type { ModifierTypeOption } from "#app/modifier/modifier-type";
-import { getPlayerModifierTypeOptions, regenerateModifierPoolThresholds } from "#app/modifier/modifier-type";
-import { ModifierPoolType } from "#enums/modifier-pool-type";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { globalScene } from "#app/global-scene";
-import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { SpeciesId } from "#enums/species-id";
+import { addPokemonDataToDexAndValidateAchievements } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
+import { getNatureName } from "#app/data/nature";
+import { getPokeballAtlasKey, getPokeballTintColor } from "#app/data/pokeball";
 import type PokemonSpecies from "#app/data/pokemon-species";
-import { allSpecies } from "#app/data/data-lists";
-import { getPokemonSpecies } from "#app/utils/pokemon-utils";
+import { trainerNamePools } from "#app/data/trainer-names";
 import { getTypeRgb } from "#app/data/type";
-import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { NumberHolder, isNullOrUndefined } from "#app/utils/common-utils";
-import { randInt, randItem, randSeedInt, randSeedShuffle } from "#app/utils/random-utils";
+import { EnemyPokemon } from "#app/field/enemy-pokemon";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
 import type { Pokemon } from "#app/field/pokemon";
-import { EnemyPokemon } from "#app/field/enemy-pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
+import { globalScene } from "#app/global-scene";
 import type { PokemonHeldItemModifier } from "#app/modifier/modifier";
 import {
   HiddenAbilityRateBoosterModifier,
   ShinyRateBoosterModifier,
   SpeciesStatBoosterModifier,
 } from "#app/modifier/modifier";
-import type { OptionSelectItem } from "#app/ui/interfaces/option-select-config";
+import type { ModifierTypeOption } from "#app/modifier/modifier-type";
+import { getPlayerModifierTypeOptions, regenerateModifierPoolThresholds } from "#app/modifier/modifier-type";
 import PokemonData from "#app/system/pokemon-data";
-import i18next from "i18next";
-import { getGenderSymbol } from "#app/data/gender";
-import { Gender } from "#enums/gender";
-import { getNatureName } from "#app/data/nature";
-import { getPokeballAtlasKey, getPokeballTintColor } from "#app/data/pokeball";
-import { getEncounterText, showEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
-import { trainerNamePools } from "#app/data/trainer-names";
-import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
-import { addPokemonDataToDexAndValidateAchievements } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
-import type { PokeballType } from "#enums/pokeball-type";
-import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui";
 import { timedEventManager } from "#app/timed-event-manager";
+import type { OptionSelectItem } from "#app/ui/interfaces/option-select-config";
+import { NumberHolder, isNil } from "#app/utils/common-utils";
+import { getPokemonSpecies } from "#app/utils/pokemon-utils";
+import { randInt, randItem, randSeedInt, randSeedShuffle } from "#app/utils/random-utils";
 import { EventModifierType } from "#enums/event-modifier-type";
+import { Gender } from "#enums/gender";
+import { ModifierPoolType } from "#enums/modifier-pool-type";
+import { ModifierTier } from "#enums/modifier-tier";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import type { PokeballType } from "#enums/pokeball-type";
+import { SpeciesId } from "#enums/species-id";
+import { TrainerSlot } from "#enums/trainer-slot";
+import i18next from "i18next";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/globalTradeSystem";
@@ -430,7 +430,7 @@ function generateTradeOption(alreadyUsedSpecies: PokemonSpecies[], originalBst?:
     bstCap = originalBst + 100;
     bstMin = originalBst - 100;
   }
-  while (isNullOrUndefined(newSpecies)) {
+  while (isNil(newSpecies)) {
     // Get all non-legendary species that fall within the Bst range requirements
     let validSpecies = allSpecies.filter((s) => {
       const isLegendLike = s.isLegendLike();
@@ -443,7 +443,7 @@ function generateTradeOption(alreadyUsedSpecies: PokemonSpecies[], originalBst?:
     if (validSpecies?.length > 20) {
       validSpecies = randSeedShuffle(validSpecies);
       newSpecies = validSpecies.pop();
-      while (isNullOrUndefined(newSpecies) || alreadyUsedSpecies.includes(newSpecies)) {
+      while (isNil(newSpecies) || alreadyUsedSpecies.includes(newSpecies)) {
         newSpecies = validSpecies.pop();
       }
     } else {

--- a/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
@@ -1,35 +1,35 @@
+import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
+import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
+import { MoneyRequirement } from "#app/data/mystery-encounters/mystery-encounter-requirements";
+import { showEncounterDialogue } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import {
   leaveEncounterWithoutBattle,
   updatePlayerMoney,
 } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { transitionMysteryEncounterIntroVisuals } from "../utils/encounter-visuals-utils";
-import { isNullOrUndefined } from "#app/utils/common-utils";
-import { randSeedInt } from "#app/utils/random-utils";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { globalScene } from "#app/global-scene";
-import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
-import { MoneyRequirement } from "#app/data/mystery-encounters/mystery-encounter-requirements";
 import {
   catchPokemon,
   getRandomSpeciesByStarterCost,
   getSpriteKeysFromPokemon,
 } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
 import type PokemonSpecies from "#app/data/pokemon-species";
-import { getPokemonSpecies, getSpecialSpeciesList } from "#app/utils/pokemon-utils";
 import { speciesStarterCosts } from "#app/data/starters";
-import { SpeciesId } from "#enums/species-id";
-import { PokeballType } from "#enums/pokeball-type";
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
 import { PlayerPokemon } from "#app/field/player-pokemon";
-import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
-import { showEncounterDialogue } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
+import { globalScene } from "#app/global-scene";
 import PokemonData from "#app/system/pokemon-data";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
+import { isNil } from "#app/utils/common-utils";
+import { getPokemonSpecies, getSpecialSpeciesList } from "#app/utils/pokemon-utils";
+import { randSeedInt } from "#app/utils/random-utils";
 import { AbilityId } from "#enums/ability-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { PokeballType } from "#enums/pokeball-type";
 import { SpeciesGroups } from "#enums/pokemon-species-groups";
+import { SpeciesId } from "#enums/species-id";
+import { transitionMysteryEncounterIntroVisuals } from "../utils/encounter-visuals-utils";
 
 /** the i18n namespace for this encounter */
 const namespace = "mysteryEncounters/thePokemonSalesman";
@@ -77,7 +77,7 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
     let tries = 0;
 
     // Reroll any species that don't have HAs
-    while ((isNullOrUndefined(species.abilityHidden) || species.abilityHidden === AbilityId.NONE) && tries < 5) {
+    while ((isNil(species.abilityHidden) || species.abilityHidden === AbilityId.NONE) && tries < 5) {
       species = getSalesmanSpeciesOffer();
       tries++;
     }
@@ -85,7 +85,7 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
     let pokemon: PlayerPokemon;
     if (
       randSeedInt(SHINY_MAGIKARP_WEIGHT) === 0
-      || isNullOrUndefined(species.abilityHidden)
+      || isNil(species.abilityHidden)
       || species.abilityHidden === AbilityId.NONE
     ) {
       // If no HA mon found or you roll 1%, give shiny Magikarp with random variant

--- a/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
+++ b/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
@@ -1,4 +1,13 @@
+import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
+import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
+import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
 import { MysteryEncounterOptionBuilder } from "#app/data/mystery-encounters/mystery-encounter-option";
+import {
+  MoveRequirement,
+  PersistentModifierRequirement,
+} from "#app/data/mystery-encounters/mystery-encounter-requirements";
+import { CHARMING_MOVES } from "#app/data/mystery-encounters/requirements/requirement-groups";
+import { queueEncounterMessage } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import type { EnemyPartyConfig } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import {
   initBattleWithEnemyConfig,
@@ -6,39 +15,30 @@ import {
   setEncounterExp,
   setEncounterRewards,
 } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { CHARMING_MOVES } from "#app/data/mystery-encounters/requirements/requirement-groups";
-import type { Pokemon } from "#app/field/pokemon";
-import { EnemyPokemon } from "#app/field/enemy-pokemon";
-import { PokemonMove } from "#app/field/pokemon-move";
-import { getPartyLuckValue } from "#app/modifier/modifier-type";
-import { MysteryEncounterType } from "#enums/mystery-encounter-type";
-import { globalScene } from "#app/global-scene";
-import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import { MysteryEncounterBuilder } from "#app/data/mystery-encounters/mystery-encounter";
-import {
-  MoveRequirement,
-  PersistentModifierRequirement,
-} from "#app/data/mystery-encounters/mystery-encounter-requirements";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import { TrainerSlot } from "#enums/trainer-slot";
 import {
   catchPokemon,
   getHighestLevelPlayerPokemon,
   getSpriteKeysFromPokemon,
 } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
-import PokemonData from "#app/system/pokemon-data";
-import { isNullOrUndefined } from "#app/utils/common-utils";
-import { randSeedInt } from "#app/utils/random-utils";
-import type { MoveId } from "#enums/move-id";
-import { BattlerIndex } from "#enums/battler-index";
-import { PokeballType } from "#enums/pokeball-type";
-import { BattlerTagType } from "#enums/battler-tag-type";
-import { queueEncounterMessage } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
+import { EnemyPokemon } from "#app/field/enemy-pokemon";
+import type { Pokemon } from "#app/field/pokemon";
+import { PokemonMove } from "#app/field/pokemon-move";
+import { globalScene } from "#app/global-scene";
 import type { BerryModifier } from "#app/modifier/modifier";
+import { getPartyLuckValue } from "#app/modifier/modifier-type";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
+import PokemonData from "#app/system/pokemon-data";
+import { isNil } from "#app/utils/common-utils";
+import { randSeedInt } from "#app/utils/random-utils";
+import { BattlerIndex } from "#enums/battler-index";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import type { MoveId } from "#enums/move-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { PokeballType } from "#enums/pokeball-type";
 import { Stat } from "#enums/stat";
-import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#app/constants/mystery-encounters";
+import { TrainerSlot } from "#enums/trainer-slot";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/uncommonBreed";
@@ -174,7 +174,7 @@ export const UncommonBreedEncounter: MysteryEncounter = MysteryEncounterBuilder.
       const encounter = globalScene.currentBattle.mysteryEncounter!;
 
       const eggMove = encounter.misc.eggMove;
-      if (!isNullOrUndefined(eggMove)) {
+      if (!isNil(eggMove)) {
         // Check what type of move the egg move is to determine target
         const pokemonMove = new PokemonMove(eggMove);
         const move = pokemonMove.getMove();

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -31,9 +31,9 @@ import { modifierTypes } from "#app/modifier/modifier-types";
 import i18next from "#app/plugins/i18n";
 import PokemonData from "#app/system/pokemon-data";
 import { settings } from "#app/system/settings/settings-manager";
-import { NumberHolder, isNullOrUndefined } from "#app/utils/common-utils";
-import { randSeedInt, randSeedShuffle } from "#app/utils/random-utils";
+import { NumberHolder, isNil } from "#app/utils/common-utils";
 import { getPokemonSpecies, getSpecialSpeciesList } from "#app/utils/pokemon-utils";
+import { randSeedInt, randSeedShuffle } from "#app/utils/random-utils";
 import { Challenges } from "#enums/challenges";
 import type { ElementalType } from "#enums/elemental-type";
 import { ModifierTier } from "#enums/modifier-tier";
@@ -557,7 +557,7 @@ function getTransformedSpecies(
   alreadyUsedSpecies: PokemonSpecies[],
 ): PokemonSpecies {
   let newSpecies: PokemonSpecies | undefined;
-  while (isNullOrUndefined(newSpecies)) {
+  while (isNil(newSpecies)) {
     const bstCap = originalBst + bstSearchRange[1];
     const bstMin = Math.max(originalBst + bstSearchRange[0], 0);
 
@@ -599,7 +599,7 @@ function getTransformedSpecies(
     if (validSpecies?.length > 20) {
       validSpecies = randSeedShuffle(validSpecies);
       newSpecies = validSpecies.pop();
-      while (isNullOrUndefined(newSpecies) || alreadyUsedSpecies.includes(newSpecies)) {
+      while (isNil(newSpecies) || alreadyUsedSpecies.includes(newSpecies)) {
         newSpecies = validSpecies.pop();
       }
     } else {
@@ -709,12 +709,12 @@ async function addEggMoveToNewPokemonMoveset(
   if (eggMoves) {
     const eggMoveIndices = randSeedShuffle([0, 1, 2, 3]);
     let randomEggMoveIndex = eggMoveIndices.pop();
-    let randomEggMove = !isNullOrUndefined(randomEggMoveIndex) ? eggMoves[randomEggMoveIndex] : null;
+    let randomEggMove = !isNil(randomEggMoveIndex) ? eggMoves[randomEggMoveIndex] : null;
     let retries = 0;
     while (retries < 3 && (!randomEggMove || newPokemon.moveset.some((m) => m.moveId === randomEggMove))) {
       // If Pokemon already knows this move, roll for another egg move
       randomEggMoveIndex = eggMoveIndices.pop();
-      randomEggMove = !isNullOrUndefined(randomEggMoveIndex) ? eggMoves[randomEggMoveIndex] : null;
+      randomEggMove = !isNil(randomEggMoveIndex) ? eggMoves[randomEggMoveIndex] : null;
       retries++;
     }
 
@@ -729,11 +729,7 @@ async function addEggMoveToNewPokemonMoveset(
       }
 
       // For pokemon that the player owns (including ones just caught), unlock the egg move
-      if (
-        !forBattle
-        && !isNullOrUndefined(randomEggMoveIndex)
-        && globalScene.gameData.dexData[speciesRootForm].caughtAttr > 0
-      ) {
+      if (!forBattle && !isNil(randomEggMoveIndex) && globalScene.gameData.dexData[speciesRootForm].caughtAttr > 0) {
         await globalScene.gameData.setEggMoveUnlocked(
           getPokemonSpecies(speciesRootForm),
           randomEggMoveIndex,

--- a/src/data/mystery-encounters/mystery-encounter-option.ts
+++ b/src/data/mystery-encounters/mystery-encounter-option.ts
@@ -1,20 +1,20 @@
 import type { OptionTextDisplay } from "#app/data/mystery-encounters/mystery-encounter-dialogue";
-import type { MoveId } from "#enums/move-id";
-import type { PlayerPokemon } from "#app/field/player-pokemon";
-import type { Pokemon } from "#app/field/pokemon";
-import { globalScene } from "#app/global-scene";
-import type { ElementalType } from "#enums/elemental-type";
 import {
   EncounterPokemonRequirement,
   EncounterSceneRequirement,
   MoneyRequirement,
   TypeRequirement,
 } from "#app/data/mystery-encounters/mystery-encounter-requirements";
+import type { PlayerPokemon } from "#app/field/player-pokemon";
+import type { Pokemon } from "#app/field/pokemon";
+import { globalScene } from "#app/global-scene";
+import { isNil } from "#app/utils/common-utils";
+import { randSeedInt } from "#app/utils/random-utils";
+import type { ElementalType } from "#enums/elemental-type";
+import type { MoveId } from "#enums/move-id";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import type { CanLearnMoveRequirementOptions } from "./requirements/can-learn-move-requirement";
 import { CanLearnMoveRequirement } from "./requirements/can-learn-move-requirement";
-import { isNullOrUndefined } from "#app/utils/common-utils";
-import { randSeedInt } from "#app/utils/random-utils";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 
 export type OptionPhaseCallback = () => Promise<void | boolean>;
 
@@ -63,7 +63,7 @@ export default class MysteryEncounterOption implements IMysteryEncounterOption {
   onPostOptionPhase?: OptionPhaseCallback;
 
   constructor(option: IMysteryEncounterOption | null) {
-    if (!isNullOrUndefined(option)) {
+    if (!isNil(option)) {
       Object.assign(this, option);
     }
     this.hasDexProgress = this.hasDexProgress ?? false;

--- a/src/data/mystery-encounters/mystery-encounter-requirements.ts
+++ b/src/data/mystery-encounters/mystery-encounter-requirements.ts
@@ -4,7 +4,7 @@ import { pokemonFormChanges } from "#app/data/pokemon-forms";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import type { AbilityId } from "#enums/ability-id";
 import { ElementalType } from "#enums/elemental-type";
 import { EvolutionItem } from "#enums/evolution-item";
@@ -224,7 +224,7 @@ export class WaveRangeRequirement extends EncounterSceneRequirement {
   }
 
   override meetsRequirement(): boolean {
-    if (!isNullOrUndefined(this.waveRange) && this.waveRange[0] <= this.waveRange[1]) {
+    if (!isNil(this.waveRange) && this.waveRange[0] <= this.waveRange[1]) {
       const waveIndex = globalScene.currentBattle.waveIndex;
       if (
         (waveIndex >= 0 && this.waveRange[0] >= 0 && this.waveRange[0] > waveIndex)
@@ -280,11 +280,7 @@ export class TimeOfDayRequirement extends EncounterSceneRequirement {
 
   override meetsRequirement(): boolean {
     const timeOfDay = globalScene.arena?.getTimeOfDay();
-    if (
-      !isNullOrUndefined(timeOfDay)
-      && this.requiredTimeOfDay?.length > 0
-      && !this.requiredTimeOfDay.includes(timeOfDay)
-    ) {
+    if (!isNil(timeOfDay) && this.requiredTimeOfDay?.length > 0 && !this.requiredTimeOfDay.includes(timeOfDay)) {
       return false;
     }
 
@@ -306,11 +302,7 @@ export class WeatherRequirement extends EncounterSceneRequirement {
 
   override meetsRequirement(): boolean {
     const currentWeather = globalScene.arena.weather?.weatherType;
-    if (
-      !isNullOrUndefined(currentWeather)
-      && this.requiredWeather?.length > 0
-      && !this.requiredWeather.includes(currentWeather!)
-    ) {
+    if (!isNil(currentWeather) && this.requiredWeather?.length > 0 && !this.requiredWeather.includes(currentWeather!)) {
       return false;
     }
 
@@ -320,7 +312,7 @@ export class WeatherRequirement extends EncounterSceneRequirement {
   override getDialogueToken(_pokemon?: PlayerPokemon): [string, string] {
     const currentWeather = globalScene.arena.weather?.weatherType;
     let token = "";
-    if (!isNullOrUndefined(currentWeather)) {
+    if (!isNil(currentWeather)) {
       token = WeatherType[currentWeather].replace("_", " ").toLocaleLowerCase();
     }
     return ["weather", token];
@@ -344,7 +336,7 @@ export class PartySizeRequirement extends EncounterSceneRequirement {
   }
 
   override meetsRequirement(): boolean {
-    if (!isNullOrUndefined(this.partySizeRange) && this.partySizeRange[0] <= this.partySizeRange[1]) {
+    if (!isNil(this.partySizeRange) && this.partySizeRange[0] <= this.partySizeRange[1]) {
       const partySize = this.excludeDisallowedPokemon
         ? globalScene.getPokemonAllowedInBattle().length
         : globalScene.getPlayerParty().length;
@@ -376,7 +368,7 @@ export class PersistentModifierRequirement extends EncounterSceneRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredHeldItemModifiers?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredHeldItemModifiers?.length < 0) {
       return false;
     }
     let modifierCount = 0;
@@ -410,7 +402,7 @@ export class MoneyRequirement extends EncounterSceneRequirement {
 
   override meetsRequirement(): boolean {
     const money = globalScene.money;
-    if (isNullOrUndefined(money)) {
+    if (isNil(money)) {
       return false;
     }
 
@@ -441,7 +433,7 @@ export class SpeciesRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredSpecies?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredSpecies?.length < 0) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -480,7 +472,7 @@ export class NatureRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredNature?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredNature?.length < 0) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -500,7 +492,7 @@ export class NatureRequirement extends EncounterPokemonRequirement {
   }
 
   override getDialogueToken(pokemon?: PlayerPokemon): [string, string] {
-    if (!isNullOrUndefined(pokemon?.nature) && this.requiredNature.includes(pokemon.nature)) {
+    if (!isNil(pokemon?.nature) && this.requiredNature.includes(pokemon.nature)) {
       return ["nature", Nature[pokemon.nature]];
     }
     return ["nature", ""];
@@ -527,7 +519,7 @@ export class TypeRequirement extends EncounterPokemonRequirement {
   override meetsRequirement(): boolean {
     let partyPokemon = globalScene.getPlayerParty();
 
-    if (isNullOrUndefined(partyPokemon)) {
+    if (isNil(partyPokemon)) {
       return false;
     }
 
@@ -579,7 +571,7 @@ export class MoveRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredMoves?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredMoves?.length < 0) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -619,7 +611,7 @@ export class CompatibleMoveRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredMoves?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredMoves?.length < 0) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -674,7 +666,7 @@ export class AbilityRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredAbilities?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredAbilities?.length < 0) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -690,7 +682,7 @@ export class AbilityRequirement extends EncounterPokemonRequirement {
 
   override getDialogueToken(pokemon?: PlayerPokemon): [string, string] {
     const matchingAbility = this.requiredAbilities.find((a) => pokemon?.hasAbility(a, false));
-    if (!isNullOrUndefined(matchingAbility)) {
+    if (!isNil(matchingAbility)) {
       return ["ability", allAbilities[matchingAbility].name];
     }
     return ["ability", ""];
@@ -713,7 +705,7 @@ export class StatusEffectRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredStatusEffect?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredStatusEffect?.length < 0) {
       return false;
     }
     const x = this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -770,7 +762,7 @@ export class CanFormChangeWithItemRequirement extends EncounterPokemonRequiremen
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredFormChangeItem?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredFormChangeItem?.length < 0) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -837,7 +829,7 @@ export class CanEvolveWithItemRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon) || this.requiredEvolutionItem?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredEvolutionItem?.length < 0) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -905,7 +897,7 @@ export class HeldItemRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon)) {
+    if (isNil(partyPokemon)) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -968,7 +960,7 @@ export class AttackTypeBoosterHeldItemTypeRequirement extends EncounterPokemonRe
 
   override meetsRequirement(): boolean {
     const partyPokemon = globalScene.getPlayerParty();
-    if (isNullOrUndefined(partyPokemon)) {
+    if (isNil(partyPokemon)) {
       return false;
     }
     return this.queryParty(partyPokemon).length >= this.minNumberOfPokemon;
@@ -1032,7 +1024,7 @@ export class LevelRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     // Party Pokemon inside required level range
-    if (!isNullOrUndefined(this.requiredLevelRange) && this.requiredLevelRange[0] <= this.requiredLevelRange[1]) {
+    if (!isNil(this.requiredLevelRange) && this.requiredLevelRange[0] <= this.requiredLevelRange[1]) {
       const partyPokemon = globalScene.getPlayerParty();
       const pokemonInRange = this.queryParty(partyPokemon);
       if (pokemonInRange.length < this.minNumberOfPokemon) {
@@ -1072,10 +1064,7 @@ export class FriendshipRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     // Party Pokemon inside required friendship range
-    if (
-      !isNullOrUndefined(this.requiredFriendshipRange)
-      && this.requiredFriendshipRange[0] <= this.requiredFriendshipRange[1]
-    ) {
+    if (!isNil(this.requiredFriendshipRange) && this.requiredFriendshipRange[0] <= this.requiredFriendshipRange[1]) {
       const partyPokemon = globalScene.getPlayerParty();
       const pokemonInRange = this.queryParty(partyPokemon);
       if (pokemonInRange.length < this.minNumberOfPokemon) {
@@ -1123,7 +1112,7 @@ export class HealthRatioRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     // Party Pokemon's health inside required health range
-    if (!isNullOrUndefined(this.requiredHealthRange) && this.requiredHealthRange[0] <= this.requiredHealthRange[1]) {
+    if (!isNil(this.requiredHealthRange) && this.requiredHealthRange[0] <= this.requiredHealthRange[1]) {
       const partyPokemon = globalScene.getPlayerParty();
       const pokemonInRange = this.queryParty(partyPokemon);
       if (pokemonInRange.length < this.minNumberOfPokemon) {
@@ -1151,7 +1140,7 @@ export class HealthRatioRequirement extends EncounterPokemonRequirement {
 
   override getDialogueToken(pokemon?: PlayerPokemon): [string, string] {
     const hpRatio = pokemon?.getHpRatio();
-    if (!isNullOrUndefined(hpRatio)) {
+    if (!isNil(hpRatio)) {
       return ["healthRatio", Math.floor(hpRatio * 100).toString() + "%"];
     }
     return ["healthRatio", ""];
@@ -1170,7 +1159,7 @@ export class WeightRequirement extends EncounterPokemonRequirement {
 
   override meetsRequirement(): boolean {
     // Party Pokemon's weight inside required weight range
-    if (!isNullOrUndefined(this.requiredWeightRange) && this.requiredWeightRange[0] <= this.requiredWeightRange[1]) {
+    if (!isNil(this.requiredWeightRange) && this.requiredWeightRange[0] <= this.requiredWeightRange[1]) {
       const partyPokemon = globalScene.getPlayerParty();
       const pokemonInRange = this.queryParty(partyPokemon);
       if (pokemonInRange.length < this.minNumberOfPokemon) {

--- a/src/data/mystery-encounters/mystery-encounter-save-data.ts
+++ b/src/data/mystery-encounters/mystery-encounter-save-data.ts
@@ -1,7 +1,7 @@
-import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { ME_BASE_SPAWN_WEIGHT } from "#app/constants/mystery-encounters";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import type { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 
 export class SeenEncounterData {
   type: MysteryEncounterType;
@@ -28,7 +28,7 @@ export class MysteryEncounterSaveData {
   queuedEncounters: QueuedEncounter[] = [];
 
   constructor(data?: MysteryEncounterSaveData) {
-    if (!isNullOrUndefined(data)) {
+    if (!isNil(data)) {
       Object.assign(this, data);
     }
 

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -1,18 +1,26 @@
 import type { EnemyPartyConfig } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import type { PlayerPokemon } from "#app/field/player-pokemon";
-import type { PokemonMove } from "#app/field/pokemon-move";
-import type { Pokemon } from "#app/field/pokemon";
-import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import type { MysteryEncounterSpriteConfig } from "#app/field/mystery-encounter-intro";
 import MysteryEncounterIntroVisuals from "#app/field/mystery-encounter-intro";
-import { isNullOrUndefined } from "#app/utils/common-utils";
-import { capitalizeFirstLetter } from "#app/utils/string-utils";
+import type { PlayerPokemon } from "#app/field/player-pokemon";
+import type { Pokemon } from "#app/field/pokemon";
+import type { PokemonMove } from "#app/field/pokemon-move";
+import { globalScene } from "#app/global-scene";
+import { isNil } from "#app/utils/common-utils";
 import { randSeedInt } from "#app/utils/random-utils";
+import { capitalizeFirstLetter } from "#app/utils/string-utils";
+import type { BattlerIndex } from "#enums/battler-index";
+import type { Challenges } from "#enums/challenges";
+import type { EncounterAnim } from "#enums/encounter-anims";
+import type { GameModes } from "#enums/game-modes";
+import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
+import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
+import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
+import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import type { StatusEffect } from "#enums/status-effect";
-import type { OptionTextDisplay } from "./mystery-encounter-dialogue";
 import type MysteryEncounterDialogue from "./mystery-encounter-dialogue";
-import type { OptionPhaseCallback } from "./mystery-encounter-option";
+import type { OptionTextDisplay } from "./mystery-encounter-dialogue";
 import type MysteryEncounterOption from "./mystery-encounter-option";
+import type { OptionPhaseCallback } from "./mystery-encounter-option";
 import { MysteryEncounterOptionBuilder } from "./mystery-encounter-option";
 import {
   EncounterPokemonRequirement,
@@ -22,14 +30,6 @@ import {
   StatusEffectRequirement,
   WaveRangeRequirement,
 } from "./mystery-encounter-requirements";
-import type { BattlerIndex } from "#enums/battler-index";
-import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
-import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
-import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
-import type { GameModes } from "#enums/game-modes";
-import type { EncounterAnim } from "#enums/encounter-anims";
-import type { Challenges } from "#enums/challenges";
-import { globalScene } from "#app/global-scene";
 
 export interface EncounterStartOfBattleEffect {
   sourcePokemon?: Pokemon;
@@ -279,7 +279,7 @@ export default class MysteryEncounter implements IMysteryEncounter {
   private seedOffset?: number;
 
   constructor(encounter: IMysteryEncounter | null) {
-    if (!isNullOrUndefined(encounter)) {
+    if (!isNil(encounter)) {
       Object.assign(this, encounter);
     }
     this.encounterTier = this.encounterTier ?? MysteryEncounterTier.COMMON;

--- a/src/data/mystery-encounters/requirements/can-learn-move-requirement.ts
+++ b/src/data/mystery-encounters/requirements/can-learn-move-requirement.ts
@@ -1,9 +1,9 @@
-import type { MoveId } from "#enums/move-id";
+import { EncounterPokemonRequirement } from "#app/data/mystery-encounters/mystery-encounter-requirements";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
-import { isNullOrUndefined } from "#app/utils/common-utils";
-import { EncounterPokemonRequirement } from "#app/data/mystery-encounters/mystery-encounter-requirements";
 import { globalScene } from "#app/global-scene";
+import { isNil } from "#app/utils/common-utils";
+import type { MoveId } from "#enums/move-id";
 
 /**
  * {@linkcode CanLearnMoveRequirement} options
@@ -44,7 +44,7 @@ export class CanLearnMoveRequirement extends EncounterPokemonRequirement {
       .getPlayerParty()
       .filter((pkm) => (this.includeFainted ? pkm.isAllowedInChallenge() : pkm.isAllowedInBattle()));
 
-    if (isNullOrUndefined(partyPokemon) || this.requiredMoves?.length < 0) {
+    if (isNil(partyPokemon) || this.requiredMoves?.length < 0) {
       return false;
     }
 

--- a/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-dialogue-utils.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
-import type { TextStyle } from "#enums/text-style";
 import { getTextWithColors } from "#app/ui/text/text-utils";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
+import type { TextStyle } from "#enums/text-style";
 import i18next from "i18next";
 
 /**
@@ -11,7 +11,7 @@ import i18next from "i18next";
  * @param primaryStyle Can define a text style to be applied to the entire string. Must be defined for BBCodeText styles to be applied correctly
  */
 export function getEncounterText(keyOrString?: string, primaryStyle?: TextStyle): string | null {
-  if (isNullOrUndefined(keyOrString)) {
+  if (isNil(keyOrString)) {
     return null;
   }
 

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -46,7 +46,7 @@ import type { UiHandler } from "#app/ui/handlers/abstract-ui-handler";
 import type { OptionSelectUiHandler } from "#app/ui/handlers/option-select-ui-handler";
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
 import type { OptionSelectItem, OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { loadMoveAnimAssets } from "#app/utils/move-anim-utils";
 import { randomString, randSeedInt } from "#app/utils/random-utils";
 import type { AiType } from "#enums/ai-type";
@@ -161,7 +161,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
   const trainerType = partyConfig?.trainerType;
   const partyTrainerConfig = partyConfig?.trainerConfig;
   let trainerConfig: TrainerConfig;
-  if (!isNullOrUndefined(trainerType) || partyTrainerConfig) {
+  if (!isNil(trainerType) || partyTrainerConfig) {
     globalScene.currentBattle.mysteryEncounter!.encounterMode = MysteryEncounterMode.TRAINER_BATTLE;
     if (globalScene.currentBattle.trainer) {
       globalScene.currentBattle.trainer.setVisible(false);
@@ -172,7 +172,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
     const doubleTrainer = trainerConfig.doubleOnly || (trainerConfig.hasDouble && !!partyConfig.doubleBattle);
     doubleBattle = doubleTrainer;
-    const trainerFemale = isNullOrUndefined(partyConfig.female) ? !randSeedInt(2) : partyConfig.female;
+    const trainerFemale = isNil(partyConfig.female) ? !randSeedInt(2) : partyConfig.female;
     const newTrainer = new Trainer(
       trainerConfig.trainerType,
       doubleTrainer ? TrainerVariant.DOUBLE : trainerFemale ? TrainerVariant.FEMALE : TrainerVariant.DEFAULT,
@@ -212,7 +212,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
   // This can be amplified or counteracted by setting levelAdditiveModifier in config
   // levelAdditiveModifier value of 0.5 will halve the modifier scaling, 2 will double it, etc.
   // Leaving null/undefined will disable level scaling
-  const mult: number = !isNullOrUndefined(partyConfig.levelAdditiveModifier) ? partyConfig.levelAdditiveModifier : 0;
+  const mult: number = !isNil(partyConfig.levelAdditiveModifier) ? partyConfig.levelAdditiveModifier : 0;
   const additive = Math.max(Math.round((globalScene.currentBattle.waveIndex / 10) * mult), 0);
   battle.enemyLevels = battle.enemyLevels.map((level) => level + additive);
 
@@ -221,7 +221,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
     let dataSource;
     let isBoss = false;
     if (!loaded) {
-      if ((!isNullOrUndefined(trainerType) || trainerConfig) && battle.trainer) {
+      if ((!isNil(trainerType) || trainerConfig) && battle.trainer) {
         // Allows overriding a trainer's pokemon to use specific species/data
         if (partyConfig?.pokemonConfigs && e < partyConfig.pokemonConfigs.length) {
           const config = partyConfig.pokemonConfigs[e];
@@ -277,7 +277,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
       enemyPokemon.resetSummonData();
     }
 
-    if ((!loaded && isNullOrUndefined(partyConfig.countAsSeen)) || partyConfig.countAsSeen) {
+    if ((!loaded && isNil(partyConfig.countAsSeen)) || partyConfig.countAsSeen) {
       globalScene.gameData.setPokemonSeen(enemyPokemon, true, !!(trainerType || trainerConfig));
     }
 
@@ -285,7 +285,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
       const config = partyConfig.pokemonConfigs[e];
 
       // Set form
-      if (!isNullOrUndefined(config.nickname)) {
+      if (!isNil(config.nickname)) {
         enemyPokemon.nickname = btoa(unescape(encodeURIComponent(config.nickname)));
       }
 
@@ -295,31 +295,31 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
       }
 
       // Set form
-      if (!isNullOrUndefined(config.formIndex)) {
+      if (!isNil(config.formIndex)) {
         enemyPokemon.formIndex = config.formIndex;
       }
 
       // Set shiny
-      if (!isNullOrUndefined(config.shiny)) {
+      if (!isNil(config.shiny)) {
         enemyPokemon.shiny = config.shiny;
       }
 
       // Set Variant
-      if (enemyPokemon.shiny && !isNullOrUndefined(config.variant)) {
+      if (enemyPokemon.shiny && !isNil(config.variant)) {
         enemyPokemon.variant = config.variant;
       }
 
       // Set custom mystery encounter data fields (such as sprite scale, custom abilities, types, etc.)
-      if (!isNullOrUndefined(config.customPokemonData)) {
+      if (!isNil(config.customPokemonData)) {
         enemyPokemon.customPokemonData = config.customPokemonData;
       }
 
       // Set Boss
       if (config.isBoss) {
-        let segments = !isNullOrUndefined(config.bossSegments)
+        let segments = !isNil(config.bossSegments)
           ? config.bossSegments!
           : globalScene.getEncounterBossSegments(globalScene.currentBattle.waveIndex, level, enemySpecies, true);
-        if (!isNullOrUndefined(config.bossSegmentModifier)) {
+        if (!isNil(config.bossSegmentModifier)) {
           segments += config.bossSegmentModifier;
         }
         enemyPokemon.setBoss(true, segments);
@@ -359,18 +359,18 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
       }
 
       // Set ability
-      if (!isNullOrUndefined(config.abilityIndex)) {
+      if (!isNil(config.abilityIndex)) {
         enemyPokemon.abilityIndex = config.abilityIndex;
       }
 
       // Set gender
-      if (!isNullOrUndefined(config.gender)) {
+      if (!isNil(config.gender)) {
         enemyPokemon.gender = config.gender!;
         enemyPokemon.summonData.gender = config.gender;
       }
 
       // Set AI type
-      if (!isNullOrUndefined(config.aiType)) {
+      if (!isNil(config.aiType)) {
         enemyPokemon.aiType = config.aiType;
       }
 
@@ -387,7 +387,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
         tags.forEach((tag) => enemyPokemon.addTag(tag));
       }
 
-      if (!isNullOrUndefined(config.teraType) && config.teraType !== ElementalType.UNKNOWN) {
+      if (!isNil(config.teraType) && config.teraType !== ElementalType.UNKNOWN) {
         enemyPokemon.teraType = config.teraType;
         if (battle.trainer) {
           battle.trainer.config.setInstantTera(e);
@@ -959,7 +959,7 @@ export function handleMysteryEncounterBattleStartEffects() {
       let source;
       if (effect.sourcePokemon) {
         source = effect.sourcePokemon;
-      } else if (!isNullOrUndefined(effect.sourceBattlerIndex)) {
+      } else if (!isNil(effect.sourceBattlerIndex)) {
         if (effect.sourceBattlerIndex === BattlerIndex.ATTACKER) {
           source = globalScene.getEnemyField()[0];
         } else if (effect.sourceBattlerIndex === BattlerIndex.ENEMY) {

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -13,9 +13,9 @@ import {
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { speciesStarterCosts } from "#app/data/starters";
 import { getStatusEffectCatchRateMultiplier } from "#app/data/status-effect";
-import type { Pokemon } from "#app/field/pokemon";
-import type { PlayerPokemon } from "#app/field/player-pokemon";
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
+import type { PlayerPokemon } from "#app/field/player-pokemon";
+import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { PokemonHeldItemModifier } from "#app/modifier/modifier";
@@ -28,9 +28,9 @@ import type { OptionSelectUiHandler } from "#app/ui/handlers/option-select-ui-ha
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
 import type { SummaryUiHandler } from "#app/ui/handlers/summary-ui-handler";
 import type { OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
-import { isNullOrUndefined } from "#app/utils/common-utils";
-import { randSeedInt } from "#app/utils/random-utils";
+import { isNil } from "#app/utils/common-utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
+import { randSeedInt } from "#app/utils/random-utils";
 import type { AbilityId } from "#enums/ability-id";
 import type { ElementalType } from "#enums/elemental-type";
 import { Gender } from "#enums/gender";
@@ -287,7 +287,7 @@ export function getRandomSpeciesByStarterCost(
 
   if (types && types.length > 0) {
     filteredSpecies = filteredSpecies.filter(
-      (s) => types.includes(s[0].type1) || (!isNullOrUndefined(s[0].type2) && types.includes(s[0].type2)),
+      (s) => types.includes(s[0].type1) || (!isNil(s[0].type2) && types.includes(s[0].type2)),
     );
   }
 

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -17,9 +17,9 @@ import Overrides from "#app/overrides";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 import type PokemonData from "#app/system/pokemon-data";
 import { EnemyBattleInfo } from "#app/ui/components/battle-info";
-import { isBetween, isNullOrUndefined, toDmgValue } from "#app/utils/common-utils";
-import { randSeedInt, randSeedItem } from "#app/utils/random-utils";
 import { MoveLockTagTypes } from "#app/utils/battler-tag-type-utils";
+import { isBetween, isNil, toDmgValue } from "#app/utils/common-utils";
+import { randSeedInt, randSeedItem } from "#app/utils/random-utils";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { AiType } from "#enums/ai-type";
 import { BattlerIndex } from "#enums/battler-index";
@@ -86,7 +86,7 @@ export class EnemyPokemon extends Pokemon {
 
     if (
       speciesId in Overrides.ENEMY_FORM_OVERRIDES
-      && !isNullOrUndefined(Overrides.ENEMY_FORM_OVERRIDES[speciesId])
+      && !isNil(Overrides.ENEMY_FORM_OVERRIDES[speciesId])
       && this.species.forms[Overrides.ENEMY_FORM_OVERRIDES[speciesId]]
     ) {
       this.formIndex = Overrides.ENEMY_FORM_OVERRIDES[speciesId];
@@ -256,7 +256,7 @@ export class EnemyPokemon extends Pokemon {
 
             const moveTargets = getMoveTargets(this, move.id)
               .targets.map((ind) => globalScene.getFieldPokemonByBattlerIndex(ind))
-              .filter((p) => !isNullOrUndefined(p) && this.isPlayer() !== p.isPlayer()) as Pokemon[];
+              .filter((p) => !isNil(p) && this.isPlayer() !== p.isPlayer()) as Pokemon[];
             // Only considers critical hits for crit-only moves or when this Pokemon is under the effect of Laser Focus
             const isCritical = move.hasAttr(CritOnlyAttr) || this.hasTag(BattlerTagType.ALWAYS_CRIT);
 

--- a/src/field/mystery-encounter-intro.ts
+++ b/src/field/mystery-encounter-intro.ts
@@ -1,11 +1,11 @@
-import type { GameObjects } from "phaser";
-import { globalScene } from "#app/global-scene";
 import type MysteryEncounter from "#app/data/mystery-encounters/mystery-encounter";
-import type { SpeciesId } from "#enums/species-id";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { getSpriteKeysFromSpecies } from "#app/data/mystery-encounters/utils/encounter-pokemon-utils";
 import type { Variant } from "#app/data/variant";
+import { globalScene } from "#app/global-scene";
+import { isNil } from "#app/utils/common-utils";
 import { ImagesFolder } from "#enums/images-folders";
+import type { SpeciesId } from "#enums/species-id";
+import type { GameObjects } from "phaser";
 import PlayAnimationConfig = Phaser.Types.Animations.PlayAnimationConfig;
 
 export class MysteryEncounterSpriteConfig {
@@ -74,7 +74,7 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
         ...config,
       };
 
-      if (!isNullOrUndefined(result.species)) {
+      if (!isNil(result.species)) {
         const keys = getSpriteKeysFromSpecies(result.species, undefined, undefined, result.isShiny, result.variant);
         result.spriteKey = keys.spriteKey;
         result.fileRoot = keys.fileRoot;
@@ -176,12 +176,12 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
         }
       }
 
-      if (!isNullOrUndefined(pokemonShinySparkle)) {
+      if (!isNil(pokemonShinySparkle)) {
         // Offset the sparkle to match the Pokemon's position
         pokemonShinySparkle.setPosition(sprite.x, sprite.y);
       }
 
-      if (!isNullOrUndefined(alpha)) {
+      if (!isNil(alpha)) {
         sprite.setAlpha(alpha);
         tintSprite.setAlpha(alpha);
       }

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -29,7 +29,7 @@ import type PokemonData from "#app/system/pokemon-data";
 import { timedEventManager } from "#app/timed-event-manager";
 import { PlayerBattleInfo } from "#app/ui/components/battle-info";
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
-import { NumberHolder, isNullOrUndefined } from "#app/utils/common-utils";
+import { NumberHolder, isNil } from "#app/utils/common-utils";
 import { PartyFilterNonFainted } from "#app/utils/party-ui-utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
 import { AbilityId } from "#enums/ability-id";
@@ -445,7 +445,7 @@ export class PlayerPokemon extends Pokemon {
         }
 
         const type2 = this.getSpeciesForm().type2;
-        if (!isNullOrUndefined(type2) && type2 !== baseFormTypes[1]) {
+        if (!isNil(type2) && type2 !== baseFormTypes[1]) {
           if (this.customPokemonData.types.length > 1) {
             this.customPokemonData.types[1] = type2;
           } else {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -160,7 +160,7 @@ import {
   deepFreeze,
   fixedNumber,
   getEnumValues,
-  isNullOrUndefined,
+  isNil,
   toDmgValue,
   type nil,
 } from "#app/utils/common-utils";
@@ -1547,7 +1547,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (Overrides.ENEMY_ABILITY_OVERRIDE && !this.isPlayer()) {
       return allAbilities[Overrides.ENEMY_ABILITY_OVERRIDE];
     }
-    if (!isNullOrUndefined(this.customPokemonData.ability) && this.customPokemonData.ability !== -1) {
+    if (!isNil(this.customPokemonData.ability) && this.customPokemonData.ability !== -1) {
       return allAbilities[this.customPokemonData.ability];
     }
     let abilityId = this.getSpeciesForm(baseOnly).getAbility(this.abilityIndex);
@@ -1571,7 +1571,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (Overrides.ENEMY_PASSIVE_ABILITY_OVERRIDE && !this.isPlayer()) {
       return allAbilities[Overrides.ENEMY_PASSIVE_ABILITY_OVERRIDE];
     }
-    if (!isNullOrUndefined(this.customPokemonData.passive) && this.customPokemonData.passive !== -1) {
+    if (!isNil(this.customPokemonData.passive) && this.customPokemonData.passive !== -1) {
       return allAbilities[this.customPokemonData.passive];
     }
 
@@ -1766,7 +1766,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public getWeight(): number {
     const autotomizedTag = this.getTag<AutotomizedTag>(BattlerTagType.AUTOTOMIZED);
     let weightRemoved = 0;
-    if (!isNullOrUndefined(autotomizedTag)) {
+    if (!isNil(autotomizedTag)) {
       weightRemoved = 100 * autotomizedTag!.autotomizeCount;
     }
     const minWeight = 0.1;
@@ -1890,7 +1890,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     simulated: boolean = true,
     cancelled?: BooleanHolder,
   ): TypeDamageMultiplier {
-    if (!isNullOrUndefined(this.turnData?.moveEffectiveness)) {
+    if (!isNil(this.turnData?.moveEffectiveness)) {
       return this.turnData?.moveEffectiveness;
     }
 
@@ -2106,11 +2106,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (pokemonEvolutions.hasOwnProperty(this.species.speciesId)) {
       const evolutions = pokemonEvolutions[this.species.speciesId];
       for (const e of evolutions) {
-        if (
-          !e.item
-          && this.level >= e.level
-          && (isNullOrUndefined(e.preFormKey) || this.getFormKey() === e.preFormKey)
-        ) {
+        if (!e.item && this.level >= e.level && (isNil(e.preFormKey) || this.getFormKey() === e.preFormKey)) {
           if (
             e.conditions === null
             || (e.conditions as SpeciesEvolutionCondition[]).every((condition) => condition.predicate(this))

--- a/src/modifier/init-modifier-pools.ts
+++ b/src/modifier/init-modifier-pools.ts
@@ -16,7 +16,7 @@ import {
 } from "#app/modifier/modifier-pools";
 import { WeightedModifierType, type WeightedModifierTypeWeightFunc } from "#app/modifier/modifier-type";
 import { modifierTypes } from "#app/modifier/modifier-types";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { AbilityId } from "#enums/ability-id";
 import { BerryType } from "#enums/berry-type";
 import { ModifierTier } from "#enums/modifier-tier";
@@ -312,7 +312,7 @@ export function initModifierPools() {
         return party.some((p) => {
           const moveset = p
             .getMoveset(true)
-            .filter((m) => !isNullOrUndefined(m))
+            .filter((m) => !isNil(m))
             .map((m) => m.moveId);
 
           const canSetStatus = p.canSetStatus(StatusEffect.TOXIC, true, true, null, true);
@@ -355,7 +355,7 @@ export function initModifierPools() {
         return party.some((p) => {
           const moveset = p
             .getMoveset(true)
-            .filter((m) => !isNullOrUndefined(m))
+            .filter((m) => !isNil(m))
             .map((m) => m.moveId);
           const canSetStatus = p.canSetStatus(StatusEffect.BURN, true, true, null, true);
           const isHoldingOrb = p.getHeldItems().some((i) => i.type.id === "FLAME_ORB" || i.type.id === "TOXIC_ORB");

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -56,7 +56,7 @@ import { settings } from "#app/system/settings/settings-manager";
 import { getVoucherTypeIcon, getVoucherTypeName } from "#app/system/voucher";
 import { getModifierTierTextTint } from "#app/ui/text/text-utils";
 import { getBerryEffectDescription, getBerryName } from "#app/utils/berry-utils";
-import { getEnumKeys, getEnumValues, isNullOrUndefined, NumberHolder } from "#app/utils/common-utils";
+import { getEnumKeys, getEnumValues, isNil, NumberHolder } from "#app/utils/common-utils";
 import { getModifierPoolForType } from "#app/utils/modifier-pool-utils";
 import { getModifierType } from "#app/utils/modifier-type-utils";
 import { randSeedInt } from "#app/utils/random-utils";
@@ -194,7 +194,7 @@ export class ModifierType {
           if (weight > 0) {
             this.tier = modifier.modifierType.tier;
             return this;
-          } else if (isNullOrUndefined(defaultTier)) {
+          } else if (isNil(defaultTier)) {
             // If weight is 0, keep track of the first tier where the item was found
             defaultTier = modifier.modifierType.tier;
           }

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -28,8 +28,8 @@ import { EvolutionPhase } from "#app/phases/evolution-phase";
 import { LearnMovePhase } from "#app/phases/learn-move-phase";
 import { LevelUpPhase } from "#app/phases/level-up-phase";
 import { addTextObject } from "#app/ui/text/text-utils";
-import { BooleanHolder, isNullOrUndefined, NumberHolder, toDmgValue } from "#app/utils/common-utils";
 import { hslToHex } from "#app/utils/color-utils";
+import { BooleanHolder, isNil, NumberHolder, toDmgValue } from "#app/utils/common-utils";
 import { getModifierType } from "#app/utils/modifier-type-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -2117,10 +2117,7 @@ export class PokemonHpRestoreModifier extends ConsumablePokemonModifier {
    * @returns `true` if the {@linkcode PokemonHpRestoreModifier} should be applied
    */
   override shouldApply(playerPokemon?: PlayerPokemon, multiplier?: number): boolean {
-    return (
-      super.shouldApply(playerPokemon)
-      && (this.fainted || (!isNullOrUndefined(multiplier) && typeof multiplier === "number"))
-    );
+    return super.shouldApply(playerPokemon) && (this.fainted || (!isNil(multiplier) && typeof multiplier === "number"));
   }
 
   /**

--- a/src/phases/check-status-effect-phase.ts
+++ b/src/phases/check-status-effect-phase.ts
@@ -1,10 +1,10 @@
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { PostTurnStatusEffectPhase } from "#app/phases/post-turn-status-effect-phase";
-import { Stat } from "#enums/stat";
+import { isNil } from "#app/utils/common-utils";
 import { PhaseId } from "#enums/phase-id";
+import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 
 /**
  * Queues a {@linkcode PostTurnStatusEffectPhase} for every active pokemon that needs one
@@ -22,10 +22,7 @@ export class CheckStatusEffectPhase extends Phase {
       .sort((a, b) => b.getEffectiveStat(Stat.SPD) - a.getEffectiveStat(Stat.SPD));
 
     pokemon.forEach((p) => {
-      if (
-        !isNullOrUndefined(p)
-        && p.hasStatusEffect([StatusEffect.BURN, StatusEffect.POISON, StatusEffect.TOXIC], false, true)
-      ) {
+      if (!isNil(p) && p.hasStatusEffect([StatusEffect.BURN, StatusEffect.POISON, StatusEffect.TOXIC], false, true)) {
         globalScene.phaseManager.unshiftPhase(new PostTurnStatusEffectPhase(p.getBattlerIndex()));
       }
     });

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -14,8 +14,8 @@ import { FieldPhase } from "#app/phases/abstract-field-phase";
 import type { TurnCommand } from "#app/turn-command-manager";
 import type { CommandUiHandler } from "#app/ui/handlers/command-ui-handler";
 import type { FightUiHandler } from "#app/ui/handlers/fight-ui-handler";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { MoveLockTagTypes, TrappedBattlerTagTypes } from "#app/utils/battler-tag-type-utils";
+import { isNil } from "#app/utils/common-utils";
 import { isFieldTargeted } from "#app/utils/move-utils";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -292,7 +292,7 @@ export class CommandPhase extends FieldPhase {
           } else if (cursor < Object.keys(globalScene.pokeballCounts).length) {
             const targetPokemon = globalScene.getEnemyField().find((p) => p.isActive(true));
 
-            if (isNullOrUndefined(targetPokemon)) {
+            if (isNil(targetPokemon)) {
               console.warn("Enemy Pokemon is missing when trying to throw Pokeball!");
               failCatchRun("battle:noPokeballForce");
             } else if (

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -29,7 +29,7 @@ import { PostKnockoutPhase } from "#app/phases/post-knockout-phase";
 import { SwitchPhase } from "#app/phases/switch-phase";
 import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
 import { ToggleDoublePositionPhase } from "#app/phases/toggle-double-position-phase";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattleType } from "#enums/battle-type";
 import type { BattlerIndex } from "#enums/battler-index";
@@ -100,12 +100,12 @@ export class FaintPhase extends PokemonPhase {
 
     const faintPokemon = this.getPokemon();
 
-    if (!isNullOrUndefined(this.source)) {
-      if (!isNullOrUndefined(this.destinyTag)) {
+    if (!isNil(this.source)) {
+      if (!isNil(this.destinyTag)) {
         this.destinyTag.lapse(this.source, BattlerTagLapseType.CUSTOM);
       }
 
-      if (!isNullOrUndefined(this.grudgeTag)) {
+      if (!isNil(this.grudgeTag)) {
         this.grudgeTag.lapse(faintPokemon, BattlerTagLapseType.CUSTOM, this.source);
       }
     }

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -30,7 +30,7 @@ import {
   HitHealModifier,
 } from "#app/modifier/modifier";
 import { HitCheckPhase } from "#app/phases/hit-check-phase";
-import { BooleanHolder, isNullOrUndefined, NumberHolder } from "#app/utils/common-utils";
+import { BooleanHolder, isNil, NumberHolder } from "#app/utils/common-utils";
 import { applyFilteredMoveAttrs, applyMoveAttrs, isFieldTargeted } from "#app/utils/move-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
@@ -90,7 +90,7 @@ export class MoveEffectPhase extends HitCheckPhase {
       if (!isDelayedAttack) {
         return super.end();
       } else {
-        if (isNullOrUndefined(user.turnData)) {
+        if (isNil(user.turnData)) {
           user.resetTurnData();
         }
       }
@@ -305,7 +305,7 @@ export class MoveEffectPhase extends HitCheckPhase {
     /** The first target hit by the move */
     const firstTarget = target === this.getTargets().find((_, i) => this.hitChecks[i][1] > 0);
 
-    if (isNullOrUndefined(user)) {
+    if (isNil(user)) {
       return;
     }
 
@@ -433,7 +433,7 @@ export class MoveEffectPhase extends HitCheckPhase {
       (attr: MoveAttr) =>
         attr instanceof MoveEffectAttr
         && attr.trigger === triggerType
-        && (isNullOrUndefined(selfTarget) || attr.selfTarget === selfTarget)
+        && (isNil(selfTarget) || attr.selfTarget === selfTarget)
         && (!attr.firstHitOnly || this.firstHit)
         && (!attr.lastHitOnly || this.lastHit)
         && (!attr.firstTargetOnly || (firstTarget ?? true)),
@@ -681,7 +681,7 @@ export class MoveEffectPhase extends HitCheckPhase {
 
     return (
       this.move.getMove().moveTarget === MoveTarget.DRAGON_DARTS
-      && !isNullOrUndefined(targetAlly)
+      && !isNil(targetAlly)
       && targetAlly.isActive(true)
       && targetAlly !== this.getUserPokemon()
       && !target?.getTag(BattlerTagType.CENTER_OF_ATTENTION)

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -31,7 +31,7 @@ import { CommonAnimPhase } from "#app/phases/common-anim-phase";
 import { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import { MoveEndPhase } from "#app/phases/move-end-phase";
 import { ShowAbilityPhase } from "#app/phases/show-ability-phase";
-import { BooleanHolder, isNullOrUndefined, NumberHolder } from "#app/utils/common-utils";
+import { BooleanHolder, isNil, NumberHolder } from "#app/utils/common-utils";
 import { applyMoveAttrs, isFieldTargeted } from "#app/utils/move-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
@@ -440,7 +440,7 @@ export class MovePhase extends BattlePhase {
           break;
         default:
           const target = globalScene.getFieldPokemonByBattlerIndex(t);
-          if (!isNullOrUndefined(target)) {
+          if (!isNil(target)) {
             targets.push(target);
           }
           break;

--- a/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
@@ -12,7 +12,7 @@ import type { OptionSelectSettings } from "#app/data/mystery-encounters/utils/en
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import type { MysteryEncounterUiHandler } from "#app/ui/handlers/mystery-encounter-ui-handler";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { PhaseId } from "#enums/phase-id";
 import { UiMode } from "#enums/ui-mode";
 import { MysteryEncounterOptionSelectedPhase } from "./option-selected-phase";
@@ -104,7 +104,7 @@ export class MysteryEncounterPhase extends Phase {
     if (option.onPreOptionPhase) {
       globalScene.executeWithSeedOffset(async () => {
         return await option.onPreOptionPhase!().then((result) => {
-          if (isNullOrUndefined(result) || result) {
+          if (isNil(result) || result) {
             this.continueEncounter();
           }
         });

--- a/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
@@ -8,7 +8,7 @@ import { getEncounterText } from "#app/data/mystery-encounters/utils/encounter-d
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { NewBattlePhase } from "#app/phases/new-battle-phase";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { PhaseId } from "#enums/phase-id";
 /**
  * Will handle (in order):
@@ -38,7 +38,7 @@ export class PostMysteryEncounterPhase extends Phase {
       globalScene.executeWithSeedOffset(
         async () => {
           return await this.onPostOptionSelect!().then((result) => {
-            if (isNullOrUndefined(result) || result) {
+            if (isNil(result) || result) {
               this.continueEncounter();
             }
           });

--- a/src/phases/pokemon-anim-phase.ts
+++ b/src/phases/pokemon-anim-phase.ts
@@ -2,7 +2,7 @@ import type { SubstituteTag } from "#app/data/battler-tags/substitute-tag";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { BattlePhase } from "#app/phases/abstract-battle-phase";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { PhaseId } from "#enums/phase-id";
 import { PokemonAnimType } from "#enums/pokemon-anim-type";
@@ -58,7 +58,7 @@ export class PokemonAnimPhase extends BattlePhase {
     const { field, tweens } = globalScene;
 
     const substitute = this.pokemon.getTag<SubstituteTag>(BattlerTagType.SUBSTITUTE);
-    if (isNullOrUndefined(substitute)) {
+    if (isNil(substitute)) {
       return this.end();
     }
 
@@ -329,7 +329,7 @@ export class PokemonAnimPhase extends BattlePhase {
     // Note: unlike the other Commander animation, this is played through the
     // Dondozo instead of the Tatsugiri.
     const tatsugiri = this.pokemon.getAlly();
-    if (isNullOrUndefined(tatsugiri)) {
+    if (isNil(tatsugiri)) {
       console.warn("Aborting COMMANDER_REMOVE anim: Tatsugiri is undefined");
       return this.end();
     }

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -6,8 +6,8 @@ import Overrides from "#app/overrides";
 import { Phase } from "#app/phase";
 import type { SaveSlotSelectUiHandler } from "#app/ui/handlers/save-slot-select-ui-handler";
 import type { StarterSelectUiHandler } from "#app/ui/handlers/starter-select-ui-handler";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { applyChallenges } from "#app/utils/challenge-utils";
+import { isNil } from "#app/utils/common-utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
 import { ChallengeType } from "#enums/challenge-type";
 import { Gender } from "#enums/gender";
@@ -62,7 +62,7 @@ export class SelectStarterPhase extends Phase {
 
       if (
         speciesId in Overrides.STARTER_FORM_OVERRIDES
-        && !isNullOrUndefined(Overrides.STARTER_FORM_OVERRIDES[speciesId])
+        && !isNil(Overrides.STARTER_FORM_OVERRIDES[speciesId])
         && species.forms[Overrides.STARTER_FORM_OVERRIDES[speciesId]]
       ) {
         starterFormIndex = Overrides.STARTER_FORM_OVERRIDES[speciesId];
@@ -103,7 +103,7 @@ export class SelectStarterPhase extends Phase {
         starterPokemon.nickname = nickname;
       }
 
-      if (!isNullOrUndefined(starter.teraType)) {
+      if (!isNil(starter.teraType)) {
         starterPokemon.teraType = starter.teraType;
       } else {
         starterPokemon.teraType = starterPokemon.species.type1;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -13,8 +13,14 @@ import {
   bypassLogin,
 } from "#app/constants/app";
 import { EntryHazardTag } from "#app/data/arena-tag";
+import { allMoves, allSpecies } from "#app/data/data-lists";
 import { defaultStarterSpecies } from "#app/data/default-starters";
+import { AbilityAttr, DexAttr } from "#app/data/dex-attributes";
+import type { Egg } from "#app/data/egg";
 import { speciesEggMoves } from "#app/data/egg-moves";
+import { MysteryEncounterSaveData } from "#app/data/mystery-encounters/mystery-encounter-save-data";
+import { pokemonPreEvolutions } from "#app/data/pokemon-pre-evolutions";
+import type PokemonSpecies from "#app/data/pokemon-species";
 import {
   STARTER_CANDY_GAIN_FROM_CATCH,
   STARTER_CANDY_MULIPLIER_FOR_BOSS,
@@ -23,17 +29,11 @@ import {
   speciesStarterCosts,
 } from "#app/data/starters";
 import { allTrainerConfigs } from "#app/data/trainer-configs/all-trainer-configs";
-import { allMoves, allSpecies } from "#app/data/data-lists";
-import { AbilityAttr, DexAttr } from "#app/data/dex-attributes";
-import type { Egg } from "#app/data/egg";
-import { MysteryEncounterSaveData } from "#app/data/mystery-encounters/mystery-encounter-save-data";
-import { pokemonPreEvolutions } from "#app/data/pokemon-pre-evolutions";
-import type PokemonSpecies from "#app/data/pokemon-species";
 import type { Variant } from "#app/data/variant";
 import { TagAddedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#app/events/arena";
-import type { Pokemon } from "#app/field/pokemon";
-import type { PlayerPokemon } from "#app/field/player-pokemon";
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
+import type { PlayerPokemon } from "#app/field/player-pokemon";
+import type { Pokemon } from "#app/field/pokemon";
 import { getGameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
 import * as Modifier from "#app/modifier/modifier";
@@ -56,10 +56,10 @@ import {
 import { vouchers } from "#app/system/voucher";
 import type { ConfirmUiHandler } from "#app/ui/handlers/confirm-ui-handler";
 import type { ConfirmModeConfig } from "#app/ui/interfaces/confirm-menu-config";
-import { NumberHolder, executeIf, fixedNumber, getEnumKeys, isNullOrUndefined } from "#app/utils/common-utils";
-import { randInt, randSeedItem } from "#app/utils/random-utils";
 import { applyChallenges } from "#app/utils/challenge-utils";
+import { NumberHolder, executeIf, fixedNumber, getEnumKeys, isNil } from "#app/utils/common-utils";
 import { getPokemonSpecies } from "#app/utils/pokemon-utils";
+import { randInt, randSeedItem } from "#app/utils/random-utils";
 import { BattleType } from "#enums/battle-type";
 import { ChallengeType } from "#enums/challenge-type";
 import type { Device } from "#enums/devices";
@@ -697,7 +697,7 @@ export class GameData {
     if (lsItem) {
       try {
         const lsTutorials: Tutorial[] = JSON.parse(lsItem);
-        lsTutorials.forEach((lsTutorial) => (!isNullOrUndefined(lsTutorial) ? tutorials.add(lsTutorial) : null));
+        lsTutorials.forEach((lsTutorial) => (!isNil(lsTutorial) ? tutorials.add(lsTutorial) : null));
       } catch (err) {
         console.warn("Failed to parse tutorial data from local storage", err);
       }

--- a/src/system/settings/settings-manager.ts
+++ b/src/system/settings/settings-manager.ts
@@ -1,8 +1,8 @@
-import type { UserFacingSettings, SettingsCategory, Settings } from "#app/@types/Settings";
+import type { Settings, SettingsCategory, UserFacingSettings } from "#app/@types/Settings";
 import { GAME_SPEEDS, SETTINGS_LS_KEY } from "#app/constants/app";
 import { eventBus } from "#app/event-bus";
+import { isNil } from "#app/utils/common-utils";
 import { version } from "../../../package.json";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { defaultSettings } from "./default-settings";
 
 //#region Types
@@ -120,7 +120,7 @@ class SettingsManager {
       throw new Error(`Unknown category: ${category}`);
     }
 
-    if (isNullOrUndefined(this._settings[category][key])) {
+    if (isNil(this._settings[category][key])) {
       eventBus.emit("settings/update/failed", { category, key, value });
       throw new Error(`Unknown key: ${category}.${String(key)}`);
     }

--- a/src/timed-event-manager.ts
+++ b/src/timed-event-manager.ts
@@ -1,7 +1,7 @@
 import type { EventBanner, TimedEvent } from "#app/@types/TimedEvent";
 import { allTimedEvents } from "#app/data/all-timed-events";
+import { isNil } from "#app/utils/common-utils";
 import { EventModifierType } from "#enums/event-modifier-type";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 
 function isActive(event: TimedEvent) {
   return event.startDate < new Date() && new Date() < event.endDate;
@@ -56,12 +56,10 @@ class TimedEventManager {
   public isEventActive(modifier: EventModifierType): boolean {
     switch (modifier) {
       case EventModifierType.WILD_SHINY_CHANCE:
-        return this.events.some(
-          (te: TimedEvent) => isActive(te) && !isNullOrUndefined(te.modifiers?.wildShinyMultiplier),
-        );
+        return this.events.some((te: TimedEvent) => isActive(te) && !isNil(te.modifiers?.wildShinyMultiplier));
       case EventModifierType.CLASSIC_CANDY_FRIENDSHIP_MULTIPLIER:
         return this.events.some(
-          (te: TimedEvent) => isActive(te) && !isNullOrUndefined(te.modifiers?.classicCandyFriendshipMultiplier),
+          (te: TimedEvent) => isActive(te) && !isNil(te.modifiers?.classicCandyFriendshipMultiplier),
         );
       case EventModifierType.EXTRA_TRAINER_REWARDS:
         return this.events.some((te: TimedEvent) => isActive(te) && te.modifiers?.specialBattleRewards);

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -13,7 +13,7 @@ import { MoveHeaderPhase } from "#app/phases/move-header-phase";
 import { MovePhase } from "#app/phases/move-phase";
 import { SwitchSummonPhase } from "#app/phases/switch-summon-phase";
 import { TerastallizationPhase } from "#app/phases/terastallization-phase";
-import { BooleanHolder, isNullOrUndefined } from "#app/utils/common-utils";
+import { BooleanHolder, isNil } from "#app/utils/common-utils";
 import { randSeedShuffle } from "#app/utils/random-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
@@ -388,7 +388,7 @@ export class TurnCommandManager {
   private handleBallCommand(turnCommand: TurnCommand): boolean {
     const { cursor, targets } = turnCommand;
 
-    if (isNullOrUndefined(cursor) || isNullOrUndefined(targets)) {
+    if (isNil(cursor) || isNil(targets)) {
       console.error("Error encountered when trying to throw Pokeball!");
       console.error(turnCommand);
       return false;
@@ -400,7 +400,7 @@ export class TurnCommandManager {
 
   private handlePokemonCommand(turnCommand: TurnCommand): boolean {
     const { pokemon, cursor } = turnCommand;
-    if (isNullOrUndefined(cursor)) {
+    if (isNil(cursor)) {
       console.error("Error encountered when trying to switch Pokemon!");
       console.error(turnCommand);
       return false;

--- a/src/ui/components/arena-flyout.ts
+++ b/src/ui/components/arena-flyout.ts
@@ -1,23 +1,23 @@
-import { addTextObject } from "#app/ui/text/text-utils";
-import { TextStyle } from "#enums/text-style";
-import { globalScene } from "#app/global-scene";
 import { EntryHazardTag } from "#app/data/arena-tag";
-import { ArenaTagSide } from "#enums/arena-tag-side";
-import { WeatherType } from "#enums/weather-type";
-import { TerrainType } from "#enums/terrain-type";
-import { addWindow } from "../ui-theme";
-import { WindowVariant } from "#enums/window-variant";
 import type { ArenaEvent } from "#app/events/arena";
 import { TagAddedEvent, TagRemovedEvent, TerrainChangedEvent, WeatherChangedEvent } from "#app/events/arena";
-import { ArenaEventType } from "#enums/arena-event-type";
-import type { TurnEndEvent } from "../../events/battle-scene";
-import { BattleSceneEventType } from "#enums/battle-scene-event-type";
-import { ArenaTagType } from "#enums/arena-tag-type";
-import { TimeOfDayWidget } from "./time-of-day-widget";
-import { fixedNumber, isNullOrUndefined } from "#app/utils/common-utils";
+import { globalScene } from "#app/global-scene";
+import { addTextObject } from "#app/ui/text/text-utils";
+import { fixedNumber, isNil } from "#app/utils/common-utils";
 import { toCamelCaseString, toTitleCase } from "#app/utils/string-utils";
+import { ArenaEventType } from "#enums/arena-event-type";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattleSceneEventType } from "#enums/battle-scene-event-type";
+import { TerrainType } from "#enums/terrain-type";
+import { TextStyle } from "#enums/text-style";
+import { WeatherType } from "#enums/weather-type";
+import { WindowVariant } from "#enums/window-variant";
 import type { ParseKeys } from "i18next";
 import i18next from "i18next";
+import type { TurnEndEvent } from "../../events/battle-scene";
+import { addWindow } from "../ui-theme";
+import { TimeOfDayWidget } from "./time-of-day-widget";
 
 /** Enum used to differentiate {@linkcode Arena} effects */
 enum ArenaEffectType {
@@ -360,7 +360,7 @@ export class ArenaFlyout extends Phaser.GameObjects.Container {
    * @param oldName - The name of the previous weather or terrain
    */
   private insertFieldEffectInfo(newInfo: ArenaEffectInfo, oldName: string): void {
-    if (isNullOrUndefined(newInfo.name)) {
+    if (isNil(newInfo.name)) {
       return;
     }
     const foundIndex = this.fieldEffectInfo.findIndex((info) => [newInfo.name, oldName].includes(info.name));

--- a/src/ui/handlers/abstract-option-select-ui-handler.ts
+++ b/src/ui/handlers/abstract-option-select-ui-handler.ts
@@ -1,12 +1,12 @@
-import { globalScene } from "#app/global-scene";
 import { GAME_WIDTH, TEXT_SCALE } from "#app/constants/ui";
+import { globalScene } from "#app/global-scene";
 import { ScrollBar } from "#app/ui/components/scroll-bar";
 import { MessageUiHandler } from "#app/ui/handlers/message-ui-handler";
 import type { OptionSelectItem, OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
 import type { UIOptionSelectItem } from "#app/ui/interfaces/option-select-ui-item";
 import { addBBCodeTextObject, getBBCodeFragment } from "#app/ui/text/text-utils";
 import { addWindow } from "#app/ui/ui-theme";
-import { fixedNumber, isNullOrUndefined } from "#app/utils/common-utils";
+import { fixedNumber, isNil } from "#app/utils/common-utils";
 import { Button } from "#enums/buttons";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
@@ -245,7 +245,7 @@ export abstract class AbstractOptionSelectUiHandler<T extends OptionSelectItem> 
         const neededSpaces = Math.ceil(maxIconWidth / singleSpaceWidth);
         label = label.padStart(label.length + neededSpaces);
         // Change the label color to fit the required text style
-        if (!isNullOrUndefined(option.color) && option.color !== DEFAULT_TEXT_STYLE) {
+        if (!isNil(option.color) && option.color !== DEFAULT_TEXT_STYLE) {
           label = getBBCodeFragment(label, option.color, true);
         }
       }
@@ -373,7 +373,7 @@ export abstract class AbstractOptionSelectUiHandler<T extends OptionSelectItem> 
       if (success) {
         // handle hover code if the option has a handler for it
         const newOption = this.getCurrentOption();
-        if (!isNullOrUndefined(newOption.onHover)) {
+        if (!isNil(newOption.onHover)) {
           newOption.onHover();
         }
       }

--- a/src/ui/handlers/message-ui-handler.ts
+++ b/src/ui/handlers/message-ui-handler.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { addTextObject } from "#app/ui/text/text-utils";
-import { getFrameMs, isNullOrUndefined } from "#app/utils/common-utils";
+import { getFrameMs, isNil } from "#app/utils/common-utils";
 import { TextStyle } from "#enums/text-style";
 import type { UiMode } from "#enums/ui-mode";
 import { AwaitableUiHandler } from "./awaitable-ui-handler";
@@ -44,7 +44,7 @@ export abstract class MessageUiHandler extends AwaitableUiHandler {
     prompt?: boolean | null,
     promptDelay?: number | null,
   ) {
-    if (isNullOrUndefined(text)) {
+    if (isNil(text)) {
       console.error(`Missing text parameter in ${this.constructor.name}#showText(), please report this`);
     }
     this.showTextInternal(text, delay, callback, callbackDelay, prompt, promptDelay);

--- a/src/ui/handlers/modifier-select-ui-handler.ts
+++ b/src/ui/handlers/modifier-select-ui-handler.ts
@@ -1,3 +1,4 @@
+import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui";
 import { allMoves } from "#app/data/data-lists";
 import { getPokeballAtlasKey } from "#app/data/pokeball";
 import { globalScene } from "#app/global-scene";
@@ -7,10 +8,9 @@ import { getPlayerShopModifierTypeOptionsForWave, TmModifierType } from "#app/mo
 import Overrides from "#app/overrides";
 import { settings } from "#app/system/settings/settings-manager";
 import { handleTutorial } from "#app/tutorial";
-import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui";
 import { MoveInfoOverlay } from "#app/ui/components/move-info-overlay";
 import { addTextObject, getModifierTierTextTint, setTextColor } from "#app/ui/text/text-utils";
-import { isNullOrUndefined, NumberHolder } from "#app/utils/common-utils";
+import { isNil, NumberHolder } from "#app/utils/common-utils";
 import { formatMoney } from "#app/utils/string-utils";
 import { Button } from "#enums/buttons";
 import { ModifierTier } from "#enums/modifier-tier";
@@ -175,7 +175,7 @@ export class ModifierSelectUiHandler extends AwaitableUiHandler {
       return false;
     }
 
-    if (isNullOrUndefined(typeOptions) || isNullOrUndefined(actionCallback) || isNullOrUndefined(rerollCost)) {
+    if (isNil(typeOptions) || isNil(actionCallback) || isNil(rerollCost)) {
       return false;
     }
 

--- a/src/ui/handlers/mystery-encounter-ui-handler.ts
+++ b/src/ui/handlers/mystery-encounter-ui-handler.ts
@@ -1,13 +1,13 @@
+import { CANVAS_SCALE, GAME_WIDTH, TEXT_SCALE } from "#app/constants/ui";
 import type MysteryEncounterOption from "#app/data/mystery-encounters/mystery-encounter-option";
 import { getEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import type { OptionSelectSettings } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { getPokeballAtlasKey } from "#app/data/pokeball";
 import { globalScene } from "#app/global-scene";
 import type { MysteryEncounterPhase } from "#app/phases/mystery-encounter-phases/mystery-encounter-phase";
-import { CANVAS_SCALE, GAME_WIDTH, TEXT_SCALE } from "#app/constants/ui";
 import { addBBCodeTextObject, addTextObject, getBBCodeFragment } from "#app/ui/text/text-utils";
 import { addWindow } from "#app/ui/ui-theme";
-import { fixedNumber, isNullOrUndefined } from "#app/utils/common-utils";
+import { fixedNumber, isNil } from "#app/utils/common-utils";
 import { Button } from "#enums/buttons";
 import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
@@ -122,10 +122,10 @@ export class MysteryEncounterUiHandler extends UiHandler {
 
   override show(settings?: OptionSelectSettings): boolean {
     this.overrideSettings = settings;
-    const showDescriptionContainer = isNullOrUndefined(this.overrideSettings?.hideDescription)
+    const showDescriptionContainer = isNil(this.overrideSettings?.hideDescription)
       ? true
       : !this.overrideSettings.hideDescription;
-    const slideInDescription = isNullOrUndefined(this.overrideSettings?.slideInDescription)
+    const slideInDescription = isNil(this.overrideSettings?.slideInDescription)
       ? true
       : this.overrideSettings.slideInDescription;
     const startingCursorIndex = this.overrideSettings?.startingCursorIndex ?? 0;
@@ -587,7 +587,7 @@ export class MysteryEncounterUiHandler extends UiHandler {
     }
     this.tooltipContainer.setVisible(true);
 
-    if (isNullOrUndefined(cursor) || cursor > this.optionsContainer.length - 2) {
+    if (isNil(cursor) || cursor > this.optionsContainer.length - 2) {
       // Ignore hovers on view party button
       // Hide dex progress if visible
       this.showHideDexProgress(false);

--- a/src/ui/handlers/party-ui-handler.ts
+++ b/src/ui/handlers/party-ui-handler.ts
@@ -3,6 +3,7 @@ import type { PartySelectCallback } from "#app/@types/PartySelectCallback";
 import type { PokemonModifierTransferSelectFilter } from "#app/@types/PokemonModifierTransferSelectFilter";
 import type { PokemonMoveSelectFilter } from "#app/@types/PokemonMoveSelectFilter";
 import type { PokemonSelectFilter } from "#app/@types/PokemonSelectFilter";
+import { GAME_WIDTH } from "#app/constants/ui";
 import { allMoves } from "#app/data/data-lists";
 import { getGenderSymbol, getGenderTextStyle } from "#app/data/gender";
 import { pokemonEvolutions } from "#app/data/init/init-pokemon-evolutions";
@@ -16,7 +17,6 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import type { PokemonFormChangeItemModifier, PokemonHeldItemModifier } from "#app/modifier/modifier";
 import type { CommandPhase } from "#app/phases/command-phase";
 import type { SelectModifierPhase } from "#app/phases/select-modifier-phase";
-import { GAME_WIDTH } from "#app/constants/ui";
 import { MoveInfoOverlay } from "#app/ui/components/move-info-overlay";
 import type { CommandUiHandler } from "#app/ui/handlers/command-ui-handler";
 import type { ConfirmUiHandler } from "#app/ui/handlers/confirm-ui-handler";
@@ -27,11 +27,11 @@ import { PokemonIconAnimHelper } from "#app/ui/helpers/pokemon-icon-anim-helper"
 import type { ConfirmModeConfig } from "#app/ui/interfaces/confirm-menu-config";
 import { addBBCodeTextObject, addTextObject, getBBCodeFragment, setTextColor } from "#app/ui/text/text-utils";
 import { addWindow } from "#app/ui/ui-theme";
-import { BooleanHolder, isNullOrUndefined } from "#app/utils/common-utils";
-import { toReadableString } from "#app/utils/string-utils";
 import { applyChallenges } from "#app/utils/challenge-utils";
+import { BooleanHolder, isNil } from "#app/utils/common-utils";
 import { FilterAllMoves } from "#app/utils/move-utils";
 import { PartyFilterAll } from "#app/utils/party-ui-utils";
+import { toReadableString } from "#app/utils/string-utils";
 import { BattleCommand } from "#enums/battle-command";
 import { Button } from "#enums/buttons";
 import { ChallengeType } from "#enums/challenge-type";
@@ -216,7 +216,7 @@ export class PartyUiHandler extends MessageUiHandler {
     tmMoveId: MoveId = MoveId.NONE,
     showMovePP: boolean = false,
   ): boolean {
-    if (this.active || isNullOrUndefined(mode)) {
+    if (this.active || isNil(mode)) {
       return false;
     }
 

--- a/src/ui/handlers/run-history-ui-handler.ts
+++ b/src/ui/handlers/run-history-ui-handler.ts
@@ -1,11 +1,11 @@
+import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui";
 import { globalScene } from "#app/global-scene";
 import type { RunEntry } from "#app/system/game-data";
 import type PokemonData from "#app/system/pokemon-data";
 import { settings } from "#app/system/settings/settings-manager";
-import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui";
 import { addTextObject } from "#app/ui/text/text-utils";
 import { addWindow } from "#app/ui/ui-theme";
-import { fixedNumber, isNullOrUndefined } from "#app/utils/common-utils";
+import { fixedNumber, isNil } from "#app/utils/common-utils";
 import { getPokemonLevelText } from "#app/utils/string-utils";
 import { BattleType } from "#enums/battle-type";
 import { Button } from "#enums/buttons";
@@ -324,7 +324,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
         this.add(enemyContainer);
       } else if (
         (data.battleType === BattleType.TRAINER || data.battleType === BattleType.MYSTERY_ENCOUNTER)
-        && !isNullOrUndefined(data.trainer)
+        && !isNil(data.trainer)
       ) {
         // Defeats from Trainers show the trainer's title and name
         const tObj = data.trainer.toTrainer();

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -15,7 +15,7 @@ import { DEFAULT_LANGUAGE_KEY } from "#app/system/settings/supported-languages";
 import { UiHandler } from "#app/ui/handlers/abstract-ui-handler";
 import { addBBCodeTextObject, addTextObject, getBBCodeFragment } from "#app/ui/text/text-utils";
 import { addWindow } from "#app/ui/ui-theme";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import {
   formatLargeNumberFixedDigits,
   formatMoney,
@@ -303,7 +303,7 @@ export class RunInfoUiHandler extends UiHandler {
       } else if (this.runInfo.enemyParty.length === 2) {
         this.parseWildDoubleDefeat(enemyContainer);
       }
-    } else if (this.runInfo.battleType === BattleType.TRAINER && !isNullOrUndefined(this.runInfo.trainer)) {
+    } else if (this.runInfo.battleType === BattleType.TRAINER && !isNil(this.runInfo.trainer)) {
       this.showTrainerSprites(enemyContainer);
       const row_limit = 3;
       this.runInfo.enemyParty.forEach((p, i) => {
@@ -436,7 +436,7 @@ export class RunInfoUiHandler extends UiHandler {
    */
   private showTrainerSprites(enemyContainer: Phaser.GameObjects.Container) {
     const { trainer } = this.runInfo;
-    if (isNullOrUndefined(trainer)) {
+    if (isNil(trainer)) {
       console.warn("Missing TrainerData in session data, cannot render trainer sprites");
       return;
     }

--- a/src/ui/handlers/save-slot-select-ui-handler.ts
+++ b/src/ui/handlers/save-slot-select-ui-handler.ts
@@ -10,7 +10,7 @@ import type { RunInfoUiHandler } from "#app/ui/handlers/run-info-ui-handler";
 import type { ConfirmModeConfig } from "#app/ui/interfaces/confirm-menu-config";
 import { addTextObject } from "#app/ui/text/text-utils";
 import { addWindow } from "#app/ui/ui-theme";
-import { fixedNumber, isNullOrUndefined } from "#app/utils/common-utils";
+import { fixedNumber, isNil } from "#app/utils/common-utils";
 import { getPlayTimeString, getPokemonLevelText } from "#app/utils/string-utils";
 import { Button } from "#enums/buttons";
 import { RunDisplayMode } from "#enums/run-display-mode";
@@ -273,7 +273,7 @@ export class SaveSlotSelectUiHandler extends MessageUiHandler {
       }
       this.setArrowVisibility(hasData);
     }
-    if (!isNullOrUndefined(prevSlotIndex)) {
+    if (!isNil(prevSlotIndex)) {
       this.revertSessionSlot(prevSlotIndex);
     }
 

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -57,7 +57,7 @@ import { addBBCodeTextObject, addTextObject, setTextColor } from "#app/ui/text/t
 import { addWindow } from "#app/ui/ui-theme";
 import { applyChallenges } from "#app/utils/challenge-utils";
 import { rgbHexToRgba } from "#app/utils/color-utils";
-import { BooleanHolder, NumberHolder, fixedNumber, isNullOrUndefined } from "#app/utils/common-utils";
+import { BooleanHolder, NumberHolder, fixedNumber, isNil } from "#app/utils/common-utils";
 import { getPokemonSpeciesForm, getPokerusStarters } from "#app/utils/pokemon-utils";
 import { capitalizeString, leftPad, toReadableString } from "#app/utils/string-utils";
 import { AbilityId } from "#enums/ability-id";
@@ -2057,7 +2057,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
           case Button.CYCLE_TERA:
             if (this.canCycleTera) {
               const speciesForm = getPokemonSpeciesForm(this.lastSpecies.speciesId, starterAttributes.form ?? 0);
-              if (speciesForm.type1 === this.teraCursor && !isNullOrUndefined(speciesForm.type2)) {
+              if (speciesForm.type1 === this.teraCursor && !isNil(speciesForm.type2)) {
                 starterAttributes.teraType = speciesForm.type2;
                 this.setSpeciesDetails(this.lastSpecies, { teraType: speciesForm.type2 });
               } else {
@@ -2231,7 +2231,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       return this.toggleShinyState(starterPrefs);
     } else if (props.shiny && this.canCycleVariant) {
       // Find next unlocked variant
-      const previousVariant = isNullOrUndefined(starterPrefs.variant) ? props.variant : starterPrefs.variant;
+      const previousVariant = isNil(starterPrefs.variant) ? props.variant : starterPrefs.variant;
       let variant = previousVariant;
       do {
         variant = (variant + 1) % 3;
@@ -2240,7 +2240,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
           // we disable shiny state instead of looking through the other variants
           return this.toggleShinyState(starterPrefs);
         }
-        if (!isNullOrUndefined(this.speciesStarterDexEntry)) {
+        if (!isNil(this.speciesStarterDexEntry)) {
           if (variant === 0 && this.speciesStarterDexEntry.caughtAttr & DexAttr.DEFAULT_VARIANT) {
             return this.switchToVariant(starterPrefs, variant);
           } else if (variant === 1 && this.speciesStarterDexEntry.caughtAttr & DexAttr.VARIANT_2) {
@@ -3272,10 +3272,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     // We will only update the sprite if there is a change to form, shiny/variant
     // or gender for species with gender sprite differences
     const shouldUpdateSprite =
-      (species?.genderDiffs && !isNullOrUndefined(female))
-      || !isNullOrUndefined(formIndex)
-      || !isNullOrUndefined(shiny)
-      || !isNullOrUndefined(variant);
+      (species?.genderDiffs && !isNil(female)) || !isNil(formIndex) || !isNil(shiny) || !isNil(variant);
 
     if (this.activeTooltip === "CANDY") {
       if (this.lastSpecies && this.pokemonCandyContainer.visible) {
@@ -3311,7 +3308,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       );
       this.abilityCursor = abilityIndex !== undefined ? abilityIndex : (abilityIndex = oldAbilityIndex);
       this.natureCursor = natureIndex !== undefined ? natureIndex : (natureIndex = oldNatureIndex);
-      this.teraCursor = !isNullOrUndefined(teraType) ? teraType : (teraType = oldTeraType);
+      this.teraCursor = !isNil(teraType) ? teraType : (teraType = oldTeraType);
       const [isInParty, partyIndex]: [boolean, number] = this.isInParty(species);
       if (isInParty) {
         this.updatePartyIcon(species, partyIndex);
@@ -3456,7 +3453,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         this.canCycleTera =
           !this.statsMode
           // && globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id)
-          && !isNullOrUndefined(getPokemonSpeciesForm(species.speciesId, formIndex ?? 0).type2);
+          && !isNil(getPokemonSpeciesForm(species.speciesId, formIndex ?? 0).type2);
       }
 
       if (dexEntry.caughtAttr && species.malePercent !== null) {
@@ -3588,7 +3585,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
           return this.starterMoveset?.indexOf(move) === i;
         }) as StarterMoveset;
 
-        if (!isNullOrUndefined(formIndex)) {
+        if (!isNil(formIndex)) {
           // If we're switching form and the Pokemon is in the team, we need to update its moveset
           this.updateSelectedStarterMoveset(species.speciesId);
         }
@@ -4069,7 +4066,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     this.canCycleTera =
       !this.statsMode
       // && globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id)
-      && !isNullOrUndefined(getPokemonSpeciesForm(this.lastSpecies.speciesId, formIndex ?? 0).type2);
+      && !isNil(getPokemonSpeciesForm(this.lastSpecies.speciesId, formIndex ?? 0).type2);
     this.updateInstructions();
   }
 

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -20,7 +20,7 @@ import { UiHandler } from "#app/ui/handlers/abstract-ui-handler";
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
 import { addBBCodeTextObject, addTextObject, getBBCodeFragment, setTextColor } from "#app/ui/text/text-utils";
 import { rgbHexToRgba } from "#app/utils/color-utils";
-import { fixedNumber, getEnumValues, isNullOrUndefined } from "#app/utils/common-utils";
+import { fixedNumber, getEnumValues, isNil } from "#app/utils/common-utils";
 import { formatStat, leftPad, toReadableString } from "#app/utils/string-utils";
 import { Button } from "#enums/buttons";
 import { ElementalType } from "#enums/elemental-type";
@@ -424,7 +424,7 @@ export class SummaryUiHandler extends UiHandler {
         break;
     }
 
-    const fromSummary = !isNullOrUndefined(pageOrMove);
+    const fromSummary = !isNil(pageOrMove);
 
     let statusTextKey: string | undefined;
     if (this.pokemon.isFainted()) {
@@ -799,7 +799,7 @@ export class SummaryUiHandler extends UiHandler {
         }
 
         if (
-          !isNullOrUndefined(this.pokemon) /*
+          !isNil(this.pokemon) /*
           && globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id) */
         ) {
           const teraIcon = globalScene.add.sprite(123, 26, "button_tera");

--- a/src/ui/handlers/target-select-ui-handler.ts
+++ b/src/ui/handlers/target-select-ui-handler.ts
@@ -2,7 +2,7 @@ import { getMoveTargets } from "#app/data/moves/move";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import type { ModifierBar } from "#app/modifier/modifier";
-import { fixedNumber, isNullOrUndefined } from "#app/utils/common-utils";
+import { fixedNumber, isNil } from "#app/utils/common-utils";
 import { isFieldTargeted } from "#app/utils/move-utils";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -70,7 +70,7 @@ export class TargetSelectUiHandler extends UiHandler {
    * @param user the Pokemon using the move
    */
   resetCursor(cursorN: number, user: Pokemon): void {
-    if (!isNullOrUndefined(cursorN)) {
+    if (!isNil(cursorN)) {
       if ([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2].includes(cursorN) || user.battleSummonData.waveTurnCount === 1) {
         // Reset cursor on the first turn of a fight or if an ally was targeted last turn
         cursorN = -1;
@@ -89,11 +89,11 @@ export class TargetSelectUiHandler extends UiHandler {
       this.targetSelectCallback(button === Button.ACTION ? targetIndexes : []);
       success = true;
       if (this.fieldIndex === BattlerIndex.PLAYER) {
-        if (isNullOrUndefined(this.cursor0) || this.cursor0 !== this.cursor) {
+        if (isNil(this.cursor0) || this.cursor0 !== this.cursor) {
           this.cursor0 = this.cursor;
         }
       } else if (this.fieldIndex === BattlerIndex.PLAYER_2) {
-        if (isNullOrUndefined(this.cursor1) || this.cursor1 !== this.cursor) {
+        if (isNil(this.cursor1) || this.cursor1 !== this.cursor) {
           this.cursor1 = this.cursor;
         }
       }
@@ -133,9 +133,7 @@ export class TargetSelectUiHandler extends UiHandler {
 
   /** @returns all valid target {@linkcode Pokemon} for the current target selection */
   protected getTargetsByIndex(): Pokemon[] {
-    return this.targets
-      .map((index) => globalScene.getFieldPokemonByBattlerIndex(index))
-      .filter((p) => !isNullOrUndefined(p));
+    return this.targets.map((index) => globalScene.getFieldPokemonByBattlerIndex(index)).filter((p) => !isNil(p));
   }
 
   /** @returns the {@linkcode Pokemon} to highlight based on the move's targeting */

--- a/src/ui/handlers/test-dialogue-ui-handler.ts
+++ b/src/ui/handlers/test-dialogue-ui-handler.ts
@@ -1,6 +1,6 @@
 import type { InputFieldConfig, ModalConfig } from "#app/ui/interfaces/modal-config";
 import type { OptionSelectItem, OptionSelectModeConfig } from "#app/ui/interfaces/option-select-config";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { UiMode } from "#enums/ui-mode";
 import i18next from "i18next";
 import type { AutoCompleteUiHandler } from "./autocomplete-ui-handler";
@@ -21,7 +21,7 @@ export class TestDialogueUiHandler extends FormModalUiHandler {
         .map((t, i) => {
           const value = Object.values(object)[i];
 
-          if (typeof value === "object" && !isNullOrUndefined(value)) {
+          if (typeof value === "object" && !isNil(value)) {
             // we check for not null or undefined here because if the language json file has a null key, the typeof will still be an object, but that object will be null, causing issues
             // If the value is an object, execute the same process
             // si el valor es un objeto ejecuta el mismo proceso
@@ -29,7 +29,7 @@ export class TestDialogueUiHandler extends FormModalUiHandler {
             return flattenKeys(value, topKey ?? t, topKey ? (midleKey ? [...midleKey, t] : [t]) : undefined).filter(
               (t) => t.length > 0,
             );
-          } else if (typeof value === "string" || isNullOrUndefined(value)) {
+          } else if (typeof value === "string" || isNil(value)) {
             // we check for null or undefined here as per above - the typeof is still an object but the value is null so we need to exit out of this and pass the null key
 
             // Return in the format expected by i18next
@@ -113,7 +113,7 @@ export class TestDialogueUiHandler extends FormModalUiHandler {
             handler: () => {
               // this is here to make sure that if you try to backspace then enter, the last known evt.data (backspace) is picked up
               // this is because evt.data is null for backspace, so without this, the autocomplete windows just closes
-              if (!isNullOrUndefined(evt.data) || evt.inputType?.toLowerCase() === "deletecontentbackward") {
+              if (!isNil(evt.data) || evt.inputType?.toLowerCase() === "deletecontentbackward") {
                 const separatedArray = inputObject.text.split(" ");
                 separatedArray[separatedArray.length - 1] = value;
                 inputObject.setText(separatedArray.join(" "));

--- a/src/ui/settings/abstract-settings-ui-handler.ts
+++ b/src/ui/settings/abstract-settings-ui-handler.ts
@@ -1,8 +1,8 @@
 import type { SettingsCategory, SettingsUiItem } from "#app/@types/Settings";
+import { GAME_HEIGHT, GAME_WIDTH, TEXT_SCALE } from "#app/constants/ui";
 import { eventBus } from "#app/event-bus";
 import { globalScene } from "#app/global-scene";
 import { settings as settingsManager } from "#app/system/settings/settings-manager";
-import { GAME_HEIGHT, GAME_WIDTH, TEXT_SCALE } from "#app/constants/ui";
 import { ScrollBar } from "#app/ui/components/scroll-bar";
 import type { ConfirmUiHandler } from "#app/ui/handlers/confirm-ui-handler";
 import { MessageUiHandler } from "#app/ui/handlers/message-ui-handler";
@@ -11,8 +11,8 @@ import type { InputsIcons } from "#app/ui/settings/abstract-control-settings-ui-
 import { NavigationManager, NavigationMenu } from "#app/ui/settings/navigation-menu";
 import { addTextObject, setTextColor } from "#app/ui/text/text-utils";
 import { addWindow } from "#app/ui/ui-theme";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { hasTouchscreen } from "#app/utils/app-utils";
+import { isNil } from "#app/utils/common-utils";
 import { capitalizeFirstLetter } from "#app/utils/string-utils";
 import { Button } from "#enums/buttons";
 import { TextStyle } from "#enums/text-style";
@@ -337,7 +337,7 @@ export class AbstractSettingsUiHandler extends MessageUiHandler {
           }
           break;
         case Button.LEFT:
-          if (!isNullOrUndefined(optionCursor)) {
+          if (!isNil(optionCursor)) {
             // Moves the option cursor left (wrapping)
             if (uiItem.doWrap) {
               success = this.setOptionCursor(cursor, Wrap(optionCursor - 1, 0, maxOptionCursor), true);
@@ -348,7 +348,7 @@ export class AbstractSettingsUiHandler extends MessageUiHandler {
           break;
         case Button.RIGHT:
           // Moves the option cursor right (wrapping)
-          if (!isNullOrUndefined(optionCursor)) {
+          if (!isNil(optionCursor)) {
             if (uiItem.doWrap) {
               success = this.setOptionCursor(cursor, Wrap(optionCursor + 1, 0, maxOptionCursor), true);
             } else if (optionCursor < optionLabels.length - 1) {

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -118,7 +118,8 @@ export function deepCopy<T>(obj: T): T {
   return Phaser.Utils.Objects.DeepCopy(obj as unknown as object) as T;
 }
 
-export function isNullOrUndefined(obj: any): obj is null | undefined {
+/** @returns Whether the input is `null` or `undefined` */
+export function isNil(obj: any): obj is null | undefined {
   return null === obj || undefined === obj;
 }
 

--- a/src/utils/pokemon-utils.ts
+++ b/src/utils/pokemon-utils.ts
@@ -3,7 +3,7 @@ import type PokemonSpecies from "#app/data/pokemon-species";
 import type { PokemonSpeciesForm } from "#app/data/pokemon-species-form";
 import { POKERUS_STARTER_COUNT, speciesStarterCosts } from "#app/data/starters";
 import { globalScene } from "#app/global-scene";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { randSeedInt, randSeedItem } from "#app/utils/random-utils";
 import { SpeciesGroups } from "#enums/pokemon-species-groups";
 import { SpeciesId } from "#enums/species-id";
@@ -51,7 +51,7 @@ export function getSpecialSpeciesList(group: SpeciesGroups, includeLegends?: boo
         return s.speciesId;
       }
     })
-    .filter((s) => !isNullOrUndefined(s));
+    .filter((s) => !isNil(s));
 
   if (includeLegends && group === SpeciesGroups.ULTRA_BEAST) {
     speciesList.push(SpeciesId.COSMOG, SpeciesId.COSMOEM, SpeciesId.LUNALA, SpeciesId.SOLGALEO, SpeciesId.NECROZMA);
@@ -96,7 +96,7 @@ export function getPokerusStarters(): PokemonSpecies[] {
  * @todo Just generate 6 random numbers instead of doing this nonsense; also make pokemon IDs into actual UUIDs
  */
 export function getIvsFromId(id?: number): number[] {
-  if (isNullOrUndefined(id)) {
+  if (isNil(id)) {
     id = randSeedInt(4294967296);
   }
 

--- a/test/eggs/egg.test.ts
+++ b/test/eggs/egg.test.ts
@@ -1,8 +1,8 @@
-import { speciesEggTiers } from "#app/data/species-egg-tiers";
 import { allSpecies } from "#app/data/data-lists";
 import { Egg, getLegendaryGachaSpeciesForTimestamp, getValidLegendaryGachaSpecies } from "#app/data/egg";
+import { speciesEggTiers } from "#app/data/species-egg-tiers";
+import { isNil } from "#app/utils/common-utils";
 import * as RandomUtils from "#app/utils/random-utils";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import { EggSourceType } from "#enums/egg-source-types";
 import { EggTier } from "#enums/egg-type";
 import { SpeciesId } from "#enums/species-id";
@@ -144,7 +144,7 @@ describe("Egg Generation Tests", () => {
   it("should return an egg with an egg move index of 0, 1, 2 or 3", () => {
     const eggMoveIndex = new Egg({ sourceType: EggSourceType.EVENT }).eggMoveIndex;
 
-    const result = !isNullOrUndefined(eggMoveIndex) && eggMoveIndex >= 0 && eggMoveIndex <= 3;
+    const result = !isNil(eggMoveIndex) && eggMoveIndex >= 0 && eggMoveIndex <= 3;
 
     expect(result).toBeTruthy();
   });

--- a/test/mystery-encounter/encounter-test-utils.ts
+++ b/test/mystery-encounter/encounter-test-utils.ts
@@ -9,7 +9,7 @@ import type { MessageUiHandler } from "#app/ui/handlers/message-ui-handler";
 import type { MysteryEncounterUiHandler } from "#app/ui/handlers/mystery-encounter-ui-handler";
 import type { OptionSelectUiHandler } from "#app/ui/handlers/option-select-ui-handler";
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import { Button } from "#enums/buttons";
 import { UiMode } from "#enums/ui-mode";
 import type { GameManager } from "#test/test-utils/gameManager";
@@ -143,7 +143,7 @@ export async function runSelectMysteryEncounterOption(
       break;
   }
 
-  if (!isNullOrUndefined(secondaryOptionSelect?.pokemonNo)) {
+  if (!isNil(secondaryOptionSelect?.pokemonNo)) {
     await handleSecondaryOptionSelect(game, secondaryOptionSelect.pokemonNo, secondaryOptionSelect.optionNo);
   } else {
     uiHandler.processInput(Button.ACTION);
@@ -170,7 +170,7 @@ async function handleSecondaryOptionSelect(game: GameManager, pokemonNo: number,
   partyUiHandler.processInput(Button.ACTION);
 
   // If there is a second choice to make after selecting a Pokemon
-  if (!isNullOrUndefined(optionNo)) {
+  if (!isNil(optionNo)) {
     // Wait for Summary menu to close and second options to spawn
     const secondOptionUiHandler = game.scene.ui.handlers[UiMode.OPTION_SELECT] as OptionSelectUiHandler;
     vi.spyOn(secondOptionUiHandler, "show");

--- a/test/test-utils/gameManager.ts
+++ b/test/test-utils/gameManager.ts
@@ -28,7 +28,7 @@ import type { CommandUiHandler } from "#app/ui/handlers/command-ui-handler";
 import type { ModifierSelectUiHandler } from "#app/ui/handlers/modifier-select-ui-handler";
 import type { PartyUiHandler } from "#app/ui/handlers/party-ui-handler";
 import type { StarterSelectUiHandler } from "#app/ui/handlers/starter-select-ui-handler";
-import { isNullOrUndefined } from "#app/utils/common-utils";
+import { isNil } from "#app/utils/common-utils";
 import type { AbilityId } from "#enums/ability-id";
 import { BattleCommand } from "#enums/battle-command";
 import { BattleStyle } from "#enums/battle-style";
@@ -241,7 +241,7 @@ export class GameManager {
    * @returns A promise that resolves when the EncounterPhase ends.
    */
   async runToMysteryEncounter(encounterType?: MysteryEncounterType, species?: SpeciesId[]) {
-    if (!isNullOrUndefined(encounterType)) {
+    if (!isNil(encounterType)) {
       this.override.trainerChance(0);
       this.override.mysteryEncounter(encounterType);
     }
@@ -273,7 +273,7 @@ export class GameManager {
     );
 
     await this.phaseInterceptor.to("EncounterPhase");
-    if (!isNullOrUndefined(encounterType)) {
+    if (!isNil(encounterType)) {
       expect(this.scene.currentBattle?.mysteryEncounter?.encounterType).toBe(encounterType);
     }
   }

--- a/test/test-utils/matchers/to-have-terrain-matcher.ts
+++ b/test/test-utils/matchers/to-have-terrain-matcher.ts
@@ -1,7 +1,7 @@
+import { isNil } from "#app/utils/common-utils";
 import { capitalizeString } from "#app/utils/string-utils";
 import { TerrainType } from "#enums/terrain-type";
 import { isGameManagerInstance, receivedStr } from "#test/test-utils/testUtils";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
 /**
@@ -50,7 +50,7 @@ export function toHaveTerrainMatcher(
  * @returns A human readable string
  */
 function toTerrainStr(terrainType?: TerrainType) {
-  if (isNullOrUndefined(terrainType)) {
+  if (isNil(terrainType)) {
     return "undefined";
   } else {
     return capitalizeString(TerrainType[terrainType], "_", false, true);

--- a/test/test-utils/matchers/to-have-weather-matcher.ts
+++ b/test/test-utils/matchers/to-have-weather-matcher.ts
@@ -1,8 +1,8 @@
+import { isNil } from "#app/utils/common-utils";
 import { capitalizeString } from "#app/utils/string-utils";
 import { WeatherType } from "#enums/weather-type";
 import { isGameManagerInstance, receivedStr } from "#test/test-utils/testUtils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
-import { isNullOrUndefined } from "#app/utils/common-utils";
 
 /**
  * Matcher to check if the {@linkcode WeatherType} is as expected
@@ -50,7 +50,7 @@ export function toHaveWeatherMatcher(
  * @returns A human readable string
  */
 function toWeatherStr(weatherType?: WeatherType) {
-  if (isNullOrUndefined(weatherType)) {
+  if (isNil(weatherType)) {
     return "undefined";
   } else {
     return capitalizeString(WeatherType[weatherType], "_", false, true);


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
This prevents an issue where VSCode would incorrectly import a same-name function from `util` instead of `src/utils/common-utils.ts` which would break things. As a bonus this makes the function name way shorter, reducing line length.

## What are the changes from a developer perspective?
`isNullOrUndefined` renamed to `isNil` and TSDocs added.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?