### PR TITLE
[Dev] Add player IV override and player + enemy Nature override

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -150,7 +150,7 @@ import { addTextObject } from "#ui/text-utils";
 import { UI } from "#ui/ui";
 import { setDocumentUiTheme, updateWindowStyle } from "#ui/ui-theme";
 import { loadCommonAnimAssets } from "#utils/anim-utils";
-import { BooleanHolder, clamp, fixedNumber, getEnumValues, isNil, NumberHolder } from "#utils/common-utils";
+import { BooleanHolder, fixedNumber, getEnumValues, isBetween, isNil, NumberHolder } from "#utils/common-utils";
 import { getModifierPoolForType } from "#utils/modifier-pool-utils";
 import { getModifierType } from "#utils/modifier-type-utils";
 import { loadMoveAnimAssets } from "#utils/move-anim-utils";
@@ -936,6 +936,28 @@ export default class BattleScene extends SceneBase {
     if (postProcess) {
       postProcess(pokemon);
     }
+
+    if (Overrides.IVS_OVERRIDE === null) {
+      // do nothing
+    } else if (Array.isArray(Overrides.IVS_OVERRIDE)) {
+      if (Overrides.IVS_OVERRIDE.length !== 6) {
+        throw new Error("The Player IVs override must be an array of length 6 or a number!");
+      }
+      if (Overrides.IVS_OVERRIDE.some((value) => !isBetween(value, IV_MIN, IV_MAX))) {
+        throw new Error(`All IVs in the player IV override must be between ${IV_MIN} and ${IV_MAX}!`);
+      }
+      pokemon.ivs = Overrides.IVS_OVERRIDE;
+    } else {
+      if (!isBetween(Overrides.IVS_OVERRIDE, IV_MIN, IV_MAX)) {
+        throw new Error(`The Player IV override must be a value between ${IV_MIN} and ${IV_MAX}!`);
+      }
+      pokemon.ivs = new Array(6).fill(Overrides.IVS_OVERRIDE);
+    }
+
+    if (Overrides.NATURE_OVERRIDE !== null) {
+      pokemon.nature = Overrides.NATURE_OVERRIDE;
+    }
+
     pokemon.init();
     return pokemon;
   }
@@ -977,14 +999,25 @@ export default class BattleScene extends SceneBase {
       postProcess(pokemon);
     }
 
-    let ENEMY_IVS_OVERRIDE_VALIDATED: number[] = [];
-    if (Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)) {
-      ENEMY_IVS_OVERRIDE_VALIDATED = Overrides.ENEMY_IVS_OVERRIDE;
-    } else if (typeof Overrides.ENEMY_IVS_OVERRIDE === "number") {
-      ENEMY_IVS_OVERRIDE_VALIDATED = new Array(6).fill(Overrides.ENEMY_IVS_OVERRIDE);
+    if (Overrides.ENEMY_IVS_OVERRIDE === null) {
+      // do nothing
+    } else if (Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)) {
+      if (Overrides.ENEMY_IVS_OVERRIDE.length !== 6) {
+        throw new Error("The Player IVs override must be an array of length 6 or a number!");
+      }
+      if (Overrides.ENEMY_IVS_OVERRIDE.some((value) => !isBetween(value, IV_MIN, IV_MAX))) {
+        throw new Error(`All IVs in the player IV override must be between ${IV_MIN} and ${IV_MAX}!`);
+      }
+      pokemon.ivs = Overrides.ENEMY_IVS_OVERRIDE;
+    } else {
+      if (!isBetween(Overrides.ENEMY_IVS_OVERRIDE, IV_MIN, IV_MAX)) {
+        throw new Error(`The Player IV override must be a value between ${IV_MIN} and ${IV_MAX}!`);
+      }
+      pokemon.ivs = new Array(6).fill(Overrides.ENEMY_IVS_OVERRIDE);
     }
-    if (ENEMY_IVS_OVERRIDE_VALIDATED.length === 6) {
-      pokemon.ivs = ENEMY_IVS_OVERRIDE_VALIDATED.map((iv) => clamp(iv, IV_MIN, IV_MAX));
+
+    if (Overrides.ENEMY_NATURE_OVERRIDE !== null) {
+      pokemon.nature = Overrides.ENEMY_NATURE_OVERRIDE;
     }
 
     pokemon.init();

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1003,15 +1003,15 @@ export default class BattleScene extends SceneBase {
       // do nothing
     } else if (Array.isArray(Overrides.ENEMY_IVS_OVERRIDE)) {
       if (Overrides.ENEMY_IVS_OVERRIDE.length !== 6) {
-        throw new Error("The Player IVs override must be an array of length 6 or a number!");
+        throw new Error("The Enemy IVs override must be an array of length 6 or a number!");
       }
       if (Overrides.ENEMY_IVS_OVERRIDE.some((value) => !isBetween(value, IV_MIN, IV_MAX))) {
-        throw new Error(`All IVs in the player IV override must be between ${IV_MIN} and ${IV_MAX}!`);
+        throw new Error(`All IVs in the enemy IV override must be between ${IV_MIN} and ${IV_MAX}!`);
       }
       pokemon.ivs = Overrides.ENEMY_IVS_OVERRIDE;
     } else {
       if (!isBetween(Overrides.ENEMY_IVS_OVERRIDE, IV_MIN, IV_MAX)) {
-        throw new Error(`The Player IV override must be a value between ${IV_MIN} and ${IV_MAX}!`);
+        throw new Error(`The Enemy IV override must be a value between ${IV_MIN} and ${IV_MAX}!`);
       }
       pokemon.ivs = new Array(6).fill(Overrides.ENEMY_IVS_OVERRIDE);
     }

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -174,7 +174,14 @@ class DefaultOverrides {
   readonly MOVESET_OVERRIDE: MoveId | MoveId[] = [];
   readonly SHINY_OVERRIDE: boolean | null = null;
   readonly VARIANT_OVERRIDE: Variant | null = null;
+  /**
+   * Overrides the IVs of player pokemon. Values must never be outside the range `0` to `31`!
+   * - If set to a number between `0` and `31`, set all IVs of all player pokemon to that number.
+   * - If set to an array, set the IVs of all player pokemon to that array. Array length must be exactly `6`!
+   * - If set to `null`, disable the override.
+   */
   readonly IVS_OVERRIDE: number | number[] | null = null;
+  /** Override the nature of all player pokemon to the specified nature. Disabled if `null`. */
   readonly NATURE_OVERRIDE: Nature | null = null;
   /**
    * If equal to `ElementalType.UNKNOWN`, then ignore this override.
@@ -195,7 +202,14 @@ class DefaultOverrides {
   readonly ENEMY_MOVESET_OVERRIDE: MoveId | MoveId[] = [];
   readonly ENEMY_SHINY_OVERRIDE: boolean | null = null;
   readonly ENEMY_VARIANT_OVERRIDE: Variant | null = null;
+  /**
+   * Overrides the IVs of enemy pokemon. Values must never be outside the range `0` to `31`!
+   * - If set to a number between `0` and `31`, set all IVs of all enemy pokemon to that number.
+   * - If set to an array, set the IVs of all enemy pokemon to that array. Array length must be exactly `6`!
+   * - If set to `null`, disable the override.
+   */
   readonly ENEMY_IVS_OVERRIDE: number | number[] | null = null;
+  /** Override the nature of all enemy pokemon to the specified nature. Disabled if `null`. */
   readonly ENEMY_NATURE_OVERRIDE: Nature | null = null;
   readonly ENEMY_FORM_OVERRIDES: Partial<Record<SpeciesId, number>> = {};
   /**

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -12,6 +12,7 @@ import { Gender } from "#enums/gender";
 import { MoveId } from "#enums/move-id";
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { Nature } from "#enums/nature";
 import { PokeballType } from "#enums/pokeball-type";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
@@ -173,6 +174,8 @@ class DefaultOverrides {
   readonly MOVESET_OVERRIDE: MoveId | MoveId[] = [];
   readonly SHINY_OVERRIDE: boolean | null = null;
   readonly VARIANT_OVERRIDE: Variant | null = null;
+  readonly IVS_OVERRIDE: number | number[] | null = null;
+  readonly NATURE_OVERRIDE: Nature | null = null;
   /**
    * If equal to `ElementalType.UNKNOWN`, then ignore this override.
    * Otherwise, override every player Pokemon's Tera type to be this type.
@@ -192,7 +195,8 @@ class DefaultOverrides {
   readonly ENEMY_MOVESET_OVERRIDE: MoveId | MoveId[] = [];
   readonly ENEMY_SHINY_OVERRIDE: boolean | null = null;
   readonly ENEMY_VARIANT_OVERRIDE: Variant | null = null;
-  readonly ENEMY_IVS_OVERRIDE: number | number[] = [];
+  readonly ENEMY_IVS_OVERRIDE: number | number[] | null = null;
+  readonly ENEMY_NATURE_OVERRIDE: Nature | null = null;
   readonly ENEMY_FORM_OVERRIDES: Partial<Record<SpeciesId, number>> = {};
   /**
    * Override to give the enemy Pokemon a given amount of health segments

--- a/test/abilities/wimp-out.test.ts
+++ b/test/abilities/wimp-out.test.ts
@@ -108,7 +108,7 @@ describe("Abilities - Wimp Out", () => {
   });
 
   it("Trapping moves do not prevent Wimp Out from activating.", async () => {
-    game.override.enemyMoveset([MoveId.SPIRIT_SHACKLE]).startingLevel(53).enemyLevel(45);
+    game.override.enemyMoveset([MoveId.SPIRIT_SHACKLE]).startingLevel(1).passiveAbility(AbilityId.STURDY);
     await game.classicMode.startBattle([SpeciesId.WIMPOD, SpeciesId.TYRUNT]);
 
     game.move.select(MoveId.SPLASH);
@@ -123,7 +123,7 @@ describe("Abilities - Wimp Out", () => {
   });
 
   it("If this Ability activates due to being hit by U-turn or Volt Switch, the user of that move will not be switched out.", async () => {
-    game.override.startingLevel(95).enemyMoveset([MoveId.U_TURN]);
+    game.override.startingLevel(1).enemyMoveset([MoveId.U_TURN]).passiveAbility(AbilityId.STURDY);
     await game.classicMode.startBattle([SpeciesId.WIMPOD, SpeciesId.TYRUNT]);
 
     game.move.select(MoveId.SPLASH);

--- a/test/test-utils/helpers/classic-mode-helper.ts
+++ b/test/test-utils/helpers/classic-mode-helper.ts
@@ -2,6 +2,7 @@ import { getGameMode } from "#app/game-mode";
 import overrides from "#app/overrides";
 import { BattleStyle } from "#enums/battle-style";
 import { GameModes } from "#enums/game-modes";
+import { Nature } from "#enums/nature";
 import type { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
 import { CommandPhase } from "#phases/command-phase";
@@ -26,6 +27,12 @@ export class ClassicModeHelper extends GameManagerHelper {
 
     if (this.game.override.disableShinies) {
       this.game.override.shiny(false).enemyShiny(false);
+    }
+    if (this.game.override.normalizeIVs) {
+      this.game.override.playerIVs(31).enemyIVs(31);
+    }
+    if (this.game.override.normalizeNatures) {
+      this.game.override.nature(Nature.HARDY).enemyNature(Nature.HARDY);
     }
 
     this.game.onNextPrompt("TitlePhase", UiMode.TITLE, () => {

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -477,7 +477,7 @@ export class OverridesHelper extends GameManagerHelper {
     if (nature === null) {
       this.log("Player Nature override disabled!");
     } else {
-      this.log(`Player Nature set to ${Nature[nature]} (${nature})!`);
+      this.log(`Player Nature set to ${Nature[nature]} (=${nature})!`);
     }
     return this;
   }
@@ -493,7 +493,7 @@ export class OverridesHelper extends GameManagerHelper {
     if (nature === null) {
       this.log("Enemy Nature override disabled!");
     } else {
-      this.log(`Enemy Nature set to ${Nature[nature]} (${nature})!`);
+      this.log(`Enemy Nature set to ${Nature[nature]} (=${nature})!`);
     }
     return this;
   }

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -34,10 +34,26 @@ import { expect, vi } from "vitest";
  * Helper to handle overrides in tests
  */
 export class OverridesHelper extends GameManagerHelper {
-  /** If `true`, removes the starting items from enemies at the start of each test; default `true` */
+  /**
+   * If `true`, removes the starting items from enemies at the start of each test.
+   * @defaultValue `true`
+   */
   public removeEnemyStartingItems: boolean = true;
-  /** If `true`, sets the shiny overrides to disable shinies at the start of each test; default `true` */
+  /**
+   * If `true`, sets the shiny overrides to disable shinies at the start of each test.
+   * @defaultValue `true`
+   */
   public disableShinies: boolean = true;
+  /**
+   * If `true`, will set the IV overrides for player and enemy pokemon to `31` at the start of each test.
+   * @defaultValue `true`
+   */
+  public normalizeIVs: boolean = true;
+  /**
+   * If `true`, will set the Nature overrides for player and enemy pokemon to a neutral nature at the start of each test.
+   * @defaultValue `true`
+   */
+  public normalizeNatures: boolean = true;
 
   /**
    * Override the starting biome
@@ -419,6 +435,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public playerIVs(ivs: number | number[] | null): this {
+    this.normalizeIVs = false;
     vi.spyOn(Overrides, "IVS_OVERRIDE", "get").mockReturnValue(ivs);
     if (ivs === null) {
       this.log("Player IVs override disabled!");
@@ -439,6 +456,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enemyIVs(ivs: number | number[] | null): this {
+    this.normalizeIVs = false;
     vi.spyOn(Overrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);
     if (ivs === null) {
       this.log("Enemy IVs override disabled!");
@@ -454,6 +472,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public nature(nature: Nature | null): this {
+    this.normalizeNatures = false;
     vi.spyOn(Overrides, "NATURE_OVERRIDE", "get").mockReturnValue(nature);
     if (nature === null) {
       this.log("Player Nature override disabled!");
@@ -469,6 +488,7 @@ export class OverridesHelper extends GameManagerHelper {
    * @returns `this`
    */
   public enemyNature(nature: Nature | null): this {
+    this.normalizeNatures = false;
     vi.spyOn(Overrides, "ENEMY_NATURE_OVERRIDE", "get").mockReturnValue(nature);
     if (nature === null) {
       this.log("Enemy Nature override disabled!");

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -1,5 +1,6 @@
 // -- start tsdoc imports --
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import type { NewArenaEvent } from "#events/battle-scene";
 import type { Arena } from "#field/arena";
 import { GameManager } from "#test/test-utils/game-manager";
 /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -15,6 +16,7 @@ import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import type { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import type { MysteryEncounterType } from "#enums/mystery-encounter-type";
+import { Nature } from "#enums/nature";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { TerrainType } from "#enums/terrain-type";
@@ -39,7 +41,7 @@ export class OverridesHelper extends GameManagerHelper {
 
   /**
    * Override the starting biome
-   * @warning Any event listeners that are attached to [NewArenaEvent](events\battle-scene.ts) may need to be handled down the line
+   * @warning Any event listeners that are attached to {@linkcode NewArenaEvent} may need to be handled down the line
    * @param biome the biome to set
    */
   public startingBiome(biome: BiomeId): this {
@@ -407,13 +409,72 @@ export class OverridesHelper extends GameManagerHelper {
   }
 
   /**
-   * Overrides the enemy (pokemon)'s IVs
-   * @param ivs a number or array of 6 numbers ranging from 0-31
+   * Overrides the IVs of the player pokemon
+   * @param ivs - If set to a number, all IVs are set to the same value. Must be between `0` and `31`!
+   *
+   * If set to an array, that array is applied to the pokemon's IV field as-is.
+   * All values must be between `0` and `31`, and the array must be of exactly length `6`!
+   *
+   * If set to `null`, the override is disabled.
    * @returns `this`
    */
-  public enemyIVs(ivs: number | number[]): this {
+  public playerIVs(ivs: number | number[] | null): this {
+    vi.spyOn(Overrides, "IVS_OVERRIDE", "get").mockReturnValue(ivs);
+    if (ivs === null) {
+      this.log("Player IVs override disabled!");
+    } else {
+      this.log(`Player IVs set to ${ivs}!`);
+    }
+    return this;
+  }
+
+  /**
+   * Overrides the IVs of the enemy pokemon
+   * @param ivs - If set to a number, all IVs are set to the same value. Must be between `0` and `31`!
+   *
+   * If set to an array, that array is applied to the pokemon's IV field as-is.
+   * All values must be between `0` and `31`, and the array must be of exactly length `6`!
+   *
+   * If set to `null`, the override is disabled.
+   * @returns `this`
+   */
+  public enemyIVs(ivs: number | number[] | null): this {
     vi.spyOn(Overrides, "ENEMY_IVS_OVERRIDE", "get").mockReturnValue(ivs);
-    this.log(`Enemy Pokemon IVs set to ${ivs}`);
+    if (ivs === null) {
+      this.log("Enemy IVs override disabled!");
+    } else {
+      this.log(`Enemy IVs set to ${ivs}!`);
+    }
+    return this;
+  }
+
+  /**
+   * Overrides the nature of the player's pokemon
+   * @param nature - The nature to set, or `null` to disable the override.
+   * @returns `this`
+   */
+  public nature(nature: Nature | null): this {
+    vi.spyOn(Overrides, "NATURE_OVERRIDE", "get").mockReturnValue(nature);
+    if (nature === null) {
+      this.log("Player Nature override disabled!");
+    } else {
+      this.log(`Player Nature set to ${Nature[nature]} (${nature})!`);
+    }
+    return this;
+  }
+
+  /**
+   * Overrides the nature of the enemy's pokemon
+   * @param nature - The nature to set, or `null` to disable the override.
+   * @returns `this`
+   */
+  public enemyNature(nature: Nature | null): this {
+    vi.spyOn(Overrides, "ENEMY_NATURE_OVERRIDE", "get").mockReturnValue(nature);
+    if (nature === null) {
+      this.log("Enemy Nature override disabled!");
+    } else {
+      this.log(`Enemy Nature set to ${Nature[nature]} (${nature})!`);
+    }
     return this;
   }
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Improved testing (both manual and automatic).

## What are the changes from a developer perspective?
- New overrides added: `IVS_OVERRIDE`, `NATURE_OVERRIDE` and `ENEMY_NATURE_OVERRIDE`.
- Helper functions added to `OverridesHelper`.
- All tests now automatically set every Pokémon's nature to a neutral nature and all IVs to 31 by default. This is disabled whenever any of the override helpers are used.

## Screenshots/Videos
<details><summary>Example</summary>
<p>

```ts
const overrides = {
  NATURE_OVERRIDE: Nature.ADAMANT,
  ENEMY_NATURE_OVERRIDE: Nature.BOLD,
  IVS_OVERRIDE: 12,
  ENEMY_IVS_OVERRIDE: [1, 2, 3, 4, 5, 6],
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

![image](https://github.com/user-attachments/assets/12f41beb-99cd-4128-910d-bb33619d5020)

</p>
</details> 

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [x] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?