### PR TITLE
[Dev] Add a `FORCE_ENEMY_TERA_OVERRIDE`

### DIFF
--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -401,7 +401,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public get teraType(): ElementalType {
     if (this.isPlayer() && Overrides.TERA_TYPE_OVERRIDE !== ElementalType.UNKNOWN) {
       return Overrides.TERA_TYPE_OVERRIDE;
-    } else if (this.isEnemy() && Overrides.ENEMY_TERA_TYPE_OVERRIDE !== ElementalType.UNKNOWN) {
+    }
+    if (this.isEnemy() && Overrides.ENEMY_TERA_TYPE_OVERRIDE !== ElementalType.UNKNOWN) {
       return Overrides.ENEMY_TERA_TYPE_OVERRIDE;
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -399,6 +399,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * - Shedinja is always Bug
    */
   public get teraType(): ElementalType {
+    if (this.isPlayer() && Overrides.TERA_TYPE_OVERRIDE !== ElementalType.UNKNOWN) {
+      return Overrides.TERA_TYPE_OVERRIDE;
+    } else if (this.isEnemy() && Overrides.ENEMY_TERA_TYPE_OVERRIDE !== ElementalType.UNKNOWN) {
+      return Overrides.ENEMY_TERA_TYPE_OVERRIDE;
+    }
+
     switch (this.species.speciesId) {
       case SpeciesId.TERAPAGOS:
         return ElementalType.STELLAR;

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -141,11 +141,6 @@ class DefaultOverrides {
    * - Infatuated: set to `true` to force its activation, set to `false` to do the opposite
    */
   readonly STATUS_ACTIVATION_OVERRIDE: boolean | null = null;
-  /**
-   * If `true`, every enemy Pokemon Terastallizes on the first turn that it decides to use a move.
-   * If `false`, this override is ignored.
-   */
-  readonly FORCE_ENEMY_TERA_OVERRIDE: boolean = false;
 
   // ----------------
   // PLAYER OVERRIDES
@@ -179,6 +174,11 @@ class DefaultOverrides {
   readonly MOVESET_OVERRIDE: MoveId | Array<MoveId> = [];
   readonly SHINY_OVERRIDE: boolean | null = null;
   readonly VARIANT_OVERRIDE: Variant | null = null;
+  /**
+   * If equal to `ElementalType.UNKNOWN`, then ignore this override.
+   * Otherwise, override every player Pokemon's Tera type to be this type.
+   */
+  readonly TERA_TYPE_OVERRIDE: ElementalType = ElementalType.UNKNOWN;
 
   // --------------------------
   // ENEMY OVERRIDES
@@ -203,6 +203,16 @@ class DefaultOverrides {
    * 2+: the Pokemon will be a boss with the given number of health segments
    */
   readonly ENEMY_HEALTH_SEGMENTS_OVERRIDE: number = 0;
+  /**
+   * If `true`, every enemy Pokemon Terastallizes on the first turn that it decides to use a move.
+   * If `false`, this override is ignored.
+   */
+  readonly FORCE_ENEMY_TERA_OVERRIDE: boolean = false;
+  /**
+   * If equal to `ElementalType.UNKNOWN`, then ignore this override.
+   * Otherwise, override every enemy Pokemon's Tera type to be this type.
+   */
+  readonly ENEMY_TERA_TYPE_OVERRIDE: ElementalType = ElementalType.UNKNOWN;
 
   // -------------
   // EGG OVERRIDES

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -141,6 +141,11 @@ class DefaultOverrides {
    * - Infatuated: set to `true` to force its activation, set to `false` to do the opposite
    */
   readonly STATUS_ACTIVATION_OVERRIDE: boolean | null = null;
+  /**
+   * If `true`, every enemy Pokemon Terastallizes on the first turn that it decides to use a move.
+   * If `false`, this override is ignored.
+   */
+  readonly FORCE_ENEMY_TERA_OVERRIDE: boolean = false;
 
   // ----------------
   // PLAYER OVERRIDES

--- a/src/phases/enemy-command-phase.ts
+++ b/src/phases/enemy-command-phase.ts
@@ -6,6 +6,7 @@ import type { Pokemon } from "#app/field/pokemon";
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";
+import Overrides from "#app/overrides";
 import { FieldPhase } from "#app/phases/abstract-field-phase";
 import { AbilityId } from "#enums/ability-id";
 import { BattleCommand } from "#enums/battle-command";
@@ -97,7 +98,10 @@ export class EnemyCommandPhase extends FieldPhase {
       }
     }
 
-    const command = trainer?.shouldTera(pokemon) ? BattleCommand.TERA : BattleCommand.FIGHT;
+    const command =
+      (Overrides.FORCE_ENEMY_TERA_OVERRIDE && !pokemon.isTerastallized) || trainer?.shouldTera(pokemon)
+        ? BattleCommand.TERA
+        : BattleCommand.FIGHT;
 
     battle.turnManager.addCommand({
       pokemon,

--- a/test/moves/tera-blast.test.ts
+++ b/test/moves/tera-blast.test.ts
@@ -72,16 +72,13 @@ describe("Moves - Tera Blast", () => {
   });
 
   it("is super effective against terastallized targets if user is Stellar tera type", async () => {
-    game.override.forceEnemyTera();
+    game.override.forceEnemyTera().teraType(ElementalType.STELLAR);
     await game.classicMode.startBattle();
-
-    const player = game.field.getPlayerPokemon();
-    game.field.forceTera(player, ElementalType.STELLAR);
 
     const enemyPokemon = game.field.getEnemyPokemon();
     vi.spyOn(enemyPokemon, "getMoveEffectiveness");
 
-    game.move.select(MoveId.TERA_BLAST);
+    game.move.select(MoveId.TERA_BLAST, 0, BattlerIndex.ENEMY, true); // Terastallize into Stellar type
     await game.toEndOfTurn();
 
     expect(enemyPokemon.isTerastallized).toBe(true);

--- a/test/moves/tera-blast.test.ts
+++ b/test/moves/tera-blast.test.ts
@@ -72,6 +72,7 @@ describe("Moves - Tera Blast", () => {
   });
 
   it("is super effective against terastallized targets if user is Stellar tera type", async () => {
+    game.override.forceEnemyTera();
     await game.classicMode.startBattle();
 
     const player = game.field.getPlayerPokemon();
@@ -79,13 +80,12 @@ describe("Moves - Tera Blast", () => {
 
     const enemyPokemon = game.field.getEnemyPokemon();
     vi.spyOn(enemyPokemon, "getMoveEffectiveness");
-    game.field.forceTera(enemyPokemon);
 
     game.move.select(MoveId.TERA_BLAST);
-    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
-    await game.phaseInterceptor.to("MoveEffectPhase");
+    await game.toEndOfTurn();
 
-    expect(enemyPokemon.getMoveEffectiveness).toHaveReturnedWith(2);
+    expect(enemyPokemon.isTerastallized).toBe(true);
+    expect(enemyPokemon.getMoveEffectiveness).toHaveLastReturnedWith(2);
   });
 
   // Currently abilities are bugged and can't see when a move's category is changed

--- a/test/test-utils/helpers/overridesHelper.ts
+++ b/test/test-utils/helpers/overridesHelper.ts
@@ -26,6 +26,7 @@ import { WeatherType } from "#enums/weather-type";
 import { GameManagerHelper } from "#test/test-utils/helpers/gameManagerHelper";
 import { expect, vi } from "vitest";
 import { TerrainType } from "#enums/terrain-type";
+import { ElementalType } from "#enums/elemental-type";
 
 /**
  * Helper to handle overrides in tests
@@ -528,10 +529,39 @@ export class OverridesHelper extends GameManagerHelper {
 
   /**
    * @param forceTera (Default `true`) If `true`, forces every enemy Pokemon to Terastallize. If `false`, disables this override.
+   * @returns `this`
    */
   public forceEnemyTera(forceTera: boolean = true): this {
     vi.spyOn(Overrides, "FORCE_ENEMY_TERA_OVERRIDE", "get").mockReturnValue(forceTera);
     this.log(`Enemy Pokemon are ${forceTera ? "" : "no longer "}forced to Terastallize!`);
+    return this;
+  }
+
+  /**
+   * @param type If equal to `ElementalType.UNKNOWN`, disable this override. Otherwise, force every player Pokemon's Tera type to be this type.
+   * @returns `this`
+   */
+  public teraType(type: ElementalType): this {
+    vi.spyOn(Overrides, "TERA_TYPE_OVERRIDE", "get").mockReturnValue(type);
+    if (type === ElementalType.UNKNOWN) {
+      this.log("Disabled override for player Tera type!");
+    } else {
+      this.log(`Player Tera type set to ${ElementalType[type]} (=${type})!`);
+    }
+    return this;
+  }
+
+  /**
+   * @param type If equal to `ElementalType.UNKNOWN`, disable this override. Otherwise, force every enemy Pokemon's Tera type to be this type.
+   * @returns `this`
+   */
+  public enemyTeraType(type: ElementalType): this {
+    vi.spyOn(Overrides, "ENEMY_TERA_TYPE_OVERRIDE", "get").mockReturnValue(type);
+    if (type === ElementalType.UNKNOWN) {
+      this.log("Disabled override for enemy Tera type!");
+    } else {
+      this.log(`Enemy Tera type set to ${ElementalType[type]} (=${type})!`);
+    }
     return this;
   }
 

--- a/test/test-utils/helpers/overridesHelper.ts
+++ b/test/test-utils/helpers/overridesHelper.ts
@@ -527,6 +527,15 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
+   * @param forceTera (Default `true`) If `true`, forces every enemy Pokemon to Terastallize. If `false`, disables this override.
+   */
+  public forceEnemyTera(forceTera: boolean = true): this {
+    vi.spyOn(Overrides, "FORCE_ENEMY_TERA_OVERRIDE", "get").mockReturnValue(forceTera);
+    this.log(`Enemy Pokemon are ${forceTera ? "" : "no longer "}forced to Terastallize!`);
+    return this;
+  }
+
+  /**
    * Override the encounter chance for a mystery encounter.
    * @param percentage the encounter chance in %
    * @returns `this`


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

If the override is enabled, then every enemy Pokemon (including wild Pokemon) will Terastallize on the first turn that it chooses to use a move.

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

Making it easier to test things while working on Terastallization (e.g., testing scenarios when both sides Terastallize on the same turn).

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

- If `FORCE_ENEMY_TERA_OVERRIDE` is `true`, then the enemy Pokemon will select `BattleCommand.TERA` instead of `BattleCommand.FIGHT` during `EnemyCommandPhase`.
- As a proof of concept, one of the Tera Blast tests is rewritten to use this override.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

https://github.com/user-attachments/assets/0f16dfe5-751c-4c50-b729-3f1d7b92d40d

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

```
  FORCE_ENEMY_TERA_OVERRIDE: true,
```

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?