### PR TITLE
[AI-Rework] Remove `appliesScoreOnKO` option

### DIFF
--- a/src/data/moves/move-attrs/move-attr.ts
+++ b/src/data/moves/move-attrs/move-attr.ts
@@ -6,8 +6,6 @@ import type { MoveConditionFunc } from "#types/move-condition-func";
 import type { BooleanHolder } from "#utils/common-utils";
 
 export interface MoveAttrOptions {
-  /** Does this attribute contribute to AI effect score when the move KOs its target? */
-  appliesScoreOnKO?: boolean;
   /** Does this attribute contribute to AI effect score when the move fails or has no effect? */
   appliesScoreOnFail?: boolean;
   /** Does this attribute override the AI's (-20) penalty when targeting an ally? */
@@ -28,16 +26,6 @@ export abstract class MoveAttr {
   constructor(selfTarget: boolean = false, options?: MoveAttrOptions) {
     this.selfTarget = selfTarget;
     this.options = options;
-  }
-
-  /**
-   * Defines whether or not this attribute contributes to effect score even when the move
-   * KOs its target.
-   * @default false
-   * @see {@linkcode getEffectScore}
-   */
-  public get appliesScoreOnKO(): boolean {
-    return this.options?.appliesScoreOnKO ?? false;
   }
 
   /**

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -768,10 +768,10 @@ export abstract class Move implements Localizable {
    * This means that the ES for an attack should rarely exceed (+1) and almost
    * never exceed (+2). Status moves may have a higher ES in comparison but
    * should typically be limited to (+3) or lower.
-   * @param user the {@linkcode Pokemon} using the move
-   * @param target the {@linkcode Pokemon} targeted by the move
-   * @param isKnockOut `true` if the move is already known to KO the target (default `false`)
-   * @param isFail `true` if the move is already known to fail or have no effect (default `false`)
+   * @param user - The {@linkcode Pokemon} using the move
+   * @param target - The {@linkcode Pokemon} targeted by the move
+   * @param isKnockOut - `true` if the move is already known to KO the target (default `false`)
+   * @param isFail - `true` if the move is already known to fail or have no effect (default `false`)
    * @returns a score value accumulated from effect score modifiers.
    */
   public getEffectScore(
@@ -796,8 +796,12 @@ export abstract class Move implements Localizable {
 
   /**
    * Calculates the combined score from this move's attributes' effect scores.
-   * @param user the {@linkcode Pokemon} evaluating this move
-   * @param target the {@linkcode Pokemon} this move is evaluated against
+   * @param user - The {@linkcode Pokemon} evaluating this move
+   * @param target - The {@linkcode Pokemon} this move is evaluated against
+   * @param isKnockOut - `true` if this move would knock out the target (as determined by
+   * {@linkcode Pokemon.getAttackScore | Attack Score})
+   * @param isFail - `true` if this move would fail or have no effect against the target
+   * (as determined by {@linkcode getConditionScore | Condition Score})
    * @returns the cumulative integer score from this move's attributes
    * @see {@linkcode getEffectScore}
    * @see {@linkcode MoveAttr.getEffectScore}
@@ -834,7 +838,7 @@ export abstract class Move implements Localizable {
 
     let attrs: MoveAttr[] = this.attrs;
     if (isKnockOut) {
-      attrs = attrs.filter((attr) => attr.appliesScoreOnKO);
+      attrs = attrs.filter((attr) => attr.selfTarget);
     }
 
     if (isFail) {


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

While implementing scores, I found that it was generally safe to assume `appliesScoreOnKO` has a 1:1 correspondence with self-targeted effects (that is, an effect applies its scoring on KO if and only if the effect is self-targeted). With the option removed, effect-scoring code should be less error-prone.

## What are the changes from a developer perspective?

- Removed `MoveAttrOptions.appliesScoreOnKO` and the getter `MoveAttr.appliesScoreOnKO`
- Attributes are now filtered via their `selfTarget` property when the move is expected to KO the target
- Updated some docs for `Move`'s new scoring functions.

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

- [x] `npm run typecheck`
- [x] `npm run depcruise`
- [x] `npm run biome` -- no new errors or warnings

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`npm run test:silent`)
  - [n/a] Have I created new automated tests (`npm run test:create`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?
