### PR TITLE
[P2] Transistor is 1.3x instead of 1.5x

### DIFF
--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -1388,7 +1388,7 @@ export function initAbilities() {
     new Ability(AbilityId.CURIOUS_MEDICINE, 8)
       .attr(PostSummonClearAllyStatStagesAbAttr),
     new Ability(AbilityId.TRANSISTOR, 8)
-      .attr(MoveTypePowerBoostAbAttr, ElementalType.ELECTRIC),
+      .attr(MoveTypePowerBoostAbAttr, ElementalType.ELECTRIC, 1.3),
     new Ability(AbilityId.DRAGONS_MAW, 8)
       .attr(MoveTypePowerBoostAbAttr, ElementalType.DRAGON),
     new Ability(AbilityId.CHILLING_NEIGH, 8)


### PR DESCRIPTION
## What are the changes the user will see?

Transistor has a 1.3x multiplier instead of 1.5x

## Why am I making these changes?

This ability was changed from gen 8 to gen 9

## What are the changes from a developer perspective?

Changed the `powerMultiplier` field to 1.3 from the default 1.5x

Technically the ability is supposed to boost the user's attacking stats by 1.3 instead of the damage, but functionally it's the same.

## Screenshots/Videos

n/a

## How to test the changes?

Override with transistor

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
