### PR TITLE
[Misc] Fix ME `build()` functions

### DIFF
--- a/src/data/mystery-encounters/mystery-encounter-option.ts
+++ b/src/data/mystery-encounters/mystery-encounter-option.ts
@@ -333,7 +333,7 @@ export class MysteryEncounterOptionBuilder implements Partial<IMysteryEncounterO
     return this;
   }
 
-  build() {
-    return new MysteryEncounterOption(this as unknown as IMysteryEncounterOption);
+  build(this: IMysteryEncounterOption) {
+    return new MysteryEncounterOption(this);
   }
 }

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -1106,7 +1106,7 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    *
    * @returns
    */
-  build(): MysteryEncounter {
-    return new MysteryEncounter(this as unknown as IMysteryEncounter);
+  build(this: IMysteryEncounter): MysteryEncounter {
+    return new MysteryEncounter(this);
   }
 }


### PR DESCRIPTION
## What are the changes the user will see?
Nothing, probably?

## Why am I making these changes?
I was reminded of this when writing PR 1113.

## What are the changes from a developer perspective?
Restored the `this` "param" to the two ME `build()` methods.

## How to test the changes?
Check some MEs I guess.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)