### PR TITLE
[Refactor] Change `Status` from class to interface

### DIFF
--- a/src/@types/Status.ts
+++ b/src/@types/Status.ts
@@ -1,0 +1,7 @@
+import type { StatusEffect } from "#enums/status-effect";
+
+export interface Status {
+  effect: StatusEffect;
+  toxicTurnCount: number;
+  sleepTurnsRemaining: number;
+}

--- a/src/@types/Status.ts
+++ b/src/@types/Status.ts
@@ -1,7 +1,19 @@
 import type { StatusEffect } from "#enums/status-effect";
 
+/** Contains fields related to {@linkcode StatusEffect}s */
 export interface Status {
-  effect: StatusEffect;
+  /** @see {@linkcode StatusEffect} */
+  readonly effect: StatusEffect;
+  /**
+   * Toxic damage is `1/16 max HP * toxicTurnCount`; increases by 1 per turn.
+   * Ignored if the effect is not {@linkcode StatusEffect.TOXIC}
+   * @defaultValue 0
+   */
   toxicTurnCount: number;
+  /**
+   * The pokemon wakes up when this is `0` and the {@linkcode effect} is {@linkcode StatusEffect.SLEEP}.
+   * Ignored if the effect is not sleep.
+   * @defaultValue 0
+   */
   sleepTurnsRemaining: number;
 }

--- a/src/constants/game-constants.ts
+++ b/src/constants/game-constants.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { SystemSaveData } from "#app/@types/SystemData";
+import type { StatusEffect } from "#enums/status-effect";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 // -- end tsdoc imports --
 
@@ -70,3 +71,19 @@ export const DEFAULT_NEW_TERRAIN_DURATION = 5;
 
 /** Abbreviations from 10^0 to 10^33 @todo localize these */
 export const LARGE_NUMBER_ABBREVIATIONS: string[] = ["", "K", "M", "B", "t", "q", "Q", "s", "S", "o", "n", "d"];
+
+/**
+ * The default min value for {@linkcode StatusEffect.SLEEP} when randomly setting the duration.
+ * Number from {@link https://bulbapedia.bulbagarden.net/wiki/Sleep_(status_condition)#Generation_V | Gen 5+}
+ *
+ * Note: This equates to `1` turn of sleep, subtract `1` from this value to get the actual duration.
+ */
+export const DEFAULT_MIN_SLEEP_DURATION = 2;
+
+/**
+ * The default max value for {@linkcode StatusEffect.SLEEP} when randomly setting the duration.
+ * Number from {@link https://bulbapedia.bulbagarden.net/wiki/Sleep_(status_condition)#Generation_V | Gen 5+}
+ *
+ * Note: This equates to `3` turns of sleep, subtract `1` from this value to get the actual duration.
+ */
+export const DEFAULT_MAX_SLEEP_DURATION = 4;

--- a/src/data/abilities/ab-attrs/reduce-sleep-duration-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/reduce-sleep-duration-ab-attr.ts
@@ -1,5 +1,4 @@
 import type { Pokemon } from "#app/field/pokemon";
-import type { NumberHolder } from "#app/utils/common-utils";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { StatusEffect } from "#enums/status-effect";
 import { AbAttr } from "./ab-attr";
@@ -27,14 +26,9 @@ export class ReduceSleepDurationAbAttr extends AbAttr {
    * - `[1]` - The number of turns remaining until the status is healed
    * @returns `true` if the ability was applied
    */
-  override apply(
-    _pokemon: Pokemon,
-    _simulated: boolean,
-    statusEffect: StatusEffect,
-    turnsRemaining: NumberHolder,
-  ): boolean {
+  override apply(pokemon: Pokemon, _simulated: boolean, statusEffect: StatusEffect): boolean {
     if (statusEffect === this.statusEffect) {
-      turnsRemaining.value -= 1;
+      pokemon.advanceStatusCounter();
       return true;
     }
 

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -13,7 +13,6 @@ import type MysteryEncounterOption from "#app/data/mystery-encounters/mystery-en
 import { showEncounterText } from "#app/data/mystery-encounters/utils/encounter-dialogue-utils";
 import { getNatureName } from "#app/data/nature";
 import type PokemonSpecies from "#app/data/pokemon-species";
-import { Status } from "#app/data/status-effect";
 import type { TrainerConfig } from "#app/data/trainer-config";
 import { allTrainerConfigs } from "#app/data/trainer-configs/all-trainer-configs";
 import type { Variant } from "#app/data/variant";
@@ -269,7 +268,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
     // Make sure basic data is clean
     enemyPokemon.hp = enemyPokemon.getMaxHp();
-    enemyPokemon.status = null;
+    enemyPokemon.resetStatus();
     enemyPokemon.passive = false;
 
     if (e < (doubleBattle ? 2 : 1)) {
@@ -350,7 +349,8 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
           : statusEffects === StatusEffect.SLEEP
             ? 3
             : undefined;
-        enemyPokemon.status = new Status(status, 0, cureTurn);
+        // @ts-expect-error - `Pokemon#setStatus` is protected; TODO: change this?
+        enemyPokemon.setStatus(status, { sleepTurnsRemaining: cureTurn });
       }
 
       // Set summon data fields

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -449,7 +449,9 @@ export function trainerThrowPokeball(
     const _2h = 2 * pokemon.hp;
     const catchRate = pokemon.species.catchRate;
     const pokeballMultiplier = getPokeballCatchMultiplier(pokeballType);
-    const statusMultiplier = pokemon.status ? getStatusEffectCatchRateMultiplier(pokemon.getStatusEffect(true)) : 1;
+    const statusMultiplier = pokemon.hasNonVolatileStatusEffect(false, true)
+      ? getStatusEffectCatchRateMultiplier(pokemon.getStatusEffect(true))
+      : 1;
     const x = Math.round((((_3m - _2h) * catchRate * pokeballMultiplier) / _3m) * statusMultiplier);
     ballTwitchRate = Math.round(65536 / Math.sqrt(Math.sqrt(255 / x)));
   }

--- a/src/data/status-effect.ts
+++ b/src/data/status-effect.ts
@@ -2,30 +2,6 @@ import { StatusEffect } from "#enums/status-effect";
 import type { ParseKeys } from "i18next";
 import i18next from "i18next";
 
-export class Status {
-  protected effect: StatusEffect;
-  /** Toxic damage is `1/16 max HP * toxicTurnCount` */
-  public toxicTurnCount: number = 0;
-  public sleepTurnsRemaining?: number;
-
-  constructor(effect: StatusEffect, toxicTurnCount: number = 0, sleepTurnsRemaining?: number) {
-    this.effect = effect;
-    this.toxicTurnCount = toxicTurnCount;
-    this.sleepTurnsRemaining = sleepTurnsRemaining;
-  }
-
-  get statusEffect(): StatusEffect {
-    return this.effect;
-  }
-
-  incrementTurn(): void {
-    this.toxicTurnCount++;
-    if (this.sleepTurnsRemaining) {
-      this.sleepTurnsRemaining--;
-    }
-  }
-}
-
 function getStatusEffectMessageKey(statusEffect: StatusEffect | undefined): string {
   switch (statusEffect) {
     case StatusEffect.POISON:

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -9,7 +9,6 @@ import { CritOnlyAttr } from "#app/data/moves/move-attrs/crit-only-attr";
 import { pokemonPreEvolutions } from "#app/data/pokemon-pre-evolutions";
 import type PokemonSpecies from "#app/data/pokemon-species";
 import { SpeciesFormChangeActiveTrigger } from "#app/data/species-form-change-triggers/species-form-change-active-trigger";
-import { Status } from "#app/data/status-effect";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
 import { Pokemon } from "#app/field/pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
@@ -75,7 +74,7 @@ export class EnemyPokemon extends Pokemon {
     }
 
     if (Overrides.ENEMY_STATUS_OVERRIDE) {
-      this.status = new Status(Overrides.ENEMY_STATUS_OVERRIDE, 0, 4);
+      this.setStatus(Overrides.ENEMY_STATUS_OVERRIDE, { sleepTurnsRemaining: 4 });
     }
 
     if (Overrides.ENEMY_GENDER_OVERRIDE) {

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -9,7 +9,6 @@ import {
   getCandyProgressRequirement,
   speciesStarterCosts,
 } from "#app/data/starters";
-import { Status } from "#app/data/status-effect";
 import { reverseCompatibleTms, tmSpecies } from "#app/data/tms";
 import type { Variant } from "#app/data/variant";
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
@@ -63,7 +62,7 @@ export class PlayerPokemon extends Pokemon {
     super(106, 148, species, level, abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource);
 
     if (Overrides.STATUS_OVERRIDE) {
-      this.status = new Status(Overrides.STATUS_OVERRIDE, 0, 4);
+      this.setStatus(Overrides.STATUS_OVERRIDE, { sleepTurnsRemaining: 4 });
     }
 
     if (Overrides.SHINY_OVERRIDE) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4066,7 +4066,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   protected setStatus(
     effect: StatusEffect,
-    { toxicTurnCount = 0, sleepTurnsRemaining = 0 }: { toxicTurnCount?: number; sleepTurnsRemaining?: number },
+    { toxicTurnCount = 0, sleepTurnsRemaining = 0 }: Partial<Omit<Status, "effect">>,
   ): void {
     this.status = {
       effect,
@@ -4093,6 +4093,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
           break;
         }
         this.status.sleepTurnsRemaining--;
+        break;
+      default:
+        // intentionally left blank
         break;
     }
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -21,7 +21,11 @@ import {
   SEMI_INVULNERABLE_BATTLER_TAG_TYPES,
   TRAPPED_BATTLER_TAG_TYPES,
 } from "#app/constants/battler-tag-constants";
-import { DYNAMAX_DAMAGE_TAKEN_FACTOR } from "#app/constants/game-constants";
+import {
+  DEFAULT_MAX_SLEEP_DURATION,
+  DEFAULT_MIN_SLEEP_DURATION,
+  DYNAMAX_DAMAGE_TAKEN_FACTOR,
+} from "#app/constants/game-constants";
 import type { AbAttr } from "#app/data/abilities/ab-attrs/ab-attr";
 import type { AddSecondStrikeAbAttr } from "#app/data/abilities/ab-attrs/add-second-strike-ab-attr";
 import type { AlliedFieldDamageReductionAbAttr } from "#app/data/abilities/ab-attrs/allied-field-damage-reduction-ab-attr";
@@ -4042,7 +4046,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const sleepTurnsRemaining: NumberHolder = new NumberHolder(0);
 
     if (effect === StatusEffect.SLEEP) {
-      sleepTurnsRemaining.value = turnsRemaining !== 0 ? turnsRemaining : this.randSeedIntRange(2, 4);
+      sleepTurnsRemaining.value =
+        turnsRemaining !== 0
+          ? turnsRemaining
+          : this.randSeedIntRange(DEFAULT_MIN_SLEEP_DURATION, DEFAULT_MAX_SLEEP_DURATION);
 
       this.setFrameRate(4);
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -4006,6 +4006,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return true;
   }
 
+  /** @todo Refactor this */
   trySetStatus(
     effect: StatusEffect,
     asPhase: boolean = false,

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -9,10 +9,18 @@ import type { FaintPhase } from "#app/phases/faint-phase";
 import type { AbilityFilterOptions } from "#app/@types/AbilityFilterOptions";
 import type { DamageCalculationResult } from "#app/@types/DamageCalculationResult";
 import type { DamageFunctionOptions } from "#app/@types/DamageFunctionOptions";
+import type { nil } from "#app/@types/nil";
 import type { PokemonTurnData } from "#app/@types/PokemonTurnData";
 import type { PokemonWaveData } from "#app/@types/PokemonWaveData";
+import type { Status } from "#app/@types/Status";
 import type { TurnMove } from "#app/@types/TurnMove";
 import type { AnySound } from "#app/audio-manager";
+import { WEAKEN_MOVE_SCREEN_ARENA_TAG_TYPES } from "#app/constants/arena-tag-constants";
+import {
+  CRIT_BOOST_BATTLER_TAG_TYPES,
+  SEMI_INVULNERABLE_BATTLER_TAG_TYPES,
+  TRAPPED_BATTLER_TAG_TYPES,
+} from "#app/constants/battler-tag-constants";
 import { DYNAMAX_DAMAGE_TAKEN_FACTOR } from "#app/constants/game-constants";
 import type { AbAttr } from "#app/data/abilities/ab-attrs/ab-attr";
 import type { AddSecondStrikeAbAttr } from "#app/data/abilities/ab-attrs/add-second-strike-ab-attr";
@@ -114,7 +122,7 @@ import { SpeciesFormChangeActiveTrigger } from "#app/data/species-form-change-tr
 import { SpeciesFormChangeMoveLearnedTrigger } from "#app/data/species-form-change-triggers/species-form-change-move-learned-trigger";
 import { SpeciesFormChangePostMoveTrigger } from "#app/data/species-form-change-triggers/species-form-change-post-move-trigger";
 import { SpeciesFormChangeStatusEffectTrigger } from "#app/data/species-form-change-triggers/species-form-change-status-effect-trigger";
-import { Status, getNonVolatileStatusEffects } from "#app/data/status-effect";
+import { getNonVolatileStatusEffects } from "#app/data/status-effect";
 import { tmPoolTiers, tmSpecies } from "#app/data/tms";
 import { getTypeDamageMultiplier, getTypeRgb, type TypeDamageMultiplier } from "#app/data/type";
 import { variantData, type Variant } from "#app/data/variant";
@@ -145,12 +153,6 @@ import type PokemonData from "#app/system/pokemon-data";
 import { settings } from "#app/system/settings/settings-manager";
 import { timedEventManager } from "#app/timed-event-manager";
 import type { BattleInfo } from "#app/ui/components/battle-info";
-import { WEAKEN_MOVE_SCREEN_ARENA_TAG_TYPES } from "#app/constants/arena-tag-constants";
-import {
-  CRIT_BOOST_BATTLER_TAG_TYPES,
-  SEMI_INVULNERABLE_BATTLER_TAG_TYPES,
-  TRAPPED_BATTLER_TAG_TYPES,
-} from "#app/constants/battler-tag-constants";
 import { applyChallenges } from "#app/utils/challenge-utils";
 import {
   BooleanHolder,
@@ -161,7 +163,6 @@ import {
   isNil,
   toDmgValue,
 } from "#app/utils/common-utils";
-import type { nil } from "#app/@types/nil";
 import { loadMoveAnimAssets } from "#app/utils/move-anim-utils";
 import { applyMoveAttrs } from "#app/utils/move-utils";
 import { getIvsFromId, getPokemonSpecies, getPokemonSpeciesForm } from "#app/utils/pokemon-utils";
@@ -229,7 +230,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public ivs: number[];
   public nature: Nature;
   public moveset: PokemonMove[];
-  public status: Status | null;
+  protected status: Status | null = null;
   public friendship: number;
   public metLevel: number;
   public metBiome: BiomeId | -1;
@@ -323,7 +324,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.nature = dataSource.nature || (0 as Nature);
       this.nickname = dataSource.nickname;
       this.moveset = dataSource.moveset;
-      this.status = dataSource.status!; // TODO: is this bang correct?
+      // @ts-expect-error - `Pokemon#status` is protected
+      this.status = dataSource.status;
       this.friendship = dataSource.friendship !== undefined ? dataSource.friendship : this.species.baseFriendship;
       this.metLevel = dataSource.metLevel || 5;
       this.luck = dataSource.luck;
@@ -423,6 +425,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   public set teraType(value: ElementalType) {
     this._teraType = value;
+  }
+
+  public get toxicTurnCount(): number {
+    return this.status?.toxicTurnCount ?? 0;
+  }
+
+  public get sleepTurnsRemaining(): number {
+    return this.status?.sleepTurnsRemaining ?? 0;
   }
 
   /**
@@ -3861,7 +3871,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   getStatusEffect(ignoreMockAbility: boolean = false): StatusEffect {
     const statusEffect = new NumberHolder(StatusEffect.NONE);
     if (this.status) {
-      statusEffect.value = this.status.statusEffect;
+      statusEffect.value = this.status.effect;
     }
     if (!ignoreMockAbility) {
       applyAbAttrs<MockStatusEffectAbAttr>(AbAttrFlag.MOCK_STATUS_EFFECT, this, false, statusEffect);
@@ -3885,7 +3895,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     sourcePokemon: Pokemon | null = null,
     ignoreField: boolean = false,
   ): boolean {
-    if (overrideStatus ? this.status?.statusEffect === effect : this.status) {
+    if (overrideStatus ? this.status?.effect === effect : this.status) {
       return false;
     }
     if (this.isGrounded() && !ignoreField && globalScene.arena.hasTerrain(TerrainType.MISTY)) {
@@ -4018,10 +4028,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return true;
     }
 
-    let sleepTurnsRemaining: NumberHolder;
+    const sleepTurnsRemaining: NumberHolder = new NumberHolder(0);
 
     if (effect === StatusEffect.SLEEP) {
-      sleepTurnsRemaining = new NumberHolder(turnsRemaining !== 0 ? turnsRemaining : this.randSeedIntRange(2, 4));
+      sleepTurnsRemaining.value = turnsRemaining !== 0 ? turnsRemaining : this.randSeedIntRange(2, 4);
 
       this.setFrameRate(4);
 
@@ -4033,8 +4043,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
 
-    sleepTurnsRemaining = sleepTurnsRemaining!; // tell TS compiler it's defined
-    this.status = new Status(effect, 0, sleepTurnsRemaining?.value);
+    this.setStatus(effect, { sleepTurnsRemaining: sleepTurnsRemaining.value });
 
     globalScene.triggerPokemonFormChange(this, SpeciesFormChangeStatusEffectTrigger, true);
     if (sourcePokemon) {
@@ -4042,6 +4051,46 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     return true;
+  }
+
+  protected setStatus(
+    effect: StatusEffect,
+    { toxicTurnCount = 0, sleepTurnsRemaining = 0 }: { toxicTurnCount?: number; sleepTurnsRemaining?: number },
+  ): void {
+    this.status = {
+      effect,
+      toxicTurnCount,
+      sleepTurnsRemaining,
+    };
+  }
+
+  public advanceStatusCounter(): void {
+    if (!this.status) {
+      return;
+    }
+    switch (this.status.effect) {
+      case StatusEffect.TOXIC:
+        this.status.toxicTurnCount++;
+        break;
+      case StatusEffect.SLEEP:
+        if (Overrides.STATUS_ACTIVATION_OVERRIDE === true) {
+          this.status.sleepTurnsRemaining = Math.max(this.status.sleepTurnsRemaining, 1);
+          break;
+        }
+        if (Overrides.STATUS_ACTIVATION_OVERRIDE === false) {
+          this.status.sleepTurnsRemaining = 0;
+          break;
+        }
+        this.status.sleepTurnsRemaining--;
+        break;
+    }
+  }
+
+  public resetToxicTurnCounter(): void {
+    if (!this.status) {
+      return;
+    }
+    this.status.toxicTurnCount = 0;
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -427,10 +427,20 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this._teraType = value;
   }
 
+  /**
+   * Toxic damage is `1/16 max HP * toxicTurnCount`; increases by 1 per turn.
+   * Ignored if the effect is not {@linkcode StatusEffect.TOXIC}
+   * @defaultValue 0
+   */
   public get toxicTurnCount(): number {
     return this.status?.toxicTurnCount ?? 0;
   }
 
+  /**
+   * The pokemon wakes up when this is `0` and the {@linkcode effect} is {@linkcode StatusEffect.SLEEP}.
+   * Ignored if the effect is not sleep.
+   * @defaultValue 0
+   */
   public get sleepTurnsRemaining(): number {
     return this.status?.sleepTurnsRemaining ?? 0;
   }
@@ -4086,6 +4096,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
+  /** If the pokemon is statused, reset {@linkcode toxicTurnCount} to 0 */
   public resetToxicTurnCounter(): void {
     if (!this.status) {
       return;

--- a/src/modifier/init-modifier-pools.ts
+++ b/src/modifier/init-modifier-pools.ts
@@ -108,7 +108,7 @@ export function initModifierPools() {
           party.filter(
             (p) =>
               p.hp
-              && !!p.status
+              && p.hasNonVolatileStatusEffect(false, true)
               && !p.getHeldItems().some((i) => {
                 if (i instanceof TurnStatusEffectModifier) {
                   return (i as TurnStatusEffectModifier).getStatusEffect() === p.getStatusEffect(true);
@@ -174,7 +174,7 @@ export function initModifierPools() {
           party.filter(
             (p) =>
               p.hp
-              && !!p.status
+              && p.hasNonVolatileStatusEffect(false, true)
               && !p.getHeldItems().some((i) => {
                 if (i instanceof TurnStatusEffectModifier) {
                   return (i as TurnStatusEffectModifier).getStatusEffect() === p.getStatusEffect(true);

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -61,7 +61,6 @@ import { getModifierPoolForType } from "#app/utils/modifier-pool-utils";
 import { getModifierType } from "#app/utils/modifier-type-utils";
 import { randSeedInt } from "#app/utils/random-utils";
 import { formatMoney, leftPad } from "#app/utils/string-utils";
-import { BattlerTagType } from "#enums/battler-tag-type";
 import { BerryType } from "#enums/berry-type";
 import { ElementalType } from "#enums/elemental-type";
 import { EvolutionItem } from "#enums/evolution-item";
@@ -404,9 +403,7 @@ export class PokemonHpRestoreModifierType extends PokemonModifierType {
         || ((pokemon: PlayerPokemon) => {
           if (
             !pokemon.hp
-            || (pokemon.isFullHp()
-              && (!this.healStatus
-                || (!pokemon.hasNonVolatileStatusEffect(false, true) && !pokemon.getTag(BattlerTagType.CONFUSED))))
+            || (pokemon.isFullHp() && (!this.healStatus || !pokemon.hasNonVolatileStatusEffect(true, true)))
           ) {
             return i18next.t(PARTY_UI_NO_EFFECT_MSG_i18N_KEY);
           }
@@ -473,10 +470,7 @@ export class PokemonStatusHealModifierType extends PokemonModifierType {
       iconImage,
       (_type, args) => new PokemonStatusHealModifier(this, (args[0] as PlayerPokemon).id),
       (pokemon: PlayerPokemon) => {
-        if (
-          !pokemon.hp
-          || (!pokemon.hasNonVolatileStatusEffect(false, true) && !pokemon.getTag(BattlerTagType.CONFUSED))
-        ) {
+        if (!pokemon.hp || !pokemon.hasNonVolatileStatusEffect(true, true)) {
           return i18next.t(PARTY_UI_NO_EFFECT_MSG_i18N_KEY);
         }
         return null;

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -405,7 +405,8 @@ export class PokemonHpRestoreModifierType extends PokemonModifierType {
           if (
             !pokemon.hp
             || (pokemon.isFullHp()
-              && (!this.healStatus || (!pokemon.status && !pokemon.getTag(BattlerTagType.CONFUSED))))
+              && (!this.healStatus
+                || (!pokemon.hasNonVolatileStatusEffect(false, true) && !pokemon.getTag(BattlerTagType.CONFUSED))))
           ) {
             return i18next.t(PARTY_UI_NO_EFFECT_MSG_i18N_KEY);
           }
@@ -472,7 +473,10 @@ export class PokemonStatusHealModifierType extends PokemonModifierType {
       iconImage,
       (_type, args) => new PokemonStatusHealModifier(this, (args[0] as PlayerPokemon).id),
       (pokemon: PlayerPokemon) => {
-        if (!pokemon.hp || (!pokemon.status && !pokemon.getTag(BattlerTagType.CONFUSED))) {
+        if (
+          !pokemon.hp
+          || (!pokemon.hasNonVolatileStatusEffect(false, true) && !pokemon.getTag(BattlerTagType.CONFUSED))
+        ) {
           return i18next.t(PARTY_UI_NO_EFFECT_MSG_i18N_KEY);
         }
         return null;

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -255,7 +255,7 @@ export class MovePhase extends BattlePhase {
       !this.followUp
       && this.pokemon.hasStatusEffect([StatusEffect.SLEEP, StatusEffect.PARALYSIS, StatusEffect.FREEZE], false, true)
     ) {
-      this.pokemon.status!.incrementTurn();
+      this.pokemon.advanceStatusCounter();
       let activated = false;
       let healed = false;
 
@@ -268,21 +268,8 @@ export class MovePhase extends BattlePhase {
           break;
         case StatusEffect.SLEEP:
           applyMoveAttrs(BypassSleepAttr, this.pokemon, null, this.move.getMove());
-          const turnsRemaining = new NumberHolder(this.pokemon.status!.sleepTurnsRemaining ?? 0);
-          applyAbAttrs<ReduceSleepDurationAbAttr>(
-            AbAttrFlag.REDUCE_SLEEP_DURATION,
-            this.pokemon,
-            false,
-            statusEffect,
-            turnsRemaining,
-          );
-          if (Overrides.STATUS_ACTIVATION_OVERRIDE === true) {
-            turnsRemaining.value = Math.max(turnsRemaining.value, 1);
-          } else if (Overrides.STATUS_ACTIVATION_OVERRIDE === false) {
-            turnsRemaining.value = 0;
-          }
-          this.pokemon.status!.sleepTurnsRemaining = turnsRemaining.value;
-          healed = this.pokemon.status!.sleepTurnsRemaining <= 0;
+          applyAbAttrs<ReduceSleepDurationAbAttr>(AbAttrFlag.REDUCE_SLEEP_DURATION, this.pokemon, false, statusEffect);
+          healed = this.pokemon.sleepTurnsRemaining <= 0;
           activated = !healed && !this.pokemon.getTag(BattlerTagType.BYPASS_SLEEP);
           break;
         case StatusEffect.FREEZE:

--- a/src/phases/obtain-status-effect-phase.ts
+++ b/src/phases/obtain-status-effect-phase.ts
@@ -39,24 +39,25 @@ export class ObtainStatusEffectPhase extends PokemonPhase {
   public override start(): void {
     const pokemon = this.getPokemon();
     if (pokemon && !pokemon.hasNonVolatileStatusEffect(false, true)) {
-      if (pokemon.trySetStatus(this.statusEffect, false, this.sourcePokemon)) {
-        if (this.turnsRemaining) {
-          // @ts-expect-error - `Pokemon#status` is protected; TODO: change this
-          pokemon.status!.sleepTurnsRemaining = this.turnsRemaining;
-        }
+      if (pokemon.trySetStatus(this.statusEffect, false, this.sourcePokemon, this.turnsRemaining, this.sourceText)) {
         pokemon.updateInfo(true);
-        new CommonBattleAnim(CommonAnim.POISON + (this.statusEffect! - 1), pokemon).play(false, () => {
-          globalScene.phaseManager.queueMessagePhase(
-            getStatusEffectObtainText(this.statusEffect, getPokemonNameWithAffix(pokemon), this.sourceText),
+        new CommonBattleAnim(CommonAnim.POISON + (this.statusEffect - 1), pokemon).play(false, () => {
+          const effectObtainText = getStatusEffectObtainText(
+            this.statusEffect,
+            getPokemonNameWithAffix(pokemon),
+            this.sourceText,
           );
+          globalScene.phaseManager.queueMessagePhase(effectObtainText);
           this.end();
         });
         return;
       }
     } else if (pokemon.getStatusEffect(true) === this.statusEffect) {
-      globalScene.phaseManager.queueMessagePhase(
-        getStatusEffectOverlapText(this.statusEffect ?? StatusEffect.NONE, getPokemonNameWithAffix(pokemon)),
+      const effectOverlapText = getStatusEffectOverlapText(
+        this.statusEffect ?? StatusEffect.NONE,
+        getPokemonNameWithAffix(pokemon),
       );
+      globalScene.phaseManager.queueMessagePhase(effectOverlapText);
     }
     this.end();
   }

--- a/src/phases/obtain-status-effect-phase.ts
+++ b/src/phases/obtain-status-effect-phase.ts
@@ -1,13 +1,13 @@
-import type { BattlerIndex } from "#enums/battler-index";
 import { CommonBattleAnim } from "#app/data/animations/common-battle-anim";
-import { CommonAnim } from "#enums/common-anim";
 import { getStatusEffectObtainText, getStatusEffectOverlapText } from "#app/data/status-effect";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import type { BattlerIndex } from "#enums/battler-index";
+import { CommonAnim } from "#enums/common-anim";
+import { PhaseId } from "#enums/phase-id";
 import { StatusEffect } from "#enums/status-effect";
 import { PokemonPhase } from "./abstract-pokemon-phase";
-import { PhaseId } from "#enums/phase-id";
 
 /**
  * Applies a status effect to a pokemon
@@ -38,9 +38,10 @@ export class ObtainStatusEffectPhase extends PokemonPhase {
 
   public override start(): void {
     const pokemon = this.getPokemon();
-    if (pokemon && !pokemon.status) {
+    if (pokemon && !pokemon.hasNonVolatileStatusEffect(false, true)) {
       if (pokemon.trySetStatus(this.statusEffect, false, this.sourcePokemon)) {
         if (this.turnsRemaining) {
+          // @ts-expect-error - `Pokemon#status` is protected; TODO: change this
           pokemon.status!.sleepTurnsRemaining = this.turnsRemaining;
         }
         pokemon.updateInfo(true);

--- a/src/phases/pokemon-heal-phase.ts
+++ b/src/phases/pokemon-heal-phase.ts
@@ -126,7 +126,7 @@ export class PokemonHealPhase extends CommonAnimPhase {
         }
       }
 
-      if (this.healStatus && !this.revive && pokemon.status) {
+      if (this.healStatus && !this.revive && pokemon.hasNonVolatileStatusEffect(false, true)) {
         lastStatusEffect = pokemon.getStatusEffect(true);
         pokemon.resetStatus();
       }

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -1,10 +1,10 @@
+import { ENTRY_HAZARD_ARENA_TAG_TYPES } from "#app/constants/arena-tag-constants";
 import type { CommanderAbAttr } from "#app/data/abilities/ab-attrs/commander-ab-attr";
 import type { PostSummonAbAttr } from "#app/data/abilities/ab-attrs/post-summon-ab-attr";
 import { applyAbAttrs } from "#app/data/abilities/apply-ab-attrs";
 import type { MysteryEncounterPostSummonTag } from "#app/data/battler-tags/mystery-encounter-post-summon-tag";
 import { globalScene } from "#app/global-scene";
 import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
-import { ENTRY_HAZARD_ARENA_TAG_TYPES } from "#app/constants/arena-tag-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import type { BattlerIndex } from "#enums/battler-index";
@@ -25,7 +25,7 @@ export class PostSummonPhase extends PokemonPhase {
     const pokemon = this.getPokemon();
 
     if (pokemon.hasStatusEffect(StatusEffect.TOXIC)) {
-      pokemon.status!.toxicTurnCount = 0;
+      pokemon.resetToxicTurnCounter();
     }
 
     // Apply pending heal effects from Healing Wish and Lunar Dance.

--- a/src/phases/post-turn-status-effect-phase.ts
+++ b/src/phases/post-turn-status-effect-phase.ts
@@ -32,7 +32,7 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
       return this.end();
     }
 
-    pokemon.status!.incrementTurn();
+    pokemon.advanceStatusCounter();
 
     const cancelled = new BooleanHolder(false);
     applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, pokemon, false, cancelled);
@@ -52,7 +52,7 @@ export class PostTurnStatusEffectPhase extends PokemonPhase {
         damage.value = pokemon.getMaxHp() / 8;
         break;
       case StatusEffect.TOXIC:
-        damage.value = (pokemon.getMaxHp() / 16) * pokemon.status!.toxicTurnCount;
+        damage.value = (pokemon.getMaxHp() / 16) * pokemon.toxicTurnCount;
         break;
       case StatusEffect.BURN:
         damage.value = pokemon.getMaxHp() / 16;

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -1,6 +1,6 @@
+import type { Status } from "#app/@types/Status";
 import { loadBattlerTag } from "#app/data/battler-tags/utils/load-battler-tag";
 import { CustomPokemonData } from "#app/data/custom-pokemon-data";
-import { Status } from "#app/data/status-effect";
 import type { Variant } from "#app/data/variant";
 import type { Pokemon } from "#app/field/pokemon";
 import { PokemonMove } from "#app/field/pokemon-move";
@@ -97,6 +97,8 @@ export default class PokemonData {
     this.teraType = source.teraType;
     this.isTerastallized = source.isTerastallized ?? false;
     this.stellarTypesBoosted = source.stellarTypesBoosted ?? [];
+    // @ts-expect-error - `Pokemon#status` is protected
+    this.status = source.status;
 
     this.customPokemonData = new CustomPokemonData(source.customPokemonData);
 
@@ -109,22 +111,15 @@ export default class PokemonData {
 
     if (isPokemon(source)) {
       this.moveset = source.moveset;
-      this.status = source.status;
       if (this.player) {
         this.summonData = source.summonData;
       }
       return;
     }
 
-    // TODO: is this `.map()` needed? why?
     this.moveset = (source.moveset || [new PokemonMove(MoveId.TACKLE), new PokemonMove(MoveId.GROWL)]).map(
       (m) => new PokemonMove(m.moveId, m.ppUsed, m.ppUp, m.virtual, m.maxPpOverride),
     );
-    // TODO: can this just be `this.status = source.status`?
-    if (source.status) {
-      // @ts-expect-error - `Status#effect` is protected but we need to use the raw values when parsing save data
-      this.status = new Status(source.status.effect, source.status.toxicTurnCount, source.status.sleepTurnsRemaining);
-    }
 
     this.summonData = new PokemonSummonData();
     if (!source.summonData) {
@@ -138,9 +133,7 @@ export default class PokemonData {
     this.summonData.ability = source.summonData.ability;
     this.summonData.types = source.summonData.types;
 
-    // TODO: is this `.map()` needed? why?
     this.summonData.moveset = source.summonData.moveset?.map((m) => PokemonMove.loadMove(m)) ?? [];
-    // TODO: is this `.map()` needed? why?
     this.summonData.tags = source.summonData.tags?.map((t) => loadBattlerTag(t)) ?? [];
   }
 

--- a/test/abilities/early-bird.test.ts
+++ b/test/abilities/early-bird.test.ts
@@ -1,6 +1,6 @@
-import { MoveResult } from "#enums/move-result";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
@@ -68,7 +68,7 @@ describe("Abilities - Early Bird", () => {
     await game.toNextTurn();
 
     expect(player.getStatusEffect(true)).toBe(StatusEffect.SLEEP);
-    expect(player.status?.sleepTurnsRemaining).toBe(1);
+    expect(player.sleepTurnsRemaining).toBe(1);
   });
 
   it("reduces 1-turn sleep to 0 turns", async () => {

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -310,7 +310,7 @@ describe("Abilities - Magic Bounce", () => {
     // Turn 1 - thunder wave immunity test
     game.move.use(MoveId.THUNDER_WAVE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
 
     // Turn 2 - soundproof immunity test
     game.move.use(MoveId.GROWL);
@@ -336,7 +336,7 @@ describe("Abilities - Magic Bounce", () => {
     vi.spyOn(opponent, "getAccuracyMultiplier").mockReturnValue(0);
     game.move.use(MoveId.SPORE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
   });
 
   it("should always apply the leftmost available target's magic bounce when bouncing moves like sticky webs in doubles", async () => {
@@ -371,7 +371,7 @@ describe("Abilities - Magic Bounce", () => {
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
     expect(game.field.getEnemyPokemon().getStatusEffect()).toBe(StatusEffect.TOXIC);
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
 
     game.override.ability(AbilityId.NO_GUARD);
     game.move.use(MoveId.CHARM);

--- a/test/abilities/magic-bounce.test.ts
+++ b/test/abilities/magic-bounce.test.ts
@@ -310,7 +310,7 @@ describe("Abilities - Magic Bounce", () => {
     // Turn 1 - thunder wave immunity test
     game.move.use(MoveId.THUNDER_WAVE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
 
     // Turn 2 - soundproof immunity test
     game.move.use(MoveId.GROWL);
@@ -336,7 +336,7 @@ describe("Abilities - Magic Bounce", () => {
     vi.spyOn(opponent, "getAccuracyMultiplier").mockReturnValue(0);
     game.move.use(MoveId.SPORE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should always apply the leftmost available target's magic bounce when bouncing moves like sticky webs in doubles", async () => {
@@ -371,7 +371,7 @@ describe("Abilities - Magic Bounce", () => {
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
     expect(game.field.getEnemyPokemon().getStatusEffect()).toBe(StatusEffect.TOXIC);
-    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
 
     game.override.ability(AbilityId.NO_GUARD);
     game.move.use(MoveId.CHARM);

--- a/test/abilities/magic-guard.test.ts
+++ b/test/abilities/magic-guard.test.ts
@@ -137,7 +137,7 @@ describe("Abilities - Magic Guard", () => {
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
 
-    const toxicStartCounter = enemyPokemon.status!.toxicTurnCount;
+    const toxicStartCounter = enemyPokemon.toxicTurnCount;
     //should be 0
 
     await game.phaseInterceptor.to("TurnEndPhase");
@@ -149,7 +149,7 @@ describe("Abilities - Magic Guard", () => {
      * - The enemy Pokemon's hypothetical CatchRateMultiplier should be 1.5
      */
     expect(enemyPokemon.hp).toBe(enemyPokemon.getMaxHp());
-    expect(enemyPokemon.status!.toxicTurnCount).toBeGreaterThan(toxicStartCounter);
+    expect(enemyPokemon.toxicTurnCount).toBeGreaterThan(toxicStartCounter);
     expect(getStatusEffectCatchRateMultiplier(enemyPokemon.getStatusEffect(true))).toBe(1.5);
   });
 

--- a/test/battle/reload.test.ts
+++ b/test/battle/reload.test.ts
@@ -176,6 +176,6 @@ describe("Reload", () => {
 
     const newPokemon = game.field.getPlayerPokemon();
     expect(newPokemon.getStatusEffect(true)).toBe(StatusEffect.TOXIC);
-    expect(newPokemon.status?.toxicTurnCount).toBe(2);
+    expect(newPokemon.toxicTurnCount).toBe(2);
   });
 });

--- a/test/data/status_effect.test.ts
+++ b/test/data/status_effect.test.ts
@@ -368,29 +368,29 @@ describe("Status Effects", () => {
       await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
       const player = game.scene.getPlayerPokemon()!;
-      // @ts-expect-error - `Pokemon#setStatus` is protected
-      player.setStatus(StatusEffect.SLEEP, { sleepTurnsRemaining: 4 });
+      player.trySetStatus(StatusEffect.SLEEP, false, undefined, 4);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP, { ignoreMockAbility: true });
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.getStatusEffect(true)).toBe(StatusEffect.SLEEP);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP, { ignoreMockAbility: true });
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.getStatusEffect(true)).toBe(StatusEffect.SLEEP);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP, { ignoreMockAbility: true });
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.getStatusEffect(true)).toBe(StatusEffect.SLEEP);
+      expect(player).toHaveStatusEffect(StatusEffect.SLEEP, { ignoreMockAbility: true });
       expect(player).toHaveMoveResult(MoveResult.FAIL);
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();
 
-      expect(player.getStatusEffect(true)).toBe(StatusEffect.NONE);
+      expect(player).toHaveStatusEffect(StatusEffect.NONE, { ignoreMockAbility: true });
       expect(player).toHaveMoveResult(MoveResult.SUCCESS);
     });
   });

--- a/test/data/status_effect.test.ts
+++ b/test/data/status_effect.test.ts
@@ -1,5 +1,4 @@
 import {
-  Status,
   getStatusEffectActivationText,
   getStatusEffectDescriptor,
   getStatusEffectHealText,
@@ -369,7 +368,8 @@ describe("Status Effects", () => {
       await game.classicMode.startBattle([SpeciesId.FEEBAS]);
 
       const player = game.scene.getPlayerPokemon()!;
-      player.status = new Status(StatusEffect.SLEEP, 0, 4);
+      // @ts-expect-error - `Pokemon#setStatus` is protected
+      player.setStatus(StatusEffect.SLEEP, { sleepTurnsRemaining: 4 });
 
       game.move.select(MoveId.SPLASH);
       await game.toNextTurn();

--- a/test/items/toxic-orb.test.ts
+++ b/test/items/toxic-orb.test.ts
@@ -52,6 +52,6 @@ describe("Items - Toxic orb", () => {
     expect(i18next.t).toHaveBeenCalledWith("statusEffect:toxic.obtainSource", expect.anything());
 
     expect(player.getStatusEffect(true)).toBe(StatusEffect.TOXIC);
-    expect(player.status?.toxicTurnCount).toBe(0);
+    expect(player.toxicTurnCount).toBe(0);
   });
 });

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -289,7 +289,7 @@ describe("Moves - Magic Coat", () => {
     // Turn 1 - thunder wave immunity test
     game.move.use(MoveId.THUNDER_WAVE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
 
     // Turn 2 - soundproof immunity test
     game.move.use(MoveId.GROWL);
@@ -315,7 +315,7 @@ describe("Moves - Magic Coat", () => {
     vi.spyOn(opponent, "getAccuracyMultiplier").mockReturnValue(0);
     game.move.use(MoveId.SPORE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
+    expect(game.field.getPlayerPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should always apply the leftmost available target's Magic Coat when bouncing moves like sticky webs in doubles", async () => {

--- a/test/moves/magic-coat.test.ts
+++ b/test/moves/magic-coat.test.ts
@@ -289,7 +289,7 @@ describe("Moves - Magic Coat", () => {
     // Turn 1 - thunder wave immunity test
     game.move.use(MoveId.THUNDER_WAVE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
 
     // Turn 2 - soundproof immunity test
     game.move.use(MoveId.GROWL);
@@ -315,7 +315,7 @@ describe("Moves - Magic Coat", () => {
     vi.spyOn(opponent, "getAccuracyMultiplier").mockReturnValue(0);
     game.move.use(MoveId.SPORE);
     await game.toEndOfTurn();
-    expect(game.field.getPlayerPokemon().status).toBeUndefined();
+    expect(game.field.getPlayerPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
   });
 
   it("should always apply the leftmost available target's Magic Coat when bouncing moves like sticky webs in doubles", async () => {

--- a/test/moves/purify.test.ts
+++ b/test/moves/purify.test.ts
@@ -43,7 +43,7 @@ describe("Moves - Purify", () => {
 
     playerPokemon.hp = playerPokemon.getMaxHp() - 1;
     enemyPokemon.trySetStatus(StatusEffect.BURN);
-    expect(enemyPokemon.hasStatusEffect(StatusEffect.BURN)).toBeTruthy();
+    expect(enemyPokemon).toHaveStatusEffect(StatusEffect.BURN);
 
     game.move.select(MoveId.PURIFY);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);

--- a/test/moves/purify.test.ts
+++ b/test/moves/purify.test.ts
@@ -1,4 +1,3 @@
-import { Status } from "#app/data/status-effect";
 import type { EnemyPokemon } from "#app/field/enemy-pokemon";
 import type { PlayerPokemon } from "#app/field/player-pokemon";
 import { BattlerIndex } from "#enums/battler-index";
@@ -43,7 +42,8 @@ describe("Moves - Purify", () => {
     const playerPokemon: PlayerPokemon = game.scene.getPlayerPokemon()!;
 
     playerPokemon.hp = playerPokemon.getMaxHp() - 1;
-    enemyPokemon.status = new Status(StatusEffect.BURN);
+    enemyPokemon.trySetStatus(StatusEffect.BURN);
+    expect(enemyPokemon.hasStatusEffect(StatusEffect.BURN)).toBeTruthy();
 
     game.move.select(MoveId.PURIFY);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);

--- a/test/moves/toxic.test.ts
+++ b/test/moves/toxic.test.ts
@@ -47,7 +47,7 @@ describe("Moves - Toxic", () => {
     game.move.select(MoveId.TOXIC);
     await game.toEndOfTurn();
 
-    expect(game.field.getEnemyPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("should hit semi-invulnerable targets if user is Poison-type", async () => {
@@ -71,7 +71,7 @@ describe("Moves - Toxic", () => {
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
 
-    expect(game.field.getEnemyPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(StatusEffect.NONE);
   });
 
   it("moves other than Toxic should not hit semi-invulnerable targets even if user is Poison-type", async () => {

--- a/test/moves/toxic.test.ts
+++ b/test/moves/toxic.test.ts
@@ -1,11 +1,11 @@
+import { allMoves } from "#app/data/data-lists";
+import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { StatusEffect } from "#enums/status-effect";
-import { BattlerIndex } from "#enums/battler-index";
-import { allMoves } from "#app/data/data-lists";
 
 describe("Moves - Toxic", () => {
   let phaserGame: Phaser.Game;
@@ -47,7 +47,7 @@ describe("Moves - Toxic", () => {
     game.move.select(MoveId.TOXIC);
     await game.toEndOfTurn();
 
-    expect(game.scene.getEnemyPokemon()!.status).toBeUndefined();
+    expect(game.field.getEnemyPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
   });
 
   it("should hit semi-invulnerable targets if user is Poison-type", async () => {
@@ -71,7 +71,7 @@ describe("Moves - Toxic", () => {
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
 
-    expect(game.scene.getEnemyPokemon()!.status).toBeUndefined();
+    expect(game.field.getEnemyPokemon().hasNonVolatileStatusEffect(false, true)).toBeFalsy();
   });
 
   it("moves other than Toxic should not hit semi-invulnerable targets even if user is Poison-type", async () => {

--- a/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
@@ -214,7 +214,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       const party = scene.getPlayerParty();
       const lapras = party.find((pkm) => pkm.species.speciesId === SpeciesId.LAPRAS)!;
       lapras.trySetStatus(StatusEffect.POISON);
-      expect(lapras.hasStatusEffect(StatusEffect.POISON)).toBeTruthy();
+      expect(lapras).toHaveStatusEffect(StatusEffect.POISON);
       const abra = party.find((pkm) => pkm.species.speciesId === SpeciesId.ABRA)!;
       vi.spyOn(abra, "isAllowedInBattle").mockReturnValue(false);
 

--- a/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
@@ -3,7 +3,6 @@ import * as InitMoveAnim from "#app/data/init/init-move-anim";
 import { FieryFalloutEncounter } from "#app/data/mystery-encounters/encounters/fiery-fallout-encounter";
 import * as MysteryEncounters from "#app/data/mystery-encounters/mystery-encounters";
 import * as EncounterPhaseUtils from "#app/data/mystery-encounters/utils/encounter-phase-utils";
-import { Status } from "#app/data/status-effect";
 import type { PokemonHeldItemModifier } from "#app/modifier/modifier";
 import { CommandPhase } from "#app/phases/command-phase";
 import type { MovePhase } from "#app/phases/move-phase";
@@ -214,7 +213,8 @@ describe("Fiery Fallout - Mystery Encounter", () => {
 
       const party = scene.getPlayerParty();
       const lapras = party.find((pkm) => pkm.species.speciesId === SpeciesId.LAPRAS)!;
-      lapras.status = new Status(StatusEffect.POISON);
+      lapras.trySetStatus(StatusEffect.POISON);
+      expect(lapras.hasStatusEffect(StatusEffect.POISON)).toBeTruthy();
       const abra = party.find((pkm) => pkm.species.speciesId === SpeciesId.ABRA)!;
       vi.spyOn(abra, "isAllowedInBattle").mockReturnValue(false);
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
General refactoring.

## What are the changes from a developer perspective?
- `Pokemon#status` is now `protected`
- Added `Pokemon#setStatus`, `Pokemon#advanceStatusCounter` and `Pokemon#resetToxicTurnCounter`
- Renamed `Status#statusEffect` to `Status#effect`
- Added getters for `toxicTurnCount` and `sleepTurnsRemaining` in `Pokemon`
- Moved `Status` interface to `src/@types/Status.ts`

## How to test the changes?
`npm run test:silent`
Do various things involving status effects.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?