### PR TITLE
[Test] `MoveHelper#changeMoveset` disables moveset overrides

### DIFF
--- a/test/moves/assist.test.ts
+++ b/test/moves/assist.test.ts
@@ -86,10 +86,11 @@ describe("Moves - Assist", () => {
   });
 
   it("should apply secondary effects of a move", async () => {
-    game.override.moveset([MoveId.ASSIST, MoveId.WOOD_HAMMER, MoveId.WOOD_HAMMER, MoveId.WOOD_HAMMER]);
     await game.classicMode.startBattle(SpeciesId.FEEBAS, SpeciesId.SHUCKLE);
 
-    const [feebas] = game.scene.getPlayerField();
+    const [feebas, shuckle] = game.scene.getPlayerField();
+    game.move.changeMoveset(feebas, [MoveId.ASSIST, MoveId.WOOD_HAMMER]);
+    game.move.changeMoveset(shuckle, [MoveId.ASSIST, MoveId.WOOD_HAMMER]);
 
     game.move.select(MoveId.ASSIST, 0);
     game.move.select(MoveId.ASSIST, 1);

--- a/test/moves/transform.test.ts
+++ b/test/moves/transform.test.ts
@@ -103,7 +103,9 @@ describe("Moves - Transform", () => {
     await game.phaseInterceptor.to("PostActionPhase");
 
     const moveset = player.getMoveset();
-    expect(moveset).toHaveLength(4);
+    const playerMovesetNames = moveset.map((m) => m.getName());
+    const enemyMovesetNames = enemy.getMoveset().map((m) => m.getName());
+    expect(moveset, `Player moveset: ${playerMovesetNames} | Enemy moveset: ${enemyMovesetNames}`).toHaveLength(4);
 
     for (const move of moveset) {
       // Should set correct maximum PP without touching `ppUp`

--- a/test/test-utils/helpers/move-helper.ts
+++ b/test/test-utils/helpers/move-helper.ts
@@ -131,11 +131,27 @@ export class MoveHelper extends GameManagerHelper {
   }
 
   /**
-   * Used when the normal moveset override can't be used (such as when it's necessary to check updated properties of the moveset).
-   * @param pokemon - The pokemon being modified
-   * @param moveset - The moveset to use
+   * Changes a pokemon's moveset to the given move(s).
+   *
+   * Used when the normal moveset override can't be used (such as when it's necessary to check or update properties of the moveset).
+   *
+   * **Note**: Will disable the moveset override matching the pokemon's party!
+   * @param pokemon - The {@linkcode Pokemon} being modified
+   * @param moveset - The {@linkcode MoveId | moves} (single or array) to change the Pokemon's moveset to
    */
   public changeMoveset(pokemon: Pokemon, moveset: MoveId | MoveId[]): void {
+    if (pokemon.isPlayer()) {
+      if (coerceArray(Overrides.MOVESET_OVERRIDE).length > 0) {
+        vi.spyOn(Overrides, "MOVESET_OVERRIDE", "get").mockReturnValue([]);
+        console.warn("Player moveset override disabled due to use of `game.move.changeMoveset`!");
+      }
+    } else {
+      if (coerceArray(Overrides.ENEMY_MOVESET_OVERRIDE).length > 0) {
+        vi.spyOn(Overrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue([]);
+        console.warn("Enemy moveset override disabled due to use of `game.move.changeMoveset`!");
+      }
+    }
+
     moveset = coerceArray(moveset);
     pokemon.moveset = [];
     moveset.forEach((moveId) => {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To prevent mistakes when writing tests.

## What are the changes from a developer perspective?
The helper function used to manually modify a Pokémon's moveset in tests will now disable the matching override.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?