### PR TITLE
[Bug] Fix parsing of local save data

### DIFF
--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -104,15 +104,15 @@ export function getDataTypeKey(dataType: GameDataType, slotId: number = 0): stri
 }
 
 export function encrypt(data: string, bypassLogin: boolean): string {
-  return (bypassLogin ? (data: string) => btoa(data) : (data: string) => AES.encrypt(data, saveKey))(
-    data,
-  ) as unknown as string; // TODO: is this correct?
+  const localFunc = (data: string): string => btoa(encodeURIComponent(data));
+  const serverFunc = (data: string): string => AES.encrypt(data, saveKey) as unknown as string; // TODO: is this correct?
+  return (bypassLogin ? localFunc : serverFunc)(data);
 }
 
 export function decrypt(data: string, bypassLogin: boolean): string {
-  return (bypassLogin ? (data: string) => atob(data) : (data: string) => AES.decrypt(data, saveKey).toString(enc.Utf8))(
-    data,
-  );
+  const localFunc = (data: string): string => decodeURIComponent(atob(data));
+  const serverFunc = (data: string): string => AES.decrypt(data, saveKey).toString(enc.Utf8);
+  return (bypassLogin ? localFunc : serverFunc)(data);
 }
 
 /**


### PR DESCRIPTION
## What are the changes the user will see?
Data saving/loading will no longer break if non-latin characters end up in the local save data somehow.

## Why am I making these changes?
Crash fix.

## What are the changes from a developer perspective?
The code path for saving and loading local save data now uses `encodeURIComponent`/`decodeURIComponent`.

## How to test the changes?
~I forgot to save the system/session data from before the fix, so I have no idea what caused it. This save is from after the fix, on the wave that was previously broken. I'm not sure if it's possible to observe the bug from it though, it was system data that was broken.~

~[sessionData1_Guest - local save encoding bug.pkty.txt](https://github.com/user-attachments/files/20053308/sessionData1_Guest.-.local.save.encoding.bug.pkty.txt)~

The following session save triggers the bug after you complete the wave (system data was freshly imported from the "everything" dev save in `test/test-utils/resources/saves/everything.pkty.txt`):

[sessionData1_Guest - local save encoding bug 2.pkty.txt](https://github.com/user-attachments/files/20053742/sessionData1_Guest.-.local.save.encoding.bug.2.pkty.txt)

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?