### PR TITLE
[Refactor] Remove unnecessary `async` from `PhaseInterceptor#to` return

### DIFF
--- a/test/test-utils/phase-interceptor.ts
+++ b/test/test-utils/phase-interceptor.ts
@@ -217,7 +217,7 @@ export class PhaseInterceptor {
    * @returns A promise that resolves when the transition is complete.
    */
   public async to(phaseTo: PhaseString, runTarget: boolean = true): Promise<void> {
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       ErrorInterceptor.getInstance().add(this);
       const targetName = this.getPhaseName(phaseTo);
       this.intervalRun = setInterval(async () => {


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
`new Promise(async ...)` is bad. cf https://biomejs.dev/linter/rules/no-async-promise-executor/

## What are the changes from a developer perspective?
`PhaseInterceptor#to` now returns `new Promise(...)` instead of `new Promise(async ...)`.

## How to test the changes?
`pnpm test:silent`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`pnpm test:silent`)