### PR TITLE
[Balance] Change exp formula to gen 1-4

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2744,7 +2744,7 @@ export default class BattleScene extends SceneBase {
   applyPartyExp(
     expValue: number,
     pokemonDefeated: boolean,
-    _useWaveIndexMultiplier?: boolean,
+    useWaveIndexMultiplier?: boolean,
     pokemonParticipantIds?: Set<number>,
   ): void {
     const participantIds = pokemonParticipantIds ?? this.currentBattle.playerParticipantIds;
@@ -2757,10 +2757,13 @@ export default class BattleScene extends SceneBase {
     const nonFaintedPartyMembers = party.filter((p) => p.hp);
     const expPartyMembers = nonFaintedPartyMembers.filter((p) => p.level < this.getMaxExpLevel());
     const partyMemberExp: number[] = [];
-    // EXP value calculation is based off Pokemon.getExpValue
-    // if (useWaveIndexMultiplier) {
-    //   expValue = Math.floor((expValue * this.currentBattle.waveIndex) / 5 + 1);
-    // }
+    /**
+     * Lots of ME code still use this
+     * TODO: Change/remove this
+     */
+    if (useWaveIndexMultiplier) {
+      expValue = Math.floor((expValue * this.currentBattle.waveIndex) / 5 + 1);
+    }
 
     if (participantIds.size > 0) {
       if (

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2744,7 +2744,7 @@ export default class BattleScene extends SceneBase {
   applyPartyExp(
     expValue: number,
     pokemonDefeated: boolean,
-    useWaveIndexMultiplier?: boolean,
+    _useWaveIndexMultiplier?: boolean,
     pokemonParticipantIds?: Set<number>,
   ): void {
     const participantIds = pokemonParticipantIds ?? this.currentBattle.playerParticipantIds;
@@ -2758,9 +2758,9 @@ export default class BattleScene extends SceneBase {
     const expPartyMembers = nonFaintedPartyMembers.filter((p) => p.level < this.getMaxExpLevel());
     const partyMemberExp: number[] = [];
     // EXP value calculation is based off Pokemon.getExpValue
-    if (useWaveIndexMultiplier) {
-      expValue = Math.floor((expValue * this.currentBattle.waveIndex) / 5 + 1);
-    }
+    // if (useWaveIndexMultiplier) {
+    //   expValue = Math.floor((expValue * this.currentBattle.waveIndex) / 5 + 1);
+    // }
 
     if (participantIds.size > 0) {
       if (

--- a/src/data/exp.ts
+++ b/src/data/exp.ts
@@ -1,5 +1,6 @@
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
+import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { CommonColor, ShadowColor } from "#enums/color";
 import { GrowthRate } from "#enums/growth-rates";
@@ -197,7 +198,7 @@ export function getGrowthRateColor(growthRate: GrowthRate) {
  * Not included from the mainline formula:
  * - Original Trainer bonus
  */
-export function genOneThroughFourExpFormula(defeatedPokemon: EnemyPokemon): number {
+export function genOneThroughFourExpFormula(defeatedPokemon: Pokemon): number {
   const baseExp = defeatedPokemon.species.baseExp;
   const enemyLevel = defeatedPokemon.level;
   // The Exp share multiplier is handled elsewhere (TODO: change that?)

--- a/src/phases/post-knockout-phase.ts
+++ b/src/phases/post-knockout-phase.ts
@@ -1,3 +1,4 @@
+import { genOneThroughFourExpFormula } from "#app/data/exp";
 import { handleMysteryEncounterVictory } from "#app/data/mystery-encounters/utils/encounter-phase-utils";
 import { globalScene } from "#app/global-scene";
 import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
@@ -38,7 +39,7 @@ export class PostKnockoutPhase extends PokemonPhase {
       gameData.gameStats.pokemonDefeated++;
     }
 
-    const expValue = this.getPokemon().getExpValue();
+    const expValue = genOneThroughFourExpFormula(this.getPokemon());
     globalScene.applyPartyExp(expValue, true);
 
     if (isMysteryEncounter) {


### PR DESCRIPTION
## What are the changes the user will see?

Exp formula has been changed

## Why am I making these changes?

Moving away from custom legacy code and to make exp scale better with the new level caps

## What are the changes from a developer perspective?

* ~~Disabled the `useWaveIndexMultiplier` in `battle-scene.ts`~~ Unfortunately all ME code uses this so it will be a very large change
* Changed `EnemyPokemon` to `Pokemon` in `genOneThroughFourExpFormula` because the PostKnockoutPhase only holds a `Pokemon` instead of `EnemyPokemon`
* Changed the exp formula to use `genOneThroughFourExpFormula` instead of `getExpValue` in `post-knockout-phase.ts`

## Screenshots/Videos

I tested with the changes in #1123 

Manually tested the first 110 waves and noted my findings. I specifically made sure to only use MEDIUM_FAST Pokemon so the exp smoothing wasn't a concern. I used two Pokemon so I could get an idea of what level the player's primary Pokemon would be compared to the rest of their party. The level scaling looks pretty good for the first 50 or so waves but the player hits the level cap earlier and earlier as the game goes on so the game is definitely handing out too many exp charms

```
8: Got Super exp charm (1) , got exp share (1)
10: get exp charm (1)
11 start: 11/6 grabbed a lure on floor 14
20: get super exp charm (2)
21 start: 16/11
23: got exp all (2)
25: hit level cap, got exp all (3)
30: got exp charm (2)
31 start: 22/20
38: hit level cap
41: 26/26
45: hit level cap
47: hit level cap
50: get exp charm (3)
51 start: 29/29
54 got exp charm (4)
55 hit level cap (all)
60: got super exp charm (4)
61 start: 33/33
62: hit level cap
63: get exp share (4)
70: get exp charm (5)
71 start: 36/36
73: hit level cap
74: hit level cap
80: got super exp charm (5)
81 start: 40/40
84: hit level cap (all)
90: get exp charm (6)
91 start: 45/45
93: hit level cap (all)
100: got super exp charm (6)
101 start: 48/48
102: hit level cap (all)
111: 52/52
```

## How to test the changes?

`npm run start`

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [ ] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->