### PR TITLE
[Refactor] Rename `getFieldPokemonByBattlerIndex`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1,3 +1,4 @@
+import type { AbstractConstructor } from "#app/@types/AbstractConstructor";
 import type { HeldModifierConfig } from "#app/@types/HeldModifierConfig";
 import type { Localizable } from "#app/@types/locales";
 import type { ModifierPredicate } from "#app/@types/ModifierPredicate";
@@ -13,8 +14,8 @@ import {
   ME_BASE_SPAWN_WEIGHT,
   ME_MAX_SPAWN_WEIGHT,
 } from "#app/constants/mystery-encounter-constants";
-import { ELITE_FOUR_1_WAVE } from "#app/constants/wave-constants";
 import { CANVAS_SCALE, GAME_HEIGHT, GAME_WIDTH } from "#app/constants/ui-constants";
+import { ELITE_FOUR_1_WAVE } from "#app/constants/wave-constants";
 import type { BlockItemTheftAbAttr } from "#app/data/abilities/ab-attrs/block-item-theft-ab-attr";
 import type { DoubleBattleChanceAbAttr } from "#app/data/abilities/ab-attrs/double-battle-chance-ab-attr";
 import type { PostBattleInitAbAttr } from "#app/data/abilities/ab-attrs/post-battle-init-ab-attr";
@@ -124,7 +125,6 @@ import { UI } from "#app/ui/ui";
 import { setDocumentUiTheme, updateWindowStyle } from "#app/ui/ui-theme";
 import { loadCommonAnimAssets } from "#app/utils/anim-utils";
 import { BooleanHolder, fixedNumber, getEnumValues, isNil, NumberHolder } from "#app/utils/common-utils";
-import type { AbstractConstructor } from "#app/@types/AbstractConstructor";
 import { getModifierPoolForType } from "#app/utils/modifier-pool-utils";
 import { getModifierType } from "#app/utils/modifier-type-utils";
 import { loadMoveAnimAssets } from "#app/utils/move-anim-utils";
@@ -820,7 +820,7 @@ export default class BattleScene extends SceneBase {
 
   /**
    * Returns a list of all Pokemon currently on the field, potentially including fainted ones.
-   * @param activeOnly If `true`, only return Pokemon which are active (e.g., not fainted). Default `false`.
+   * @param activeOnly - (Default `false`) If `true`, only return Pokemon which are active (e.g., not fainted).
    */
   public getField(activeOnly: boolean = false): Pokemon[] {
     let ret: Pokemon[] = this.getPlayerField();
@@ -831,9 +831,9 @@ export default class BattleScene extends SceneBase {
   /**
    * Returns the Pokemon currently on the field that has a certain battler index, or `undefined` if no such Pokemon exists.
    * This function is allowed to return non-active (e.g., fainted) Pokemon.
-   * @param battlerIndex The battler index to search for.
+   * @param battlerIndex - The battler index to search for.
    */
-  public getFieldPokemonByBattlerIndex(battlerIndex?: BattlerIndex): Pokemon | undefined {
+  public getPokemonByBattlerIndex(battlerIndex: BattlerIndex): Pokemon | undefined {
     return this.getField().find((p) => p.getBattlerIndex() === battlerIndex);
   }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -831,7 +831,7 @@ export default class BattleScene extends SceneBase {
   /**
    * Returns the Pokemon currently on the field that has a certain battler index, or `undefined` if no such Pokemon exists.
    * This function is allowed to return non-active (e.g., fainted) Pokemon.
-   * @param battlerIndex - The battler index to search for.
+   * @param battlerIndex - The {@linkcode BattlerIndex} to search for.
    */
   public getPokemonByBattlerIndex(battlerIndex: BattlerIndex): Pokemon | undefined {
     return this.getField().find((p) => p.getBattlerIndex() === battlerIndex);

--- a/src/data/animations/move-anim.ts
+++ b/src/data/animations/move-anim.ts
@@ -1,12 +1,12 @@
-import { allMoves } from "#app/data/data-lists";
 import { LegacyAnimConfig } from "#app/data/animations/anim-config";
-import { BattleAnim } from "./battle-anims";
 import { moveAnims } from "#app/data/animations/move-anims";
+import { allMoves } from "#app/data/data-lists";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
 import type { BattlerIndex } from "#enums/battler-index";
 import { MoveFlags } from "#enums/move-flags";
 import type { MoveId } from "#enums/move-id";
+import { BattleAnim } from "./battle-anims";
 
 /**
  * Animation for effects during the use of a move.
@@ -17,7 +17,7 @@ export class MoveAnim extends BattleAnim {
   public moveId: MoveId;
 
   constructor(move: MoveId, user: Pokemon, targetIndex: BattlerIndex, playOnEmptyField: boolean = false) {
-    super(user, globalScene.getFieldPokemonByBattlerIndex(targetIndex), playOnEmptyField);
+    super(user, globalScene.getPokemonByBattlerIndex(targetIndex), playOnEmptyField);
 
     this.moveId = move;
   }

--- a/src/data/arena-tag.ts
+++ b/src/data/arena-tag.ts
@@ -547,7 +547,7 @@ class WishTag extends ArenaTag {
   }
 
   override onRemove(_arena: Arena): void {
-    const target = globalScene.getFieldPokemonByBattlerIndex(this.battlerIndex);
+    const target = globalScene.getPokemonByBattlerIndex(this.battlerIndex);
     if (target?.isActive(true)) {
       globalScene.phaseManager.queueMessagePhase(this.triggerMessage);
       globalScene.phaseManager.queuePokemonHealPhase(target.getBattlerIndex(), this.healHp);

--- a/src/data/battler-tags/move-lock-tag.ts
+++ b/src/data/battler-tags/move-lock-tag.ts
@@ -105,9 +105,9 @@ export abstract class MoveLockTag extends BattlerTag {
       }
 
       // Note: this assumes the locked move is single-target
-      const lastTarget = globalScene.getFieldPokemonByBattlerIndex(this.lastTargets[0]);
+      const lastTarget = globalScene.getPokemonByBattlerIndex(this.lastTargets[0]);
       const adjacentIndex = this.lastTargets[0] + (this.lastTargets[0] % 2 === 0 ? 1 : -1);
-      const adjacentTarget = globalScene.getFieldPokemonByBattlerIndex(adjacentIndex);
+      const adjacentTarget = globalScene.getPokemonByBattlerIndex(adjacentIndex);
 
       if (
         !lastTarget?.isActive(true)

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -1,4 +1,5 @@
 import type { TurnMove } from "#app/@types/TurnMove";
+import { MOVE_LOCK_TAG_TYPES } from "#app/constants/battler-tag-constants";
 import { DYNAMAX_DAMAGE_TAKEN_FACTOR, PLAYER_PARTY_MAX_SIZE } from "#app/constants/game-constants";
 import type { EncoreTag } from "#app/data/battler-tags/encore-tag";
 import { allMoves } from "#app/data/data-lists";
@@ -17,7 +18,6 @@ import Overrides from "#app/overrides";
 import { StatStageChangePhase } from "#app/phases/stat-stage-change-phase";
 import type PokemonData from "#app/system/pokemon-data";
 import { EnemyBattleInfo } from "#app/ui/components/battle-info";
-import { MOVE_LOCK_TAG_TYPES } from "#app/constants/battler-tag-constants";
 import { isBetween, isNil, toDmgValue } from "#app/utils/common-utils";
 import { randSeedInt, randSeedItem } from "#app/utils/random-utils";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
@@ -255,7 +255,7 @@ export class EnemyPokemon extends Pokemon {
             }
 
             const moveTargets = getMoveTargets(this, move.id)
-              .targets.map((ind) => globalScene.getFieldPokemonByBattlerIndex(ind))
+              .targets.map((ind) => globalScene.getPokemonByBattlerIndex(ind))
               .filter((p) => !isNil(p) && this.isPlayer() !== p.isPlayer()) as Pokemon[];
             // Only considers critical hits for crit-only moves or when this Pokemon is under the effect of Laser Focus
             const isCritical = move.hasAttr(CritOnlyAttr) || this.hasTag(BattlerTagType.ALWAYS_CRIT);
@@ -297,7 +297,7 @@ export class EnemyPokemon extends Pokemon {
                 break;
               }
 
-              const target = globalScene.getFieldPokemonByBattlerIndex(mt)!;
+              const target = globalScene.getPokemonByBattlerIndex(mt)!;
               /**
                * The "target score" of a move is given by the move's user benefit score + the move's target benefit score.
                * If the target is an ally, the target benefit score is multiplied by -1.

--- a/src/phases/abstract-pokemon-phase.ts
+++ b/src/phases/abstract-pokemon-phase.ts
@@ -1,7 +1,7 @@
-import { BattlerIndex } from "#enums/battler-index";
+import type { nil } from "#app/@types/nil";
 import type { Pokemon } from "#app/field/pokemon";
 import { globalScene } from "#app/global-scene";
-import type { nil } from "#app/@types/nil";
+import { BattlerIndex } from "#enums/battler-index";
 import { FieldPhase } from "./abstract-field-phase";
 
 /**
@@ -37,7 +37,7 @@ export abstract class PokemonPhase extends FieldPhase {
     if (this.battlerIndex > BattlerIndex.ENEMY_2) {
       pokemon = globalScene.getPokemonById(this.battlerIndex);
     } else {
-      pokemon = globalScene.getFieldPokemonByBattlerIndex(this.battlerIndex);
+      pokemon = globalScene.getPokemonByBattlerIndex(this.battlerIndex);
     }
     // TODO: Remove this bang
     return pokemon!;

--- a/src/phases/common-anim-phase.ts
+++ b/src/phases/common-anim-phase.ts
@@ -1,8 +1,8 @@
+import { CommonBattleAnim } from "#app/data/animations/common-battle-anim";
+import { globalScene } from "#app/global-scene";
+import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
 import type { BattlerIndex } from "#enums/battler-index";
 import type { CommonAnim } from "#enums/common-anim";
-import { CommonBattleAnim } from "#app/data/animations/common-battle-anim";
-import { PokemonPhase } from "#app/phases/abstract-pokemon-phase";
-import { globalScene } from "#app/global-scene";
 import { PhaseId } from "#enums/phase-id";
 
 /**
@@ -29,9 +29,7 @@ export class CommonAnimPhase extends PokemonPhase {
 
   public override start(): void {
     const user = this.getPokemon();
-    const target = globalScene.getFieldPokemonByBattlerIndex(this.targetIndex) ?? user;
-    new CommonBattleAnim(this.anim, user, target).play(false, () => {
-      this.end();
-    });
+    const target = this.targetIndex ? globalScene.getPokemonByBattlerIndex(this.targetIndex) : user;
+    new CommonBattleAnim(this.anim, user, target ?? user).play(false, () => this.end());
   }
 }

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -606,7 +606,7 @@ export class MoveEffectPhase extends HitCheckPhase {
      * due to a quirk where `getFirstTarget()` returns `undefined` if the target is fainted.
      */
     if (this.move.getMove().moveTarget === MoveTarget.DRAGON_DARTS) {
-      const ogTarget = globalScene.getFieldPokemonByBattlerIndex(this.targets[0]);
+      const ogTarget = globalScene.getPokemonByBattlerIndex(this.targets[0]);
       const allyPokemon = ogTarget?.getAlly();
       if (ogTarget?.isFainted() && allyPokemon?.isActive(true) && allyPokemon.id !== this.getUserPokemon()?.id) {
         this.targets = [allyPokemon.getBattlerIndex()];

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -439,7 +439,7 @@ export class MovePhase extends BattlePhase {
           targets.push(...globalScene.getField(true));
           break;
         default:
-          const target = globalScene.getFieldPokemonByBattlerIndex(t);
+          const target = globalScene.getPokemonByBattlerIndex(t);
           if (!isNil(target)) {
             targets.push(target);
           }
@@ -763,7 +763,7 @@ export class MovePhase extends BattlePhase {
       if (this.pokemon.turnData.attacksReceived.length) {
         this.targets[0] = this.pokemon.turnData.attacksReceived[0].sourceBattlerIndex;
         const [target] = this.targets;
-        const targetPkm = globalScene.getFieldPokemonByBattlerIndex(target);
+        const targetPkm = globalScene.getPokemonByBattlerIndex(target);
 
         // account for metal burst and comeuppance hitting remaining targets in double battles
         // counterattack will redirect to remaining ally if original attacker faints

--- a/src/phases/select-target-phase.ts
+++ b/src/phases/select-target-phase.ts
@@ -29,8 +29,8 @@ export class SelectTargetPhase extends PokemonPhase {
     const targetSelectedCallback = (targets: BattlerIndex[]) => {
       ui.setMessageMode();
 
-      const user = globalScene.getFieldPokemonByBattlerIndex(this.fieldIndex);
-      const firstTarget = globalScene.getFieldPokemonByBattlerIndex(targets[0]);
+      const user = globalScene.getPokemonByBattlerIndex(this.fieldIndex);
+      const firstTarget = globalScene.getPokemonByBattlerIndex(targets[0]);
       const moveObject = allMoves.get(moveId);
 
       // TODO: Resolve bang

--- a/src/ui/handlers/target-select-ui-handler.ts
+++ b/src/ui/handlers/target-select-ui-handler.ts
@@ -133,22 +133,24 @@ export class TargetSelectUiHandler extends UiHandler {
 
   /** @returns all valid target {@linkcode Pokemon} for the current target selection */
   protected getTargetsByIndex(): Pokemon[] {
-    return this.targets.map((index) => globalScene.getFieldPokemonByBattlerIndex(index)).filter((p) => !isNil(p));
+    return this.targets.map((index) => globalScene.getPokemonByBattlerIndex(index)).filter((p) => !isNil(p));
   }
 
   /** @returns the {@linkcode Pokemon} to highlight based on the move's targeting */
   protected getHighlightedPokemon(cursor: number): Pokemon[] {
     if (this.targets.includes(BattlerIndex.BOTH_SIDES)) {
       return globalScene.getField(true);
-    } else if (this.targets.includes(BattlerIndex.ENEMY_SIDE)) {
-      return globalScene.getEnemyField().filter((p) => p.isActive(true));
-    } else if (this.targets.includes(BattlerIndex.PLAYER_SIDE)) {
-      return globalScene.getPlayerField().filter((p) => p.isActive(true));
-    } else if (this.isMultipleTargets) {
-      return this.getTargetsByIndex();
-    } else {
-      return [globalScene.getFieldPokemonByBattlerIndex(cursor)!];
     }
+    if (this.targets.includes(BattlerIndex.ENEMY_SIDE)) {
+      return globalScene.getEnemyField().filter((p) => p.isActive(true));
+    }
+    if (this.targets.includes(BattlerIndex.PLAYER_SIDE)) {
+      return globalScene.getPlayerField().filter((p) => p.isActive(true));
+    }
+    if (this.isMultipleTargets) {
+      return this.getTargetsByIndex();
+    }
+    return [globalScene.getPokemonByBattlerIndex(cursor)!];
   }
 
   public override setCursor(cursor: number): boolean {


### PR DESCRIPTION
Also make param required

## What are the changes the user will see?
N/A

## Why am I making these changes?
The function name is a bit long, and the `battlerIndex` parameter should be required.

## What are the changes from a developer perspective?
- `BattleScene#getFieldPokemonByBattlerIndex` renamed to `BattleScene#getPokemonByBattlerIndex` (only field pokemon can have a battler index).
- Made `battlerIndex` a required parameter.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?