### PR TITLE
[Dev] Add `test/` to the `depcruise` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "biome-all:unsafe": "biome check --write --unsafe --no-errors-on-unmatched",
     "prettier": "prettier . --write",
     "docs": "typedoc",
-    "depcruise": "depcruise src",
+    "depcruise": "depcruise src test",
     "depcruise:graph": "depcruise src --output-type dot | node scripts/dependency-graph.js > dependency-graph.svg",
     "postinstall": "lefthook install && lefthook run post-merge",
     "update-version:patch": "pnpm version patch --force --no-git-tag-version",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Prevent circular import issues in the `test/` directory.

## What are the changes from a developer perspective?
The `depcruise` command (which is run automatically in a GitHub workflow) now also checks `test/`.

## How to test the changes?
`pnpm depcruise`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?