### PR TITLE
[Dev] Biome Lint: remove `.` from `biome-ci` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint-ci": "eslint .",
     "biome": "biome check --write --changed --no-errors-on-unmatched",
     "biome:unsafe": "biome check --write --unsafe --changed --no-errors-on-unmatched",
-    "biome-ci": "biome ci --diagnostic-level=error --reporter=github --no-errors-on-unmatched .",
+    "biome-ci": "biome ci --diagnostic-level=error --reporter=github --no-errors-on-unmatched",
     "biome-all": "biome check --write --no-errors-on-unmatched",
     "biome-all:unsafe": "biome check --write --unsafe --no-errors-on-unmatched",
     "prettier": "prettier . --write",


### PR DESCRIPTION
## What are the changes the user will see?

n/a

## Why am I making these changes?

Without that `.` in the command, the annotations will also properly display in the `Files` tab in any PR

## What are the changes from a developer perspective?

- remove `.` from `biome-ci` script

## Screenshots/Videos

The screenshot is form this check:
https://github.com/Despair-Games/poketernity/actions/runs/15220473644/job/42815037181

<img width="556" alt="image" src="https://github.com/user-attachments/assets/03f0aeca-52ef-4c66-b7f8-7f4294591154" />


## How to test the changes?

You can't really. You'll just have to trust Moka and me that we visually confirmed it working

## Checklist

- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`npm run test:silent`)
