### PR TITLE
[Bug] Fix timing of Terastallization phase

### DIFF
--- a/src/enums/battle-command.ts
+++ b/src/enums/battle-command.ts
@@ -1,3 +1,14 @@
+// -- start tsdoc imports --
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { CommandPhase } from "#app/phases/command-phase";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+// -- end tsdoc imports --
+
+/**
+ * Commands that can be executed from a {@linkcode CommandPhase}.
+ */
+// Note: Do not re-order this without a good reason! The cursor positioning
+// relies on their values being as they are now.
 export enum BattleCommand {
   FIGHT,
   BALL,

--- a/src/phases/terastallization-phase.ts
+++ b/src/phases/terastallization-phase.ts
@@ -22,12 +22,6 @@ export class TerastallizationPhase extends BattlePhase {
   public override start(): void {
     super.start();
 
-    // Failsafe to prevent a crash if the pokemon faints before the phase runs
-    // TODO: remove this when Tera phase timing is fixed
-    if (this.pokemon.isFainted()) {
-      return super.end();
-    }
-
     new CommonBattleAnim(CommonAnim.TERASTALLIZE, this.pokemon).play(false, () => {
       globalScene.phaseManager.queueMessagePhase(
         i18next.t("battle:pokemonTerastallized", {

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -36,6 +36,7 @@ import { PhaseId } from "#enums/phase-id";
 import { Stat } from "#enums/stat";
 import { SwitchType } from "#enums/switch-type";
 
+/** Lower number = lower priority */
 const COMMAND_PRIORITY_MAP = {
   [BattleCommand.FIGHT]: 0,
   [BattleCommand.TERA]: 1,
@@ -426,6 +427,13 @@ export class TurnCommandManager {
     }
   }
 
+  /**
+   * Validates a given {@linkcode BattleCommand.TERA | Tera} command and
+   * schedules a {@linkcode TerastallizationPhase} if valid.
+   * Then queues a new {@linkcode BattleCommand.FIGHT | Fight} command.
+   * @param turnCommand - The {@linkcode TurnCommand} to validate
+   * @returns Whether the command was successful
+   */
   private handleTeraCommand(turnCommand: TurnCommand): boolean {
     const { pokemon } = turnCommand;
     if (!pokemon.isActive(true)) {

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -36,6 +36,14 @@ import { PhaseId } from "#enums/phase-id";
 import { Stat } from "#enums/stat";
 import { SwitchType } from "#enums/switch-type";
 
+const COMMAND_PRIORITY_MAP = {
+  [BattleCommand.FIGHT]: 0,
+  [BattleCommand.TERA]: 1,
+  [BattleCommand.POKEMON]: 2,
+  [BattleCommand.BALL]: 3,
+  [BattleCommand.RUN]: 4,
+} as const;
+
 /**
  * Interface representing an action taken by a Pokemon for the turn.
  * Encompasses both Player and Enemy commands.
@@ -317,12 +325,9 @@ export class TurnCommandManager {
   private sortPostSpeed(quiet: boolean = true): void {
     this.turnCommands.sort((a: TurnCommand, b: TurnCommand) => {
       if (a.command !== b.command) {
-        if (a.command === BattleCommand.FIGHT) {
-          return 1;
-        } else if (b.command === BattleCommand.FIGHT) {
-          return -1;
-        }
-      } else if (a.command === BattleCommand.FIGHT) {
+        return COMMAND_PRIORITY_MAP[a.command] > COMMAND_PRIORITY_MAP[b.command] ? -1 : 1;
+      }
+      if (a.command === BattleCommand.FIGHT) {
         const [aQuashed, bQuashed] = [a, b].map((tc) => tc.pokemon.hasTag(BattlerTagType.QUASHED));
         if ((aQuashed || bQuashed) && aQuashed !== bQuashed) {
           return aQuashed ? 1 : -1;
@@ -371,6 +376,8 @@ export class TurnCommandManager {
     let success: boolean = false;
     switch (turnCommand.command) {
       case BattleCommand.TERA:
+        success = this.handleTeraCommand(turnCommand);
+        break;
       case BattleCommand.FIGHT:
         success = this.handleFightCommand(turnCommand);
         break;
@@ -407,6 +414,7 @@ export class TurnCommandManager {
   private getNextTurnCommandPhaseId(turnCommand: TurnCommand): PhaseId {
     switch (turnCommand.command) {
       case BattleCommand.TERA:
+        return PhaseId.TERASTALLIZATION;
       case BattleCommand.FIGHT:
         return PhaseId.MOVE;
       case BattleCommand.BALL:
@@ -418,6 +426,21 @@ export class TurnCommandManager {
     }
   }
 
+  private handleTeraCommand(turnCommand: TurnCommand): boolean {
+    const { pokemon } = turnCommand;
+    if (!pokemon.isActive(true)) {
+      return false;
+    }
+
+    globalScene.phaseManager.unshiftPhase(new TerastallizationPhase(pokemon));
+
+    const newCommand = turnCommand;
+    newCommand.command = BattleCommand.FIGHT;
+
+    this.addCommand(newCommand);
+    return true;
+  }
+
   /**
    * Validates a given {@linkcode BattleCommand.FIGHT | FIGHT} command
    * and, if valid, schedules a {@linkcode MovePhase} for the command.
@@ -425,7 +448,7 @@ export class TurnCommandManager {
    * @returns `true` if the turn command is scheduled successfully
    */
   private handleFightCommand(turnCommand: TurnCommand): boolean {
-    const { pokemon, cursor, turnMove, targets, command } = turnCommand;
+    const { pokemon, cursor, turnMove, targets } = turnCommand;
     if (!pokemon.isActive(true) || !turnMove) {
       return false;
     }
@@ -433,10 +456,6 @@ export class TurnCommandManager {
     const move =
       pokemon.getMoveset().find((m) => m.moveId === turnMove.move.id && m.ppUsed < m.getMovePp())
       ?? new PokemonMove(turnMove.move.id);
-
-    if (command === BattleCommand.TERA) {
-      globalScene.phaseManager.unshiftPhase(new TerastallizationPhase(pokemon));
-    }
 
     globalScene.phaseManager.queueMovePhase({
       pokemon,


### PR DESCRIPTION
## What are the changes the user will see?
Terastallization will happen after switches and before moves.

## Why am I making these changes?
Fixes #1085 
Resolves #988 

## What are the changes from a developer perspective?
- Turn commands are sorted by priority via a mapping of command to priority value.
- When a Tera command is handled by the turn manager, a Terastallization Phase is unshifted and then a new Fight command is added to the turn queue for that Pokémon to be handled later. Previously both a Terastallization Phase and a Move Phase would be queued at the same time.
- The check for the Pokémon being fainted is removed from Terastallization Phase as it should no longer be necessary.

## How to test the changes?
Use the following overrides:
```ts
const overrides = {
  ENEMY_LEVEL_OVERRIDE: 20,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.REGIELEKI,
  BATTLE_TYPE_OVERRIDE: "double",
  STARTING_MODIFIER_OVERRIDE: [{name: "TERA_ORB"}],
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```
Start with 3 pokemon. Have one Terastallize and use a move, and the other switch to your third pokemon. First the switch should happen, then the other pokemon should Terastallize, then one of the enemies should use a move.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?