### PR TITLE
[Refactor] Initialize `waveData` and `turnData` in constructor

### DIFF
--- a/src/data/abilities/apply-ab-attrs.ts
+++ b/src/data/abilities/apply-ab-attrs.ts
@@ -74,7 +74,7 @@ function applyAbAttrsInternal<TAttr extends AbAttr = never>(
         if (pokemon.summonData && !pokemon.summonData.abilitiesApplied.includes(ability.id)) {
           pokemon.summonData.abilitiesApplied.push(ability.id);
         }
-        if (pokemon.waveData && !pokemon.waveData.abilitiesApplied.includes(ability.id)) {
+        if (!pokemon.waveData.abilitiesApplied.includes(ability.id)) {
           pokemon.waveData.abilitiesApplied.push(ability.id);
           pokemon.waveData.abilitiesRevealed.push(ability.id);
         }

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -6,9 +6,9 @@ import { getStatusEffectHealText } from "#app/data/status-effect";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { getBerryName } from "#app/utils/berry-utils";
 import { NumberHolder, toDmgValue } from "#app/utils/common-utils";
 import { randSeedInt } from "#app/utils/random-utils";
-import { getBerryName } from "#app/utils/berry-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { BerryType } from "#enums/berry-type";
@@ -61,14 +61,13 @@ export function getBerryPredicate(berryType: BerryType): BerryPredicate {
 
 export type BerryEffectFunc = (pokemon: Pokemon, berryOwner?: Pokemon) => void;
 
+// TODO: simplify this
 export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
   switch (berryType) {
     case BerryType.SITRUS:
     case BerryType.ENIGMA:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
-        if (pokemon.waveData) {
-          pokemon.waveData.berriesEaten.push(berryType);
-        }
+        pokemon.waveData.berriesEaten.push(berryType);
         const hpHealed = new NumberHolder(toDmgValue(pokemon.getMaxHp() / 4));
         applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, hpHealed);
         globalScene.phaseManager.queuePokemonHealPhase(pokemon.getBattlerIndex(), hpHealed.value, {
@@ -81,9 +80,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
       };
     case BerryType.LUM:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
-        if (pokemon.waveData) {
-          pokemon.waveData.berriesEaten.push(berryType);
-        }
+        pokemon.waveData.berriesEaten.push(berryType);
         if (pokemon.hasNonVolatileStatusEffect(false, true)) {
           globalScene.phaseManager.queueMessagePhase(
             getStatusEffectHealText(pokemon.getStatusEffect(true), getPokemonNameWithAffix(pokemon)),
@@ -99,9 +96,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
     case BerryType.APICOT:
     case BerryType.SALAC:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
-        if (pokemon.waveData) {
-          pokemon.waveData.berriesEaten.push(berryType);
-        }
+        pokemon.waveData.berriesEaten.push(berryType);
         // Offset BerryType such that LIECHI -> Stat.ATK = 1, GANLON -> Stat.DEF = 2, so on and so forth
         const stat: BattleStat = berryType - BerryType.ENIGMA;
         const statStages = new NumberHolder(1);
@@ -117,17 +112,13 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
       };
     case BerryType.LANSAT:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
-        if (pokemon.waveData) {
-          pokemon.waveData.berriesEaten.push(berryType);
-        }
+        pokemon.waveData.berriesEaten.push(berryType);
         pokemon.addTag(BattlerTagType.CRIT_BOOST);
         applyAbAttrs<PostItemLostAbAttr>(AbAttrFlag.POST_ITEM_LOST, berryOwner ?? pokemon, false);
       };
     case BerryType.STARF:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
-        if (pokemon.waveData) {
-          pokemon.waveData.berriesEaten.push(berryType);
-        }
+        pokemon.waveData.berriesEaten.push(berryType);
         const randStat = randSeedInt(Stat.SPD, Stat.ATK);
         const stages = new NumberHolder(2);
         applyAbAttrs<DoubleBerryEffectAbAttr>(AbAttrFlag.DOUBLE_BERRY_EFFECT, pokemon, false, stages);
@@ -142,9 +133,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
       };
     case BerryType.LEPPA:
       return (pokemon: Pokemon, berryOwner?: Pokemon) => {
-        if (pokemon.waveData) {
-          pokemon.waveData.berriesEaten.push(berryType);
-        }
+        pokemon.waveData.berriesEaten.push(berryType);
         const ppRestoreMove = pokemon.getMoveset().find((m) => !m.getPpRatio())
           ? pokemon.getMoveset().find((m) => !m.getPpRatio())
           : pokemon.getMoveset().find((m) => m.getPpRatio() < 1);

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -185,8 +185,8 @@ import { getNonVolatileStatusEffects } from "#app/data/status-effect";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { NumberHolder, toDmgValue } from "#app/utils/common-utils";
 import { getWeatherCondition, normalTypeMoveConversionCondition } from "#app/utils/ability-utils";
+import { NumberHolder, toDmgValue } from "#app/utils/common-utils";
 import { applyMoveAttrs } from "#app/utils/move-utils";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -1683,10 +1683,6 @@ function getTerrainCondition(...terrainTypes: TerrainType[]): AbAttrCondition {
  */
 function getSheerForceHitDisableAbCondition(): AbAttrCondition {
   return (pokemon: Pokemon) => {
-    if (!pokemon.turnData) {
-      return true;
-    }
-
     const lastReceivedAttack = pokemon.turnData.attacksReceived[0];
     if (!lastReceivedAttack) {
       return true;
@@ -1714,7 +1710,7 @@ function getSheerForceHitDisableAbCondition(): AbAttrCondition {
  */
 function getOncePerBattleCondition(ability: AbilityId): AbAttrCondition {
   return (pokemon: Pokemon) => {
-    return !pokemon.waveData?.abilitiesApplied.includes(ability);
+    return !pokemon.waveData.abilitiesApplied.includes(ability);
   };
 }
 

--- a/src/data/moves/move-attrs/last-move-double-power-attr.ts
+++ b/src/data/moves/move-attrs/last-move-double-power-attr.ts
@@ -34,10 +34,10 @@ export class LastMoveDoublePowerAttr extends VariablePowerAttr {
       const userAlly = user.getAlly();
       const enemyAlly = target?.getAlly();
 
-      if (userAlly && userAlly.turnData.acted) {
+      if (userAlly?.turnData.acted) {
         pokemonActed.push(userAlly);
       }
-      if (enemyAlly && enemyAlly.turnData.acted) {
+      if (enemyAlly?.turnData.acted) {
         pokemonActed.push(enemyAlly);
       }
     }

--- a/src/data/moves/move-attrs/round-power-attr.ts
+++ b/src/data/moves/move-attrs/round-power-attr.ts
@@ -1,7 +1,7 @@
-import type { Pokemon } from "#app/field/pokemon";
-import type { NumberHolder } from "#app/utils/common-utils";
 import type { Move } from "#app/data/moves/move";
 import { VariablePowerAttr } from "#app/data/moves/move-attrs/variable-power-attr";
+import type { Pokemon } from "#app/field/pokemon";
+import type { NumberHolder } from "#app/utils/common-utils";
 
 /**
  * Variable Power attribute for {@link https://bulbapedia.bulbagarden.net/wiki/Round_(move) | Round}.
@@ -10,7 +10,7 @@ import { VariablePowerAttr } from "#app/data/moves/move-attrs/variable-power-att
  */
 export class RoundPowerAttr extends VariablePowerAttr {
   override apply(user: Pokemon, _target: Pokemon, _move: Move, power: NumberHolder): boolean {
-    if (user.turnData?.joinedRound) {
+    if (user.turnData.joinedRound) {
       power.value *= 2;
       return true;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -156,8 +156,6 @@ import {
   BooleanHolder,
   NumberHolder,
   coerceArray,
-  deepCopy,
-  deepFreeze,
   fixedNumber,
   getEnumValues,
   isNil,
@@ -210,31 +208,6 @@ interface AbilityData {
   passive: boolean;
 }
 
-const defaultWaveData = deepFreeze<PokemonWaveData>({
-  hitCount: 0,
-  berriesEaten: [],
-  abilitiesApplied: [],
-  abilitiesRevealed: [],
-});
-
-const defaultTurnData = deepFreeze<PokemonTurnData>({
-  flinched: false,
-  acted: false,
-  hitCount: 0,
-  hitsLeft: -1,
-  totalDamageDealt: 0,
-  singleHitDamageDealt: 0,
-  damageTaken: 0,
-  attacksReceived: [],
-  order: 0,
-  statStagesIncreased: false,
-  statStagesDecreased: false,
-  moveEffectiveness: null,
-  switchedInThisTurn: false,
-  failedRunAway: false,
-  joinedRound: false,
-});
-
 export abstract class Pokemon extends Phaser.GameObjects.Container {
   public id: number;
   public override name: string;
@@ -274,8 +247,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   private summonDataPrimer: PokemonSummonData | null;
 
   public summonData: PokemonSummonData;
+  // Default data defined in `resetWaveData()`
   public waveData: PokemonWaveData;
   public battleSummonData: PokemonBattleSummonData;
+  // Default data defined in `resetTurnData()`
   public turnData: PokemonTurnData;
   public customPokemonData: CustomPokemonData;
 
@@ -406,6 +381,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (!dataSource) {
       this.calculateStats();
     }
+
+    this.resetWaveData();
+    this.resetTurnData();
   }
 
   /**
@@ -1562,7 +1540,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   public hasRevealedAbility(abilityId: AbilityId) {
-    return this.waveData?.abilitiesRevealed.includes(abilityId);
+    return this.waveData.abilitiesRevealed.includes(abilityId);
   }
 
   /**
@@ -1869,8 +1847,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     simulated: boolean = true,
     cancelled?: BooleanHolder,
   ): TypeDamageMultiplier {
-    if (!isNil(this.turnData?.moveEffectiveness)) {
-      return this.turnData?.moveEffectiveness;
+    if (!isNil(this.turnData.moveEffectiveness)) {
+      return this.turnData.moveEffectiveness;
     }
 
     const applyAbFunc = getAbApplyFunc(abilityApplyMode);
@@ -3378,9 +3356,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     amount = Math.min(amount, this.hp);
     this.hp = this.hp - amount;
-    if (this.turnData) {
-      this.turnData.damageTaken += amount;
-    }
+    this.turnData.damageTaken += amount;
     if (this.isFainted() && !ignoreFaintPhase) {
       globalScene.phaseManager.queueBattlerFaintPhase(this.getBattlerIndex(), { preventEndure });
     }
@@ -4149,7 +4125,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   resetWaveData(): void {
-    this.waveData = deepCopy<PokemonWaveData>(defaultWaveData);
+    this.waveData = {
+      hitCount: 0,
+      berriesEaten: [],
+      abilitiesApplied: [],
+      abilitiesRevealed: [],
+    };
   }
 
   resetBattleSummonData(): void {
@@ -4163,7 +4144,23 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   resetTurnData(): void {
-    this.turnData = deepCopy<PokemonTurnData>(defaultTurnData);
+    this.turnData = {
+      flinched: false,
+      acted: false,
+      hitCount: 0,
+      hitsLeft: -1,
+      totalDamageDealt: 0,
+      singleHitDamageDealt: 0,
+      damageTaken: 0,
+      attacksReceived: [],
+      order: 0,
+      statStagesIncreased: false,
+      statStagesDecreased: false,
+      moveEffectiveness: null,
+      switchedInThisTurn: false,
+      failedRunAway: false,
+      joinedRound: false,
+    };
   }
 
   /**
@@ -4175,10 +4172,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   stopMultiHit(): void {
-    if (this.turnData) {
-      this.turnData.hitCount = 1;
-      this.turnData.hitsLeft = 1;
-    }
+    this.turnData.hitCount = 1;
+    this.turnData.hitsLeft = 1;
   }
 
   setFrameRate(frameRate: number) {

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -164,7 +164,7 @@ export class FaintPhase extends PokemonPhase {
     );
     globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeActiveTrigger, true);
 
-    if (this.source && pokemon.turnData?.attacksReceived?.length) {
+    if (this.source && pokemon.turnData.attacksReceived.length > 0) {
       const lastAttack = pokemon.turnData.attacksReceived[0];
       applyAbAttrs<PostFaintAbAttr>(
         AbAttrFlag.POST_FAINT,
@@ -180,7 +180,7 @@ export class FaintPhase extends PokemonPhase {
 
     const alivePlayField = globalScene.getField(true);
     alivePlayField.forEach((p) => applyAbAttrs<PostKnockOutAbAttr>(AbAttrFlag.POST_KNOCK_OUT, p, false, pokemon));
-    if (pokemon.turnData?.attacksReceived?.length) {
+    if (pokemon.turnData.attacksReceived.length > 0) {
       const defeatSource = globalScene.getPokemonById(pokemon.turnData.attacksReceived[0].sourceId);
       if (defeatSource?.isOnField()) {
         applyAbAttrs<PostVictoryAbAttr>(AbAttrFlag.POST_VICTORY, defeatSource, false);

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -85,15 +85,9 @@ export class MoveEffectPhase extends HitCheckPhase {
     const targets = this.getTargets();
 
     const isDelayedAttack = this.move.getMove().hasAttr(DelayedAttackAttr);
-    /** If the user was somehow removed from the field and it's not a delayed attack, end this phase */
-    if (!user.isOnField()) {
-      if (!isDelayedAttack) {
-        return super.end();
-      } else {
-        if (isNil(user.turnData)) {
-          user.resetTurnData();
-        }
-      }
+    // If the user was somehow removed from the field and it's not a delayed attack, end this phase
+    if (!user.isOnField() && !isDelayedAttack) {
+      return super.end();
     }
 
     /**

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -1,3 +1,4 @@
+import { CANVAS_SCALE } from "#app/constants/ui-constants";
 import type { PostStatStageChangeAbAttr } from "#app/data/abilities/ab-attrs/post-stat-stage-change-ab-attr";
 import type { ProtectStatAbAttr } from "#app/data/abilities/ab-attrs/protect-stat-ab-attr";
 import type { ReflectStatStageChangeAbAttr } from "#app/data/abilities/ab-attrs/reflect-stat-stage-change-ab-attr";
@@ -11,7 +12,6 @@ import { ResetNegativeStatStageModifier } from "#app/modifier/modifier";
 import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
 import { settings } from "#app/system/settings/settings-manager";
 import { handleTutorial } from "#app/tutorial";
-import { CANVAS_SCALE } from "#app/constants/ui-constants";
 import { BooleanHolder, NumberHolder } from "#app/utils/common-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -177,16 +177,8 @@ export class StatStageChangePhase extends PokemonPhase {
 
       for (const s of filteredStats) {
         if (stages.value > 0 && pokemon.getStatStage(s) < 6) {
-          if (!pokemon.turnData) {
-            // Temporary fix for missing turn data struct on turn 1
-            pokemon.resetTurnData();
-          }
           pokemon.turnData.statStagesIncreased = true;
         } else if (stages.value < 0 && pokemon.getStatStage(s) > -6) {
-          if (!pokemon.turnData) {
-            // Temporary fix for missing turn data struct on turn 1
-            pokemon.resetTurnData();
-          }
           pokemon.turnData.statStagesDecreased = true;
         }
 

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -75,9 +75,7 @@ export class TurnCommandManager {
    */
   public addCommand(turnCommand: TurnCommand) {
     const { pokemon } = turnCommand;
-    if (pokemon.turnData) {
-      pokemon.turnData.turnCommand = turnCommand;
-    }
+    pokemon.turnData.turnCommand = turnCommand;
     // Remove any existing commands by the Pokemon before adding
     this.tryRemoveCommand((tc) => tc.pokemon === pokemon);
     this.turnCommands.push(turnCommand);


### PR DESCRIPTION
## What are the changes the user will see?
Nothing, ideally.

## Why am I making these changes?
`Pokemon#turnData` and `Pokemon#waveData` could be `undefined` at times, which causes many issues (and was not properly communicated by the type system).

## What are the changes from a developer perspective?
Both `turnData` and `waveData` are now initialized in the `Pokemon` constructor, and all the guards for them being `undefined` are removed.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)