### PR TITLE
[Dev] Enforce type-only imports in `@types/` and `enums/`

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -2,11 +2,23 @@
 module.exports = {
   forbidden: [
     {
+      name: "only-type-imports",
+      severity: "error",
+      comment: "Files in 'enums/' and '@types/' must only use type imports.",
+      from: {
+        path: ["(^|/)src/@types", "(^|/)src/enums"],
+        pathNot: ["(^|/)src/@types/phaser.d.ts"],
+      },
+      to: {
+        dependencyTypesNot: ["type-only"],
+      },
+    },
+    {
       name: "no-circular-at-runtime",
       severity: "error",
       comment:
         "This dependency is part of a circular relationship. You might want to revise "
-        + "your solution (i.e. use dependency inversion, make sure the modules have a single responsibility) ",
+        + "your solution (i.e. use dependency inversion, make sure the modules have a single responsibility).",
       from: {},
       to: {
         circular: true,
@@ -18,7 +30,7 @@ module.exports = {
     {
       name: "no-orphans",
       comment:
-        "This is an orphan module - it's likely not used (anymore?). Either use it or "
+        "This is an orphan module - it's likely not used [any more]. Either use it or "
         + "remove it. If it's logical this module is an orphan (i.e. it's a config file), "
         + "add an exception for it in your dependency-cruiser configuration. By default "
         + "this rule does not scrutinize dot-files (e.g. .eslintrc.js), TypeScript declaration "
@@ -120,7 +132,7 @@ module.exports = {
       },
     },
 
-    /* rules you might want to tweak for your specific situation: */
+    // rules you might want to tweak for your specific situation:
 
     {
       name: "not-to-spec",

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -30,7 +30,7 @@ module.exports = {
     {
       name: "no-orphans",
       comment:
-        "This is an orphan module - it's likely not used [any more]. Either use it or "
+        "This is an orphan module - it's likely not used [anymore]. Either use it or "
         + "remove it. If it's logical this module is an orphan (i.e. it's a config file), "
         + "add an exception for it in your dependency-cruiser configuration. By default "
         + "this rule does not scrutinize dot-files (e.g. .eslintrc.js), TypeScript declaration "

--- a/src/@types/pokemon-summon-data.ts
+++ b/src/@types/pokemon-summon-data.ts
@@ -1,6 +1,6 @@
 // -- start tsdoc imports --
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { MoveId } from "#enums/move-id";
+import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 // -- end tsdoc imports

--- a/src/enums/challenge-type.ts
+++ b/src/enums/challenge-type.ts
@@ -1,6 +1,6 @@
 // -- start tsdoc imports
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Challenge } from "#data/challenge";
+import type { Challenge } from "#data/challenge";
 /* eslint-enable @typescript-eslint/no-unused-vars */
 // -- end tsdoc imports --
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Anything in `@types/` and `enums/` should not be importing other files.

## What are the changes from a developer perspective?
New rule added to dependency cruiser to prevent non-type-only imports in the `@types/` and `enums/` directories.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?