### PR TITLE
[UI][P3] Fix option select cursor misalignement when scrolling down

### DIFF
--- a/src/ui/handlers/base-option-select-ui-handler.ts
+++ b/src/ui/handlers/base-option-select-ui-handler.ts
@@ -191,6 +191,10 @@ export abstract class BaseOptionSelectUiHandler<T extends OptionSelectItem> exte
     }
   }
 
+  /**
+   * Place the cursor in front of the currently selected option.
+   * Initializes the cursor sprite if it doesn't exist.
+   */
   private updateCursorPlacement() {
     if (!this.cursorObj) {
       this.cursorObj = globalScene.add.image(0, 0, "cursor");

--- a/src/ui/handlers/base-option-select-ui-handler.ts
+++ b/src/ui/handlers/base-option-select-ui-handler.ts
@@ -181,9 +181,28 @@ export abstract class BaseOptionSelectUiHandler<T extends OptionSelectItem> exte
     );
 
     this.optionSelectBg.setSize(bgWidth, bgHeight);
+
+    if (this.cursorObj) {
+      this.updateCursorPlacement();
+    }
+
     if (this.config?.onResize) {
       this.config.onResize(bgWidth, bgHeight);
     }
+  }
+
+  private updateCursorPlacement() {
+    if (!this.cursorObj) {
+      this.cursorObj = globalScene.add.image(0, 0, "cursor");
+      this.optionSelectContainer.add(this.cursorObj);
+      this.cursorObj.setScale(this.scale * 6);
+    }
+
+    this.cursorObj.setPositionRelative(
+      this.optionSelectBg,
+      10,
+      102 * this.scale + this.cursor * (114 * this.scale - 3) - 2,
+    );
   }
 
   /**
@@ -405,17 +424,7 @@ export abstract class BaseOptionSelectUiHandler<T extends OptionSelectItem> exte
       this.cursor = cursor;
     }
 
-    if (!this.cursorObj) {
-      this.cursorObj = globalScene.add.image(0, 0, "cursor");
-      this.optionSelectContainer.add(this.cursorObj);
-    }
-
-    this.cursorObj.setScale(this.scale * 6);
-    this.cursorObj.setPositionRelative(
-      this.optionSelectBg,
-      10,
-      102 * this.scale + this.cursor * (114 * this.scale - 3) - 2,
-    );
+    this.updateCursorPlacement();
 
     return changed;
   }


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

The cursor no longer overlaps with the text when a menu is resized dynamically upon scrolling

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

Currently the cursor placement in option select is updated in `setCursor` when the cursor index is changed.
When scrolling down/up only the scrolling cursor is updated, not the base cursor, so `setCursor` is not called, and thus the cursor is not moved. This is an issue when scrolling down results in the window being resized to fit wider options, resulting in the cursor overlapping the text.

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

- Move the code responsible to place the cursor in a dedicated function
- Call this function in `setCursor` like before, as well as in `updateSizeForOptions` so that the cursor is moved when the window is resized


<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

Before: scrolling down the nature list of a Pokemon (need many natures unlocked for this behavior to kick in, also depends on language probably)
![image](https://github.com/user-attachments/assets/ffe254b0-fcc0-40bd-b2c6-0e0e8a3971db)

After:
![image](https://github.com/user-attachments/assets/10246b59-74f4-4768-99b1-d2250a95b189)


<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

- New game
- Find a Pokemon with a lot of natures unlocked
- Open its menu > Manage Natures
- Scroll down the list and make sure the cursor gets moved if the window becomes larger

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [X] Otherwise: **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [X] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`npm run test:silent`)
  - [] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [] Have I made sure that any UI change works for both UI themes (dark and light)?

#### If there are no locale changes:
- [X] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `npm run update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `npm run update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->