### PR TITLE
[Refactor] Remove deprecated `nextCommandPhaseQueue` and deferred phase scheduling

### DIFF
--- a/src/data/abilities/ab-attrs/heal-from-berry-use-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/heal-from-berry-use-ab-attr.ts
@@ -27,7 +27,6 @@ export class HealFromBerryUseAbAttr extends AbAttr {
     const abilityName = this.source.name;
     if (!simulated) {
       globalScene.phaseManager.queuePokemonHealPhase(
-        true,
         pokemon.getBattlerIndex(),
         toDmgValue(pokemon.getMaxHp() * this.healPercent),
         {

--- a/src/data/abilities/ab-attrs/post-summon-ally-heal-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-ally-heal-ab-attr.ts
@@ -21,7 +21,6 @@ export class PostSummonAllyHealAbAttr extends PostSummonAbAttr {
     if (target?.isActive(true)) {
       if (!simulated) {
         globalScene.phaseManager.queuePokemonHealPhase(
-          true,
           target.getBattlerIndex(),
           toDmgValue(pokemon.getMaxHp() / this.healRatio),
           {

--- a/src/data/abilities/ab-attrs/post-turn-heal-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-turn-heal-ab-attr.ts
@@ -10,17 +10,12 @@ export class PostTurnHealAbAttr extends PostTurnAbAttr {
     if (!pokemon.isFullHp()) {
       if (!simulated) {
         const abilityName = this.source.name;
-        globalScene.phaseManager.queuePokemonHealPhase(
-          true,
-          pokemon.getBattlerIndex(),
-          toDmgValue(pokemon.getMaxHp() / 16),
-          {
-            message: i18next.t("abilityTriggers:postTurnHeal", {
-              pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-              abilityName,
-            }),
-          },
-        );
+        globalScene.phaseManager.queuePokemonHealPhase(pokemon.getBattlerIndex(), toDmgValue(pokemon.getMaxHp() / 16), {
+          message: i18next.t("abilityTriggers:postTurnHeal", {
+            pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
+            abilityName,
+          }),
+        });
       }
 
       return true;

--- a/src/data/abilities/ab-attrs/post-turn-status-heal-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-turn-status-heal-ab-attr.ts
@@ -26,7 +26,6 @@ export class PostTurnStatusHealAbAttr extends PostTurnAbAttr {
         if (!simulated) {
           const abilityName = this.source.name;
           globalScene.phaseManager.queuePokemonHealPhase(
-            true,
             pokemon.getBattlerIndex(),
             toDmgValue(pokemon.getMaxHp() / 8),
             {

--- a/src/data/abilities/ab-attrs/post-weather-lapse-heal-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-weather-lapse-heal-ab-attr.ts
@@ -37,7 +37,6 @@ export class PostWeatherLapseHealAbAttr extends PostWeatherLapseAbAttr {
       const abilityName = this.source.name;
       if (!simulated) {
         globalScene.phaseManager.queuePokemonHealPhase(
-          true,
           pokemon.getBattlerIndex(),
           toDmgValue(pokemon.getMaxHp() * this.healRatio),
           {

--- a/src/data/abilities/ab-attrs/type-immunity-heal-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/type-immunity-heal-ab-attr.ts
@@ -25,17 +25,12 @@ export class TypeImmunityHealAbAttr extends TypeImmunityAbAttr {
     if (ret) {
       if (!pokemon.isFullHp() && !simulated) {
         const abilityName = this.source.name;
-        globalScene.phaseManager.queuePokemonHealPhase(
-          true,
-          pokemon.getBattlerIndex(),
-          toDmgValue(pokemon.getMaxHp() / 4),
-          {
-            message: i18next.t("abilityTriggers:typeImmunityHeal", {
-              pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-              abilityName,
-            }),
-          },
-        );
+        globalScene.phaseManager.queuePokemonHealPhase(pokemon.getBattlerIndex(), toDmgValue(pokemon.getMaxHp() / 4), {
+          message: i18next.t("abilityTriggers:typeImmunityHeal", {
+            pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
+            abilityName,
+          }),
+        });
         cancelled.value = true; // Suppresses "No Effect" message
       }
       return true;

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -550,7 +550,7 @@ class WishTag extends ArenaTag {
     const target = globalScene.getFieldPokemonByBattlerIndex(this.battlerIndex);
     if (target?.isActive(true)) {
       globalScene.phaseManager.queueMessagePhase(this.triggerMessage);
-      globalScene.phaseManager.queuePokemonHealPhase(true, target.getBattlerIndex(), this.healHp);
+      globalScene.phaseManager.queuePokemonHealPhase(target.getBattlerIndex(), this.healHp);
     }
   }
 }
@@ -1005,7 +1005,7 @@ export class PendingHealTag extends ArenaTag {
         return this.apply(arena, simulated, pokemon);
       }
 
-      globalScene.phaseManager.queuePokemonHealPhase(true, targetIndex, pokemon.getMaxHp(), {
+      globalScene.phaseManager.queuePokemonHealPhase(targetIndex, pokemon.getMaxHp(), {
         message: i18next.t(healMessageKey, { pokemonName: getPokemonNameWithAffix(sourcePokemon) }),
         healStatus: true,
         fullRestorePP: restorePP,

--- a/src/data/battler-tags/aqua-ring-tag.ts
+++ b/src/data/battler-tags/aqua-ring-tag.ts
@@ -30,17 +30,12 @@ export class AquaRingTag extends BattlerTag {
     const ret = lapseType !== BattlerTagLapseType.CUSTOM || super.lapse(pokemon, lapseType);
 
     if (ret) {
-      globalScene.phaseManager.queuePokemonHealPhase(
-        true,
-        pokemon.getBattlerIndex(),
-        toDmgValue(pokemon.getMaxHp() / 16),
-        {
-          message: i18next.t("battlerTags:aquaRingLapse", {
-            moveName: this.getMoveName(),
-            pokemonName: getPokemonNameWithAffix(pokemon),
-          }),
-        },
-      );
+      globalScene.phaseManager.queuePokemonHealPhase(pokemon.getBattlerIndex(), toDmgValue(pokemon.getMaxHp() / 16), {
+        message: i18next.t("battlerTags:aquaRingLapse", {
+          moveName: this.getMoveName(),
+          pokemonName: getPokemonNameWithAffix(pokemon),
+        }),
+      });
     }
 
     return ret;

--- a/src/data/battler-tags/ingrain-tag.ts
+++ b/src/data/battler-tags/ingrain-tag.ts
@@ -33,14 +33,9 @@ export class IngrainTag extends TrappedTag {
     const ret = lapseType !== BattlerTagLapseType.CUSTOM || super.lapse(pokemon, lapseType);
 
     if (ret) {
-      globalScene.phaseManager.queuePokemonHealPhase(
-        true,
-        pokemon.getBattlerIndex(),
-        toDmgValue(pokemon.getMaxHp() / 16),
-        {
-          message: i18next.t("battlerTags:ingrainLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
-        },
-      );
+      globalScene.phaseManager.queuePokemonHealPhase(pokemon.getBattlerIndex(), toDmgValue(pokemon.getMaxHp() / 16), {
+        message: i18next.t("battlerTags:ingrainLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
+      });
     }
 
     return ret;

--- a/src/data/battler-tags/seed-tag.ts
+++ b/src/data/battler-tags/seed-tag.ts
@@ -67,7 +67,6 @@ export class SeedTag extends BattlerTag {
           const reverseDrain = pokemon.hasAbilityWithAttr(AbAttrFlag.REVERSE_DRAIN, false);
 
           globalScene.phaseManager.queuePokemonHealPhase(
-            true,
             source.getBattlerIndex(),
             !reverseDrain ? damage : damage * -1,
             {

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -71,7 +71,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         }
         const hpHealed = new NumberHolder(toDmgValue(pokemon.getMaxHp() / 4));
         applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, hpHealed);
-        globalScene.phaseManager.queuePokemonHealPhase(true, pokemon.getBattlerIndex(), hpHealed.value, {
+        globalScene.phaseManager.queuePokemonHealPhase(pokemon.getBattlerIndex(), hpHealed.value, {
           message: i18next.t("battle:hpHealBerry", {
             pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
             berryName: getBerryName(berryType),
@@ -107,6 +107,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         const statStages = new NumberHolder(1);
         applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, statStages);
         globalScene.phaseManager.queueStatStageChangePhase(
+          true,
           pokemon.getBattlerIndex(),
           pokemon,
           [stat],
@@ -131,6 +132,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
         const stages = new NumberHolder(2);
         applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, stages);
         globalScene.phaseManager.queueStatStageChangePhase(
+          true,
           pokemon.getBattlerIndex(),
           pokemon,
           [randStat],

--- a/src/data/moves/move-attrs/heal-attr.ts
+++ b/src/data/moves/move-attrs/heal-attr.ts
@@ -47,7 +47,6 @@ export class HealAttr extends MoveEffectAttr {
    */
   addHealPhase(target: Pokemon, healRatio: number) {
     globalScene.phaseManager.queuePokemonHealPhase(
-      true,
       target.getBattlerIndex(),
       toDmgValue(target.getMaxHp() * healRatio),
       {

--- a/src/data/moves/move-attrs/hit-heal-attr.ts
+++ b/src/data/moves/move-attrs/hit-heal-attr.ts
@@ -52,7 +52,7 @@ export class HitHealAttr extends MoveEffectAttr {
         message = "";
       }
     }
-    globalScene.phaseManager.queuePokemonHealPhase(true, user.getBattlerIndex(), healAmount, {
+    globalScene.phaseManager.queuePokemonHealPhase(user.getBattlerIndex(), healAmount, {
       message,
       showFullHpMessage: false,
       skipAnim: true,

--- a/src/data/moves/move-attrs/present-power-attr.ts
+++ b/src/data/moves/move-attrs/present-power-attr.ts
@@ -33,14 +33,9 @@ export class PresentPowerAttr extends VariablePowerAttr {
     } else if (powerSeed < 100) {
       // If this move is multi-hit, disable all other hits
       user.stopMultiHit();
-      globalScene.phaseManager.queuePokemonHealPhase(
-        true,
-        target.getBattlerIndex(),
-        toDmgValue(target.getMaxHp() / 4),
-        {
-          message: i18next.t("moveTriggers:regainedHealth", { pokemonName: getPokemonNameWithAffix(target) }),
-        },
-      );
+      globalScene.phaseManager.queuePokemonHealPhase(target.getBattlerIndex(), toDmgValue(target.getMaxHp() / 4), {
+        message: i18next.t("moveTriggers:regainedHealth", { pokemonName: getPokemonNameWithAffix(target) }),
+      });
     }
 
     return true;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1684,7 +1684,6 @@ export class TurnHealModifier extends PokemonHeldItemModifier {
   override apply(pokemon: Pokemon): boolean {
     if (!pokemon.isFullHp()) {
       globalScene.phaseManager.queuePokemonHealPhase(
-        true,
         pokemon.getBattlerIndex(),
         toDmgValue(pokemon.getMaxHp() / 16) * this.stackCount,
         {
@@ -1789,7 +1788,6 @@ export class HitHealModifier extends PokemonHeldItemModifier {
   override apply(pokemon: Pokemon): boolean {
     if (pokemon.turnData.totalDamageDealt && !pokemon.isFullHp()) {
       globalScene.phaseManager.queuePokemonHealPhase(
-        true,
         pokemon.getBattlerIndex(),
         toDmgValue(pokemon.turnData.totalDamageDealt / 8) * this.stackCount,
         {
@@ -1978,19 +1976,14 @@ export class PokemonInstantReviveModifier extends PokemonHeldItemModifier {
    */
   override apply(pokemon: Pokemon): boolean {
     // Restore the Pokemon to half HP
-    globalScene.phaseManager.queuePokemonHealPhase(
-      true,
-      pokemon.getBattlerIndex(),
-      toDmgValue(pokemon.getMaxHp() / 2),
-      {
-        message: i18next.t("modifier:pokemonInstantReviveApply", {
-          pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-          typeName: this.type.name,
-        }),
-        showFullHpMessage: false,
-        revive: true,
-      },
-    );
+    globalScene.phaseManager.queuePokemonHealPhase(pokemon.getBattlerIndex(), toDmgValue(pokemon.getMaxHp() / 2), {
+      message: i18next.t("modifier:pokemonInstantReviveApply", {
+        pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
+        typeName: this.type.name,
+      }),
+      showFullHpMessage: false,
+      revive: true,
+    });
 
     // Remove any status the Pokemon had before fainting
     pokemon.resetStatus(false, true);

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { MoveEffectPhase } from "#app/phases/move-effect-phase";
 import type { VictoryPhase } from "#app/phases/victory-phase";
+import type { ChargeAnim } from "#enums/charge-anim";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 // -- end tsdoc imports --
 
@@ -22,14 +23,12 @@ import { MovePhase } from "#app/phases/move-phase";
 import { NewBattlePhase } from "#app/phases/new-battle-phase";
 import { PokemonHealPhase } from "#app/phases/pokemon-heal-phase";
 import { SelectTargetPhase } from "#app/phases/select-target-phase";
-import { StatStageChangePhase, type SSCPhaseOptions } from "#app/phases/stat-stage-change-phase";
+import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 import { TitlePhase } from "#app/phases/title-phase";
 import { TurnInitPhase } from "#app/phases/turn-init-phase";
 import type { BattlerIndex } from "#enums/battler-index";
-import type { ChargeAnim } from "#enums/charge-anim";
 import type { MoveId } from "#enums/move-id";
 import type { PhaseId } from "#enums/phase-id";
-import type { BattleStat } from "#enums/stat";
 
 interface UseMoveInit {
   pokemon: Pokemon;
@@ -81,7 +80,6 @@ export class PhaseManager {
   /** overrides default of inserting phases to end of phaseQueuePrepend array, useful for inserting Phases "out of order" */
   private phaseQueuePrependSpliceIndex: number = -1;
   private conditionalQueue: Array<[() => boolean, Phase]> = [];
-  private nextCommandPhaseQueue: Phase[] = [];
 
   private currentPhase: Phase | null = null;
   private standbyPhase: Phase | null = null;
@@ -115,8 +113,8 @@ export class PhaseManager {
    * @param defer - If `false`, adds the phase to `phaseQueue`. If `true`, adds the phase to `nextCommandPhaseQueue`. Default `false`.
    * @todo replace with a factory function for Phases based on `PhaseId`, ex: `public pushPhase<P extends Phase>(phase: PhaseId, ...params: ConstructorParameters<P>)`
    */
-  public pushPhase(phase: Phase, defer: boolean = false): void {
-    (!defer ? this.phaseQueue : this.nextCommandPhaseQueue).push(phase);
+  public pushPhase(phase: Phase): void {
+    this.phaseQueue.push(phase);
   }
 
   /**
@@ -145,7 +143,7 @@ export class PhaseManager {
    * Clears all phase-related stuff, including all phase queues, the current and standby phases, and a splice index.
    */
   public clearAllPhases(): void {
-    for (const queue of [this.phaseQueue, this.phaseQueuePrepend, this.conditionalQueue, this.nextCommandPhaseQueue]) {
+    for (const queue of [this.phaseQueue, this.phaseQueuePrepend, this.conditionalQueue]) {
       queue.splice(0, queue.length);
     }
     this.currentPhase = null;
@@ -274,18 +272,6 @@ export class PhaseManager {
     }
   }
 
-  /**
-   * @todo this is unused, may be removed?
-   */
-  public tryReplacePhase(phaseFilter: (phase: Phase) => boolean, phase: Phase): boolean {
-    const phaseIndex = this.phaseQueue.findIndex(phaseFilter);
-    if (phaseIndex > -1) {
-      this.phaseQueue[phaseIndex] = phase;
-      return true;
-    }
-    return false;
-  }
-
   public tryRemovePhase(phaseFilter: (phase: Phase) => boolean): boolean {
     const phaseIndex = this.phaseQueue.findIndex(phaseFilter);
     if (phaseIndex > -1) {
@@ -353,10 +339,6 @@ export class PhaseManager {
    * Moves everything from the {@linkcode nextCommandPhaseQueue} to the {@linkcode phaseQueue} (keeping order)
    */
   public populatePhaseQueue(): void {
-    if (this.nextCommandPhaseQueue.length) {
-      this.phaseQueue.push(...this.nextCommandPhaseQueue);
-      this.nextCommandPhaseQueue.splice(0, this.nextCommandPhaseQueue.length);
-    }
     this.phaseQueue.push(new TurnInitPhase());
   }
 
@@ -386,19 +368,13 @@ export class PhaseManager {
 
   /**
    * Queues a new {@linkcode PokemonHealPhase} for the given {@linkcode BattlerIndex}.
-   * @param eager - Whether to add the {@linkcode PokemonHealPhase} to the front of the phase queue or defer it
    * @param battlerIndex - The {@linkcode BattlerIndex} of the pokemon to heal
    * @param hpHealed - The amount of HP to heal
    * @param params_2 - The various {@linkcode PokemonHealPhaseOptions | optional parameters} of `PokemonHealPhase`
    */
-  public queuePokemonHealPhase(eager: boolean, ...params: ConstructorParameters<typeof PokemonHealPhase>) {
+  public queuePokemonHealPhase(...params: ConstructorParameters<typeof PokemonHealPhase>) {
     const pokemonHealPhase = new PokemonHealPhase(...params);
-
-    if (eager) {
-      this.unshiftPhase(pokemonHealPhase);
-    } else {
-      this.pushPhase(pokemonHealPhase, true);
-    }
+    this.unshiftPhase(pokemonHealPhase);
   }
 
   /**
@@ -407,16 +383,16 @@ export class PhaseManager {
    * @param targets - Array of target `BattlerIndex`es
    * @param move - The {@linkcode PokemonMove} being used
    */
-  public queueMoveChargePhase(battlerIndex: BattlerIndex, targets: BattlerIndex[], move: PokemonMove): void {
-    this.unshiftPhase(new MoveChargePhase(battlerIndex, targets, move));
+  public queueMoveChargePhase(...params: ConstructorParameters<typeof MoveChargePhase>): void {
+    this.unshiftPhase(new MoveChargePhase(...params));
   }
 
   /**
    * Inserts a new {@linkcode SelectTargetPhase} to the phase queue.
-   * @param battlerIndex - The selected target's {@linkcode BattlerIndex}
+   * @param fieldIndex - The selected target's {@linkcode BattlerIndex}
    */
-  public queueSelectTargetPhase(battlerIndex: BattlerIndex): void {
-    this.unshiftPhase(new SelectTargetPhase(battlerIndex));
+  public queueSelectTargetPhase(...params: ConstructorParameters<typeof SelectTargetPhase>): void {
+    this.unshiftPhase(new SelectTargetPhase(...params));
   }
 
   /**
@@ -425,8 +401,8 @@ export class PhaseManager {
    * @param moveId - The {@linkcode MoveId} to be used
    * @param user - The {@linkcode Pokemon} using the move
    */
-  public queueMoveAnimPhase(chargeAnim: ChargeAnim, moveId: MoveId, user: Pokemon): void {
-    this.unshiftPhase(new MoveAnimPhase(new MoveChargeAnim(chargeAnim, moveId, user)));
+  public queueMoveAnimPhase(...params: ConstructorParameters<typeof MoveChargeAnim>): void {
+    this.unshiftPhase(new MoveAnimPhase(new MoveChargeAnim(...params)));
   }
 
   /**
@@ -540,15 +516,19 @@ export class PhaseManager {
     }
   }
 
+  /**
+   * @param eager - (Optional) `true` to use {@linkcode unshiftPhase}, `false` for {@linkcode pushPhase}
+   * @param battlerIndex - The {@linkcode BattlerIndex} of the affected {@linkcode Pokemon}
+   * @param source - The {@linkcode Pokemon} that caused the stat stage change
+   * @param stats - The {@linkcode BattleStat | stats} modified by this phase
+   * @param stages - The change in each affected stat stage
+   * @param params_4 - (Optional) The {@linkcode SSCPhaseOptions} for the generated phase
+   */
   public queueStatStageChangePhase(
-    battlerIndex: BattlerIndex,
-    source: Pokemon | null,
-    stats: BattleStat[],
-    stages: number,
-    options: SSCPhaseOptions = {},
-    eager: boolean = true,
+    eager: boolean,
+    ...params: ConstructorParameters<typeof StatStageChangePhase>
   ): void {
-    const statStageChangePhase = new StatStageChangePhase(battlerIndex, source, stats, stages, options);
+    const statStageChangePhase = new StatStageChangePhase(...params);
     if (eager) {
       this.unshiftPhase(statStageChangePhase);
     } else {

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -517,7 +517,7 @@ export class PhaseManager {
   }
 
   /**
-   * @param eager - (Optional) `true` to use {@linkcode unshiftPhase}, `false` for {@linkcode pushPhase}
+   * @param eager - `true` to use {@linkcode unshiftPhase}, `false` for {@linkcode pushPhase}
    * @param battlerIndex - The {@linkcode BattlerIndex} of the affected {@linkcode Pokemon}
    * @param source - The {@linkcode Pokemon} that caused the stat stage change
    * @param stats - The {@linkcode BattleStat | stats} modified by this phase

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -168,7 +168,7 @@ export class QuietFormChangePhase extends BattlePhase {
 
     if (globalScene?.currentBattle.isClassicFinalBoss && this.pokemon.isEnemy()) {
       globalScene.audioManager.playBgm();
-      globalScene.phaseManager.queuePokemonHealPhase(true, this.pokemon.getBattlerIndex(), this.pokemon.getMaxHp(), {
+      globalScene.phaseManager.queuePokemonHealPhase(this.pokemon.getBattlerIndex(), this.pokemon.getMaxHp(), {
         showFullHpMessage: false,
         healStatus: true,
       });

--- a/src/phases/turn-end-phase.ts
+++ b/src/phases/turn-end-phase.ts
@@ -32,7 +32,6 @@ export class TurnEndPhase extends FieldPhase {
 
         if (terrain?.terrainType === TerrainType.GRASSY && pokemon.isGrounded()) {
           globalScene.phaseManager.queuePokemonHealPhase(
-            true,
             pokemon.getBattlerIndex(),
             Math.max(pokemon.getMaxHp() >> 4, 1),
             {


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

Recent changes to Healing Wish and Lunar Dance (#1022) removed the last use case for deferred phase scheduling.

## What are the changes from a developer perspective?

In `phase-manager.ts`:
- Removed `nextCommandPhaseQueue` and the `defer` option from `pushPhase`
- Removed the `eager` option from `queuePokemonHealPhase`. This function now only queues the phase with `unshiftPhase`.
- Changed some bespoke phase scheduling functions' signatures to match the style of `queuePokemonHealPhase` and take advantage of `ConstructorParameters`.

## Screenshots/Videos

N/A

## How to test the changes?

`npm run test:silent` should be fine enough; this PR for the most part just removes now-unused code.

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?