### PR TITLE
[Dev] Ignore Vitest `*.setup.ts` files in depcruise orphan file check

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -43,6 +43,7 @@ module.exports = {
           "[.]d[.]ts$", // TypeScript declaration files
           "(^|/)tsconfig[.]json$", // TypeScript config
           "(^|/)(?:babel|webpack)[.]config[.](?:js|cjs|mjs|ts|cts|mts|json)$", // other configs
+          "(^|/)test/.+[.]setup[.]ts", // Vitest setup files
         ],
       },
       to: {},


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Preparation to enable dependency cruiser to check `test/`.

## What are the changes from a developer perspective?
Dependency cruiser will no longer consider `test/*.setup.ts` files to be orphan files.

## Screenshots/videos
`no-circular-at-runtime` and `no-non-package-json` temporarily disabled when grabbing the screenshots (the errors generated by them are fixed in other PRs anyway).
<details><summary>Before</summary>
<p>

![image](https://github.com/user-attachments/assets/1b5fda11-f507-4771-9aa4-d125ff9e7a0d)

</p>
</details> 
<details><summary>After</summary>
<p>

![image](https://github.com/user-attachments/assets/b0e89d67-ea0a-4867-a205-6d3dd35a5900)

</p>
</details> 

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?