### PR TITLE
[Dev] Update `compilerOptions.target` to `ES2022` from `ES2020`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@eslint/js": "^9.24.0",
         "@hpcc-js/wasm": "^2.22.4",
         "@stylistic/eslint-plugin-ts": "^4.2.0",
+        "@types/crypto-js": "^4.2.2",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.14.1",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
@@ -2192,6 +2193,13 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@eslint/js": "^9.24.0",
     "@hpcc-js/wasm": "^2.22.4",
     "@stylistic/eslint-plugin-ts": "^4.2.0",
+    "@types/crypto-js": "^4.2.2",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.14.1",
     "@typescript-eslint/eslint-plugin": "^8.29.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "ES2022",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## What are the changes the user will see?
N/A?

## Why am I making these changes?
> [es2022](https://www.typescriptlang.org/docs/handbook/modules/reference.html#es2015-es2020-es2022-esnext): Adds support for top-level await to es2020.

~While apparently we're supposed to be using `nodenext`, that causes a billion errors so would potentially require extensive refactoring.~
~`npm run typecheck` output when using `nodenext`: "Found 3684 errors in 559 files."~
> ~`node16`, `node18`, and `nodenext` are the only correct `module` options for all apps and libraries that are intended to run in Node.js v12 or later, whether they use ES modules or not.~

## What are the changes from a developer perspective?
Top level `await` now supported.
> [!NOTE]
> I tried also updating `compilerOptions.target` to `ES2022` but that caused a strange bug with session loading where movesets would get deleted for all pokemon. Need to investigate further to change that. 

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)