### PR TITLE
[Bug][Move] Fix firstTarget calculation when a target was fainted by a spread move

### DIFF
--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -215,13 +215,14 @@ export class MoveEffectPhase extends HitCheckPhase {
       if (this.firstHit) {
         user.pushMoveHistory(this.moveHistoryEntry);
       }
-
+      let firstTarget = true;
       for (const target of targets) {
         const [hitCheckResult, effectiveness] = this.hitChecks[targets.indexOf(target)];
 
         switch (hitCheckResult) {
           case HitCheckResult.HIT:
-            this.applyMoveEffects(target, effectiveness);
+            this.applyMoveEffects(target, effectiveness, firstTarget);
+            firstTarget = false;
             break;
           case HitCheckResult.NO_EFFECT:
             if (move.id === MoveId.SHEER_COLD) {
@@ -289,16 +290,13 @@ export class MoveEffectPhase extends HitCheckPhase {
 
   /**
    * Applies all move effects that trigger in the event of a successful hit.
-   * @param target the {@linkcode Pokemon} hit by this phase's move.
-   * @param effectiveness the effectiveness of the move (as previously evaluated in {@linkcode hitCheck})
+   * @param target - The {@linkcode Pokemon} hit by this phase's move.
+   * @param effectiveness - The effectiveness of the move (as previously evaluated in {@linkcode hitCheck})
+   * @param isFirstTarget - Whether this target is the first to be successfully hit by the move.
    */
-  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier): void {
+  protected applyMoveEffects(target: Pokemon, effectiveness: TypeDamageMultiplier, isFirstTarget: boolean): void {
     const user = this.getUserPokemon();
     const move = this.move.getMove();
-
-    /** The first target hit by the move */
-    const firstTarget = target === this.getTargets().find((_, i) => this.hitChecks[i][1] > 0);
-
     if (isNil(user)) {
       return;
     }
@@ -308,15 +306,15 @@ export class MoveEffectPhase extends HitCheckPhase {
     const hitResult = this.applyMove(target, effectiveness);
 
     if (move.checkFlag(MoveFlags.G_MAX_MOVE, user, target)) {
-      this.applyGMaxUserEffects(user, target, firstTarget);
+      this.applyGMaxUserEffects(user, target, isFirstTarget);
     } else {
-      this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, target, firstTarget, true);
+      this.triggerMoveEffects(MoveEffectTrigger.POST_APPLY, user, target, isFirstTarget, true);
     }
 
     if (move.checkFlag(MoveFlags.G_MAX_MOVE, user, target)) {
-      this.applyGMaxTargetEffects(user, target, hitResult, firstTarget);
+      this.applyGMaxTargetEffects(user, target, hitResult, isFirstTarget);
     } else if (!move.hitsSubstitute(user, target)) {
-      this.applyOnTargetEffects(user, target, hitResult, firstTarget);
+      this.applyOnTargetEffects(user, target, hitResult, isFirstTarget);
     }
     if (this.lastHit) {
       globalScene.triggerPokemonFormChange(user, SpeciesFormChangePostMoveTrigger);

--- a/test/moves/make-it-rain.test.ts
+++ b/test/moves/make-it-rain.test.ts
@@ -72,7 +72,7 @@ describe("Moves - Make It Rain", () => {
     game.move.select(MoveId.MAKE_IT_RAIN);
     game.move.select(MoveId.SPLASH, 1);
 
-    await game.phaseInterceptor.to("StatStageChangePhase");
+    await game.phaseInterceptor.to("PostActionPhase");
 
     enemyPokemon.forEach((p) => expect(p.isFainted()).toBe(true));
     expect(playerPokemon.getStatStage(Stat.SPATK)).toBe(-1);


### PR DESCRIPTION
## What are the changes the user will see?

Spread moves like make it rain will now properly only apply their post attack effects once if the first target struck by the move faints.

## Why am I making these changes?

This fixes a bug where spread moves that have an after-use effect occur twice if the target fainted.

## What are the changes from a developer perspective?

Add a `isFirstTarget` parameter to the `applyMoveEffect` method of the move effect phase and removed the buggy check for `firstTarget`.

Added tracking for `firstTarget` that starts true and is set to false after the first successful `applyMoveEffect` call.
Passed this `firstTarget` to the `applyMoveEffect` method.

Also fixed the test in `test/moves/make-it-rain.test.ts` that was testing this exact scenario. The problem was that the second stat stage drop happens in a separate phase, but the automated test was only moving to the first one before ensuring that the stat stage was only -1. 

The issue with the existing check is that the `firstTarget` method was calling the `getTargets()` method. Pokemon that have fainted would not be returned by that method, and as such, the second target of the attack would appear to be the first target.

## Screenshots/Videos

<details><summary>Current behavior</summary>

https://github.com/user-attachments/assets/6539b583-8af8-4511-9986-af9d65958db7
</details>

<details><summary>Fixed behavior</summary>

https://github.com/user-attachments/assets/63e740da-8503-434b-99e7-c63452b2e04b
</details>


## How to test the changes?

I use these overrides:

```ts
const overrides = {
  MOVESET_OVERRIDE: [MoveId.MAKE_IT_RAIN],
  BATTLE_TYPE_OVERRIDE: "double",
  STARTING_LEVEL_OVERRIDE: 100,
  ENEMY_SPECIES_OVERRIDE: SpeciesId.MAGIKARP,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

Then, I just start up a run and use make it rain.

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`npm run update-version:patch` / `npm run update version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - ~~[ ] Have I made sure that any UI change works for both UI themes (dark and light)?~~

#### If there are no locale changes:
- [x] Have I made sure **not** to commit any changes to the locale repo on this branch?
