### PR TITLE
[Dev] Move `typedoc` settings from `tsconfig.json` to `typedoc.json`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -2709,8 +2709,8 @@ export default class BattleScene extends SceneBase {
 
   /**
    * This function retrieves the sprite and audio keys for active Pokemon.
+   *
    * Active Pokemon include both enemy and player Pokemon of the current wave.
-   * Note: Questions on garbage collection go to @frutescens
    * @returns a string array of active sprite and audio keys that should not be deleted
    */
   getActiveKeys(): string[] {

--- a/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-stat-stage-change-on-arena-ab-attr.ts
@@ -16,10 +16,7 @@ import type { Pokemon } from "#field/pokemon";
  * @extends PostSummonStatStageChangeAbAttr
  */
 export class PostSummonStatStageChangeOnArenaAbAttr extends PostSummonStatStageChangeAbAttr {
-  /**
-   * The type of arena tag that conditions the stat change.
-   * @private
-   */
+  /** The type of arena tag that conditions the stat change. */
   private readonly tagType: ArenaTagType;
 
   constructor(tagType: ArenaTagType, stats: BattleStat[] = [Stat.ATK], stages: number = 1) {

--- a/src/data/animations/anim-config-schema.ts
+++ b/src/data/animations/anim-config-schema.ts
@@ -123,33 +123,20 @@ function getNumberArrayKeyFrameSetSchema(
 const animPropSchema: JSONSchemaType<AnimProp> = {
   type: "object",
   properties: {
-    /**
-     * For battle animations, the origin point for keyframes is defined
-     * along the line connecting the start point ("source") and end point ("target").
-     * The `u`-value is the fraction of the distance between the start and end point
-     * the origin point is away from the source. If `u = 0`, then the origin point is
-     * the source; if `u = 1`, then the origin point is the target.
-     */
     u: getNumberKeyFrameSetSchema({
       type: "number",
       minimum: 0,
       maximum: 1,
     }),
 
-    /** The horizontal coordinate relative to the keyframe's origin point. */
     x: getNumberKeyFrameSetSchema({
       type: "number",
     }),
 
-    /**
-     * The vertical coordinate relative to the keyframe's origin point.
-     * An increase in `y` will move the sprite downward.
-     */
     y: getNumberKeyFrameSetSchema({
       type: "number",
     }),
 
-    /** Horizontal scale factor (%) */
     scaleX: {
       ...getNumberKeyFrameSetSchema({
         type: "number",
@@ -158,7 +145,6 @@ const animPropSchema: JSONSchemaType<AnimProp> = {
       nullable: true,
     },
 
-    /** Vertical scale factor (%) */
     scaleY: {
       ...getNumberKeyFrameSetSchema({
         type: "number",
@@ -167,7 +153,6 @@ const animPropSchema: JSONSchemaType<AnimProp> = {
       nullable: true,
     },
 
-    /** The alpha value for the animated sprite, in the range [0, 255] */
     alpha: {
       ...getNumberKeyFrameSetSchema({
         type: "number",
@@ -177,12 +162,6 @@ const animPropSchema: JSONSchemaType<AnimProp> = {
       nullable: true,
     },
 
-    /**
-     * The rotation angle of the sprite in degrees.
-     * Phaser uses a right-hand clockwise rotation system, where 0 is right,
-     * 90 is down, and -90 is up. The value of this should be in the interval
-     * [-180, 180].
-     */
     angle: {
       ...getNumberKeyFrameSetSchema({
         type: "number",
@@ -192,22 +171,16 @@ const animPropSchema: JSONSchemaType<AnimProp> = {
       nullable: true,
     },
 
-    /** If `true`, flips the sprite horizontally */
     mirror: {
       ...getBooleanKeyFrameSetSchema({ type: "boolean" }),
       nullable: true,
     },
 
-    /** If `false`, hides the sprite */
     visible: {
       ...getBooleanKeyFrameSetSchema({ type: "boolean" }),
       nullable: true,
     },
 
-    /**
-     * The blend mode to specify how the sprite is rendered on the canvas
-     * @see {@link https://docs.phaser.io/api-documentation/constant/blendmodes}
-     */
     blendType: {
       ...getNumberKeyFrameSetSchema({
         type: "integer",
@@ -216,17 +189,11 @@ const animPropSchema: JSONSchemaType<AnimProp> = {
       nullable: true,
     },
 
-    /**
-     * If this keyframe is for a graphic, specifies the tile index used
-     * for the graphic during the tween. This is only relevant for VFX
-     * properties.
-     */
     graphicFrame: {
       ...getNumberKeyFrameSetSchema({ type: "integer" }),
       nullable: true,
     },
 
-    /** A tone to pipeline over the animated sprite (RGBA, normalized) */
     tone: {
       ...getNumberArrayKeyFrameSetSchema({
         type: "array",
@@ -241,13 +208,6 @@ const animPropSchema: JSONSchemaType<AnimProp> = {
       nullable: true,
     },
 
-    /**
-     * The z-depth of the animated sprite during the tween
-     * - 0 is behind all other sprites (except BG)
-     * - 1 is on top of player field
-     * - 3 is on top of both fields
-     * - 5 is on top of player sprite
-     */
     priority: {
       ...getNumberKeyFrameSetSchema({
         type: "integer",
@@ -271,13 +231,11 @@ const animTimedEventSchema: JSONSchemaType<AnimTimedEvent> = {
   properties: {
     // Required fields
 
-    /** The type of event to execute. */
     eventType: {
       type: "string",
       enum: Object.values(AnimTimedEventType),
     },
 
-    /** The delay from the start of the animation to the given event (in frames) */
     time: {
       type: "number",
       minimum: 0,
@@ -287,10 +245,6 @@ const animTimedEventSchema: JSONSchemaType<AnimTimedEvent> = {
 
     // Timed Sound Event fields
 
-    /**
-     * The volume of the played sound effect
-     * @default 100
-     */
     volume: {
       type: "number",
       default: 100,
@@ -298,10 +252,6 @@ const animTimedEventSchema: JSONSchemaType<AnimTimedEvent> = {
       nullable: true,
     },
 
-    /**
-     * The pitch of the played sound effect
-     * @default 100
-     */
     pitch: {
       type: "number",
       default: 100,
@@ -311,27 +261,23 @@ const animTimedEventSchema: JSONSchemaType<AnimTimedEvent> = {
 
     // Background Image Event fields
 
-    /** The x-coordinate of the background image */
     bgX: {
       type: "number",
       default: 0,
       nullable: true,
     },
 
-    /** The y-coordinate of the background image */
     bgY: {
       type: "number",
       default: 0,
       nullable: true,
     },
 
-    /** The duration the image is displayed (in frames) */
     duration: {
       type: "number",
       nullable: true,
     },
 
-    /** Scale factor (%) for the background image */
     scale: {
       type: "number",
       default: 100,
@@ -357,44 +303,21 @@ const animTimedEventSchema: JSONSchemaType<AnimTimedEvent> = {
 export const animConfigSchema: JSONSchemaType<AnimConfig> = {
   type: "object",
   properties: {
-    /**
-     * The {@linkcode MoveId | identifier} for the move
-     * associated with the anim (if applicable).
-     * This is required for all {@linkcode MoveAnim | MoveAnims}.
-     */
     moveId: {
       type: "integer",
       enum: getTSEnumValues(MoveId),
       nullable: true,
     },
 
-    /** The name of the tileset used for the animation. */
+    // The name of the tileset used for the animation.
     graphic: { type: "string", nullable: true },
 
-    /**
-     * Contains all properties applied to the sprite of the
-     * "source" object (e.g. the {@linkcode Pokemon} using a move)
-     * @see {@linkcode animPropSchema}
-     */
     sourceProperties: { ...animPropSchema, nullable: true },
 
-    /**
-     * Contains all properties applied to the sprite of the
-     * "target" object (e.g. the {@linkcode Pokemon} attacked by a move)
-     * @see {@linkcode animPropSchema}
-     */
     targetProperties: { ...animPropSchema, nullable: true },
 
-    /**
-     * Contains all properties applied to the animation's VFX
-     * @see {@linkcode animPropSchema}
-     */
     vfxProperties: { ...animPropSchema, nullable: true },
 
-    /**
-     * Contains all timed events played during the animation.
-     * @see {@linkcode animTimedEventSchema}
-     */
     timedEvents: {
       type: "array",
       items: animTimedEventSchema,

--- a/src/data/animations/anim-config.ts
+++ b/src/data/animations/anim-config.ts
@@ -20,6 +20,8 @@ export interface AnimConfig {
   /**
    * If this is for a {@linkcode MoveAnim}, this specifies the {@linkcode MoveId}
    * associated with the animation.
+   *
+   * This is required for all {@linkcode MoveAnim | MoveAnims}.
    */
   readonly moveId?: MoveId;
 
@@ -55,9 +57,11 @@ export interface AnimProp {
   /**
    * For battle animations, the origin point for keyframes is defined
    * along the line connecting the start point ("source") and end point ("target").
+   *
    * The `u`-value is the fraction of the distance between the start and end point
-   * the origin point is away from the source. If `u = 0`, then the origin point is
-   * the source; if `u = 1`, then the origin point is the target.
+   * the origin point is away from the source.
+   *
+   * If `u = 0`, then the origin point is the source; if `u = 1`, then the origin point is the target.
    */
   readonly u: AnimKeyFrame<number>[];
 
@@ -76,14 +80,16 @@ export interface AnimProp {
   /** Vertical scale factor (%) */
   readonly scaleY?: AnimKeyFrame<number>[];
 
-  /** The alpha value for the sprite, in the range [0, 255] */
+  /** The alpha value for the sprite, in the range `[0, 255]` */
   readonly alpha?: AnimKeyFrame<number>[];
 
   /**
    * The rotation angle of the sprite in degrees.
-   * Phaser uses a right-hand clockwise rotation system, where 0 is right,
-   * 90 is down, and -90 is up. The value of this should be in the interval
-   * [-180, 180].
+   *
+   * Phaser uses a right-hand clockwise rotation system, where `0` is right,
+   * `90` is down, and `-90` is up.
+   *
+   * The value of this should be in the interval `[-180, 180]`.
    */
   readonly angle?: AnimKeyFrame<number>[];
 
@@ -99,7 +105,11 @@ export interface AnimProp {
    */
   readonly blendType?: AnimKeyFrame<AnimBlendType>[];
 
-  /** If this is a VFX property, specifies the graphic's tile index */
+  /**
+   * If this keyframe is for a graphic, specifies the tile index used for the graphic during the tween.
+   *
+   * This is only relevant for VFX properties.
+   */
   readonly graphicFrame?: AnimKeyFrame<number>[];
 
   /** A tone to pipeline over the animated sprite (normalized RGBA, A is optional) */
@@ -107,10 +117,10 @@ export interface AnimProp {
 
   /**
    * The z-depth of the animated sprite during the tween
-   * - 0 is behind all other sprites (except BG)
-   * - 1 is on top of player field
-   * - 3 is on top of both fields
-   * - 5 is on top of player sprite
+   * - `0` is behind all other sprites (except BG)
+   * - `1` is on top of player field
+   * - `3` is on top of both fields
+   * - `5` is on top of player sprite
    * @todo define the allowed priority values as an enum
    */
   readonly priority?: AnimKeyFrame<0 | 1 | 3 | 5>[];
@@ -145,7 +155,7 @@ export interface AnimTimedEvent {
    */
   readonly eventType: AnimTimedEventType;
 
-  /** The start time for the event */
+  /** The delay from the start of the animation to the given event (in frames) */
   readonly time: number;
 
   /** The name of the file containing assets used in the event */
@@ -155,13 +165,13 @@ export interface AnimTimedEvent {
 
   /**
    * The volume of the played sound effect (%).
-   * @default 100
+   * @defaultValue `100`
    */
   readonly volume?: number;
 
   /**
    * The pitch of the played sound effect (%).
-   * @default 100
+   * @defaultValue `100`
    */
   readonly pitch?: number;
 
@@ -178,7 +188,7 @@ export interface AnimTimedEvent {
 
   /**
    * Scale factor (%) for the background image.
-   * @default 100
+   * @defaultValue `100`
    */
   readonly scale?: number;
 }

--- a/src/data/arena-tags/arena-tag.ts
+++ b/src/data/arena-tags/arena-tag.ts
@@ -7,11 +7,7 @@ import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import i18next from "i18next";
 
-/**
- * Base class for any special effects that apply to the {@linkcode Arena | field}
- * during battle.
- * @abstract
- */
+/** Base class for any special effects that apply to the {@linkcode Arena | field} during battle. */
 export abstract class ArenaTag {
   constructor(
     /** An {@linkcode ArenaTagType | identifier} for the tag's effect. */

--- a/src/data/arena-tags/conditional-protect-tag.ts
+++ b/src/data/arena-tags/conditional-protect-tag.ts
@@ -17,7 +17,6 @@ import i18next from "i18next";
 /**
  * Class to implement conditional team protection.
  * Applies protection based on the attributes of incoming moves.
- * @abstract
  * @extends ArenaTag
  */
 export abstract class ConditionalProtectTag extends ArenaTag {

--- a/src/data/arena-tags/entry-hazard-tag.ts
+++ b/src/data/arena-tags/entry-hazard-tag.ts
@@ -7,7 +7,6 @@ import type { Pokemon } from "#field/pokemon";
 
 /**
  * Abstract class to implement arena entry hazards.
- * @abstract
  * @extends ArenaTag
  */
 export abstract class EntryHazardTag extends ArenaTag {

--- a/src/data/arena-tags/type-hazard-tag.ts
+++ b/src/data/arena-tags/type-hazard-tag.ts
@@ -18,7 +18,6 @@ import i18next from "i18next";
  * Class used for hazards that damage based on type. The two existing ones are
  * Stealth rock (produced by stealth rock and stone axe) and
  * Sharp steel (produced by G-Max steelsurge)
- * @abstract
  * @extends EntryHazardTag
  */
 export abstract class TypeHazardTag extends EntryHazardTag {

--- a/src/data/arena-tags/weaken-move-screen-tag.ts
+++ b/src/data/arena-tags/weaken-move-screen-tag.ts
@@ -14,7 +14,6 @@ import { type NumberHolder, BooleanHolder } from "#utils/common-utils";
 
 /**
  * Reduces the damage of specific move categories in the arena.
- * @abstract
  * @extends ArenaTag
  */
 export abstract class WeakenMoveScreenTag extends ArenaTag {

--- a/src/data/arena-tags/weaken-move-type-tag.ts
+++ b/src/data/arena-tags/weaken-move-type-tag.ts
@@ -7,7 +7,6 @@ import type { NumberHolder } from "#utils/common-utils";
 
 /**
  * Weakens the power of moves of a specific {@linkcode ElementalType}
- * @abstract
  * @extends ArenaTag
  */
 export abstract class WeakenMoveTypeTag extends ArenaTag {

--- a/src/data/battler-tags/battler-tag.ts
+++ b/src/data/battler-tags/battler-tag.ts
@@ -39,7 +39,7 @@ export class BattlerTag {
   /**
    * `true` if this tag can be transferred to another Pokemon
    * via {@link http://bulbapedia.bulbagarden.net/wiki/Baton_Pass_(move) | Baton Pass}.
-   * @default false
+   * @defaultValue `false`
    */
   public isBatonPassable: boolean;
 

--- a/src/data/battler-tags/grounded-tag.ts
+++ b/src/data/battler-tags/grounded-tag.ts
@@ -11,9 +11,10 @@ import type { Pokemon } from "#field/pokemon";
 import i18next from "i18next";
 
 /**
- * Tag for effects that ground the source, allowing Ground-type moves to hit them.
+ * Tag for effects that ground the source (i.e. from Smack Down and Thousand Waves),
+ * allowing Ground-type moves to hit them.
  *
- * `IGNORE_FLYING`: Persistent grounding effects (i.e. from Smack Down and Thousand Waves)
+ * @see {@linkcode BattlerTagType.IGNORE_FLYING}
  * @extends BattlerTag
  */
 export class GroundedTag extends BattlerTag {

--- a/src/data/battler-tags/grounded-tag.ts
+++ b/src/data/battler-tags/grounded-tag.ts
@@ -12,7 +12,8 @@ import i18next from "i18next";
 
 /**
  * Tag for effects that ground the source, allowing Ground-type moves to hit them.
- * @description `IGNORE_FLYING`: Persistent grounding effects (i.e. from Smack Down and Thousand Waves)
+ *
+ * `IGNORE_FLYING`: Persistent grounding effects (i.e. from Smack Down and Thousand Waves)
  * @extends BattlerTag
  */
 export class GroundedTag extends BattlerTag {

--- a/src/data/battler-tags/imprisoning-tag.ts
+++ b/src/data/battler-tags/imprisoning-tag.ts
@@ -14,7 +14,6 @@ import i18next from "i18next";
  * {@link https://bulbapedia.bulbagarden.net/wiki/Imprison_(move) | Imprison}.
  * Disables all opposing Pokemon's moves that are also found in the tag owner's moveset.
  * @extends BattlerTag
- * @implements `RestrictingBattlerTag`
  */
 export class ImprisoningTag extends BattlerTag implements RestrictingBattlerTag {
   constructor() {

--- a/src/data/battler-tags/move-restriction-battler-tag.ts
+++ b/src/data/battler-tags/move-restriction-battler-tag.ts
@@ -15,7 +15,6 @@ import type { MovePhase } from "#phases/move-phase";
  * match a condition. A restricted move gets cancelled before it is used. Players and enemies should not be allowed
  * to select restricted moves.
  * @extends BattlerTag
- * @implements `RestrictingBattlerTag`
  */
 export abstract class MoveRestrictionBattlerTag extends BattlerTag implements RestrictingBattlerTag {
   /** @override */

--- a/src/data/battler-tags/terrain-highest-stat-boost-tag.ts
+++ b/src/data/battler-tags/terrain-highest-stat-boost-tag.ts
@@ -10,7 +10,6 @@ import type { TerrainType } from "#enums/terrain-type";
  * (i.e. {@link https://bulbapedia.bulbagarden.net/wiki/Quark_Drive_(Ability) | Quark Drive})
  * while a given {@linkcode TerrainType | terrain} is active.
  * @extends HighestStatBoostTag
- * @implements `TerrainBattlerTag`
  */
 export class TerrainHighestStatBoostTag extends HighestStatBoostTag implements TerrainBattlerTag {
   public terrainTypes: TerrainType[];

--- a/src/data/battler-tags/utils/load-battler-tag.ts
+++ b/src/data/battler-tags/utils/load-battler-tag.ts
@@ -4,7 +4,7 @@ import { getBattlerTag } from "#battler-tags/get-battler-tag";
 /**
  * When given a battler tag or json representing one, creates an actual BattlerTag object with the same data.
  * @param source A battler tag
- * @return The valid battler tag
+ * @returns The valid battler tag
  */
 export function loadBattlerTag(source: BattlerTag | any): BattlerTag {
   const tag = getBattlerTag(source.tagType, source.turnCount, source.sourceMoveId, source.sourceId);

--- a/src/data/battler-tags/weather-highest-stat-boost-tag.ts
+++ b/src/data/battler-tags/weather-highest-stat-boost-tag.ts
@@ -10,7 +10,6 @@ import type { WeatherType } from "#enums/weather-type";
  * (i.e. {@link https://bulbapedia.bulbagarden.net/wiki/Protosynthesis_(Ability) | Protosynthesis})
  * while a given {@linkcode WeatherType | weather} is active.
  * @extends HighestStatBoostTag
- * @implements `WeatherBattlerTag`
  */
 export class WeatherHighestStatBoostTag extends HighestStatBoostTag implements WeatherBattlerTag {
   public weatherTypes: WeatherType[];

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -3552,7 +3552,7 @@ export function initMoves() {
 
 /**
  * All damaging (aka {@linkcode AttackMove}) Fire-type moves can now thaw a frozen target, regardless of whether or not they have a chance to burn.
- * @source {@link https://bulbapedia.bulbagarden.net/wiki/Freeze_(status_condition) | Bulbapedia - Freeze (Status Condition)}
+ * @see {@link https://bulbapedia.bulbagarden.net/wiki/Freeze_(status_condition) | Bulbapedia - Freeze (Status Condition)}
  */
 function addFireMovesThawFrozenTargetAttribute(move: Move) {
   if (move.type === ElementalType.FIRE && move.isAttackMove()) {

--- a/src/data/moves/move-attrs/add-arena-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-arena-tag-attr.ts
@@ -38,7 +38,7 @@ export class AddArenaTagAttr extends ChanceBasedMoveEffectAttr {
 
   /**
    * The number of turns the added tag remains in effect.
-   * @default 0, which denotes an arena tag that lasts indefinitely until the next arena reset.
+   * @defaultValue `0`, which denotes an arena tag that lasts indefinitely until the next arena reset.
    */
   public get turnCount() {
     return this.options?.turnCount ?? 0;
@@ -47,7 +47,7 @@ export class AddArenaTagAttr extends ChanceBasedMoveEffectAttr {
   /**
    * If `true`, causes the move to fail when a tag already exists
    * where it would otherwise be added on the field.
-   * @default false
+   * @defaultValue `false`
    */
   public get failOnOverlap() {
     return this.options?.failOnOverlap ?? false;

--- a/src/data/moves/move-attrs/add-battler-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-battler-tag-attr.ts
@@ -32,7 +32,7 @@ export class AddBattlerTagAttr extends ChanceBasedMoveEffectAttr {
   /**
    * If `true`, causes the move to fail if the target already
    * has a tag of the same type.
-   * @default false
+   * @defaultValue `false`
    */
   public get failOnOverlap() {
     return this.options?.failOnOverlap ?? false;
@@ -40,7 +40,7 @@ export class AddBattlerTagAttr extends ChanceBasedMoveEffectAttr {
 
   /**
    * The minimum number of turns the tag is active
-   * @default 0
+   * @defaultValue `0`
    */
   public get turnCountMin() {
     return this.options?.turnCountMin ?? 0;
@@ -48,7 +48,7 @@ export class AddBattlerTagAttr extends ChanceBasedMoveEffectAttr {
 
   /**
    * The maximum number of turns the tag is active.
-   * @default turnCountMin
+   * @defaultValue {@linkcode turnCountMin}
    */
   public get turnCountMax() {
     return this.options?.turnCountMax ?? this.turnCountMin;

--- a/src/data/moves/move-attrs/move-attr.ts
+++ b/src/data/moves/move-attrs/move-attr.ts
@@ -6,7 +6,6 @@ import type { BooleanHolder } from "#utils/common-utils";
 
 /**
  * Base class defining all {@linkcode Move} Attributes
- * @abstract
  * @see {@linkcode apply}
  */
 export abstract class MoveAttr {

--- a/src/data/moves/move-attrs/move-effect-attr.ts
+++ b/src/data/moves/move-attrs/move-effect-attr.ts
@@ -36,7 +36,7 @@ export abstract class MoveEffectAttr extends MoveAttr {
 
   /**
    * Defines when this effect should trigger in the move's effect order.
-   * @default MoveEffectTrigger.POST_APPLY
+   * @defaultValue {@linkcode MoveEffectTrigger.POST_APPLY}
    * @see {@linkcode MoveEffectTrigger}
    */
   public get trigger() {
@@ -46,7 +46,7 @@ export abstract class MoveEffectAttr extends MoveAttr {
   /**
    * `true` if this effect should only trigger on the first hit of
    * multi-hit moves.
-   * @default false
+   * @defaultValue `false`
    */
   public get firstHitOnly() {
     return this.options?.firstHitOnly ?? false;
@@ -55,7 +55,7 @@ export abstract class MoveEffectAttr extends MoveAttr {
   /**
    * `true` if this effect should only trigger on the last hit of
    * multi-hit moves.
-   * @default false
+   * @defaultValue `false`
    */
   public get lastHitOnly() {
     return this.options?.lastHitOnly ?? false;
@@ -64,7 +64,7 @@ export abstract class MoveEffectAttr extends MoveAttr {
   /**
    * `true` if this effect should apply only upon hitting a target
    * for the first time when targeting multiple {@linkcode Pokemon}.
-   * @default false
+   * @defaultValue `false`
    */
   public get firstTargetOnly() {
     return this.options?.firstTargetOnly ?? false;

--- a/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
@@ -8,10 +8,11 @@ import type { MoveConditionFunc } from "#types/move-condition-func";
 
 /**
  * Attr used for moves that faint the user but revive a different Pokemon
- * @protected restorePP - whether or not PP is restored to the revived Pokemon. Lunar dance does this
- * @protected moveMessage - the associated key for the move trigger message
+ *
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Healing_Wish_(move) | Healing Wish}
  * and {@link https://bulbapedia.bulbagarden.net/wiki/Lunar_Dance_(move) | Lunar Dance}.
+ * @param restorePP - Whether or not PP is restored to the revived Pokemon. Used by Lunar Dance
+ * @param moveMessage - The associated key for the move trigger message.
  * @extends SacrificialAttr
  */
 export class SacrificialFullRestoreAttr extends SacrificialAttr {

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -47,7 +47,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
   /**
    * The condition required for the stat stage change to apply.
-   * Defaults to `null` (i.e. no condition required).
+   * @defaultValue `null` (i.e. no condition required).
    */
   private get condition() {
     return this.options?.condition ?? null;
@@ -55,7 +55,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
   /**
    * `true` to display a message for the stat change.
-   * @default true
+   * @defaultValue `true`
    */
   private get showMessage() {
     return this.options?.showMessage ?? true;

--- a/src/data/moves/move-attrs/weather-heal-attr.ts
+++ b/src/data/moves/move-attrs/weather-heal-attr.ts
@@ -8,7 +8,6 @@ import type { Move } from "#moves/move";
  * Attribute to restore the user's HP.
  * The heal ratio varies based on the active weather.
  * @extends HealAttr
- * @abstract
  * @see {@linkcode getWeatherHealRatio}
  */
 export abstract class WeatherHealAttr extends HealAttr {

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -543,8 +543,9 @@ export default class MysteryEncounter implements IMysteryEncounter {
 }
 
 /**
- * Builder class for creating a MysteryEncounter
- * must call `build()` at the end after specifying all params for the MysteryEncounter
+ * Builder class for creating a MysteryEncounter.
+ *
+ * Must call `build()` at the end after specifying all params for the MysteryEncounter
  */
 export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
   options: [MysteryEncounterOption, MysteryEncounterOption, ...MysteryEncounterOption[]];
@@ -578,7 +579,8 @@ export class MysteryEncounterBuilder implements Partial<IMysteryEncounter> {
    */
 
   /**
-   * @statif Defines the type of encounter which is used as an identifier, should be tied to a unique MysteryEncounterType
+   * Defines the type of encounter which is used as an identifier, should be tied to a unique {@linkcode MysteryEncounterType}.
+   *
    * NOTE: if new functions are added to {@linkcode MysteryEncounter} class
    * @param encounterType
    * @returns this

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -1,3 +1,9 @@
+// -- start tsdoc imports --
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { IMysteryEncounter } from "#mystery-encounters/mystery-encounter";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+// -- end tsdoc imports --
+
 import type Battle from "#app/battle";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -464,7 +470,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
 /**
  * Load special move animations/sfx for hard-coded encounter-specific moves that a pokemon uses at the start of an encounter
- * See: [startOfBattleEffects](IMysteryEncounter.startOfBattleEffects) for more details
+ * See: {@linkcode IMysteryEncounter.startOfBattleEffects} for more details
  *
  * This promise does not need to be awaited on if called in an encounter onInit (will just load lazily)
  * @param moveIds The move or moves the Pokemon uses at the start of the encounter

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -1000,7 +1000,7 @@ export function handleMysteryEncounterBattleStartEffects() {
 /**
  * Can queue extra phases or logic during {@linkcode TurnInitPhase}
  * Should mostly just be used for injecting custom phases into the battle system on turn start
- * @return boolean - if true, will skip the remainder of the {@linkcode TurnInitPhase}
+ * @returns Whether to skip the remainder of the {@linkcode TurnInitPhase}
  */
 export function handleMysteryEncounterTurnStartEffects(): boolean {
   const encounter = globalScene.currentBattle.mysteryEncounter;

--- a/src/data/pokemon-evolutions.ts
+++ b/src/data/pokemon-evolutions.ts
@@ -14,8 +14,8 @@ import { randSeedInt } from "#utils/random-utils";
 
 /**
  * Pokemon Evolution tuple type consisting of:
- * @property 0 {@linkcode SpeciesId} The species of the Pokemon.
- * @property 1 The level at which the Pokemon evolves.
+ * - `species` - The {@linkcode SpeciesId} of the Pokemon.
+ * - `level` - The level at which the Pokemon evolves.
  */
 export type EvolutionLevel = [species: SpeciesId, level: number];
 

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -9,8 +9,8 @@ import i18next from "i18next";
 
 /**
  * Class representing Terrain effects
- * @var terrainType - The {@linkcode TerrainType} that is being represented
- * @var turnsLeft - How many turns the terrain still has left
+ * @param terrainType - The {@linkcode TerrainType} that is being represented
+ * @param turnsLeft - How many turns the terrain still has left
  */
 export class Terrain {
   public terrainType: TerrainType;

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -7,15 +7,15 @@ import type { Move } from "#moves/move";
 import { ProtectAttr } from "#moves/protect-attr";
 import i18next from "i18next";
 
-/**
- * Class representing Terrain effects
- * @param terrainType - The {@linkcode TerrainType} that is being represented
- * @param turnsLeft - How many turns the terrain still has left
- */
+/** Class representing Terrain effects */
 export class Terrain {
   public terrainType: TerrainType;
   public turnsLeft: number;
 
+  /**
+   * @param terrainType - The {@linkcode TerrainType} that is being represented
+   * @param turnsLeft - How many turns the terrain still has left
+   */
   constructor(terrainType: TerrainType, turnsLeft: number = 0) {
     this.terrainType = terrainType;
     this.turnsLeft = turnsLeft;

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -11,8 +11,8 @@ import i18next from "i18next";
 
 /**
  * Class representing Weather effects
- * @var weatherType - The {@linkcode WeatherType} that is being represented
- * @var turnsLeft - How many turns the weather still has left (0 if immutable)
+ * @param weatherType - The {@linkcode WeatherType} that is being represented
+ * @param turnsLeft - How many turns the weather still has left (0 if immutable)
  */
 export class Weather {
   public weatherType: WeatherType;

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -9,15 +9,15 @@ import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import i18next from "i18next";
 
-/**
- * Class representing Weather effects
- * @param weatherType - The {@linkcode WeatherType} that is being represented
- * @param turnsLeft - How many turns the weather still has left (0 if immutable)
- */
+/** Class representing Weather effects */
 export class Weather {
   public weatherType: WeatherType;
   public turnsLeft: number;
 
+  /**
+   * @param weatherType - The {@linkcode WeatherType} that is being represented
+   * @param turnsLeft - How many turns the weather still has left (0 if immutable)
+   */
   constructor(weatherType: WeatherType, turnsLeft: number = 0) {
     this.weatherType = weatherType;
     this.turnsLeft = !this.isPrimal() ? turnsLeft : 0;

--- a/src/enums/exp-gains-speed.ts
+++ b/src/enums/exp-gains-speed.ts
@@ -8,7 +8,7 @@
  * - `2` - Faster: Faster speed.
  * - `3` - Skip: Skip gaining exp animation.
  *
- * @default 0 - Uses the default normal speed.
+ * @defaultValue `0`
  */
 export enum ExpGainsSpeed {
   /** The normal speed. */

--- a/src/enums/ui-window-style.ts
+++ b/src/enums/ui-window-style.ts
@@ -1,12 +1,16 @@
 export enum UiWindowStyle {
-  /** @hex #c73625 */
+  /** #c73625 */
   RED_ORANGE,
-  /** @hex #20B098 */
+  /** #20B098 */
   TEAL,
-  /** @hex #d7d7d7 */
+  /** #d7d7d7 */
   LIGHT_GRAY,
-  /** Also known as vivid orange-yellow @hex #ffb745 */
+  /**
+   * Also known as vivid orange-yellow
+   *
+   * #ffb745
+   */
   GOLDENROD,
-  /** @hex #b2b2b2 */
+  /** #b2b2b2 */
   MEDIUM_GRAY,
 }

--- a/src/field/mystery-encounter-intro.ts
+++ b/src/field/mystery-encounter-intro.ts
@@ -5,16 +5,17 @@ import type { SpeciesId } from "#enums/species-id";
 import { getSpriteKeysFromSpecies } from "#mystery-encounters/encounter-pokemon-utils";
 import type MysteryEncounter from "#mystery-encounters/mystery-encounter";
 import { isNil } from "#utils/common-utils";
-import type { GameObjects } from "phaser";
-import PlayAnimationConfig = Phaser.Types.Animations.PlayAnimationConfig;
+import Phaser from "phaser";
 
 export class MysteryEncounterSpriteConfig {
   /** The sprite key (which is the image file name). e.g. "ace_trainer_f" */
   spriteKey: string;
   /**
-   * Refer to images in the [/public/images](../../public/images) directory for all folder names
-   * TODO: currently the 'string' type is needed for Pokemon sprites because `globalScene.loadPokemonAtlas` expects
-   * the fileroot to contain the folder + filename.
+   * Refer to images in the `/public/images/` directory for all folder names.
+   * @todo
+   * Currently the `string` type is needed for Pokemon sprites because {@linkcode globalScene.loadPokemonAtlas}
+   * expects the fileroot to contain the folder + filename.
+   *
    * However this should be changed to have a separate folder and fileNameRoot attributes, like for other loading functions.
    */
   fileRoot: ImagesFolder | string;
@@ -122,8 +123,8 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
     this.spriteConfigs?.forEach((config) => {
       const { spriteKey, isItem, hasShadow, scale, x, y, yShadow, alpha, isPokemon, isShiny, variant } = config;
 
-      let sprite: GameObjects.Sprite;
-      let tintSprite: GameObjects.Sprite;
+      let sprite: Phaser.GameObjects.Sprite;
+      let tintSprite: Phaser.GameObjects.Sprite;
       let pokemonShinySparkle: Phaser.GameObjects.Sprite | undefined;
 
       if (isItem) {
@@ -348,7 +349,7 @@ export default class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Con
     const tintSprites = this.getTintSprites();
     this.spriteConfigs.forEach((config, i) => {
       if (!config.disableAnimation) {
-        const trainerAnimConfig: PlayAnimationConfig = {
+        const trainerAnimConfig: Phaser.Types.Animations.PlayAnimationConfig = {
           key: config.spriteKey,
           repeat: config?.repeat ? -1 : 0,
           startFrame: config?.startFrame ?? 0,

--- a/src/field/pokemon-move.ts
+++ b/src/field/pokemon-move.ts
@@ -86,7 +86,7 @@ export class PokemonMove {
   /**
    * Copies an existing move or creates a valid PokemonMove object from json representing one
    * @param source The data for the {@linkcode PokemonMove | move} to copy
-   * @return A valid {@linkcode PokemonMove} object
+   * @returns A valid {@linkcode PokemonMove} object
    */
   static loadMove(source: PokemonMove | any): PokemonMove {
     return new PokemonMove(source.moveId, source.ppUsed, source.ppUp, source.virtual, source.maxPpOverride);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2742,7 +2742,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param abilityApplyMode the {@linkcode AbilityApplyMode} determining how abilities are applied
    * @param isCritical determines whether a critical hit has occurred or not (`false` by default)
    * @param simulated determines whether effects are applied without altering game state (`true` by default)
-   * @return the stat stage multiplier to be used for effective stat calculation
+   * @returns the stat stage multiplier to be used for effective stat calculation
    */
   getStatStageMultiplier(
     stat: EffectiveStat,

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -779,7 +779,6 @@ export type SpeciesStatBoosterItem = keyof typeof SpeciesStatBoosterModifierType
 /**
  * Modifier type for {@linkcode SpeciesStatBoosterModifier}
  * @extends PokemonHeldItemModifierType
- * @implements GeneratedPersistentModifierType
  */
 export class SpeciesStatBoosterModifierType
   extends PokemonHeldItemModifierType

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -411,7 +411,6 @@ export class AddVoucherModifier extends ConsumableModifier {
  * will reset {@linkcode battleCount} back to {@linkcode maxBattles} of the
  * existing modifier instead of adding that modifier directly.
  * @extends PersistentModifier
- * @abstract
  * @see {@linkcode add}
  */
 export abstract class LapsingPersistentModifier extends PersistentModifier {

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -1690,8 +1690,8 @@ export class TurnStatusEffectModifier extends PokemonHeldItemModifier {
    * would be the only item able to {@linkcode apply} successfully.
    * @override
    * @param modifier {@linkcode Modifier} being type tested
-   * @return `true` if {@linkcode modifier} is an instance of
-   * TurnStatusEffectModifier, false otherwise
+   * @returns `true` if {@linkcode modifier} is an instance of
+   * {@linkcode TurnStatusEffectModifier}, `false` otherwise
    */
   matchType(modifier: Modifier): boolean {
     return modifier instanceof TurnStatusEffectModifier;

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -56,7 +56,7 @@ interface ToTitleScreenInit {
 }
 
 interface ToLoginScreenInit {
-  /** Whether to show text. @default true */
+  /** Whether to show text. @defaultValue `true` */
   showText?: boolean;
   /** Whether to add the {@linkcode LoginPhase} to the front of the phase queue or defer it. */
   eager?: boolean;

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -131,7 +131,6 @@ export class CommandPhase extends FieldPhase {
    * @param command - Which of {@linkcode BattleCommand.BALL} or {@linkcode BattleCommand.RUN} was chosen
    * @param cursor - Cursor index for the selected Pokeball
    * @returns `true` if the command was successful
-   * @overload
    */
   public handleCommand(command: BattleCommand.BALL | BattleCommand.RUN, cursor: number): boolean;
   /**
@@ -140,7 +139,6 @@ export class CommandPhase extends FieldPhase {
    * @param ignorePp - (optional) `true` if the move shouldn't use PP
    * @param turnMove - (optional) A {@linkcode TurnMove} object for an existing queued move
    * @returns `true` if the command was successful
-   * @overload
    */
   public handleCommand(command: FightCommand, cursor: number, ignorePp?: boolean, turnMove?: TurnMove): boolean;
   /**
@@ -148,7 +146,6 @@ export class CommandPhase extends FieldPhase {
    * @param cursor - Cursor index for the selected Pokemon
    * @param isBaton - `true` if the pokemon being switched out is holding the Baton item
    * @returns `true` if the command was successful
-   * @overload
    */
   public handleCommand(command: BattleCommand.POKEMON, cursor: number, isBaton: boolean): boolean;
   public handleCommand(command: BattleCommand, cursor: number, ...args: unknown[]): boolean {

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -40,7 +40,7 @@ export class EvolutionPhase extends FormChangeBasePhase {
   private evolutionBgm: AnySound;
 
   /**
-   * A {@linecode BooleanHolder} whose value indicates whether or not the player has cancelled the evolution.
+   * A {@linkcode BooleanHolder} whose value indicates whether or not the player has cancelled the evolution.
    */
   private cancelled: BooleanHolder = new BooleanHolder(false);
 

--- a/src/phases/mystery-encounter-phases/battle-phase.ts
+++ b/src/phases/mystery-encounter-phases/battle-phase.ts
@@ -48,10 +48,7 @@ export class MysteryEncounterBattlePhase extends Phase {
     this.doMysteryEncounterBattle();
   }
 
-  /**
-   * Gets intro battle message for new battle
-   * @private
-   */
+  /** Gets intro battle message for new battle */
   private getBattleMessage(): string {
     const { currentBattle } = globalScene;
     const { double, mysteryEncounter, trainer } = currentBattle;
@@ -75,10 +72,7 @@ export class MysteryEncounterBattlePhase extends Phase {
       : i18next.t("battle:multiWildAppeared", { pokemonName1: enemyField[0].name, pokemonName2: enemyField[1].name });
   }
 
-  /**
-   * Queues {@linkcode SummonPhase}s for the new battle, and handles trainer animations/dialogue if it's a Trainer battle
-   * @private
-   */
+  /** Queues {@linkcode SummonPhase}s for the new battle, and handles trainer animations/dialogue if it's a Trainer battle */
   private doMysteryEncounterBattle(): void {
     const { currentBattle, ui } = globalScene;
     const { double, mysteryEncounter, trainer } = currentBattle;
@@ -153,10 +147,7 @@ export class MysteryEncounterBattlePhase extends Phase {
     }
   }
 
-  /**
-   * Initiate {@linkcode SummonPhase}s, {@linkcode ScanIvsPhase}, {@linkcode PostSummonPhase}s, etc.
-   * @private
-   */
+  /** Initiate {@linkcode SummonPhase}s, {@linkcode ScanIvsPhase}, {@linkcode PostSummonPhase}s, etc. */
   private endBattleSetup(): void {
     const { currentBattle } = globalScene;
     const { double, mysteryEncounter } = currentBattle;
@@ -211,10 +202,7 @@ export class MysteryEncounterBattlePhase extends Phase {
     this.end();
   }
 
-  /**
-   * Ease in enemy trainer
-   * @private
-   */
+  /** Ease in enemy trainer */
   private showEnemyTrainer(): void {
     const { currentBattle, tweens } = globalScene;
     const { trainer } = currentBattle;

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1767,7 +1767,7 @@ export class GameData {
   }
 
   /**
-   * Checks whether the root species of a given {@PokemonSpecies} has been unlocked in the dex
+   * Checks whether the root species of a given {@linkcode PokemonSpecies} has been unlocked in the dex
    */
   isRootSpeciesUnlocked(species: PokemonSpecies): boolean {
     return !!this.dexData[species.getRootSpeciesId()]?.caughtAttr;

--- a/src/ui/handlers/base-option-select-ui-handler.ts
+++ b/src/ui/handlers/base-option-select-ui-handler.ts
@@ -31,7 +31,7 @@ const DEFAULT_TEXT_STYLE = TextStyle.WINDOW;
  * At initialization the size of the first {@linkcode NUM_PRE_COMPUTED_OPTIONS} is measured.
  * Then the window's size is updated as needed when a non initialized option needs to be displayed.
  *
- * @template T the specifc type of {@linkcode OptionSelectItem} that this handler displays
+ * @typeParam T - The specifc type of {@linkcode OptionSelectItem} that this handler displays
  */
 export abstract class BaseOptionSelectUiHandler<T extends OptionSelectItem> extends MessageUiHandler {
   private config: OptionSelectModeConfig<T> | null;

--- a/src/ui/handlers/egg-hatch-summary-ui-handler.ts
+++ b/src/ui/handlers/egg-hatch-summary-ui-handler.ts
@@ -126,7 +126,6 @@ export class EggHatchSummaryUiHandler extends MessageUiHandler {
     this.eggHatchBg.setVisible(false);
     this.getUi().hideTooltip();
 
-    // Note: Questions on garbage collection go to @frutescens
     const activeKeys = globalScene.getActiveKeys();
     // Removing unnecessary sprites from animation manager
     const animKeys = Object.keys(globalScene.anims["anims"]["entries"]);

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -650,7 +650,7 @@ export class RunInfoUiHandler extends UiHandler {
 
   /**
    * This function parses the Challenges section of the Run Entry and returns a list of active challenge.
-   * @return string[] of active challenge names
+   * @returns An array of the active challenge names
    */
   private challengeParser(): string[] {
     const rules: string[] = [];

--- a/src/ui/interfaces/option-select-config.ts
+++ b/src/ui/interfaces/option-select-config.ts
@@ -7,7 +7,7 @@ import type { TextStyle } from "#enums/text-style";
 /**
  * Customizations options for UI's {@linkcode UiMode.OPTION_SELECT}
  *
- * @template T the specifc type of {@linkcode OptionSelectItem} contained by this config
+ * @typeParam T - The specifc type of {@linkcode OptionSelectItem} contained by this config
  */
 export interface OptionSelectModeConfig<T extends OptionSelectItem = OptionSelectItem> extends OptionMenuSettings {
   /** The {@linkcode OptionSelectItem}s to display. */

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -218,7 +218,7 @@ export function animationFileName(moveId: MoveId): string {
 /**
  * Transforms a camelCase string into a kebab-case string
  *
- * @source {@link https://stackoverflow.com/a/67243723/}
+ * @see {@link https://stackoverflow.com/a/67243723/}
  */
 export function camelCaseToKebabCase(str: string): string {
   return str.replace(/[A-Z]+(?![a-z])|[A-Z]/g, (s, o) => (o ? "-" : "") + s.toLowerCase());

--- a/test/test-utils/mocks/mock-console.ts
+++ b/test/test-utils/mocks/mock-console.ts
@@ -107,7 +107,7 @@ export class MockConsole {
    * Also appends the white ANSI code as an extra argument, so that the added color does not leak to future messages.
    * @param color An ANSI escape sequence representing a color.
    * @param args The args that the color should be applied to.
-   * @return A copy of `args` with the color prepended to every argument.
+   * @returns A copy of `args` with the color prepended to every argument.
    */
   private addColor(color: string, ...args: any[]): any[] {
     return [...args.map((a) => `${color}${typeof a === "string" ? a : this.getStr(a)}`), WHITE_ANSI_CODE];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -75,11 +75,5 @@
     "outDir": "./build",
     "noEmit": true
   },
-  "typedocOptions": {
-    "entryPoints": ["./src"],
-    "entryPointStrategy": "expand",
-    "exclude": "**/*+.test.ts",
-    "out": "typedoc"
-  },
   "exclude": ["node_modules", "dist", "vite.config.ts", "vitest.config.ts", "vitest.workspace.ts"]
 }

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/tsdoc/v0/tsdoc.schema.json",
+    "noStandardTags": false,
+    "tagDefinitions": [
+        {
+            "tagName": "@todo",
+            "syntaxKind": "block"
+        },
+        {
+            "tagName": "@implements",
+            "syntaxKind": "block"
+        },
+        {
+            "tagName": "@extends",
+            "syntaxKind": "block"
+        },
+        {
+            "tagName": "@linkcode",
+            "syntaxKind": "inline"
+        }
+    ]
+}

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -7,10 +7,6 @@
             "syntaxKind": "block"
         },
         {
-            "tagName": "@implements",
-            "syntaxKind": "block"
-        },
-        {
             "tagName": "@extends",
             "syntaxKind": "block"
         },

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,15 @@
+{
+    "entryPoints": ["./src"],
+    "entryPointStrategy": "expand",
+    "exclude": ["**/*+.test.ts"],
+    "out": "typedoc",
+    "highlightLanguages": [
+        "javascript",
+        "json",
+        "jsonc",
+        "json5",
+        "tsx",
+        "typescript",
+        "markdown"
+    ]
+  }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Improved `typedoc` behavior and TSDocs.

## What are the changes from a developer perspective?
- Moved `typedoc` settings from `tsconfig.json` to `typedoc.json`.
- Added `tsdoc.json` to define custom tags.
  - Added block tags: `@todo`, `@extends`
  - Added inline tags: `@linkcode`
- Cleaned up a bunch of TSDocs that were using invalid syntax.

## How to test the changes?
`npm run docs`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?