### PR TITLE
[Dev] Enable `lint/suspicious/noPrototypeBuiltins` Biome rule

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -63,7 +63,7 @@
         "noDoubleEquals": "error",
         "noExplicitAny": "off", // TODO: Refactor and make this an error
         "noAssignInExpressions": "warn",
-        "noPrototypeBuiltins": "off", // TODO: investigate adding `"lib": ["ES2022"]` to `tsconfig.json`
+        "noPrototypeBuiltins": "error",
         "noFallthroughSwitchClause": "error", // Prevents accidental automatic fallthroughs in switch cases (use disable comment if needed)
         "noImplicitAnyLet": "warn", // TODO: Refactor and make this an error
         "noRedeclare": "error",

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2656,7 +2656,7 @@ export default class BattleScene extends SceneBase {
 
   validateAchv(achv: Achievement, ...args: unknown[]): boolean {
     if (
-      (!Object.hasOwn(this.gameData.achvUnlocks.hasOwnProperty, achv.id) || Overrides.ACHIEVEMENTS_REUNLOCK_OVERRIDE)
+      (!Object.hasOwn(this.gameData.achvUnlocks, achv.id) || Overrides.ACHIEVEMENTS_REUNLOCK_OVERRIDE)
       && achv.validate(...args)
     ) {
       this.gameData.achvUnlocks[achv.id] = new Date().getTime();

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2030,7 +2030,7 @@ export default class BattleScene extends SceneBase {
               .filter(speciesFilter)
               .map((s) => {
                 if (!filterAllEvolutions) {
-                  while (pokemonPreEvolutions.hasOwnProperty(s.speciesId)) {
+                  while (Object.hasOwn(pokemonPreEvolutions, s.speciesId)) {
                     s = getPokemonSpecies(pokemonPreEvolutions[s.speciesId]);
                   }
                 }
@@ -2587,7 +2587,7 @@ export default class BattleScene extends SceneBase {
     delayed: boolean = false,
     modal: boolean = false,
   ): boolean {
-    if (pokemonFormChanges.hasOwnProperty(pokemon.species.speciesId)) {
+    if (Object.hasOwn(pokemonFormChanges, pokemon.species.speciesId)) {
       // in case this is NECROZMA, determine which forms this
       const matchingFormChangeOpts = pokemonFormChanges[pokemon.species.speciesId].filter(
         (fc) => fc.findTrigger(formChangeTriggerType) && fc.canChange(pokemon),
@@ -2656,12 +2656,12 @@ export default class BattleScene extends SceneBase {
 
   validateAchv(achv: Achievement, ...args: unknown[]): boolean {
     if (
-      (!this.gameData.achvUnlocks.hasOwnProperty(achv.id) || Overrides.ACHIEVEMENTS_REUNLOCK_OVERRIDE)
+      (!Object.hasOwn(this.gameData.achvUnlocks.hasOwnProperty, achv.id) || Overrides.ACHIEVEMENTS_REUNLOCK_OVERRIDE)
       && achv.validate(...args)
     ) {
       this.gameData.achvUnlocks[achv.id] = new Date().getTime();
       this.ui.achvBar.showAchv(achv);
-      if (vouchers.hasOwnProperty(achv.id)) {
+      if (Object.hasOwn(vouchers, achv.id)) {
         this.validateVoucher(vouchers[achv.id]);
       }
       return true;
@@ -2671,7 +2671,7 @@ export default class BattleScene extends SceneBase {
   }
 
   validateVoucher(voucher: Voucher, ...args: unknown[]): boolean {
-    if (!this.gameData.voucherUnlocks.hasOwnProperty(voucher.id) && voucher.validate(...args)) {
+    if (!Object.hasOwn(this.gameData.voucherUnlocks, voucher.id) && voucher.validate(...args)) {
       this.gameData.voucherUnlocks[voucher.id] = new Date().getTime();
       this.ui.achvBar.showAchv(voucher);
       this.gameData.voucherCounts[voucher.voucherType]++;
@@ -3003,7 +3003,7 @@ export default class BattleScene extends SceneBase {
     let encounter: MysteryEncounter | null;
     if (
       !isNil(Overrides.MYSTERY_ENCOUNTER_OVERRIDE)
-      && allMysteryEncounters.hasOwnProperty(Overrides.MYSTERY_ENCOUNTER_OVERRIDE)
+      && Object.hasOwn(allMysteryEncounters, Overrides.MYSTERY_ENCOUNTER_OVERRIDE)
     ) {
       encounter = allMysteryEncounters[Overrides.MYSTERY_ENCOUNTER_OVERRIDE];
       if (canBypass) {

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -381,7 +381,7 @@ export class SingleGenerationChallenge extends Challenge {
       const speciesToCheck = [pokemon.speciesId];
       while (speciesToCheck.length) {
         const checking = speciesToCheck.pop();
-        if (checking && pokemonEvolutions.hasOwnProperty(checking)) {
+        if (checking && Object.hasOwn(pokemonEvolutions, checking)) {
           pokemonEvolutions[checking].forEach((e) => {
             speciesToCheck.push(e.speciesId);
             generations.push(getPokemonSpecies(e.speciesId).generation);
@@ -559,13 +559,13 @@ export class SingleTypeChallenge extends Challenge {
       const speciesToCheck = [pokemon.speciesId];
       while (speciesToCheck.length) {
         const checking = speciesToCheck.pop();
-        if (checking && pokemonEvolutions.hasOwnProperty(checking)) {
+        if (checking && Object.hasOwn(pokemonEvolutions, checking)) {
           pokemonEvolutions[checking].forEach((e) => {
             speciesToCheck.push(e.speciesId);
             types.push(getPokemonSpecies(e.speciesId).type1, getPokemonSpecies(e.speciesId).type2);
           });
         }
-        if (checking && pokemonFormChanges.hasOwnProperty(checking)) {
+        if (checking && Object.hasOwn(pokemonFormChanges, checking)) {
           pokemonFormChanges[checking].forEach((f1) => {
             getPokemonSpecies(checking).forms.forEach((f2) => {
               if (f1.formKey === f2.formKey) {

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -447,7 +447,7 @@ export class Egg {
     let speciesPool = Object.keys(speciesEggTiers)
       .filter((s) => speciesEggTiers[s] === this.tier)
       .map((s) => Number.parseInt(s) as SpeciesId)
-      .filter((s) => !pokemonPreEvolutions.hasOwnProperty(s) && ignoredSpecies.indexOf(s) === -1);
+      .filter((s) => !Object.hasOwn(pokemonPreEvolutions, s) && ignoredSpecies.indexOf(s) === -1);
 
     // If this is the 10th egg without unlocking something new, attempt to force it.
     if (globalScene.gameData.unlockPity[this.tier] >= 9) {

--- a/src/data/init/init-anims.ts
+++ b/src/data/init/init-anims.ts
@@ -52,7 +52,7 @@ export async function populateAnims() {
     }
     const nameIndex = nameField.indexOf(":", 5) + 1;
     const animName = nameField.slice(nameIndex, nameField.indexOf("\n", nameIndex));
-    if (!moveNameToId.hasOwnProperty(animName) && !commonAnimId && !chargeAnimId) {
+    if (!Object.hasOwn(moveNameToId, animName) && !commonAnimId && !chargeAnimId) {
       continue;
     }
     const anim = commonAnimId || chargeAnimId ? new LegacyAnimConfig() : new LegacyAnimConfig();
@@ -193,7 +193,7 @@ export async function populateAnims() {
                   value = Number.parseInt(value);
                   break;
               }
-              if (timedEvent.hasOwnProperty(prop)) {
+              if (Object.hasOwn(timedEvent, prop)) {
                 timedEvent[prop] = value;
               }
             }

--- a/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-expert-pokemon-breeder-encounter.ts
@@ -297,12 +297,12 @@ export const TheExpertPokemonBreederEncounter: MysteryEncounter = MysteryEncount
             text: `${namespace}:outro`,
           },
         ];
-        if (encounter.dialogueTokens.hasOwnProperty("pokemon1CommonEggs")) {
+        if (Object.hasOwn(encounter.dialogueTokens, "pokemon1CommonEggs")) {
           encounter.dialogue.outro.push({
             text: i18next.t(`${namespace}:gained_eggs`, { numEggs: encounter.dialogueTokens["pokemon1CommonEggs"] }),
           });
         }
-        if (encounter.dialogueTokens.hasOwnProperty("pokemon1RareEggs")) {
+        if (Object.hasOwn(encounter.dialogueTokens, "pokemon1RareEggs")) {
           encounter.dialogue.outro.push({
             text: i18next.t(`${namespace}:gained_eggs`, { numEggs: encounter.dialogueTokens["pokemon1RareEggs"] }),
           });
@@ -349,12 +349,12 @@ export const TheExpertPokemonBreederEncounter: MysteryEncounter = MysteryEncount
             text: `${namespace}:outro`,
           },
         ];
-        if (encounter.dialogueTokens.hasOwnProperty("pokemon2CommonEggs")) {
+        if (Object.hasOwn(encounter.dialogueTokens, "pokemon2CommonEggs")) {
           encounter.dialogue.outro.push({
             text: i18next.t(`${namespace}:gained_eggs`, { numEggs: encounter.dialogueTokens["pokemon2CommonEggs"] }),
           });
         }
-        if (encounter.dialogueTokens.hasOwnProperty("pokemon2RareEggs")) {
+        if (Object.hasOwn(encounter.dialogueTokens, "pokemon2RareEggs")) {
           encounter.dialogue.outro.push({
             text: i18next.t(`${namespace}:gained_eggs`, { numEggs: encounter.dialogueTokens["pokemon2RareEggs"] }),
           });
@@ -401,12 +401,12 @@ export const TheExpertPokemonBreederEncounter: MysteryEncounter = MysteryEncount
             text: `${namespace}:outro`,
           },
         ];
-        if (encounter.dialogueTokens.hasOwnProperty("pokemon3CommonEggs")) {
+        if (Object.hasOwn(encounter.dialogueTokens, "pokemon3CommonEggs")) {
           encounter.dialogue.outro.push({
             text: i18next.t(`${namespace}:gained_eggs`, { numEggs: encounter.dialogueTokens["pokemon3CommonEggs"] }),
           });
         }
-        if (encounter.dialogueTokens.hasOwnProperty("pokemon3RareEggs")) {
+        if (Object.hasOwn(encounter.dialogueTokens, "pokemon3RareEggs")) {
           encounter.dialogue.outro.push({
             text: i18next.t(`${namespace}:gained_eggs`, { numEggs: encounter.dialogueTokens["pokemon3RareEggs"] }),
           });
@@ -528,7 +528,7 @@ function calculateEggRewardsForPokemon(pokemon: PlayerPokemon): [number, number]
   const rootSpecies = pokemon.species.getRootSpeciesId();
   let pointsFromStarterTier = 0;
   // 2 points for every 1 below 7 that the pokemon's starter tier is (max 12, min 0)
-  if (speciesStarterCosts.hasOwnProperty(rootSpecies)) {
+  if (Object.hasOwn(speciesStarterCosts, rootSpecies)) {
     const starterTier = speciesStarterCosts[rootSpecies];
     pointsFromStarterTier = Math.min(Math.max(Math.floor(7 - starterTier) * 2, 0), 12);
   }

--- a/src/data/mystery-encounters/mystery-encounter-requirements.ts
+++ b/src/data/mystery-encounters/mystery-encounter-requirements.ts
@@ -762,7 +762,7 @@ export class CanFormChangeWithItemRequirement extends EncounterPokemonRequiremen
 
   filterByForm(pokemon, formChangeItem) {
     if (
-      pokemonFormChanges.hasOwnProperty(pokemon.species.speciesId)
+      Object.hasOwn(pokemonFormChanges, pokemon.species.speciesId)
       // Get all form changes for this species with an item trigger, including any compound triggers
       && pokemonFormChanges[pokemon.species.speciesId]
         .filter((fc) => fc.trigger.hasTriggerType(SpeciesFormChangeItemTrigger))
@@ -829,7 +829,7 @@ export class CanEvolveWithItemRequirement extends EncounterPokemonRequirement {
       return false;
     }
     if (
-      pokemonEvolutions.hasOwnProperty(pokemon.species.speciesId)
+      Object.hasOwn(pokemonEvolutions, pokemon.species.speciesId)
       && pokemonEvolutions[pokemon.species.speciesId].filter(
         (e) =>
           e.item === evolutionItem

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -1063,7 +1063,7 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
               currentBiome = biomes[randSeedInt(biomes.length)];
             }
           }
-        } else if (biomeLinks.hasOwnProperty(currentBiome)) {
+        } else if (Object.hasOwn(biomeLinks, currentBiome)) {
           currentBiome = biomeLinks[currentBiome] as BiomeId;
         } else {
           // Special logic for endless mode

--- a/src/data/pokemon-species-form.ts
+++ b/src/data/pokemon-species-form.ts
@@ -95,7 +95,7 @@ export abstract class PokemonSpeciesForm {
    */
   getRootSpeciesId(forStarter: boolean = false): SpeciesId {
     let ret = this.speciesId;
-    while (pokemonPreEvolutions.hasOwnProperty(ret) && (!forStarter || !speciesStarterCosts.hasOwnProperty(ret))) {
+    while (Object.hasOwn(pokemonPreEvolutions, ret) && (!forStarter || !Object.hasOwn(speciesStarterCosts, ret))) {
       ret = pokemonPreEvolutions[ret];
     }
     return ret;
@@ -148,8 +148,8 @@ export abstract class PokemonSpeciesForm {
 
   getLevelMoves(): LevelMoves {
     if (
-      pokemonFormLevelMoves.hasOwnProperty(this.speciesId)
-      && pokemonFormLevelMoves[this.speciesId].hasOwnProperty(this.formIndex)
+      Object.hasOwn(pokemonFormLevelMoves, this.speciesId)
+      && Object.hasOwn(pokemonFormLevelMoves[this.speciesId], this.formIndex)
     ) {
       return pokemonFormLevelMoves[this.speciesId][this.formIndex].slice(0);
     }
@@ -400,15 +400,15 @@ export abstract class PokemonSpeciesForm {
   validateStarterMoveset(moveset: StarterMoveset, eggMoves: number): boolean {
     const rootSpeciesId = this.getRootSpeciesId();
     for (const moveId of moveset) {
-      if (speciesEggMoves.hasOwnProperty(rootSpeciesId)) {
+      if (Object.hasOwn(speciesEggMoves, rootSpeciesId)) {
         const eggMoveIndex = speciesEggMoves[rootSpeciesId].findIndex((m) => m === moveId);
         if (eggMoveIndex > -1 && eggMoves & (1 << eggMoveIndex)) {
           continue;
         }
       }
       if (
-        pokemonFormLevelMoves.hasOwnProperty(this.speciesId)
-        && pokemonFormLevelMoves[this.speciesId].hasOwnProperty(this.formIndex)
+        Object.hasOwn(pokemonFormLevelMoves, this.speciesId)
+        && Object.hasOwn(pokemonFormLevelMoves[this.speciesId], this.formIndex)
       ) {
         if (!pokemonFormLevelMoves[this.speciesId][this.formIndex].find((lm) => lm[0] <= 5 && lm[1] === moveId)) {
           return false;

--- a/src/data/pokemon-species.ts
+++ b/src/data/pokemon-species.ts
@@ -145,7 +145,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     }
 
     // If the species cannot evolve, we are done
-    if (!pokemonEvolutions.hasOwnProperty(this.speciesId)) {
+    if (!Object.hasOwn(pokemonEvolutions, this.speciesId)) {
       return this.speciesId;
     }
 
@@ -208,7 +208,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
     player: boolean = false,
   ): EvolutionLevel[] {
     const ret: EvolutionLevel[] = [];
-    if (pokemonPreEvolutions.hasOwnProperty(this.speciesId)) {
+    if (Object.hasOwn(pokemonPreEvolutions, this.speciesId)) {
       const preEvolutionLevels = this.getPreEvolutionLevels().reverse();
       const levelDiff = player ? 0 : forTrainer || isBoss ? (forTrainer && isBoss ? 2.5 : 5) : 10;
       ret.push([preEvolutionLevels[0][0], 1]);
@@ -251,14 +251,14 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
   }
 
   getCompatibleFusionSpeciesFilter(): PokemonSpeciesFilter {
-    const hasEvolution = pokemonEvolutions.hasOwnProperty(this.speciesId);
-    const hasPreEvolution = pokemonPreEvolutions.hasOwnProperty(this.speciesId);
+    const hasEvolution = Object.hasOwn(pokemonEvolutions, this.speciesId);
+    const hasPreEvolution = Object.hasOwn(pokemonPreEvolutions, this.speciesId);
     const category = this.group;
     return (species) => {
       return (
         (category !== SpeciesGroups.COMMON
-          || (pokemonEvolutions.hasOwnProperty(species.speciesId) === hasEvolution
-            && pokemonPreEvolutions.hasOwnProperty(species.speciesId) === hasPreEvolution))
+          || (Object.hasOwn(pokemonEvolutions, species.speciesId) === hasEvolution
+            && Object.hasOwn(pokemonPreEvolutions, species.speciesId) === hasPreEvolution))
         && species.group === category
         && (this.isTrainerForbidden() || !species.isTrainerForbidden())
         && species.speciesId !== SpeciesId.DITTO
@@ -274,7 +274,7 @@ export default class PokemonSpecies extends PokemonSpeciesForm implements Locali
         variantDataIndex = `${variantDataIndex}-${formKey}`;
       }
     }
-    return variantData.hasOwnProperty(variantDataIndex) || variantData.hasOwnProperty(this.speciesId);
+    return Object.hasOwn(variantData, variantDataIndex) || Object.hasOwn(variantData, this.speciesId);
   }
 
   getFormSpriteKey(formIndex?: number) {

--- a/src/data/trainer-configs/rival-trainer-configs.ts
+++ b/src/data/trainer-configs/rival-trainer-configs.ts
@@ -159,8 +159,8 @@ export const rivalTrainerConfigs: TrainerConfigs = {
       2,
       getSpeciesFilterRandomPartyMemberFunc(
         (species: PokemonSpecies) =>
-          !pokemonEvolutions.hasOwnProperty(species.speciesId)
-          && !pokemonPreEvolutions.hasOwnProperty(species.speciesId)
+          !Object.hasOwn(pokemonEvolutions, species.speciesId)
+          && !Object.hasOwn(pokemonPreEvolutions, species.speciesId)
           && species.baseTotal >= 450,
       ),
     ),
@@ -233,8 +233,8 @@ export const rivalTrainerConfigs: TrainerConfigs = {
       2,
       getSpeciesFilterRandomPartyMemberFunc(
         (species: PokemonSpecies) =>
-          !pokemonEvolutions.hasOwnProperty(species.speciesId)
-          && !pokemonPreEvolutions.hasOwnProperty(species.speciesId)
+          !Object.hasOwn(pokemonEvolutions, species.speciesId)
+          && !Object.hasOwn(pokemonPreEvolutions, species.speciesId)
           && species.baseTotal >= 450,
       ),
     )
@@ -309,8 +309,8 @@ export const rivalTrainerConfigs: TrainerConfigs = {
       2,
       getSpeciesFilterRandomPartyMemberFunc(
         (species: PokemonSpecies) =>
-          !pokemonEvolutions.hasOwnProperty(species.speciesId)
-          && !pokemonPreEvolutions.hasOwnProperty(species.speciesId)
+          !Object.hasOwn(pokemonEvolutions, species.speciesId)
+          && !Object.hasOwn(pokemonPreEvolutions, species.speciesId)
           && species.baseTotal >= 450,
       ),
     )
@@ -399,8 +399,8 @@ export const rivalTrainerConfigs: TrainerConfigs = {
       2,
       getSpeciesFilterRandomPartyMemberFunc(
         (species: PokemonSpecies) =>
-          !pokemonEvolutions.hasOwnProperty(species.speciesId)
-          && !pokemonPreEvolutions.hasOwnProperty(species.speciesId)
+          !Object.hasOwn(pokemonEvolutions, species.speciesId)
+          && !Object.hasOwn(pokemonPreEvolutions, species.speciesId)
           && species.baseTotal >= 450,
       ),
     )
@@ -503,8 +503,8 @@ export const rivalTrainerConfigs: TrainerConfigs = {
       2,
       getSpeciesFilterRandomPartyMemberFunc(
         (species: PokemonSpecies) =>
-          !pokemonEvolutions.hasOwnProperty(species.speciesId)
-          && !pokemonPreEvolutions.hasOwnProperty(species.speciesId)
+          !Object.hasOwn(pokemonEvolutions, species.speciesId)
+          && !Object.hasOwn(pokemonPreEvolutions, species.speciesId)
           && species.baseTotal >= 450,
       ),
     )

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1562,7 +1562,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     let starterSpeciesId = this.species.speciesId;
-    while (pokemonPreEvolutions.hasOwnProperty(starterSpeciesId)) {
+    while (Object.hasOwn(pokemonPreEvolutions, starterSpeciesId)) {
       starterSpeciesId = pokemonPreEvolutions[starterSpeciesId];
     }
     return allAbilities[starterPassiveAbilities[starterSpeciesId]];
@@ -2089,7 +2089,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   getEvolution(): SpeciesFormEvolution | null {
-    if (pokemonEvolutions.hasOwnProperty(this.species.speciesId)) {
+    if (Object.hasOwn(pokemonEvolutions, this.species.speciesId)) {
       const evolutions = pokemonEvolutions[this.species.speciesId];
       for (const e of evolutions) {
         if (!e.item && this.level >= e.level && (isNil(e.preFormKey) || this.getFormKey() === e.preFormKey)) {
@@ -2322,7 +2322,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // Checks if there is no variant data for both the index or index with form
     if (
       !this.shiny
-      || (!variantData.hasOwnProperty(variantDataIndex) && !variantData.hasOwnProperty(this.species.speciesId))
+      || (!Object.hasOwn(variantData, variantDataIndex) && !Object.hasOwn(variantData, this.species.speciesId))
     ) {
       return 0;
     }

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -43,7 +43,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
   ) {
     super(globalScene, -72, 80);
     this.type = "Trainer";
-    this.config = allTrainerConfigs.hasOwnProperty(trainerType)
+    this.config = Object.hasOwn(allTrainerConfigs, trainerType)
       ? allTrainerConfigs[trainerType]
       : allTrainerConfigs[TrainerType.ACE_TRAINER];
 
@@ -58,7 +58,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
         : randSeedWeightedItem(this.config.partyTemplates.map((_, i) => i)),
       this.config.partyTemplates.length - 1,
     );
-    if (trainerNamePools.hasOwnProperty(trainerType)) {
+    if (Object.hasOwn(trainerNamePools, trainerType)) {
       const namePool = trainerNamePools[trainerType];
       this.name =
         name
@@ -340,11 +340,11 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
         // If the battle is not one of the named trainer doubles
         if (!(this.config.trainerTypeDouble && this.isDouble() && !this.config.doubleOnly)) {
-          if (this.config.partyMemberFuncs.hasOwnProperty(index)) {
+          if (Object.hasOwn(this.config.partyMemberFuncs, index)) {
             ret = this.config.partyMemberFuncs[index](level, strength);
             return;
           }
-          if (this.config.partyMemberFuncs.hasOwnProperty(index - template.size)) {
+          if (Object.hasOwn(this.config.partyMemberFuncs, index - template.size)) {
             ret = this.config.partyMemberFuncs[index - template.size](level, template.getStrength(index));
             return;
           }
@@ -464,7 +464,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
                 ? TrainerPoolTier.SUPER_RARE
                 : TrainerPoolTier.ULTRA_RARE;
       console.log(TrainerPoolTier[tier]);
-      while (!this.config.speciesPools.hasOwnProperty(tier) || !this.config.speciesPools[tier].length) {
+      while (!Object.hasOwn(this.config.speciesPools, tier) || !this.config.speciesPools[tier].length) {
         console.log(
           `Downgraded trainer Pokemon rarity tier from ${TrainerPoolTier[tier]} to ${TrainerPoolTier[tier - 1]}`,
         );
@@ -481,7 +481,7 @@ export default class Trainer extends Phaser.GameObjects.Container {
 
     console.log(ret.getName());
 
-    if (pokemonPreEvolutions.hasOwnProperty(baseSpecies.speciesId) && ret.speciesId !== baseSpecies.speciesId) {
+    if (Object.hasOwn(pokemonPreEvolutions, baseSpecies.speciesId) && ret.speciesId !== baseSpecies.speciesId) {
       retry = true;
     } else if (template.isBalanced(battle.enemyParty.length)) {
       const partyMemberTypes = battle.enemyParty.flatMap((p) => p.getTypes(true));

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -293,7 +293,7 @@ export class GameMode implements GameModeConfig {
   isFixedBattle(waveIndex: number): boolean {
     const dummyConfig = new FixedBattleConfig();
     return (
-      this.battleConfig.hasOwnProperty(waveIndex)
+      Object.hasOwn(this.battleConfig, waveIndex)
       || applyChallenges(this, ChallengeType.FIXED_BATTLES, waveIndex, dummyConfig)
     );
   }

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -144,7 +144,7 @@ export class ModifierType {
     for (const type of poolTypes) {
       const pool = getModifierPoolForType(type);
       for (const tier of getEnumValues(ModifierTier)) {
-        if (!pool.hasOwnProperty(tier)) {
+        if (!Object.hasOwn(pool, tier)) {
           continue;
         }
         if (pool[tier].find((m) => (m as WeightedModifierType).modifierType.id === this.id)) {
@@ -1090,7 +1090,7 @@ export class EvolutionItemModifierType extends PokemonModifierType implements Ge
       (_type, args) => new EvolutionItemModifier(this, (args[0] as PlayerPokemon).id),
       (pokemon: PlayerPokemon) => {
         if (
-          pokemonEvolutions.hasOwnProperty(pokemon.species.speciesId)
+          Object.hasOwn(pokemonEvolutions, pokemon.species.speciesId)
           && pokemonEvolutions[pokemon.species.speciesId].filter(
             (e) =>
               e.item === this.evolutionItem
@@ -1136,7 +1136,7 @@ export class FormChangeItemModifierType extends PokemonModifierType implements G
       (pokemon: PlayerPokemon) => {
         // Make sure the Pokemon has alternate forms
         if (
-          pokemonFormChanges.hasOwnProperty(pokemon.species.speciesId)
+          Object.hasOwn(pokemonFormChanges, pokemon.species.speciesId)
           // Get all form changes for this species with an item trigger, including any compound triggers
           && pokemonFormChanges[pokemon.species.speciesId]
             .filter(
@@ -1386,7 +1386,7 @@ export class EvolutionItemModifierTypeGenerator extends ModifierTypeGenerator {
       const evolutionItemPool = party
         .filter(
           (p) =>
-            pokemonEvolutions.hasOwnProperty(p.species.speciesId)
+            Object.hasOwn(pokemonEvolutions, p.species.speciesId)
             && (!p.pauseEvolutions
               || p.species.speciesId === SpeciesId.SLOWPOKE
               || p.species.speciesId === SpeciesId.EEVEE),
@@ -1423,7 +1423,7 @@ export class FormChangeItemModifierTypeGenerator extends ModifierTypeGenerator {
       const formChangeItemPool = [
         ...new Set(
           party
-            .filter((p) => pokemonFormChanges.hasOwnProperty(p.species.speciesId))
+            .filter((p) => Object.hasOwn(pokemonFormChanges, p.species.speciesId))
             .flatMap((p) => {
               const formChanges = pokemonFormChanges[p.species.speciesId];
               let formChangeItemTriggers = formChanges
@@ -2038,7 +2038,7 @@ function getNewModifierTypeOption(
     }
 
     tier += upgradeCount;
-    while (tier && (!modifierPool.hasOwnProperty(tier) || !modifierPool[tier].length)) {
+    while (tier && (!Object.hasOwn(modifierPool, tier) || !modifierPool[tier].length)) {
       tier--;
       if (upgradeCount) {
         upgradeCount--;
@@ -2049,7 +2049,7 @@ function getNewModifierTypeOption(
     if (tier < ModifierTier.MASTER && allowLuckUpgrades) {
       const partyLuckValue = getPartyLuckValue(party);
       const upgradeOdds = Math.floor(128 / ((partyLuckValue + 4) / 4));
-      while (modifierPool.hasOwnProperty(tier + upgradeCount + 1) && modifierPool[tier + upgradeCount + 1].length) {
+      while (Object.hasOwn(modifierPool, tier + upgradeCount + 1) && modifierPool[tier + upgradeCount + 1].length) {
         if (randSeedInt(upgradeOdds) < 4) {
           upgradeCount++;
         } else {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2279,7 +2279,7 @@ export class EvolutionItemModifier extends ConsumablePokemonModifier {
    * @returns `true` if the evolution was successful
    */
   override apply(playerPokemon: PlayerPokemon): boolean {
-    const matchingEvolution = pokemonEvolutions.hasOwnProperty(playerPokemon.species.speciesId)
+    const matchingEvolution = Object.hasOwn(pokemonEvolutions, playerPokemon.species.speciesId)
       ? pokemonEvolutions[playerPokemon.species.speciesId].find(
           (e) =>
             e.item === this.type.evolutionItem

--- a/src/phases/select-biome-phase.ts
+++ b/src/phases/select-biome-phase.ts
@@ -83,7 +83,7 @@ export class SelectBiomePhase extends BattlePhase {
       } else {
         setNextBiome(biomes[randSeedInt(biomes.length)]);
       }
-    } else if (biomeLinks.hasOwnProperty(currentBiome)) {
+    } else if (Object.hasOwn(biomeLinks, currentBiome)) {
       setNextBiome(biomeLinks[currentBiome]);
     } else {
       setNextBiome(this.generateNextBiome());

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -335,7 +335,7 @@ export class TitlePhase extends Phase {
     }
 
     for (const achv of Object.keys(gameData.achvUnlocks)) {
-      if (vouchers.hasOwnProperty(achv) && achv !== "CLASSIC_VICTORY") {
+      if (Object.hasOwn(vouchers, achv) && achv !== "CLASSIC_VICTORY") {
         globalScene.validateVoucher(vouchers[achv]);
       }
     }

--- a/src/phases/trainer-victory-phase.ts
+++ b/src/phases/trainer-victory-phase.ts
@@ -42,7 +42,7 @@ export class TrainerVictoryPhase extends BattlePhase {
 
     const trainerType = trainer.config.trainerType;
     // Validate Voucher for boss trainers
-    if (vouchers.hasOwnProperty(TrainerType[trainerType])) {
+    if (Object.hasOwn(vouchers, TrainerType[trainerType])) {
       if (!globalScene.validateVoucher(vouchers[TrainerType[trainerType]]) && trainer.config.isBoss) {
         globalScene.phaseManager.unshiftPhase(
           new ModifierRewardPhase(

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -380,7 +380,7 @@ export class GameData {
 
         if (systemData.unlocks) {
           for (const key of Object.keys(systemData.unlocks)) {
-            if (this.unlocks.hasOwnProperty(key)) {
+            if (Object.hasOwn(this.unlocks, key)) {
               this.unlocks[key] = systemData.unlocks[key];
             }
           }
@@ -388,7 +388,7 @@ export class GameData {
 
         if (systemData.achvUnlocks) {
           for (const a of Object.keys(systemData.achvUnlocks)) {
-            if (achvs.hasOwnProperty(a)) {
+            if (Object.hasOwn(achvs, a)) {
               this.achvUnlocks[a] = systemData.achvUnlocks[a];
             }
           }
@@ -396,7 +396,7 @@ export class GameData {
 
         if (systemData.voucherUnlocks) {
           for (const v of Object.keys(systemData.voucherUnlocks)) {
-            if (vouchers.hasOwnProperty(v)) {
+            if (Object.hasOwn(vouchers, v)) {
               this.voucherUnlocks[v] = systemData.voucherUnlocks[v];
             }
           }
@@ -654,7 +654,7 @@ export class GameData {
     } catch (err) {
       console.error("Error parsing mapping configs from localStorage:", err);
     }
-    if (mappingConfigs.hasOwnProperty(deviceName)) {
+    if (Object.hasOwn(mappingConfigs, deviceName)) {
       // Delete the config for this device and update local storage
       delete mappingConfigs[deviceName];
       localStorage.setItem(MAPPING_CONFIG_LS_KEY, JSON.stringify(mappingConfigs));
@@ -725,7 +725,7 @@ export class GameData {
     const key = getDataTypeKey(GameDataType.SEEN_DIALOGUES);
     const ret: SeenDialogues = {};
 
-    if (!localStorage.hasOwnProperty(key)) {
+    if (!Object.hasOwn(localStorage, key)) {
       return ret;
     }
 
@@ -1016,7 +1016,7 @@ export class GameData {
       let daily: string[] = [];
 
       if (sessionData.gameMode === GameModes.DAILY) {
-        if (localStorage.hasOwnProperty("daily")) {
+        if (Object.hasOwn(localStorage, "daily")) {
           daily = JSON.parse(atob(localStorage.getItem("daily")!)); // TODO: is this bang correct?
           if (daily.includes(seed)) {
             return resolve(false);
@@ -1083,7 +1083,7 @@ export class GameData {
         for (const pd of v) {
           // TODO: remove later, temporary to prevent devs from needing to wipe their local storage
           // due to the field in `PokemonData` being renamed from `species` to `speciesId`
-          if (pd.hasOwnProperty("species")) {
+          if (Object.hasOwn(pd, "species")) {
             pd.speciesId = pd.species;
           }
           ret.push(new PokemonData(pd));
@@ -1563,7 +1563,7 @@ export class GameData {
       dexEntry.caughtAttr |= dexAttr;
 
       // Unlock ability and nature
-      if (speciesStarterCosts.hasOwnProperty(species.speciesId)) {
+      if (Object.hasOwn(speciesStarterCosts, species.speciesId)) {
         const starterData = this.starterData[species.speciesId];
         starterData.abilityAttr |=
           pokemon.abilityIndex !== 1 || pokemon.species.ability2
@@ -1573,7 +1573,7 @@ export class GameData {
         starterData.natureAttr |= 1 << pokemon.nature;
       }
 
-      const hasPreEvolution = pokemonPreEvolutions.hasOwnProperty(species.speciesId);
+      const hasPreEvolution = Object.hasOwn(pokemonPreEvolutions, species.speciesId);
       const newCatch = !caughtAttr;
       const hasNewAttr = (caughtAttr & dexAttr) !== dexAttr;
 
@@ -1622,7 +1622,7 @@ export class GameData {
         }
       };
 
-      if (newCatch && speciesStarterCosts.hasOwnProperty(species.speciesId)) {
+      if (newCatch && Object.hasOwn(speciesStarterCosts, species.speciesId)) {
         unlockedStarters.push(species.speciesId);
         if (!showMessage) {
           checkPreEvolution(unlockedStarters);
@@ -1732,7 +1732,7 @@ export class GameData {
   ): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const speciesId = species.speciesId;
-      if (!speciesEggMoves.hasOwnProperty(speciesId) || !speciesEggMoves[speciesId][eggMoveIndex]) {
+      if (!Object.hasOwn(speciesEggMoves, speciesId) || !speciesEggMoves[speciesId][eggMoveIndex]) {
         resolve(false);
         return;
       }
@@ -1784,12 +1784,12 @@ export class GameData {
 
     const _unlockSpeciesNature = (speciesId: SpeciesId) => {
       // If it's a starter, unlock the nature
-      if (speciesStarterCosts.hasOwnProperty(species.speciesId)) {
+      if (Object.hasOwn(speciesStarterCosts, species.speciesId)) {
         this.starterData[speciesId].natureAttr |= 1 << nature;
       }
 
       // If it has a pre-evolution, recursively unlock the nature for it
-      if (pokemonPreEvolutions.hasOwnProperty(speciesId)) {
+      if (Object.hasOwn(pokemonPreEvolutions, speciesId)) {
         _unlockSpeciesNature(pokemonPreEvolutions[speciesId]);
       }
     };
@@ -1803,7 +1803,7 @@ export class GameData {
   updateSpeciesDexIvs(speciesId: SpeciesId, ivs: number[]): void {
     const doUpdateIvs = (speciesId: SpeciesId) => {
       // If it's a starter, update its IVs
-      if (speciesStarterCosts.hasOwnProperty(speciesId)) {
+      if (Object.hasOwn(speciesStarterCosts, speciesId)) {
         const starterEntry = globalScene.gameData.starterData[speciesId];
         const starterIvs = starterEntry.ivs;
         for (let i = 0; i < starterIvs.length; i++) {
@@ -1817,7 +1817,7 @@ export class GameData {
       }
 
       // If it has a pre-evolution, recursively update its IVs
-      if (pokemonPreEvolutions.hasOwnProperty(speciesId)) {
+      if (Object.hasOwn(pokemonPreEvolutions, speciesId)) {
         doUpdateIvs(pokemonPreEvolutions[speciesId]);
       }
     };

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -102,7 +102,7 @@ export default class PokemonData {
 
     this.customPokemonData = new CustomPokemonData(source.customPokemonData);
 
-    if (source.hasOwnProperty("bossSegments")) {
+    if (Object.hasOwn(source, "bossSegments")) {
       // @ts-expect-error - The `if` statement doesn't tell TS that this isn't a `Pokemon` object
       this.boss = source.bossSegments > 0;
       // @ts-expect-error - The `if` statement doesn't tell TS that this isn't a `Pokemon` object

--- a/src/system/trainer-data.ts
+++ b/src/system/trainer-data.ts
@@ -12,7 +12,7 @@ export default class TrainerData {
   constructor(source: Trainer | any) {
     const sourceTrainer = source.type === "Trainer" ? (source as Trainer) : null;
     this.trainerType = sourceTrainer ? sourceTrainer.config.trainerType : source.trainerType;
-    this.variant = source.hasOwnProperty("variant")
+    this.variant = Object.hasOwn(source, "variant")
       ? source.variant
       : source.female
         ? TrainerVariant.FEMALE

--- a/src/touch-controls.ts
+++ b/src/touch-controls.ts
@@ -117,7 +117,7 @@ export default class TouchControl {
    */
   simulateKeyboardEvent(eventType: string, key: string): boolean {
     console.log("simulateKeyboardEvent", eventType, key);
-    if (!Button.hasOwnProperty(key) || this.disabled) {
+    if (!Object.hasOwn(Button, key) || this.disabled) {
       return false;
     }
     const button = Button[key];

--- a/src/ui-inputs.ts
+++ b/src/ui-inputs.ts
@@ -35,7 +35,7 @@ export class UiInputs {
   detectInputMethod(evt): void {
     if (evt.controller_type === "keyboard") {
       //if the touch property is present and defined, then this is a simulated keyboard event from the touch screen
-      if (evt.hasOwnProperty("isTouch") && evt.isTouch) {
+      if (Object.hasOwn(evt, "isTouch") && evt.isTouch) {
         globalScene.inputMethod = "touch";
       } else {
         globalScene.inputMethod = "keyboard";
@@ -52,7 +52,7 @@ export class UiInputs {
         this.detectInputMethod(event);
 
         const actions = this.getActionsKeyDown();
-        if (!actions.hasOwnProperty(event.button)) {
+        if (!Object.hasOwn(actions, event.button)) {
           return;
         }
         actions[event.button]();
@@ -64,7 +64,7 @@ export class UiInputs {
       "input_up",
       (event) => {
         const actions = this.getActionsKeyUp();
-        if (!actions.hasOwnProperty(event.button)) {
+        if (!Object.hasOwn(actions, event.button)) {
           return;
         }
         actions[event.button]();

--- a/src/ui/components/pokemon-hatch-info-container.ts
+++ b/src/ui/components/pokemon-hatch-info-container.ts
@@ -162,7 +162,7 @@ export class PokemonHatchInfoContainer extends PokemonInfoContainer {
     this.pokemonNumberText.setText(leftPad(species.speciesId, 4));
     this.pokemonNameText.setText(species.name);
 
-    const hasEggMoves = species && speciesEggMoves.hasOwnProperty(species.speciesId);
+    const hasEggMoves = species && Object.hasOwn(speciesEggMoves, species.speciesId);
 
     for (let em = 0; em < 4; em++) {
       const eggMove = hasEggMoves ? allMoves.get(speciesEggMoves[species.speciesId][em]) : null;

--- a/src/ui/handlers/achievements-ui-handler.ts
+++ b/src/ui/handlers/achievements-ui-handler.ts
@@ -188,8 +188,8 @@ export class AchievementsUiHandler extends MessageUiHandler {
 
   protected showAchv(achv: Achievement) {
     const achvUnlocks = globalScene.gameData.achvUnlocks;
-    const unlocked = achvUnlocks.hasOwnProperty(achv.id);
-    const hidden = !unlocked && achv.secret && (!achv.parentId || !achvUnlocks.hasOwnProperty(achv.parentId));
+    const unlocked = Object.hasOwn(achvUnlocks, achv.id);
+    const hidden = !unlocked && achv.secret && (!achv.parentId || !Object.hasOwn(achvUnlocks, achv.parentId));
     this.titleText.setText(unlocked ? achv.name : "???");
     this.showText(!hidden ? achv.description : "");
     this.unlockText.setText(
@@ -199,7 +199,7 @@ export class AchievementsUiHandler extends MessageUiHandler {
 
   protected showVoucher(voucher: Voucher) {
     const voucherUnlocks = globalScene.gameData.voucherUnlocks;
-    const unlocked = voucherUnlocks.hasOwnProperty(voucher.id);
+    const unlocked = Object.hasOwn(voucherUnlocks, voucher.id);
 
     this.titleText.setText(getVoucherTypeName(voucher.voucherType));
     this.showText(voucher.description);
@@ -379,8 +379,8 @@ export class AchievementsUiHandler extends MessageUiHandler {
 
     achvRange.forEach((achv: Achievement, i: number) => {
       const icon = this.icons[i];
-      const unlocked = achvUnlocks.hasOwnProperty(achv.id);
-      const hidden = !unlocked && achv.secret && (!achv.parentId || !achvUnlocks.hasOwnProperty(achv.parentId));
+      const unlocked = Object.hasOwn(achvUnlocks, achv.id);
+      const hidden = !unlocked && achv.secret && (!achv.parentId || !Object.hasOwn(achvUnlocks, achv.parentId));
       const tinted = !hidden && !unlocked;
 
       icon.setFrame(!hidden ? achv.iconImage : "unknown");
@@ -418,7 +418,7 @@ export class AchievementsUiHandler extends MessageUiHandler {
 
     voucherRange.forEach((voucher: Voucher, i: number) => {
       const icon = this.icons[i];
-      const unlocked = voucherUnlocks.hasOwnProperty(voucher.id);
+      const unlocked = Object.hasOwn(voucherUnlocks, voucher.id);
 
       icon.setFrame(getVoucherTypeIcon(voucher.voucherType));
       icon.setVisible(true);

--- a/src/ui/handlers/base-option-select-ui-handler.ts
+++ b/src/ui/handlers/base-option-select-ui-handler.ts
@@ -91,7 +91,7 @@ export abstract class BaseOptionSelectUiHandler<T extends OptionSelectItem> exte
    * @param args - args[0] should be of type `OptionSelectModeConfig<T>`.
    */
   public override show(...args: unknown[]): boolean {
-    if (!args[0]?.hasOwnProperty("options")) {
+    if (!Object.hasOwn(args[0] ?? {}, "options")) {
       console.error("Missing `OptionSelectModeConfig` argument for Mode.OPTION_SELECT");
       return false;
     }

--- a/src/ui/handlers/modal-ui-handler.ts
+++ b/src/ui/handlers/modal-ui-handler.ts
@@ -100,7 +100,7 @@ export abstract class ModalUiHandler extends UiHandler {
   }
 
   public override show(config: ModalConfig | any, ..._args: unknown[]): boolean {
-    if (!config.hasOwnProperty("buttonActions")) {
+    if (!Object.hasOwn(config, "buttonActions")) {
       return false;
     }
 

--- a/src/ui/handlers/party-ui-handler.ts
+++ b/src/ui/handlers/party-ui-handler.ts
@@ -892,7 +892,7 @@ export class PartyUiHandler extends MessageUiHandler {
       this.options.push(PartyOption.SUMMARY);
       this.options.push(PartyOption.RENAME);
 
-      if (pokemonEvolutions.hasOwnProperty(pokemon.species.speciesId)) {
+      if (Object.hasOwn(pokemonEvolutions, pokemon.species.speciesId)) {
         this.options.push(PartyOption.UNPAUSE_EVOLUTION);
       }
 

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -711,7 +711,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     starterBoxContainer.add(this.cursorObj);
 
     for (const species of allSpecies) {
-      if (!speciesStarterCosts.hasOwnProperty(species.speciesId)) {
+      if (!Object.hasOwn(speciesStarterCosts, species.speciesId)) {
         continue;
       }
 
@@ -1984,7 +1984,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
               options: options,
             });
           };
-          if (!pokemonPreEvolutions.hasOwnProperty(this.lastSpecies.speciesId)) {
+          if (!Object.hasOwn(pokemonPreEvolutions, this.lastSpecies.speciesId)) {
             options.push({
               label: i18next.t("starterSelectUiHandler:useCandies"),
               handler: () => {
@@ -2436,7 +2436,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     const formIndex = globalScene.gameData.getSpeciesDexAttrProps(this.lastSpecies, this.dexAttrCursor).formIndex;
     const starterData = globalScene.gameData.starterData[speciesId];
 
-    if (pokemonFormLevelMoves.hasOwnProperty(speciesId)) {
+    if (Object.hasOwn(pokemonFormLevelMoves, speciesId)) {
       // Species has forms with different movesets
       if (!starterData.moveset || Array.isArray(starterData.moveset)) {
         starterData.moveset = {};
@@ -2707,7 +2707,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       // First, ensure you have the caught attributes for the species else default to bigint 0
       const caughtAttr = globalScene.gameData.dexData[container.species.speciesId]?.caughtAttr || BigInt(0);
       const starterData = globalScene.gameData.starterData[container.species.speciesId];
-      const isStarterProgressable = speciesEggMoves.hasOwnProperty(container.species.speciesId);
+      const isStarterProgressable = Object.hasOwn(speciesEggMoves, container.species.speciesId);
 
       // Gen filter
       const fitsGen = this.filterBar.getVals(DropDownColumn.GEN).includes(container.species.generation);
@@ -3163,7 +3163,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         this.pokemonCaughtHatchedContainer.setVisible(true);
         this.pokemonFormText.setVisible(true);
 
-        if (pokemonPreEvolutions.hasOwnProperty(species.speciesId)) {
+        if (Object.hasOwn(pokemonPreEvolutions, species.speciesId)) {
           this.pokemonCaughtHatchedContainer.setY(16);
           this.pokemonShinyIcon.setY(135);
           this.pokemonShinyIcon.setFrame(getVariantTierForVariant(variant));
@@ -3516,7 +3516,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
         this.canCycleTera =
           !this.statsMode
-          // && globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id)
+          // && Object.hasOwn(globalScene.gameData.achvUnlocks, achvs.TERASTALLIZE.id)
           && !isNil(getPokemonSpeciesForm(species.speciesId, formIndex ?? 0).type2);
       }
 
@@ -3602,16 +3602,16 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
         let levelMoves: LevelMoves;
         if (
-          pokemonFormLevelMoves.hasOwnProperty(species.speciesId)
+          Object.hasOwn(pokemonFormLevelMoves, species.speciesId)
           && formIndex
-          && pokemonFormLevelMoves[species.speciesId].hasOwnProperty(formIndex)
+          && Object.hasOwn(pokemonFormLevelMoves[species.speciesId], formIndex)
         ) {
           levelMoves = pokemonFormLevelMoves[species.speciesId][formIndex];
         } else {
           levelMoves = pokemonSpeciesLevelMoves[species.speciesId];
         }
         this.speciesStarterMoves.push(...levelMoves.filter((lm) => lm[0] > 0 && lm[0] <= 5).map((lm) => lm[1]));
-        if (speciesEggMoves.hasOwnProperty(species.speciesId)) {
+        if (Object.hasOwn(speciesEggMoves, species.speciesId)) {
           for (let em = 0; em < 4; em++) {
             if (globalScene.gameData.starterData[species.speciesId].eggMoves & (1 << em)) {
               this.speciesStarterMoves.push(speciesEggMoves[species.speciesId][em]);
@@ -3626,7 +3626,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
             : speciesMoveData[formIndex!] // TODO: is this bang correct?
           : null;
         const availableStarterMoves = this.speciesStarterMoves.concat(
-          speciesEggMoves.hasOwnProperty(species.speciesId)
+          Object.hasOwn(speciesEggMoves, species.speciesId)
             ? speciesEggMoves[species.speciesId].filter(
                 (_, em: number) => globalScene.gameData.starterData[species.speciesId].eggMoves & (1 << em),
               )
@@ -3670,7 +3670,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         this.teraIcon.setFrame(ElementalType[this.teraCursor].toLowerCase());
         this.teraIcon.setVisible(
           !this.statsMode /*
-            && globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id) */,
+            && Object.hasOwn(globalScene.gameData.achvUnlocks, achvs.TERASTALLIZE.id) */,
         );
       } else {
         this.pokemonAbilityText.setText("");
@@ -3701,7 +3701,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       this.pokemonMoveContainers[m].setVisible(!!move);
     }
 
-    const hasEggMoves = species && speciesEggMoves.hasOwnProperty(species.speciesId);
+    const hasEggMoves = species && Object.hasOwn(speciesEggMoves, species.speciesId);
 
     for (let em = 0; em < 4; em++) {
       const eggMove = hasEggMoves ? allMoves.get(speciesEggMoves[species.speciesId][em]) : null;
@@ -4120,7 +4120,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     this.pokemonSprite.setVisible(!!this.speciesStarterDexEntry?.caughtAttr);
     this.statsContainer.updateIvs(null);
     this.teraIcon.setVisible(true);
-    // this.teraIcon.setVisible(globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id));
+    // this.teraIcon.setVisible(Object.hasOwn(globalScene.gameData.achvUnlocks, achvs.TERASTALLIZE.id));
     const props = globalScene.gameData.getSpeciesDexAttrProps(
       this.lastSpecies,
       this.getCurrentDexProps(this.lastSpecies.speciesId),
@@ -4128,7 +4128,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
     const formIndex = props.formIndex;
     this.canCycleTera =
       !this.statsMode
-      // && globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id)
+      // && Object.hasOwn(globalScene.gameData.achvUnlocks, achvs.TERASTALLIZE.id)
       && !isNil(getPokemonSpeciesForm(this.lastSpecies.speciesId, formIndex ?? 0).type2);
     this.updateInstructions();
   }

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -808,7 +808,7 @@ export class SummaryUiHandler extends UiHandler {
 
         if (
           !isNil(this.pokemon) /*
-          && globalScene.gameData.achvUnlocks.hasOwnProperty(achvs.TERASTALLIZE.id) */
+          && Object.hasOwn(globalScene.gameData.achvUnlocks, achvs.TERASTALLIZE.id) */
         ) {
           const teraIcon = globalScene.add.sprite(123, 26, "button_tera");
           teraIcon.setName("terrastallize-icon");

--- a/src/ui/ui-theme.ts
+++ b/src/ui/ui-theme.ts
@@ -81,7 +81,7 @@ export function updateWindowStyle(windowStyle: UiWindowStyle): void {
   document.documentElement.dataset.windowStyle = UiWindowStyle[settings.display.uiWindowStyle];
 
   const traverse = (object: any) => {
-    if (object.hasOwnProperty("children") && object.children instanceof Phaser.GameObjects.DisplayList) {
+    if (Object.hasOwn(object, "children") && object.children instanceof Phaser.GameObjects.DisplayList) {
       const children = object.children as Phaser.GameObjects.DisplayList;
       for (const child of children.getAll()) {
         traverse(child);

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -161,7 +161,7 @@ export function deepFreeze<T>(obj: T): Readonly<T> {
 
 /** @returns `true` if the input is a `Pokemon` object */
 export function isPokemon(data: any): data is Pokemon {
-  return data.hasOwnProperty("type") && data.type === "Pokemon";
+  return Object.hasOwn(data, "type") && data.type === "Pokemon";
 }
 
 /**

--- a/test/sprites/pokemon-sprite.test.ts
+++ b/test/sprites/pokemon-sprite.test.ts
@@ -48,7 +48,7 @@ describe("check if every variant's sprite are correctly set", () => {
           continue;
         }
         if (name.includes("_")) {
-        } else if (!mlist.hasOwnProperty(name)) {
+        } else if (!Object.hasOwn(mlist, name)) {
           errors.push(`[${name}] - missing key ${name} in masterlist for ${trimmedFilePath}`);
         } else {
           const raw = fs.readFileSync(filePath, { encoding: "utf8", flag: "r" });

--- a/test/test-utils/mocks/mock-local-storage.ts
+++ b/test/test-utils/mocks/mock-local-storage.ts
@@ -11,7 +11,7 @@ export const mockLocalStorage = () => {
     },
 
     hasOwnProperty(key: string) {
-      return store.hasOwnProperty(key);
+      return Object.hasOwn(store, key);
     },
 
     removeItem(key: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    // Modifying this option requires all values to be set manually because the defaults get overridden
+    // Values other than "ES2022.Object" taken from https://github.com/microsoft/TypeScript/blob/main/src/lib/es2020.full.d.ts
+    "lib": ["ES2020", "ES2022.Object", "DOM", "DOM.AsyncIterable", "DOM.Iterable", "ScriptHost", "WebWorker.ImportScripts"],
     "target": "ES2020",
     "module": "ES2022",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Enabling recommended rule: https://biomejs.dev/linter/rules/no-prototype-builtins/

## What are the changes from a developer perspective?
`tsconfig.json` updated to add `"ES2022.Object"` to `"lib"`, granting access to [`Object.hasOwn`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn).

`Object.hasOwn(thing, prop)` should be used instead of `thing.hasOwnProperty(prop)`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)