### PR TITLE
[Refactor] Use Phasers "orientationchange" event instead of window resize

### DIFF
--- a/src/ui/settings/general-settings-ui-handler.ts
+++ b/src/ui/settings/general-settings-ui-handler.ts
@@ -1,9 +1,9 @@
 import { globalScene } from "#app/global-scene";
+import { AbstractSettingsUiHandler } from "#app/ui/settings/abstract-settings-ui-handler";
 import { generalSettingsUiItems } from "#app/ui/settings/settings-ui-items";
 import { hasTouchscreen, isLandscapeMode } from "#app/utils/app-utils";
 import { t } from "i18next";
 import Phaser from "phaser";
-import { AbstractSettingsUiHandler } from "./abstract-settings-ui-handler";
 
 export class GeneralSettingsUiHandler extends AbstractSettingsUiHandler {
   /** Buffer to be able to unsubscribe on {@linkcode tearDown} */

--- a/src/ui/settings/general-settings-ui-handler.ts
+++ b/src/ui/settings/general-settings-ui-handler.ts
@@ -2,10 +2,12 @@ import { globalScene } from "#app/global-scene";
 import { generalSettingsUiItems } from "#app/ui/settings/settings-ui-items";
 import { hasTouchscreen, isLandscapeMode } from "#app/utils/app-utils";
 import { t } from "i18next";
+import Phaser from "phaser";
 import { AbstractSettingsUiHandler } from "./abstract-settings-ui-handler";
 
 export class GeneralSettingsUiHandler extends AbstractSettingsUiHandler {
-  private onWindowResizeEvent = () => this.updateMoveTouchControlsSettingsLabel();
+  /** Buffer to be able to unsubscribe on {@linkcode tearDown} */
+  private onOrientationChange = () => this.updateMoveTouchControlsSettingsLabel();
 
   constructor() {
     super("general", generalSettingsUiItems);
@@ -15,15 +17,12 @@ export class GeneralSettingsUiHandler extends AbstractSettingsUiHandler {
     super.setup();
 
     if (hasTouchscreen()) {
-      // TODO: we should user Phaser's scale 'orientationchange' event instead
-      window.addEventListener("resize", this.onWindowResizeEvent);
+      globalScene.scale.on(Phaser.Scale.Events.ORIENTATION_CHANGE, this.onOrientationChange);
     }
   }
 
   protected override tearDown(): void {
-    if (hasTouchscreen()) {
-      window.removeEventListener("resize", this.onWindowResizeEvent);
-    }
+    globalScene.scale.off(Phaser.Scale.Events.ORIENTATION_CHANGE, this.onOrientationChange); // Always remove listener. No error is thrown if listener was never present
     super.tearDown();
   }
 


### PR DESCRIPTION
## What are the changes the user will see?

n/a

## Why am I making these changes?

Closes #1097 

## What are the changes from a developer perspective?

- Replace a plain `"resize"` event to detect orientation change with the phaser `"orientationchange"` one

## Screenshots/Videos

https://github.com/user-attachments/assets/a0ae823b-7601-4c81-8dcb-318dee67df82

<sub> The log you see in the video, is not part of the final solution. It was just added for debugging and presentation </sub>

## How to test the changes?

1. Launch the game in your browser
2. Activate "mobile device emulation" on your browser: <img width="25" alt="image" src="https://github.com/user-attachments/assets/baed0a85-3bfd-4968-8964-56b75e27802b" />
3. Press the `switch orientation` button and see that the game still reacts to it
    - Buttons should change positions
    - Opening the settings you should see the viewport name displayed for moving the touchscreen buttons



## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)