### PR TITLE
[Addendum] Add support for multi-Phase input in Phase scheduling methods

### DIFF
--- a/src/data/abilities/ab-attrs/post-damage-force-switch-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-damage-force-switch-ab-attr.ts
@@ -150,8 +150,8 @@ class ForceSwitchOutHelper {
       if (switchOutTarget.hp > 0) {
         switchOutTarget.leaveField(this.switchType === SwitchType.SWITCH);
         globalScene.phaseManager.prependToPhase(
-          new LegacySwitchPhase(this.switchType, switchOutTarget.getFieldIndex(), true, true),
           PhaseId.POST_ACTION,
+          new LegacySwitchPhase(this.switchType, switchOutTarget.getFieldIndex(), true, true),
         );
         return true;
       }
@@ -167,8 +167,8 @@ class ForceSwitchOutHelper {
         switchOutTarget.leaveField(this.switchType === SwitchType.SWITCH);
         const summonIndex = trainer ? trainer.getNextSummonIndex((switchOutTarget as EnemyPokemon).trainerSlot) : 0;
         globalScene.phaseManager.prependToPhase(
-          new SwitchSummonPhase(this.switchType, switchOutTarget.getFieldIndex(), summonIndex, false, false),
           PhaseId.POST_ACTION,
+          new SwitchSummonPhase(this.switchType, switchOutTarget.getFieldIndex(), summonIndex, false, false),
         );
         return true;
       }

--- a/src/data/moves/move-attrs/force-switch-out-attr.ts
+++ b/src/data/moves/move-attrs/force-switch-out-attr.ts
@@ -82,14 +82,14 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
           switchOutTarget.leaveField(true);
           const slotIndex = eligibleNewIndices[user.randSeedInt(eligibleNewIndices.length)];
           globalScene.phaseManager.prependToPhase(
-            new SwitchSummonPhase(this.switchType, switchOutTarget.getFieldIndex(), slotIndex, false, true),
             PhaseId.POST_ACTION,
+            new SwitchSummonPhase(this.switchType, switchOutTarget.getFieldIndex(), slotIndex, false, true),
           );
         } else {
           switchOutTarget.leaveField(this.switchType === SwitchType.SWITCH);
           globalScene.phaseManager.prependToPhase(
-            new LegacySwitchPhase(this.switchType, switchOutTarget.getFieldIndex(), true, true),
             PhaseId.POST_ACTION,
+            new LegacySwitchPhase(this.switchType, switchOutTarget.getFieldIndex(), true, true),
           );
           return true;
         }
@@ -115,12 +115,13 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
           switchOutTarget.leaveField(true);
           const slotIndex = eligibleNewIndices[user.randSeedInt(eligibleNewIndices.length)];
           globalScene.phaseManager.prependToPhase(
-            new SwitchSummonPhase(this.switchType, switchOutTarget.getFieldIndex(), slotIndex, false, false),
             PhaseId.POST_ACTION,
+            new SwitchSummonPhase(this.switchType, switchOutTarget.getFieldIndex(), slotIndex, false, false),
           );
         } else {
           switchOutTarget.leaveField(this.switchType === SwitchType.SWITCH);
           globalScene.phaseManager.prependToPhase(
+            PhaseId.POST_ACTION,
             new SwitchSummonPhase(
               this.switchType,
               switchOutTarget.getFieldIndex(),
@@ -128,7 +129,6 @@ export class ForceSwitchOutAttr extends MoveEffectAttr {
               false,
               false,
             ),
-            PhaseId.POST_ACTION,
           );
         }
       }

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -891,8 +891,7 @@ export function handleMysteryEncounterVictory(addHealPhase: boolean = false, doN
     return;
   }
   if (encounter.encounterMode === MysteryEncounterMode.NO_BATTLE) {
-    globalScene.phaseManager.pushPhase(new MysteryEncounterRewardsPhase(addHealPhase));
-    globalScene.phaseManager.pushPhase(new EggLapsePhase());
+    globalScene.phaseManager.pushPhase(new MysteryEncounterRewardsPhase(addHealPhase), new EggLapsePhase());
   } else if (
     // If any enemy Pokemon are still alive on the field or waiting for its fainting animation, do not advance a wave.
     // Also, if the enemy is a Trainer with other Pokemon alive in their party backline, do not advance a wave.

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -184,8 +184,8 @@ export class PlayerPokemon extends Pokemon {
         (slotIndex: number, _option: PartyOption) => {
           if (slotIndex >= globalScene.currentBattle.getBattlerCount() && slotIndex < 6) {
             globalScene.phaseManager.prependToPhase(
-              new SwitchSummonPhase(switchType, this.getFieldIndex(), slotIndex, false),
               PhaseId.POST_ACTION,
+              new SwitchSummonPhase(switchType, this.getFieldIndex(), slotIndex, false),
             );
           }
           globalScene.ui.setMessageMode().then(resolve);

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -73,15 +73,26 @@ interface PokemonFaintInit {
  * This is responsible for managing the game's {@linkcode Phase | phases}.
  */
 export class PhaseManager {
-  /** dequeue/remove the first element to get the next phase */
+  /**
+   * The main queue where {@linkcode Phase | Phases} are scheduled.
+   * The first Phase in this queue is {@linkcode Phase.start | run} whenever
+   * {@linkcode shiftPhase} is called.
+   */
   private phaseQueue: Phase[] = [];
-  /** A temporary storage of what will be added to the front of {@linkcode phaseQueue} */
+  /**
+   * When {@linkcode shiftPhase} is called, the Phases in this queue are inserted
+   * in queue order to the front of {@linkcode phaseQueue}.
+   */
   private phaseQueuePrepend: Phase[] = [];
   /** overrides default of inserting phases to end of phaseQueuePrepend array, useful for inserting Phases "out of order" */
   private phaseQueuePrependSpliceIndex: number = -1;
   private conditionalQueue: [() => boolean, Phase][] = [];
 
   private currentPhase: Phase | null = null;
+  /**
+   * Stores an {@linkcode overridePhase | overridden} {@linkcode Phase}
+   * to restart once the overriding Phase finishes running
+   */
   private standbyPhase: Phase | null = null;
 
   public getCurrentPhase<P extends Phase = Phase>(): P | null {
@@ -108,25 +119,28 @@ export class PhaseManager {
   }
 
   /**
-   * Queues a phase to be run at a future point in time.
-   * @param phase - The {@linkcode Phase} to add
-   * @param defer - If `false`, adds the phase to `phaseQueue`. If `true`, adds the phase to `nextCommandPhaseQueue`. Default `false`.
+   * Queues one or more phases to be run at a future point in time.
+   * @param phase - The first {@linkcode Phase} to push to the {@link phaseQueue | main queue}.
+   * @param otherPhases - Additional (optional) phases to queue. These phases are scheduled after {@linkcode phase} in array order.
    * @todo replace with a factory function for Phases based on `PhaseId`, ex: `public pushPhase<P extends Phase>(phase: PhaseId, ...params: ConstructorParameters<P>)`
    */
-  public pushPhase(phase: Phase): void {
-    this.phaseQueue.push(phase);
+  public pushPhase(phase: Phase, ...otherPhases: Phase[]): void {
+    const phases = [phase, ...otherPhases];
+    this.phaseQueue.push(...phases);
   }
 
   /**
-   * Adds a phase to the end of {@linkcode phaseQueuePrepend},
+   * Adds one or more phases to the end of {@linkcode phaseQueuePrepend},
    * or at {@linkcode phaseQueuePrependSpliceIndex} if it's set.
-   * @param phase - The {@linkcode Phase} to add
+   * @param phase - The first {@linkcode Phase} to push to {@linkcode phaseQueuePrepend}.
+   * @param otherPhases - Additional (optional) phases to queue. These phases are scheduled after {@linkcode phase} in array order.
    */
-  public unshiftPhase(phase: Phase): void {
+  public unshiftPhase(phase: Phase, ...otherPhases: Phase[]): void {
+    const phases = [phase, ...otherPhases];
     if (this.phaseQueuePrependSpliceIndex === -1) {
-      this.phaseQueuePrepend.push(phase);
+      this.phaseQueuePrepend.push(...phases);
     } else {
-      this.phaseQueuePrepend.splice(this.phaseQueuePrependSpliceIndex, 0, phase);
+      this.phaseQueuePrepend.splice(this.phaseQueuePrependSpliceIndex, 0, ...phases);
     }
   }
 
@@ -226,6 +240,13 @@ export class PhaseManager {
     }
   }
 
+  /**
+   * Cancels the {@link currentPhase | current Phase} to run another {@linkcode Phase}.
+   * The overridden Phase will restart after the overriding Phase finishes running.
+   * If a Phase is already on {@link standbyPhase | standby}, this does nothing.
+   * @param phase - The {@linkcode Phase} overriding the current Phase
+   * @returns `true` if the overriding Phase
+   */
   public overridePhase(phase: Phase): boolean {
     if (this.standbyPhase) {
       return false;
@@ -296,38 +317,40 @@ export class PhaseManager {
   /**
    * Tries to add the input phase to the index before the target phase in the {@linkcode phaseQueue},
    * otherwise it calls {@linkcode unshiftPhase} instead
-   * @param phase - The {@linkcode Phase} to be added
    * @param targetPhaseId - The {@linkcode PhaseId | id} of the phase to search for in the {@linkcode phaseQueue}
+   * @param phase - The {@linkcode Phase} to be added
+   * @param otherPhases - Additional (optional) Phases to add. These Phases are scheduled after {@linkcode phase} in array order
    * @returns `true` if the phase was successfully added to the queue before the target phase,
    *   `false` if the target phase wasn't found and {@linkcode unshiftPhase} was called instead
    */
-  public prependToPhase(phase: Phase, targetPhaseId: PhaseId): boolean {
+  public prependToPhase(targetPhaseId: PhaseId, phase: Phase, ...otherPhases: Phase[]): boolean {
     const targetIndex = this.phaseQueue.findIndex(({ id }) => id === targetPhaseId);
 
     if (targetIndex !== -1) {
-      this.phaseQueue.splice(targetIndex, 0, phase);
+      this.phaseQueue.splice(targetIndex, 0, phase, ...otherPhases);
       return true;
     }
-    this.unshiftPhase(phase);
+    this.unshiftPhase(phase, ...otherPhases);
     return false;
   }
 
   /**
    * Tries to add the input phase to the index after the target phase in the {@linkcode phaseQueue},
    * otherwise it calls {@linkcode unshiftPhase} instead
-   * @param phase - The {@linkcode Phase} to be added
    * @param targetPhaseId - The {@linkcode PhaseId | id} of the phase to search for in the {@linkcode phaseQueue}
+   * @param phase - The {@linkcode Phase} to be added
+   * @param otherPhases - Additional (optional) Phases to add. These Phases are scheduled after {@linkcode phase} in array order
    * @returns `true` if the phase was successfully added to the queue after the target phase,
    *   `false` if the target phase wasn't found and {@linkcode unshiftPhase} was called instead
    */
-  public appendToPhase(phase: Phase, targetPhaseId: PhaseId): boolean {
+  public appendToPhase(targetPhaseId: PhaseId, phase: Phase, ...otherPhases: Phase[]): boolean {
     const targetIndex = this.phaseQueue.findIndex(({ id }) => id === targetPhaseId);
 
     if (targetIndex !== -1 && this.phaseQueue.length > targetIndex) {
-      this.phaseQueue.splice(targetIndex + 1, 0, phase);
+      this.phaseQueue.splice(targetIndex + 1, 0, phase, ...otherPhases);
       return true;
     }
-    this.unshiftPhase(phase);
+    this.unshiftPhase(phase, ...otherPhases);
     return false;
   }
 
@@ -451,10 +474,10 @@ export class PhaseManager {
         this.pushPhase(movePhase);
         break;
       case "before":
-        this.prependToPhase(movePhase, phaseId!);
+        this.prependToPhase(phaseId!, movePhase);
         break;
       case "after":
-        this.appendToPhase(movePhase, phaseId!);
+        this.appendToPhase(phaseId!, movePhase);
         break;
       default:
         throw new Error(`Unknown useMove.when: ${when}`);
@@ -466,8 +489,7 @@ export class PhaseManager {
    * @param isVictory - Whether the player won the battle
    */
   public queueNextBattle(isVictory: boolean): void {
-    this.pushPhase(new BattleEndPhase(isVictory));
-    this.pushPhase(new NewBattlePhase());
+    this.pushPhase(new BattleEndPhase(isVictory), new NewBattlePhase());
   }
 
   /**

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -125,8 +125,7 @@ export class PhaseManager {
    * @todo replace with a factory function for Phases based on `PhaseId`, ex: `public pushPhase<P extends Phase>(phase: PhaseId, ...params: ConstructorParameters<P>)`
    */
   public pushPhase(phase: Phase, ...otherPhases: Phase[]): void {
-    const phases = [phase, ...otherPhases];
-    this.phaseQueue.push(...phases);
+    this.phaseQueue.push(phase, ...otherPhases);
   }
 
   /**
@@ -136,11 +135,10 @@ export class PhaseManager {
    * @param otherPhases - Additional (optional) phases to queue. These phases are scheduled after {@linkcode phase} in array order.
    */
   public unshiftPhase(phase: Phase, ...otherPhases: Phase[]): void {
-    const phases = [phase, ...otherPhases];
     if (this.phaseQueuePrependSpliceIndex === -1) {
-      this.phaseQueuePrepend.push(...phases);
+      this.phaseQueuePrepend.push(phase, ...otherPhases);
     } else {
-      this.phaseQueuePrepend.splice(this.phaseQueuePrependSpliceIndex, 0, ...phases);
+      this.phaseQueuePrepend.splice(this.phaseQueuePrependSpliceIndex, 0, phase, ...otherPhases);
     }
   }
 

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -397,8 +397,7 @@ export class CommandPhase extends FieldPhase {
 
   public cancel(): void {
     if (this.fieldIndex) {
-      globalScene.phaseManager.unshiftPhase(new CommandPhase(0));
-      globalScene.phaseManager.unshiftPhase(new CommandPhase(1));
+      globalScene.phaseManager.unshiftPhase(new CommandPhase(0), new CommandPhase(1));
       this.end();
     }
   }

--- a/src/phases/revival-blessing-phase.ts
+++ b/src/phases/revival-blessing-phase.ts
@@ -56,14 +56,14 @@ export class RevivalBlessingPhase extends BattlePhase {
               // Revived ally pokemon
               globalScene.phaseManager.unshiftPhase(
                 new SwitchSummonPhase(SwitchType.SWITCH, pokemon.getFieldIndex(), slotIndex, false, true),
+                new ToggleDoublePositionPhase(true),
               );
-              globalScene.phaseManager.unshiftPhase(new ToggleDoublePositionPhase(true));
             } else if (allyPokemon?.isFainted()) {
               // Revived party pokemon, and ally pokemon is fainted
               globalScene.phaseManager.unshiftPhase(
                 new SwitchSummonPhase(SwitchType.SWITCH, allyPokemon.getFieldIndex(), slotIndex, false, true),
+                new ToggleDoublePositionPhase(true),
               );
-              globalScene.phaseManager.unshiftPhase(new ToggleDoublePositionPhase(true));
             }
           }
         }

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -246,10 +246,12 @@ export class TurnCommandManager {
   /** Schedules all phases for the game's end-of-turn sequence */
   public endTurn(): void {
     const { phaseManager } = globalScene;
-    phaseManager.unshiftPhase(new WeatherEffectPhase());
-    phaseManager.unshiftPhase(new BerryPhase());
-    phaseManager.unshiftPhase(new CheckStatusEffectPhase());
-    phaseManager.unshiftPhase(new TurnEndPhase());
+    phaseManager.unshiftPhase(
+      new WeatherEffectPhase(),
+      new BerryPhase(),
+      new CheckStatusEffectPhase(),
+      new TurnEndPhase(),
+    );
   }
 
   public isEmpty(): boolean {
@@ -398,8 +400,8 @@ export class TurnCommandManager {
 
       const forMove = turnCommand.command === BattleCommand.FIGHT;
       globalScene.phaseManager.appendToPhase(
-        new PostActionPhase(turnCommand.pokemon.getBattlerIndex(), forMove),
         this.getNextTurnCommandPhaseId(turnCommand),
+        new PostActionPhase(turnCommand.pokemon.getBattlerIndex(), forMove),
       );
       this.commandsInProgress++;
     }
@@ -492,7 +494,7 @@ export class TurnCommandManager {
       return false;
     }
 
-    globalScene.phaseManager.appendToPhase(new AttemptCapturePhase(targets[0] % 2, cursor), PhaseId.POST_ACTION);
+    globalScene.phaseManager.appendToPhase(PhaseId.POST_ACTION, new AttemptCapturePhase(targets[0] % 2, cursor));
     return true;
   }
 
@@ -512,8 +514,8 @@ export class TurnCommandManager {
 
     const switchType = args?.[0] ? SwitchType.BATON_PASS : SwitchType.SWITCH;
     globalScene.phaseManager.appendToPhase(
-      new SwitchSummonPhase(switchType, pokemon.getFieldIndex(), cursor, true, pokemon.isPlayer()),
       PhaseId.POST_ACTION,
+      new SwitchSummonPhase(switchType, pokemon.getFieldIndex(), cursor, true, pokemon.isPlayer()),
     );
     return true;
   }
@@ -536,7 +538,7 @@ export class TurnCommandManager {
         runningPokemon = hasRunAway ?? fasterPokemon;
       }
     }
-    globalScene.phaseManager.appendToPhase(new AttemptRunPhase(runningPokemon.getFieldIndex()), PhaseId.POST_ACTION);
+    globalScene.phaseManager.appendToPhase(PhaseId.POST_ACTION, new AttemptRunPhase(runningPokemon.getFieldIndex()));
     return true;
   }
 

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -3943,8 +3943,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       ui.setMode<StarterSelectUiHandler>(UiMode.STARTER_SELECT);
       globalScene.phaseManager.clearPhaseQueue();
       if (globalScene.gameMode.isChallenge) {
-        globalScene.phaseManager.pushPhase(new SelectChallengePhase());
-        globalScene.phaseManager.pushPhase(new EncounterPhase());
+        globalScene.phaseManager.pushPhase(new SelectChallengePhase(), new EncounterPhase());
       } else {
         globalScene.phaseManager.toTitleScreen();
       }


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

#1236 currently makes it so multiple phases need to be scheduled at once to carry out a switch (or "Pokemon") turn action. However, the turn manager appends phases from commands after the first queued `POST_ACTION` phase, which can cause problems with phase order when scheduling multiple phases. These changes should help make phase ordering more intuitive when using `appendToPhase` or `prependToPhase` and make some Phase scheduling calls more readable.

## What are the changes from a developer perspective?

- In `PhaseManager`:
  - `pushPhase`, `unshiftPhase`, `prependToPhase`, and `appendToPhase` now accept multiple Phases as input. For example, `pushPhase`'s signature has been changed to
    ```ts
    public pushPhase(phase: Phase, ...otherPhases: Phase[]): void;
    ```
  - Updated docs
- Updated some instances of multiple consecutive `unshiftPhase` or `pushPhase` calls to make use of the new parameters

## How to test the changes?

Code review only (the parent PR runs into errors atm)

## Checklist

<sub>Other parts of the usual checklist aren't relevant for this PR...</sub>

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?