### PR TITLE
[Docs] Add TSDocs to TypeScript enum utility functions

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -150,7 +150,7 @@ import { addTextObject } from "#ui/text-utils";
 import { UI } from "#ui/ui";
 import { setDocumentUiTheme, updateWindowStyle } from "#ui/ui-theme";
 import { loadCommonAnimAssets } from "#utils/anim-utils";
-import { BooleanHolder, fixedNumber, getEnumValues, isBetween, isNil, NumberHolder } from "#utils/common-utils";
+import { BooleanHolder, fixedNumber, getTSEnumValues, isBetween, isNil, NumberHolder } from "#utils/common-utils";
 import { getModifierPoolForType } from "#utils/modifier-pool-utils";
 import { getModifierType } from "#utils/modifier-type-utils";
 import { loadMoveAnimAssets } from "#utils/move-anim-utils";
@@ -1117,7 +1117,7 @@ export default class BattleScene extends SceneBase {
     this.lockModifierTiers = false;
 
     this.pokeballCounts = Object.fromEntries(
-      getEnumValues(PokeballType)
+      getTSEnumValues(PokeballType)
         .filter((p) => p <= PokeballType.MASTER_BALL)
         .map((t) => [t, 0]),
     );
@@ -1189,7 +1189,7 @@ export default class BattleScene extends SceneBase {
         ...allSpecies,
         ...allMoves.values(),
         ...allAbilities,
-        ...getEnumValues(ModifierPoolType)
+        ...getTSEnumValues(ModifierPoolType)
           .map((mpt) => getModifierPoolForType(mpt))
           .flatMap((mp) =>
             Object.values(mp)

--- a/src/data/animations/anim-config-schema.ts
+++ b/src/data/animations/anim-config-schema.ts
@@ -3,7 +3,7 @@ import { easeFunctions } from "#animations/ease-functions";
 import { AnimBlendType } from "#enums/anim-blend-type";
 import { AnimTimedEventType } from "#enums/anim-timed-event-type";
 import { MoveId } from "#enums/move-id";
-import { getEnumValues } from "#utils/common-utils";
+import { getTSEnumValues } from "#utils/common-utils";
 import type { JSONSchemaType } from "ajv";
 
 /** JSON Schema properties applicable to keyframes for any animation property. */
@@ -211,7 +211,7 @@ const animPropSchema: JSONSchemaType<AnimProp> = {
     blendType: {
       ...getNumberKeyFrameSetSchema({
         type: "integer",
-        enum: getEnumValues(AnimBlendType),
+        enum: getTSEnumValues(AnimBlendType),
       }),
       nullable: true,
     },
@@ -364,7 +364,7 @@ export const animConfigSchema: JSONSchemaType<AnimConfig> = {
      */
     moveId: {
       type: "integer",
-      enum: getEnumValues(MoveId),
+      enum: getTSEnumValues(MoveId),
       nullable: true,
     },
 

--- a/src/data/animations/battle-anims.ts
+++ b/src/data/animations/battle-anims.ts
@@ -8,7 +8,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import type { Pokemon } from "#field/pokemon";
 import { settings } from "#system/settings-manager";
 import type { nil } from "#types/nil";
-import { getEnumValues, getFrameMs, isNil } from "#utils/common-utils";
+import { getFrameMs, isNil } from "#utils/common-utils";
 import Phaser from "phaser";
 
 interface GraphicFrameData {
@@ -656,7 +656,7 @@ export abstract class BattleAnim {
             );
           }
         }
-        const targets = getEnumValues(AnimFrameTarget);
+        const targets = Object.values(AnimFrameTarget);
         for (const i of targets) {
           const count = graphicFrameCount;
           if (count < spriteCache[i].length) {

--- a/src/data/egg-moves.ts
+++ b/src/data/egg-moves.ts
@@ -1,7 +1,7 @@
 import { allMoves } from "#data/data-lists";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { getEnumKeys, getEnumValues } from "#utils/common-utils";
+import { getTSEnumKeys, getTSEnumValues } from "#utils/common-utils";
 
 export const speciesEggMoves = {
   [SpeciesId.BULBASAUR]: [MoveId.SAPPY_SEED, MoveId.MALIGNANT_CHAIN, MoveId.EARTH_POWER, MoveId.MATCHA_GOTCHA],
@@ -591,8 +591,8 @@ export const speciesEggMoves = {
 function parseEggMoves(content: string): void {
   let output = "";
 
-  const speciesNames = getEnumKeys(SpeciesId);
-  const speciesValues = getEnumValues(SpeciesId);
+  const speciesNames = getTSEnumKeys(SpeciesId);
+  const speciesValues = getTSEnumValues(SpeciesId);
   const lines = content.split(/\n/g);
 
   lines.forEach((line, _l) => {

--- a/src/data/init/init-anims.ts
+++ b/src/data/init/init-anims.ts
@@ -18,10 +18,10 @@ import { getEnumKeys, getEnumValues } from "#utils/common-utils";
 export async function populateAnims() {
   const commonAnimNames = getEnumKeys(CommonAnim).map((k) => k.toLowerCase());
   const commonAnimMatchNames = commonAnimNames.map((k) => k.replace(/\_/g, ""));
-  const commonAnimIds = getEnumValues(CommonAnim) as CommonAnim[];
+  const commonAnimIds: CommonAnim[] = getEnumValues(CommonAnim);
   const chargeAnimNames = getEnumKeys(ChargeAnim).map((k) => k.toLowerCase());
   const chargeAnimMatchNames = chargeAnimNames.map((k) => k.replace(/\_/g, " "));
-  const chargeAnimIds = getEnumValues(ChargeAnim) as ChargeAnim[];
+  const chargeAnimIds: ChargeAnim[] = getEnumValues(ChargeAnim);
   const commonNamePattern = /name: (?:Common:)?(Opp )?(.*)/;
   const moveNameToId = {};
   for (const move of getEnumValues(MoveId).slice(1)) {

--- a/src/data/init/init-anims.ts
+++ b/src/data/init/init-anims.ts
@@ -13,18 +13,18 @@ import type { AnimFocus } from "#enums/anim-focus";
 import { ChargeAnim } from "#enums/charge-anim";
 import { CommonAnim } from "#enums/common-anim";
 import { MoveId } from "#enums/move-id";
-import { getEnumKeys, getEnumValues } from "#utils/common-utils";
+import { getTSEnumKeys, getTSEnumValues } from "#utils/common-utils";
 
 export async function populateAnims() {
-  const commonAnimNames = getEnumKeys(CommonAnim).map((k) => k.toLowerCase());
+  const commonAnimNames = getTSEnumKeys(CommonAnim).map((k) => k.toLowerCase());
   const commonAnimMatchNames = commonAnimNames.map((k) => k.replace(/\_/g, ""));
-  const commonAnimIds: CommonAnim[] = getEnumValues(CommonAnim);
-  const chargeAnimNames = getEnumKeys(ChargeAnim).map((k) => k.toLowerCase());
+  const commonAnimIds: CommonAnim[] = getTSEnumValues(CommonAnim);
+  const chargeAnimNames = getTSEnumKeys(ChargeAnim).map((k) => k.toLowerCase());
   const chargeAnimMatchNames = chargeAnimNames.map((k) => k.replace(/\_/g, " "));
-  const chargeAnimIds: ChargeAnim[] = getEnumValues(ChargeAnim);
+  const chargeAnimIds: ChargeAnim[] = getTSEnumValues(ChargeAnim);
   const commonNamePattern = /name: (?:Common:)?(Opp )?(.*)/;
   const moveNameToId = {};
-  for (const move of getEnumValues(MoveId).slice(1)) {
+  for (const move of getTSEnumValues(MoveId).slice(1)) {
     const moveName = MoveId[move].toUpperCase().replace(/\_/g, "");
     moveNameToId[moveName] = move;
   }

--- a/src/data/init/init-common-anims.ts
+++ b/src/data/init/init-common-anims.ts
@@ -2,12 +2,12 @@ import { LegacyAnimConfig } from "#animations/anim-config";
 import { commonAnims } from "#animations/common-anims";
 import { globalScene } from "#app/global-scene";
 import { CommonAnim } from "#enums/common-anim";
-import { getEnumKeys, getEnumValues } from "#utils/common-utils";
+import { getTSEnumKeys, getTSEnumValues } from "#utils/common-utils";
 
 export function initCommonAnims(): Promise<void> {
   return new Promise((resolve) => {
-    const commonAnimNames = getEnumKeys(CommonAnim);
-    const commonAnimIds = getEnumValues(CommonAnim);
+    const commonAnimNames = getTSEnumKeys(CommonAnim);
+    const commonAnimIds = getTSEnumValues(CommonAnim);
     const commonAnimFetches: Promise<Map<CommonAnim, LegacyAnimConfig>>[] = [];
     for (let ca = 0; ca < commonAnimIds.length; ca++) {
       const commonAnimId = commonAnimIds[ca];

--- a/src/data/init/init-encounter-anims.ts
+++ b/src/data/init/init-encounter-anims.ts
@@ -2,7 +2,7 @@ import { LegacyAnimConfig } from "#animations/anim-config";
 import { encounterAnims } from "#animations/encounter-anims";
 import { globalScene } from "#app/global-scene";
 import { EncounterAnim } from "#enums/encounter-anims";
-import { coerceArray, getEnumKeys, isNil } from "#utils/common-utils";
+import { coerceArray, getTSEnumKeys, isNil } from "#utils/common-utils";
 
 /**
  * Fetches animation configs to be used in a Mystery Encounter
@@ -10,7 +10,7 @@ import { coerceArray, getEnumKeys, isNil } from "#utils/common-utils";
  */
 export async function initEncounterAnims(encounterAnim: EncounterAnim | EncounterAnim[]): Promise<void> {
   const anims = coerceArray(encounterAnim);
-  const encounterAnimNames = getEnumKeys(EncounterAnim);
+  const encounterAnimNames = getTSEnumKeys(EncounterAnim);
   const encounterAnimFetches: Promise<Map<EncounterAnim, LegacyAnimConfig>>[] = [];
   for (const anim of anims) {
     if (encounterAnims.has(anim) && !isNil(encounterAnims.get(anim))) {

--- a/src/data/moves/move-attrs/metronome-attr.ts
+++ b/src/data/moves/move-attrs/metronome-attr.ts
@@ -3,7 +3,7 @@ import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
 import { CallMoveAttr } from "#moves/call-move-attr";
 import type { Move } from "#moves/move";
-import { getEnumValues, type BooleanHolder } from "#utils/common-utils";
+import { getTSEnumValues, type BooleanHolder } from "#utils/common-utils";
 import { getMaxMoveList } from "#utils/move-utils";
 
 /**
@@ -24,7 +24,7 @@ export class MetronomeAttr extends CallMoveAttr {
    * This function is only public for usage by automated tests. Please use {@linkcode apply} instead.
    */
   public getRandomMove(user: Pokemon): MoveId {
-    const moveIds = getEnumValues(MoveId).filter(
+    const moveIds = getTSEnumValues(MoveId).filter(
       (m) => !this.invalidMoves.has(m) && !allMoves.get(m).name.endsWith(" (N)"),
     );
 

--- a/src/enums/anim-frame-target.ts
+++ b/src/enums/anim-frame-target.ts
@@ -1,4 +1,7 @@
-/** Specifies the type of sprite affected by an animation */
+/**
+ * Specifies the type of sprite affected by an animation
+ * @todo Start values at `1`
+ */
 export const AnimFrameTarget = {
   /**
    * Affects the animation's source or start point, e.g.

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -36,7 +36,7 @@ import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { CommonAnimPhase } from "#phases/common-anim-phase";
 import { ShowAbilityPhase } from "#phases/show-ability-phase";
-import { coerceArray, getEnumValues } from "#utils/common-utils";
+import { coerceArray, getTSEnumValues } from "#utils/common-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { randSeedInt, weightedPick } from "#utils/random-utils";
 
@@ -654,7 +654,7 @@ export class Arena {
   setRandomWeather(): void {
     const weatherPool = allBiomes.get(this.biomeId).weatherPool;
     const weatherMap = new Map<WeatherType, number>();
-    for (const id of getEnumValues(WeatherType)) {
+    for (const id of getTSEnumValues(WeatherType)) {
       weatherMap.set(id, weatherPool[id] ?? 0);
     }
 
@@ -673,7 +673,7 @@ export class Arena {
   setRandomTerrain(): void {
     const terrainPool = allBiomes.get(this.biomeId).terrainPool;
     const terrainMap = new Map<TerrainType, number>();
-    for (const id of getEnumValues(TerrainType)) {
+    for (const id of getTSEnumValues(TerrainType)) {
       terrainMap.set(id, terrainPool[id] ?? 0);
     }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -198,7 +198,7 @@ import {
   clamp,
   coerceArray,
   fixedNumber,
-  getEnumValues,
+  getTSEnumValues,
   isNil,
   toDmgValue,
 } from "#utils/common-utils";
@@ -1289,7 +1289,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   generateNature(naturePool?: Nature[]): void {
     if (naturePool === undefined) {
-      naturePool = getEnumValues(Nature);
+      naturePool = getTSEnumValues(Nature);
     }
     const nature = naturePool[randSeedInt(naturePool.length)];
     this.setNature(nature);

--- a/src/inputs-controller.ts
+++ b/src/inputs-controller.ts
@@ -16,7 +16,7 @@ import pad_xbox360 from "#inputs/pad_xbox360";
 import { settings } from "#system/settings-manager";
 import type { SettingsUpdateEventArgs } from "#types/Settings";
 import { MoveTouchControlsHandler } from "#ui/move-touch-controls-handler";
-import { deepCopy, getEnumValues } from "#utils/common-utils";
+import { deepCopy, getTSEnumValues } from "#utils/common-utils";
 import Phaser from "phaser";
 
 export interface DeviceMapping {
@@ -105,7 +105,7 @@ export class InputsController {
       [Device.KEYBOARD]: "default",
     };
 
-    for (const b of getEnumValues(Button)) {
+    for (const b of getTSEnumValues(Button)) {
       this.interactions[b] = {
         pressTime: false,
         isPressed: false,

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -31,7 +31,7 @@ import { initAchievements } from "#system/achievements";
 import { initVouchers } from "#system/init-vouchers";
 import { DEFAULT_LANGUAGE_KEY } from "#system/supported-languages";
 import { getWindowVariantSuffix } from "#ui/ui-theme";
-import { getEnumKeys, getEnumValues } from "#utils/common-utils";
+import { getTSEnumKeys, getTSEnumValues } from "#utils/common-utils";
 import i18next from "i18next";
 
 export class LoadingScene extends SceneBase {
@@ -53,7 +53,7 @@ export class LoadingScene extends SceneBase {
     this.loadImage("logo");
 
     /** UI Elements that change based on the {@linkcode UiWindowStyle} */
-    for (const windowVariant of getEnumValues(WindowVariant)) {
+    for (const windowVariant of getTSEnumValues(WindowVariant)) {
       this.loadSpritesheet(`window${getWindowVariantSuffix(windowVariant)}`, ImagesFolder.UI_WINDOWS, 24, 24, {
         windowStyleDependant: true,
         uiThemeDependant: true,
@@ -212,7 +212,7 @@ export class LoadingScene extends SceneBase {
 
     // Load arena images
     this.loadImage("default_bg", ImagesFolder.ARENAS);
-    getEnumValues(BiomeId).map((bt) => {
+    getTSEnumValues(BiomeId).map((bt) => {
       const btKey = BiomeId[bt].toLowerCase();
       const isBaseAnimated = btKey === "end";
       const baseAKey = `${btKey}_a`;
@@ -273,7 +273,7 @@ export class LoadingScene extends SceneBase {
     this.loadAtlas("egg_icons", ImagesFolder.EGG);
     this.loadAtlas("egg_shard", ImagesFolder.EGG);
     this.loadAtlas("egg_lightrays", ImagesFolder.EGG);
-    getEnumKeys(GachaType).forEach((gt) => {
+    getTSEnumKeys(GachaType).forEach((gt) => {
       const key = gt.toLowerCase();
       this.loadImage(`gacha_${key}`, ImagesFolder.EGG);
       this.loadAtlas(`gacha_underlay_${key}`, ImagesFolder.EGG);

--- a/src/modifier/init-modifier-types.ts
+++ b/src/modifier/init-modifier-types.ts
@@ -80,7 +80,7 @@ import {
   TurnHeldItemTransferModifierType,
 } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
-import { getEnumValues } from "#utils/common-utils";
+import { getTSEnumValues } from "#utils/common-utils";
 import { randSeedInt } from "#utils/random-utils";
 import { t } from "i18next";
 
@@ -206,7 +206,7 @@ export function initModifierTypes() {
       if (pregenArgs && pregenArgs.length === 1 && pregenArgs[0] in Nature) {
         return new PokemonNatureChangeModifierType(pregenArgs[0] as Nature);
       }
-      return new PokemonNatureChangeModifierType(randSeedInt(getEnumValues(Nature).length) as Nature);
+      return new PokemonNatureChangeModifierType(randSeedInt(getTSEnumValues(Nature).length) as Nature);
     });
 
   modifierTypes.BERRY = () =>
@@ -214,7 +214,7 @@ export function initModifierTypes() {
       if (pregenArgs && pregenArgs.length === 1 && pregenArgs[0] in BerryType) {
         return new BerryModifierType(pregenArgs[0] as BerryType);
       }
-      const berryTypes = getEnumValues(BerryType);
+      const berryTypes = getTSEnumValues(BerryType);
       let randBerryType: BerryType;
       const rand = randSeedInt(12);
       if (rand < 2) {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -71,7 +71,7 @@ import type { PokemonMoveSelectFilter } from "#types/PokemonMoveSelectFilter";
 import type { PokemonSelectFilter } from "#types/PokemonSelectFilter";
 import { getModifierTierTextTint } from "#ui/text-utils";
 import { getBerryEffectDescription, getBerryName } from "#utils/berry-utils";
-import { clamp, getEnumKeys, getEnumValues, isNil, NumberHolder } from "#utils/common-utils";
+import { clamp, getTSEnumKeys, getTSEnumValues, isNil, NumberHolder } from "#utils/common-utils";
 import { getModifierPoolForType } from "#utils/modifier-pool-utils";
 import { getModifierType } from "#utils/modifier-type-utils";
 import { randSeedInt } from "#utils/random-utils";
@@ -143,7 +143,7 @@ export class ModifierType {
     // Try multiple pool types in case of stolen items
     for (const type of poolTypes) {
       const pool = getModifierPoolForType(type);
-      for (const tier of getEnumValues(ModifierTier)) {
+      for (const tier of getTSEnumValues(ModifierTier)) {
         if (!Object.hasOwn(pool, tier)) {
           continue;
         }
@@ -599,7 +599,7 @@ export class PokemonNatureChangeModifierType extends PokemonModifierType {
     super(
       "",
       `mint_${
-        getEnumKeys(Stat)
+        getTSEnumKeys(Stat)
           .find((s) => getNatureStatMultiplier(nature, Stat[s]) > 1)
           ?.toLowerCase() || "neutral"
       }`,

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -73,7 +73,7 @@ import type { AchvUnlocks, SystemSaveData, Unlocks, VoucherCounts, VoucherUnlock
 import type { ConfirmModeConfig } from "#ui/confirm-menu-config";
 import type { ConfirmUiHandler } from "#ui/confirm-ui-handler";
 import { applyChallenges } from "#utils/challenge-utils";
-import { NumberHolder, executeIf, fixedNumber, getEnumKeys, getEnumLength, isNil } from "#utils/common-utils";
+import { NumberHolder, executeIf, fixedNumber, getTSEnumKeys, getTSEnumLength, isNil } from "#utils/common-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { randInt } from "#utils/random-utils";
 import { AES, enc } from "crypto-js";
@@ -345,7 +345,7 @@ export class GameData {
         }
 
         // TODO: Temporary starter data migration, to be removed later
-        const allNaturesAttr = Math.pow(2, getEnumLength(Nature)) - 1;
+        const allNaturesAttr = Math.pow(2, getTSEnumLength(Nature)) - 1;
         for (const starterData of Object.values(systemData.starterData)) {
           if (!starterData.natureAttr || !starterData.ivs) {
             const unlocked = starterData.abilityAttr !== 0;
@@ -403,7 +403,7 @@ export class GameData {
         }
 
         if (systemData.voucherCounts) {
-          getEnumKeys(VoucherType).forEach((key) => {
+          getTSEnumKeys(VoucherType).forEach((key) => {
             const index = VoucherType[key];
             this.voucherCounts[index] = systemData.voucherCounts[index] || 0;
           });

--- a/src/ui/components/daily-run-scoreboard.ts
+++ b/src/ui/components/daily-run-scoreboard.ts
@@ -6,7 +6,7 @@ import { WindowVariant } from "#enums/window-variant";
 import type { RankingEntry } from "#types/RankingEntry";
 import { addTextObject } from "#ui/text-utils";
 import { addWindow } from "#ui/ui-theme";
-import { executeIf, getEnumKeys } from "#utils/common-utils";
+import { executeIf, getTSEnumKeys } from "#utils/common-utils";
 import i18next from "i18next";
 
 export class DailyRunScoreboard extends Phaser.GameObjects.Container {
@@ -79,7 +79,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
 
     this.prevCategoryButton.setInteractive(new Phaser.Geom.Rectangle(0, 0, 6, 10), Phaser.Geom.Rectangle.Contains);
     this.prevCategoryButton.on("pointerup", () => {
-      this.update(this.category ? this.category - 1 : getEnumKeys(ScoreboardCategory).length - 1);
+      this.update(this.category ? this.category - 1 : getTSEnumKeys(ScoreboardCategory).length - 1);
     });
 
     this.nextCategoryButton = globalScene.add.sprite(window.displayWidth - 4, 4, "cursor");
@@ -88,7 +88,7 @@ export class DailyRunScoreboard extends Phaser.GameObjects.Container {
 
     this.nextCategoryButton.setInteractive(new Phaser.Geom.Rectangle(0, 0, 6, 10), Phaser.Geom.Rectangle.Contains);
     this.nextCategoryButton.on("pointerup", () => {
-      this.update(this.category < getEnumKeys(ScoreboardCategory).length - 1 ? this.category + 1 : 0);
+      this.update(this.category < getTSEnumKeys(ScoreboardCategory).length - 1 ? this.category + 1 : 0);
     });
 
     this.prevPageButton = globalScene.add.sprite(

--- a/src/ui/handlers/egg-gacha-ui-handler.ts
+++ b/src/ui/handlers/egg-gacha-ui-handler.ts
@@ -16,7 +16,7 @@ import { getVoucherTypeIcon } from "#system/voucher";
 import { MessageUiHandler } from "#ui/message-ui-handler";
 import { addTextObject, getEggTierTextTint } from "#ui/text-utils";
 import { addWindow } from "#ui/ui-theme";
-import { fixedNumber, getEnumKeys, getEnumValues } from "#utils/common-utils";
+import { fixedNumber, getTSEnumKeys, getTSEnumValues } from "#utils/common-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { randSeedShuffle } from "#utils/random-utils";
 import i18next from "i18next";
@@ -91,7 +91,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
       });
     }
 
-    getEnumValues(GachaType).forEach((gachaType, g) => {
+    getTSEnumValues(GachaType).forEach((gachaType, g) => {
       const gachaTypeKey = GachaType[gachaType].toString().toLowerCase();
       const gachaContainer = globalScene.add.container(180 * g, 18);
 
@@ -273,7 +273,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
 
     this.eggGachaContainer.add(this.eggGachaOptionsContainer);
 
-    new Array(getEnumKeys(VoucherType).length).fill(null).map((_, i) => {
+    new Array(getTSEnumKeys(VoucherType).length).fill(null).map((_, i) => {
       const container = globalScene.add.container(GAME_WIDTH - 56 * i, 0);
 
       const bg = addWindow(0, 0, 56, 22);
@@ -787,7 +787,7 @@ export class EggGachaUiHandler extends MessageUiHandler {
             }
             break;
           case Button.RIGHT:
-            if (this.gachaCursor < getEnumKeys(GachaType).length - 1) {
+            if (this.gachaCursor < getTSEnumKeys(GachaType).length - 1) {
               success = this.setGachaCursor(this.gachaCursor + 1);
             }
             break;

--- a/src/ui/handlers/menu-ui-handler.ts
+++ b/src/ui/handlers/menu-ui-handler.ts
@@ -31,7 +31,7 @@ import type { TestDialogueUiHandler } from "#ui/test-dialogue-ui-handler";
 import { addTextObject } from "#ui/text-utils";
 import { addWindow } from "#ui/ui-theme";
 import { getCookie } from "#utils/app-utils";
-import { fixedNumber, getEnumKeys } from "#utils/common-utils";
+import { fixedNumber, getTSEnumKeys } from "#utils/common-utils";
 import i18next from "i18next";
 
 enum MenuOptions {
@@ -151,7 +151,7 @@ export class MenuUiHandler extends OptionSelectUiHandler {
   }
 
   getMenuOptionsConfig(): OptionSelectModeConfig {
-    const validOptions = getEnumKeys(MenuOptions)
+    const validOptions = getTSEnumKeys(MenuOptions)
       .map((m) => Number.parseInt(MenuOptions[m]) as MenuOptions)
       .filter((m) => {
         return !this.excludedMenus().some((option) => option.excluded && option.options.includes(m));

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -31,7 +31,7 @@ import type { PartyUiHandler } from "#ui/party-ui-handler";
 import { addBBCodeTextObject, addTextObject, getBBCodeFragment, setTextColor } from "#ui/text-utils";
 import { UiHandler } from "#ui/ui-handler";
 import { rgbHexToRgba } from "#utils/color-utils";
-import { fixedNumber, getEnumValues, isNil } from "#utils/common-utils";
+import { fixedNumber, getTSEnumValues, isNil } from "#utils/common-utils";
 import { formatStat, leftPad, toReadableString } from "#utils/string-utils";
 import { argbFromRgba } from "@material/material-color-utilities";
 import i18next from "i18next";
@@ -563,7 +563,7 @@ export class SummaryUiHandler extends UiHandler {
         }
         success = true;
       } else {
-        const pages = getEnumValues(SummaryUiPage);
+        const pages = getTSEnumValues(SummaryUiPage);
         switch (button) {
           case Button.UP:
           case Button.DOWN: {

--- a/src/ui/settings/settings-ui-items.ts
+++ b/src/ui/settings/settings-ui-items.ts
@@ -25,7 +25,7 @@ import type {
   SettingsUiItem,
   SettingUiItemOption,
 } from "#types/Settings";
-import { getEnumLength } from "#utils/common-utils";
+import { getTSEnumLength } from "#utils/common-utils";
 import i18next, { t } from "i18next";
 
 //#region Types
@@ -231,7 +231,7 @@ export const displaySettingUiItems: SettingsUiItem<DisplaySettingsKey>[] = [
   {
     key: "uiWindowStyle",
     label: t("settings:windowType"),
-    options: Array.from({ length: getEnumLength(UiWindowStyle) }).map((_, i) => ({ value: i, label: `${i + 1}` })),
+    options: Array.from({ length: getTSEnumLength(UiWindowStyle) }).map((_, i) => ({ value: i, label: `${i + 1}` })),
     doWrap: true,
   },
   {

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -25,7 +25,7 @@ export function getCurrentTime(): number {
  * - **DO NOT** use on an enum with string values!
  * @returns The keys of a TypeScript enum
  */
-export function getEnumKeys(enumType: any): string[] {
+export function getTSEnumKeys(enumType: any): string[] {
   return Object.values(enumType)
     .filter((v) => Number.isNaN(Number.parseInt(v!.toString())))
     .map((v) => v!.toString());
@@ -39,7 +39,7 @@ export function getEnumKeys(enumType: any): string[] {
  * - Any non-number values are discarded!
  * @returns **ONLY** the number values of a TypeScript enum
  */
-export function getEnumValues(enumType: any): number[] {
+export function getTSEnumValues(enumType: any): number[] {
   return Object.values(enumType)
     .filter((v) => !Number.isNaN(Number.parseInt(v!.toString())))
     .map((v) => Number.parseInt(v!.toString()));
@@ -48,8 +48,8 @@ export function getEnumValues(enumType: any): number[] {
 /**
  * @returns length of the TypeScript enum
  */
-export function getEnumLength(input: any): number {
-  return getEnumKeys(input).length;
+export function getTSEnumLength(input: any): number {
+  return getTSEnumKeys(input).length;
 }
 
 export function executeIf<T>(condition: boolean, promiseFunc: () => Promise<T>): Promise<T | null> {

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -17,12 +17,28 @@ export function getCurrentTime(): number {
   return ((date.getHours() * 60 + date.getMinutes()) / 1440 + 0.675) % 1;
 }
 
+/**
+ * Gets the keys of a TypeScript enum.
+ *
+ * **Warning**:
+ * - **ONLY** use with TypeScript enums.
+ * - **DO NOT** use on an enum with string values!
+ * @returns The keys of a TypeScript enum
+ */
 export function getEnumKeys(enumType: any): string[] {
   return Object.values(enumType)
     .filter((v) => Number.isNaN(Number.parseInt(v!.toString())))
     .map((v) => v!.toString());
 }
 
+/**
+ * Gets the number values of a TypeScript enum.
+ *
+ * **Warning**:
+ * - **ONLY** use with TypeScript enums.
+ * - Any non-number values are discarded!
+ * @returns **ONLY** the number values of a TypeScript enum
+ */
 export function getEnumValues(enumType: any): number[] {
   return Object.values(enumType)
     .filter((v) => !Number.isNaN(Number.parseInt(v!.toString())))

--- a/src/utils/move-utils.ts
+++ b/src/utils/move-utils.ts
@@ -11,7 +11,7 @@ import type { PokemonMove } from "#field/pokemon-move";
 import type { Move, MoveAttrFilter } from "#moves/move";
 import type { MoveAttr } from "#moves/move-attr";
 import type { AbstractConstructor } from "#types/AbstractConstructor";
-import { BooleanHolder, getEnumKeys, toDmgValue } from "#utils/common-utils";
+import { BooleanHolder, getTSEnumKeys, toDmgValue } from "#utils/common-utils";
 import { t } from "i18next";
 
 //#region Exports
@@ -65,7 +65,7 @@ export function applyMoveChargeAttrs<TAttr extends MoveAttr>(
  */
 export function getGmaxMoveList(): MoveId[] {
   const ret: MoveId[] = [];
-  for (const move_name of getEnumKeys(MoveId)) {
+  for (const move_name of getTSEnumKeys(MoveId)) {
     if (move_name.startsWith("G_MAX_")) {
       ret.push(MoveId[move_name]);
     }
@@ -81,7 +81,7 @@ export function getGmaxMoveList(): MoveId[] {
  */
 export function getMaxMoveList(): MoveId[] {
   const ret = getGmaxMoveList();
-  for (const move_name of getEnumKeys(MoveId)) {
+  for (const move_name of getTSEnumKeys(MoveId)) {
     if (move_name.startsWith("MAX_")) {
       ret.push(MoveId[move_name]);
     }

--- a/test/abilities/solar-power.test.ts
+++ b/test/abilities/solar-power.test.ts
@@ -6,14 +6,14 @@ import { Stat } from "#enums/stat";
 import { WeatherType } from "#enums/weather-type";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import { GameManager } from "#test/test-utils/game-manager";
-import { getEnumKeys, toDmgValue } from "#utils/common-utils";
+import { getTSEnumKeys, toDmgValue } from "#utils/common-utils";
 import { capitalizeString } from "#utils/string-utils";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 //#region Test Constants
 
-const allWeathers = getEnumKeys(WeatherType).map((key) => ({
+const allWeathers = getTSEnumKeys(WeatherType).map((key) => ({
   weatherName: key === "NONE" ? "no" : capitalizeString(key, "_", false, true),
   weatherType: WeatherType[key],
 }));


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Improve documentation and clarity of code.

## What are the changes from a developer perspective?
- Renamed `getEnumKeys` to `getTSEnumKeys`, `getEnumValues` to `getTSEnumValues` and `getEnumLength` to `getTSEnumLength`.
- Added TSDocs to `getTSEnumKeys` and `getTSEnumValues`.
- Replaced a couple instances of `as thing` with `: thing`.
- Added note to `AnimFrameTarget` to change starting value to `1`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?