### PR TITLE
[Bug] The form change message now correctly displays the Pokemon's previous form

### DIFF
--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -133,9 +133,9 @@ export class FormChangePhase extends FormChangeBasePhase {
    */
   private handleFormChangeComplete(formChangedPokemon: Pokemon): void {
     const { time, tweens, ui, animations } = globalScene;
-    const onFormChangeComplete = (): void => {
-      const preName = getPokemonNameWithAffix(this.pokemon);
+    const preName = getPokemonNameWithAffix(this.pokemon);
 
+    const onFormChangeComplete = (): void => {
       tweens.add({
         targets: this.bgOverlay,
         alpha: 0,


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

When a Pokemon changes form and the game displays "[preName] has Mega Evolved into [newName]", the preName is now correctly displayed as the Pokemon's name before, not after, the form change.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

Bug reported in #1107.

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

`preName` is moved earlier so that it gets set before the Pokemon has officially changed form.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

<details><summary>Before the changes: [preName] is "Mega Audino"</summary>
<p>

![20250502 Before Fix Form Name](https://github.com/user-attachments/assets/fda22abd-2a51-4059-ad07-6a52089f4190)

</p>
</details> 

<details><summary>After the changes: [preName] is "Audino"</summary>
<p>

![20250502 After Fix Form Name](https://github.com/user-attachments/assets/9a64565c-7d23-45da-af51-e70f7f797418)

</p>
</details> 

<details><summary>After the changes: Also works correctly if the Pokemon is nicknamed</summary>
<p>

![20250502 After Fix Nickname](https://github.com/user-attachments/assets/8cd22472-78c6-46d8-a31a-8281091f766c)

</p>
</details> 

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

```
  STARTING_MODIFIER_OVERRIDE: [{name: "MEGA_BRACELET"}],
  ITEM_REWARD_OVERRIDE: [{name: "RARE_FORM_CHANGE_ITEM"}],
```

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [ ] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?