### PR TITLE
[Bug] Court Change no longer fails if the enemy is semi-invul

### DIFF
--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -1,3 +1,5 @@
+import { CONDITIONAL_PROTECT_ARENA_TAG_TYPES } from "#app/constants/arena-tag-constants";
+import { SEMI_INVULNERABLE_BATTLER_TAG_TYPES, TRAPPED_BATTLER_TAG_TYPES } from "#app/constants/battler-tag-constants";
 import type { ShellTrapTag } from "#app/data/battler-tags/shell-trap-tag";
 import type { StockpilingTag } from "#app/data/battler-tags/stockpiling-tag";
 import { allMoves } from "#app/data/data-lists";
@@ -238,8 +240,6 @@ import { userSleptOrComatoseCondition } from "#app/data/moves/move-conditions/us
 import { getNonVolatileStatusEffects } from "#app/data/status-effect";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { CONDITIONAL_PROTECT_ARENA_TAG_TYPES } from "#app/constants/arena-tag-constants";
-import { SEMI_INVULNERABLE_BATTLER_TAG_TYPES, TRAPPED_BATTLER_TAG_TYPES } from "#app/constants/battler-tag-constants";
 import { isNil } from "#app/utils/common-utils";
 import { crashDamageFunc } from "#app/utils/move-utils";
 import { AbilityId } from "#enums/ability-id";
@@ -2831,7 +2831,8 @@ export function initMoves() {
       .attr(SwapArenaTagsAttr, courtChangeArenaTags)
       .condition((_user, _target, _move) =>
         globalScene.arena.tags.some((arenaTag) => courtChangeArenaTags.includes(arenaTag.tagType)),
-      ),
+      )
+      .target(MoveTarget.BOTH_SIDES),
     new AttackMove(MoveId.MAX_FLARE, ElementalType.FIRE, MoveCategory.PHYSICAL, 10, -1, 10, -1, 0, 8)
       .target(MoveTarget.NEAR_ENEMY)
       .unimplemented(),

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -1,10 +1,12 @@
+import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/gameManager";
 import Phaser from "phaser";
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Moves - Court Change", () => {
   let phaserGame: Phaser.Game;
@@ -23,27 +25,27 @@ describe("Moves - Court Change", () => {
   beforeEach(() => {
     game = new GameManager(phaserGame);
 
-    game.override.battleType("single");
-
-    game.override.moveset([MoveId.COURT_CHANGE, MoveId.SAFEGUARD]);
-    game.override.enemySpecies(SpeciesId.NINJASK);
-
-    game.override.startingLevel(100);
-    game.override.enemyLevel(100);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.NINJASK)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyAbility(AbilityId.BALL_FETCH);
   });
 
-  test("should swap arena tags to opponent", async () => {
-    await game.classicMode.startBattle([SpeciesId.SHUCKLE]);
+  it("should swap arena tags to opponent", async () => {
     game.override.enemyMoveset([MoveId.SPLASH]);
+    await game.classicMode.startBattle([SpeciesId.SHUCKLE]);
 
-    game.move.select(MoveId.SAFEGUARD);
+    game.move.use(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
     const tag1 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)!;
     expect(tag1.turnCount).toBe(4);
     expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeFalsy();
 
-    game.move.select(MoveId.COURT_CHANGE);
+    game.move.use(MoveId.COURT_CHANGE);
     await game.toNextTurn();
 
     const tag2 = game.scene.arena.findTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)!;
@@ -51,20 +53,21 @@ describe("Moves - Court Change", () => {
     expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeFalsy();
   });
 
-  test("should not miss", async () => {
+  it("should not miss", async () => {
+    game.override.enemyMoveset([MoveId.FLY]);
     await game.classicMode.startBattle([SpeciesId.SHUCKLE]);
 
-    game.override.enemyMoveset([MoveId.FLY]);
-
-    game.move.select(MoveId.SPLASH);
+    game.move.use(MoveId.SPLASH);
     await game.toNextTurn();
-    game.move.select(MoveId.SAFEGUARD);
+    game.move.use(MoveId.SAFEGUARD);
     await game.toNextTurn();
 
     expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.PLAYER)).toBeTruthy();
     expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeFalsy();
 
-    game.move.select(MoveId.COURT_CHANGE);
+    game.move.use(MoveId.COURT_CHANGE);
+    await game.phaseInterceptor.to("MoveEndPhase");
+    expect(game.field.getEnemyPokemon().hasTag(BattlerTagType.FLYING)).toBeTruthy();
     await game.toNextTurn();
 
     expect(game.scene.arena.hasTag(ArenaTagType.SAFEGUARD, ArenaTagSide.ENEMY)).toBeTruthy();

--- a/test/moves/court-change.test.ts
+++ b/test/moves/court-change.test.ts
@@ -27,10 +27,10 @@ describe("Moves - Court Change", () => {
 
     game.override
       .battleType("single")
-      .enemySpecies(SpeciesId.NINJASK)
       .startingLevel(100)
-      .enemyLevel(100)
       .ability(AbilityId.BALL_FETCH)
+      .enemySpecies(SpeciesId.NINJASK)
+      .enemyLevel(100)
       .enemyAbility(AbilityId.BALL_FETCH);
   });
 


### PR DESCRIPTION
## What are the changes the user will see?
Court Change will no longer fail if used when the enemy is in a semi-invulnerable state (such as from Fly).

## Why am I making these changes?
The move (and tests) were bugged.

## What are the changes from a developer perspective?
Court Change now targets "Both Sides".
The Court Change tests were updated to be accurate.

## How to test the changes?
`npm run test court-change`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?