### PR TITLE
[Refactor] Consolidate `try/catch` for sprites in one place

### DIFF
--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -610,11 +610,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
 
     [tradedPokemonSprite, tradedPokemonTintSprite].map((sprite) => {
       const spriteKey = tradedPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -633,11 +629,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
 
     [receivedPokemonSprite, receivedPokemonTintSprite].map((sprite) => {
       const spriteKey = receivedPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],

--- a/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
+++ b/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
@@ -1,5 +1,5 @@
-import type { PlayerPokemon } from "#app/field/player-pokemon";
 import { getTypeRgb } from "#app/data/type";
+import type { PlayerPokemon } from "#app/field/player-pokemon";
 import { globalScene } from "#app/global-scene";
 import { TransformationScreenPosition } from "#enums/transformation-screen-position";
 
@@ -60,11 +60,7 @@ export function doPokemonTransformationSequence(
 
     [pokemonSprite, pokemonTintSprite, pokemonEvoSprite, pokemonEvoTintSprite].map((sprite) => {
       const spriteKey = previousPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipeline(globalScene.spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -83,11 +79,7 @@ export function doPokemonTransformationSequence(
 
     [pokemonEvoSprite, pokemonEvoTintSprite].map((sprite) => {
       const spriteKey = transformPokemon.getSpriteKey(true);
-      try {
-        sprite.play(spriteKey);
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey);
 
       sprite.setPipelineData("ignoreTimeTint", true);
       sprite.setPipelineData("spriteKey", transformPokemon.getSpriteKey());

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -857,27 +857,17 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Attempts to animate a given {@linkcode Phaser.GameObjects.Sprite}
    * @see {@linkcode Phaser.GameObjects.Sprite.play}
-   * @param sprite {@linkcode Phaser.GameObjects.Sprite} to animate
-   * @param tintSprite {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
-   * @param animConfig {@linkcode String} to pass to {@linkcode Phaser.GameObjects.Sprite.play}
-   * @returns true if the sprite was able to be animated
+   * @param sprite - {@linkcode Phaser.GameObjects.Sprite} to animate
+   * @param tintSprite - {@linkcode Phaser.GameObjects.Sprite} placed on top of the sprite to add a color tint
+   * @param key - animation key to pass to {@linkcode Phaser.GameObjects.Sprite.play}
    */
-  tryPlaySprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite, key: string): boolean {
-    // Catch errors when trying to play an animation that doesn't exist
-    try {
-      sprite.play(key);
-      tintSprite.play(key);
-    } catch (error: unknown) {
-      console.error(`Couldn't play animation for '${key}'!\nIs the image for this Pokemon missing?\n`, error);
-
-      return false;
-    }
-
-    return true;
+  playSprite(sprite: Phaser.GameObjects.Sprite, tintSprite: Phaser.GameObjects.Sprite | null, key: string): void {
+    sprite.play(key);
+    tintSprite?.play(key);
   }
 
   playAnim(): void {
-    this.tryPlaySprite(this.getSprite(), this.getTintSprite()!, this.getBattleSpriteKey()); // TODO: is the bag correct?
+    this.playSprite(this.getSprite(), this.getTintSprite(), this.getBattleSpriteKey());
   }
 
   getFieldPositionOffset(): [number, number] {
@@ -4193,16 +4183,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   setFrameRate(frameRate: number) {
     globalScene.anims.get(this.getBattleSpriteKey()).frameRate = frameRate;
-    try {
-      this.getSprite().play(this.getBattleSpriteKey());
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${this.getBattleSpriteKey()}`, err);
-    }
-    try {
-      this.getTintSprite()?.play(this.getBattleSpriteKey());
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${this.getBattleSpriteKey()}`, err);
-    }
+    this.playAnim();
   }
 
   tint(color: number, alpha?: number, duration?: number, ease?: string) {

--- a/src/phaser-extensions.ts
+++ b/src/phaser-extensions.ts
@@ -1,16 +1,16 @@
 import Phaser from "phaser";
 
-// #region Original Functions
-
-const originalPlay = Phaser.GameObjects.Sprite.prototype.play;
-const originalStop = Phaser.GameObjects.Sprite.prototype.stop;
-
-// #endregion
 // #region Types
 
 type GuideObject = Phaser.GameObjects.Components.Origin
   & Phaser.GameObjects.Components.Size
   & Phaser.GameObjects.Components.Transform;
+
+// #endregion
+// #region Original Functions
+
+const originalPlay = Phaser.GameObjects.Sprite.prototype.play;
+const originalStop = Phaser.GameObjects.Sprite.prototype.stop;
 
 // #endregion
 // #region Extensions

--- a/src/phaser-extensions.ts
+++ b/src/phaser-extensions.ts
@@ -1,24 +1,34 @@
 import Phaser from "phaser";
 
-//#region Types
+// #region Original Functions
 
-type GuideObject = Phaser.GameObjects.Components.Origin &
-  Phaser.GameObjects.Components.Size &
-  Phaser.GameObjects.Components.Transform;
+const originalPlay = Phaser.GameObjects.Sprite.prototype.play;
+const originalStop = Phaser.GameObjects.Sprite.prototype.stop;
 
-//#endregion
-//#region Extensions
+// #endregion
+// #region Types
+
+type GuideObject = Phaser.GameObjects.Components.Origin
+  & Phaser.GameObjects.Components.Size
+  & Phaser.GameObjects.Components.Transform;
+
+// #endregion
+// #region Extensions
 
 Phaser.GameObjects.Container.prototype.setPositionRelative = setPositionRelative<Phaser.GameObjects.Container>;
-Phaser.GameObjects.Container.prototype.getByType = getByType;
 Phaser.GameObjects.Sprite.prototype.setPositionRelative = setPositionRelative<Phaser.GameObjects.Sprite>;
 Phaser.GameObjects.Image.prototype.setPositionRelative = setPositionRelative<Phaser.GameObjects.Image>;
 Phaser.GameObjects.NineSlice.prototype.setPositionRelative = setPositionRelative<Phaser.GameObjects.NineSlice>;
 Phaser.GameObjects.Text.prototype.setPositionRelative = setPositionRelative<Phaser.GameObjects.Text>;
 Phaser.GameObjects.Rectangle.prototype.setPositionRelative = setPositionRelative<Phaser.GameObjects.Rectangle>;
 
-//#endregion
-//#region Utility Functions
+Phaser.GameObjects.Container.prototype.getByType = getByType;
+
+Phaser.GameObjects.Sprite.prototype.play = play;
+Phaser.GameObjects.Sprite.prototype.stop = stop;
+
+// #endregion
+// #region Utility Functions
 
 /**
  * Positions this object relative to the {@linkcode guideObject}.
@@ -53,4 +63,26 @@ function getByType<T extends Phaser.GameObjects.GameObject>(
   return (Phaser.Utils.Array.GetFirst(this.list, "type", type) as T) ?? null;
 }
 
-//#endregion
+function play<T extends Phaser.GameObjects.Sprite>(
+  this: T,
+  key: string | Phaser.Animations.Animation | Phaser.Types.Animations.PlayAnimationConfig,
+  ignoreIfPlaying?: boolean,
+): Phaser.GameObjects.Sprite {
+  try {
+    return originalPlay.apply(this, [key, ignoreIfPlaying]);
+  } catch (err: unknown) {
+    console.error(`Failed to play animation for ${key}!`, err);
+    return this;
+  }
+}
+
+function stop<T extends Phaser.GameObjects.Sprite>(this: T): Phaser.GameObjects.Sprite {
+  try {
+    return originalStop.apply(this);
+  } catch (err: unknown) {
+    console.error("Failed to stop animation!", err);
+    return this;
+  }
+}
+
+// #endregion

--- a/src/phases/abstract-form-change-base-phase.ts
+++ b/src/phases/abstract-form-change-base-phase.ts
@@ -1,8 +1,8 @@
+import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui-constants";
 import { getTypeRgb } from "#app/data/type";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
-import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui-constants";
 import type { FormChangeSceneUiHandler } from "#app/ui/handlers/form-change-scene-ui-handler";
 import { UiMode } from "#enums/ui-mode";
 
@@ -99,11 +99,7 @@ export abstract class FormChangeBasePhase extends Phase {
       [this.pokemonSprite, this.pokemonTintSprite, this.pokemonNewFormSprite, this.pokemonNewFormTintSprite].map(
         (sprite) => {
           const spriteKey = this.pokemon.getSpriteKey(true);
-          try {
-            sprite.play(spriteKey);
-          } catch (err: unknown) {
-            console.error(`Failed to play animation for ${spriteKey}`, err);
-          }
+          sprite.play(spriteKey);
 
           sprite.setPipeline(spritePipeline, {
             tone: [0.0, 0.0, 0.0, 0.0],

--- a/src/phases/egg-hatch-phase.ts
+++ b/src/phases/egg-hatch-phase.ts
@@ -1,4 +1,5 @@
 import type { AnySound } from "#app/audio-manager";
+import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui-constants";
 import type { Egg } from "#app/data/egg";
 import type { EggHatchData } from "#app/data/egg-hatch-data";
 import { EggCountChangedEvent } from "#app/events/egg";
@@ -6,7 +7,6 @@ import type { PlayerPokemon } from "#app/field/player-pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { Phase } from "#app/phase";
-import { GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui-constants";
 import { EggCounterContainer } from "#app/ui/components/egg-counter-container";
 import { PokemonInfoContainer } from "#app/ui/components/pokemon-info-container";
 import type { EggHatchSceneUiHandler } from "#app/ui/handlers/egg-hatch-scene-ui-handler";
@@ -339,11 +339,7 @@ export class EggHatchPhase extends Phase {
     this.eggContainer.setVisible(false);
 
     const spriteKey = this.pokemon.getSpriteKey(true);
-    try {
-      this.pokemonSprite.play(spriteKey);
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    this.pokemonSprite.play(spriteKey);
 
     this.pokemonSprite.setPipelineData("ignoreTimeTint", true);
     this.pokemonSprite.setPipelineData("spriteKey", this.pokemon.getSpriteKey());

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -73,11 +73,7 @@ export class EvolutionPhase extends FormChangeBasePhase {
         this.pokemon.getPossibleEvolution(this.evolution).then((evolvedPokemon) => {
           [this.pokemonNewFormSprite, this.pokemonNewFormTintSprite].map((sprite) => {
             const spriteKey = evolvedPokemon.getSpriteKey(true);
-            try {
-              sprite.play(spriteKey);
-            } catch (err: unknown) {
-              console.error(`Failed to play animation for ${spriteKey}`, err);
-            }
+            sprite.play(spriteKey);
 
             sprite.setPipelineData("ignoreTimeTint", true);
             sprite.setPipelineData("spriteKey", evolvedPokemon.getSpriteKey());

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -65,11 +65,7 @@ export class FormChangePhase extends FormChangeBasePhase {
     this.pokemon.getPossibleForm(this.formChange).then((formChangedPokemon) => {
       [this.pokemonNewFormSprite, this.pokemonNewFormTintSprite].map((sprite) => {
         const spriteKey = formChangedPokemon.getSpriteKey(true);
-        try {
-          sprite.play(spriteKey);
-        } catch (err: unknown) {
-          console.error(`Failed to play animation for ${spriteKey}`, err);
-        }
+        sprite.play(spriteKey);
 
         sprite.setPipelineData("ignoreTimeTint", true);
         sprite.setPipelineData("spriteKey", formChangedPokemon.getSpriteKey());

--- a/src/phases/quiet-form-change-phase.ts
+++ b/src/phases/quiet-form-change-phase.ts
@@ -64,11 +64,7 @@ export class QuietFormChangePhase extends BattlePhase {
       sprite.setOrigin(0.5, 1);
 
       const spriteKey = this.pokemon.getBattleSpriteKey();
-      try {
-        sprite.play(spriteKey).stop();
-      } catch (err: unknown) {
-        console.error(`Failed to play animation for ${spriteKey}`, err);
-      }
+      sprite.play(spriteKey).stop();
 
       sprite.setPipeline(spritePipeline, {
         tone: [0.0, 0.0, 0.0, 0.0],
@@ -115,11 +111,7 @@ export class QuietFormChangePhase extends BattlePhase {
           pokemonFormTintSprite.setScale(0.01);
 
           const spriteKey = this.pokemon.getBattleSpriteKey();
-          try {
-            pokemonFormTintSprite.play(spriteKey).stop();
-          } catch (err: unknown) {
-            console.error(`Failed to play animation for ${spriteKey}`, err);
-          }
+          pokemonFormTintSprite.play(spriteKey).stop();
 
           pokemonFormTintSprite.setVisible(true);
 

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -337,11 +337,7 @@ export class SummaryUiHandler extends UiHandler {
     setTextColor(this.numberText, this.pokemon.isShiny() ? TextStyle.SUMMARY_GOLD : TextStyle.SUMMARY);
 
     const spriteKey = this.pokemon.getSpriteKey(true);
-    try {
-      this.pokemonSprite.play(spriteKey);
-    } catch (err: unknown) {
-      console.error(`Failed to play animation for ${spriteKey}`, err);
-    }
+    this.pokemonSprite.play(spriteKey);
     this.pokemonSprite.setPipelineData("teraColor", getTypeRgb(this.pokemon.teraType));
     this.pokemonSprite.setPipelineData("isTerastallized", this.pokemon.isTerastallized);
     this.pokemonSprite.setPipelineData("ignoreTimeTint", true);


### PR DESCRIPTION
Third time's the charm.

## What are the changes the user will see?
Potentially less crashes due to animation issues, though most were already surrounded with `try/catch` so likely no change.

## Why am I making these changes?
Reduce duplicated code.
Resolves #1071 

## What are the changes from a developer perspective?
All `try/catch` surrounding `sprite.play()` are removed and instead `Phaser.GameObjects.Sprite.prototype.play` is overridden to have a `try/catch` inside it.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?