### PR TITLE
[AI-Rework] Add caching for invariant scoring calculations

### DIFF
--- a/src/@types/pokemon-score-data.ts
+++ b/src/@types/pokemon-score-data.ts
@@ -1,0 +1,30 @@
+// -- start tsdoc imports --
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { EnemyPokemon } from "#field/enemy-pokemon";
+import type { Pokemon } from "#field/pokemon";
+import type { PokemonTurnData } from "#types/pokemon-turn-data";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+// -- end tsdoc imports --
+
+import type { MoveId } from "#enums/move-id";
+
+/**
+ * Caches invariant data for the Enemy AI to reuse
+ * during its score calculations for turn action selection against
+ * a "target" {@linkcode Pokemon}. This is stored within a "source"
+ * Pokemon's {@linkcode PokemonTurnData}, and is thus reset at the start of each turn.
+ */
+export interface PokemonScoreData {
+  /**
+   * A score for grading the source Pokemon's matchup against
+   * the target Pokemon.
+   * @see {@linkcode EnemyPokemon.getMatchupScore}
+   */
+  matchupScore?: number;
+  /**
+   * The expected values of the source Pokemon's Attack Scores
+   * against the target Pokemon for each of the source's moves.
+   * @see {@linkcode Pokemon.getExpectedAttackScore}
+   */
+  expectedAttackScores: Map<MoveId, number>;
+}

--- a/src/@types/pokemon-turn-data.ts
+++ b/src/@types/pokemon-turn-data.ts
@@ -2,6 +2,7 @@ import type { TurnCommand } from "#app/turn-command-manager";
 import type { TypeDamageMultiplier } from "#data/type";
 import type { MoveId } from "#enums/move-id";
 import type { AttackMoveResult } from "#types/attack-move-result";
+import type { PokemonScoreData } from "#types/pokemon-score-data";
 
 export interface PokemonTurnData {
   turnCommand?: TurnCommand;
@@ -26,4 +27,9 @@ export interface PokemonTurnData {
   switchedInThisTurn: boolean;
   failedRunAway: boolean;
   joinedRound: boolean;
+  /**
+   * Contains invariant scoring data for this Pokemon
+   * against all Pokemon on the field, mapped by their id.
+   */
+  scoreData: Map<number, PokemonScoreData>;
 }

--- a/src/constants/ai-constants.ts
+++ b/src/constants/ai-constants.ts
@@ -9,6 +9,17 @@ import type { Pokemon } from "#field/pokemon";
 export const KO_ATTACK_SCORE = 4;
 
 /**
+ * The damage (in terms of % maximum HP) a projected attack must deal
+ * to a target to reach the next scoring "tier". An attack projected to deal
+ * damage below this threshold will receive an Attack Score of either 0 or 1.
+ * On the other hand, attacks projected to deal damage above this threshold
+ * will receive an Attack Score of either 1 or 2.
+ * @see {@linkcode Pokemon.getAttackScore}
+ * @see {@linkcode Pokemon.getExpectedAttackScore}
+ */
+export const ATTACK_SCORE_HP_THRESHOLD = 40;
+
+/**
  * A relatively major bonus to a move attribute's {@link MoveAttr.getEffectScore | Effect Score}.
  * Used when a move with the attribute gains a decisive advantage in
  * a given battle state.

--- a/src/enums/move-id.ts
+++ b/src/enums/move-id.ts
@@ -1,4 +1,20 @@
+// -- start tsdoc imports --
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Pokemon } from "#field/pokemon";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+// -- end tsdoc imports --
+
 export enum MoveId {
+  /**
+   * The {@linkcode Pokemon.getSimulatedMoves | simulated move}
+   * of a Pokemon's primary type.
+   */
+  SIMULATED_MOVE_1 = -2,
+  /**
+   * The {@linkcode Pokemon.getSimulatedMoves | simulated move}
+   * of a Pokemon's secondary type.
+   */
+  SIMULATED_MOVE_2,
   /**{@link https://bulbapedia.bulbagarden.net/wiki/None_(move) | Source} */
   NONE,
   /**{@link https://bulbapedia.bulbagarden.net/wiki/Pound_(move) | Source} */

--- a/src/enums/move-id.ts
+++ b/src/enums/move-id.ts
@@ -8,6 +8,11 @@ export enum MoveId {
   /**
    * The {@linkcode Pokemon.getSimulatedMoves | simulated move}
    * of a Pokemon's primary type.
+   *
+   * @privateremarks
+   * This and {@linkcode SIMULATED_MOVE_2} are negative values
+   * to maintain parity between the IDs of real moves
+   * and their IDs in the mainline games.
    */
   SIMULATED_MOVE_1 = -2,
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1431,7 +1431,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Generates placeholder moves for this Pokemon with properties based
+   * Generates placeholder attacks for this Pokemon with properties based
    * on the Pokemon's type(s), attacking stats, and the current wave index.
    * This generates up to 2 moves:
    * - One move for each of the Pokemon's base type(s).
@@ -1452,13 +1452,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * - Each move has 0 priority and no secondary effects.
    * @returns
    */
-  protected getSimulatedMoves(): Move[] {
+  private getSimulatedMoves(): Move[] {
     const types = this.getTypes(false, false, true);
     const category = this.getStat(Stat.ATK) >= this.getStat(Stat.SPATK) ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
     const ret: Move[] = [];
 
     for (let i = 0; i < Math.min(types.length, 4 - this.waveData.revealedMoves.size); i++) {
-      ret.push(new AttackMove(MoveId.NONE, types[i], category, this.getSimulatedMovePower(), 100, 10, -1, 0, 0));
+      const moveId = i % 2 === 0 ? MoveId.SIMULATED_MOVE_1 : MoveId.SIMULATED_MOVE_2;
+      ret.push(new AttackMove(moveId, types[i], category, this.getSimulatedMovePower(), 100, 10, -1, 0, 0));
     }
 
     return ret;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -208,6 +208,7 @@ import { getIvsFromId, getPokemonSpecies, getPokemonSpeciesForm } from "#utils/p
 import { randSeedInt } from "#utils/random-utils";
 import i18next from "i18next";
 import type { PokemonScoreData } from "#types/pokemon-score-data";
+import { ATTACK_SCORE_HP_THRESHOLD } from "#constants/ai-constants";
 
 interface AbilityData {
   ability: Ability;
@@ -2209,11 +2210,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     const damagePct = Math.floor((damage / opponent.getMaxHp()) * 100);
 
-    if (damagePct >= 80) {
+    if (damagePct >= 2 * ATTACK_SCORE_HP_THRESHOLD) {
       return 2;
     }
-    const minAttackScore = Math.floor(damagePct / 40);
-    const tierUpChance = (damagePct % 40) * (100 / 40);
+    const minAttackScore = Math.floor(damagePct / ATTACK_SCORE_HP_THRESHOLD);
+    const tierUpChance = (damagePct % ATTACK_SCORE_HP_THRESHOLD) * (100 / ATTACK_SCORE_HP_THRESHOLD);
 
     if (this.randSeedInt(100) < tierUpChance) {
       return minAttackScore + 1;
@@ -2248,7 +2249,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       score = -1;
     } else {
       const damagePct = Math.floor((damage / opponent.getMaxHp()) * 100);
-      score = damagePct / 40;
+      score = damagePct / ATTACK_SCORE_HP_THRESHOLD;
     }
 
     this.cacheEas(opponent, move, score);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1458,6 +1458,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const ret: Move[] = [];
 
     for (let i = 0; i < Math.min(types.length, 4 - this.waveData.revealedMoves.size); i++) {
+      /**
+       * Each simulated move is assigned a unique ID so that its {@linkcode getExpectedAttackScore | EAS}
+       * can be properly cached. The simulated move of the Pokemon's primary type is
+       * assigned the ID {@linkcode MoveId.SIMULATED_MOVE_1}, and the simulated move
+       * of its secondary type is assigned {@linkcode MoveId.SIMULATED_MOVE_2}.
+       */
       const moveId = i % 2 === 0 ? MoveId.SIMULATED_MOVE_1 : MoveId.SIMULATED_MOVE_2;
       ret.push(new AttackMove(moveId, types[i], category, this.getSimulatedMovePower(), 100, 10, -1, 0, 0));
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -207,6 +207,7 @@ import { applyMoveAttrs } from "#utils/move-utils";
 import { getIvsFromId, getPokemonSpecies, getPokemonSpeciesForm } from "#utils/pokemon-utils";
 import { randSeedInt } from "#utils/random-utils";
 import i18next from "i18next";
+import type { PokemonScoreData } from "#types/pokemon-score-data";
 
 interface AbilityData {
   ability: Ability;
@@ -2226,16 +2227,44 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @see {@linkcode getAttackScore}
    */
   public getExpectedAttackScore(opponent: Pokemon, move: Move): number {
+    const cachedScore = this.turnData.scoreData.get(opponent.id)?.expectedAttackScores.get(move.id);
+    if (!isNil(cachedScore)) {
+      return cachedScore;
+    }
+
     const damage = opponent.getEstimatedAttackDamage(this, move);
 
+    let score: number = 0;
     if (damage >= opponent.hp) {
-      return this.getAttackScoreOnKnockOut(move);
+      score = this.getAttackScoreOnKnockOut(move);
+    } else if (damage <= 0) {
+      score = -1;
+    } else {
+      const damagePct = Math.floor((damage / opponent.getMaxHp()) * 100);
+      score = damagePct / 40;
     }
-    if (damage <= 0) {
-      return -1;
+
+    this.cacheEas(opponent, move, score);
+    return score;
+  }
+
+  /**
+   * Caches a {@linkcode PokemonScoreData} entry in this Pokemon's
+   * {@linkcode turnData} with the given data.
+   * @param opponent - The {@linkcode Pokemon} that {@linkcode move} is evaluated against
+   * @param move - The {@linkcode Move} being evaluated
+   * @param score - The calculated score for the move action
+   * @see {@linkcode getExpectedAttackScore}
+   */
+  private cacheEas(opponent: Pokemon, move: Move, score: number): void {
+    const oppScoreData = this.turnData.scoreData.get(opponent.id);
+    if (!oppScoreData) {
+      this.turnData.scoreData.set(opponent.id, {
+        expectedAttackScores: new Map<MoveId, number>([[move.id, score]]),
+      });
+    } else {
+      oppScoreData.expectedAttackScores.set(move.id, score);
     }
-    const damagePct = Math.floor((damage / opponent.getMaxHp()) * 100);
-    return damagePct / 40;
   }
 
   /**
@@ -2265,6 +2294,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @returns the calculated score for the matchup.
    */
   public getMatchupScore(opponent: Pokemon): number {
+    const cachedScore = this.turnData.scoreData.get(opponent.id)?.matchupScore;
+    if (!isNil(cachedScore)) {
+      return cachedScore;
+    }
+
     const speed = this.getEffectiveStat(Stat.SPD, opponent, undefined, AbilityApplyMode.REVEALED);
     const oppSpeed = opponent.getEffectiveStat(Stat.SPD, this, undefined, AbilityApplyMode.REVEALED);
     const userCanOutspeed = speed >= oppSpeed;
@@ -2275,16 +2309,40 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const eas = Math.max(...attackMoves.map((mv) => this.getExpectedAttackScore(opponent, mv)));
     const oppEas = Math.max(...oppAttackMoves.map((mv) => opponent.getExpectedAttackScore(this, mv)));
 
+    let score: number = 0;
     if (this.isActive(true)) {
       if (eas >= 4 && (userCanOutspeed || oppEas < eas)) {
-        return Number.POSITIVE_INFINITY;
+        score = Number.POSITIVE_INFINITY;
+      } else if (oppEas >= 4 && (!userCanOutspeed || eas < oppEas)) {
+        score = 0;
+      } else {
+        score = eas * (3 - oppEas + (userCanOutspeed ? 1 : 0));
       }
-      if (oppEas >= 4 && (!userCanOutspeed || eas < oppEas)) {
-        return 0;
-      }
-      return eas * (3 - oppEas + (userCanOutspeed ? 1 : 0));
+    } else {
+      score = Math.max(eas * (2 - oppEas + (userCanOutspeed ? 1 : 0)), 0);
     }
-    return Math.max(eas * (2 - oppEas + (userCanOutspeed ? 1 : 0)), 0);
+
+    this.cacheMatchupScore(opponent, score);
+    return score;
+  }
+
+  /**
+   * Caches a {@linkcode PokemonScoreData} entry in this Pokemon's
+   * {@linkcode turnData} with the given Matchup Score data.
+   * @param opponent - The opposing Pokemon that this Pokemon is evaluated against
+   * @param matchupScore - This Pokemon's Matchup Score against {@linkcode opponent}
+   * @see {@linkcode getMatchupScore}
+   */
+  private cacheMatchupScore(opponent: Pokemon, matchupScore: number) {
+    const oppScoreData = this.turnData.scoreData.get(opponent.id);
+    if (!oppScoreData) {
+      this.turnData.scoreData.set(opponent.id, {
+        matchupScore,
+        expectedAttackScores: new Map<MoveId, number>(),
+      });
+    } else {
+      oppScoreData.matchupScore = matchupScore;
+    }
   }
 
   /**
@@ -4446,6 +4504,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       switchedInThisTurn: false,
       failedRunAway: false,
       joinedRound: false,
+      scoreData: new Map<number, PokemonScoreData>(),
     };
   }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2259,7 +2259,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   private cacheEas(opponent: Pokemon, move: Move, score: number): void {
     const oppScoreData = this.turnData.scoreData.get(opponent.id);
-    if (!oppScoreData) {
+    if (isNil(oppScoreData)) {
       this.turnData.scoreData.set(opponent.id, {
         expectedAttackScores: new Map<MoveId, number>([[move.id, score]]),
       });
@@ -2336,7 +2336,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    */
   private cacheMatchupScore(opponent: Pokemon, matchupScore: number) {
     const oppScoreData = this.turnData.scoreData.get(opponent.id);
-    if (!oppScoreData) {
+    if (isNil(oppScoreData)) {
       this.turnData.scoreData.set(opponent.id, {
         matchupScore,
         expectedAttackScores: new Map<MoveId, number>(),


### PR DESCRIPTION
## What are the changes the user will see?

Very minor improvements (for now) in performance within `EnemyCommandPhase`

## Why am I making these changes?

Some implemented and/or planned Effect Scores for move attributes refer to a Pokemon's Matchup Score (MUS) or Expected Attack Score (EAS) to determine whether a bonus or penalty should apply. Before this change, these values would have to be recalculated even though they are invariant for the turn. The added runtime from this is especially noticeable in newly added unit tests which statistically analyze move selection over 300 trials. 

## What are the changes from a developer perspective?

A new field has been added to all Pokemon's `turnData`:

```ts
scoreData: Map<number, PokemonScoreData>;
```

`scoreData` is mapped by other active Pokemon's `id`s. The data in each `PokemonScoreData` entry may contain the Pokemon's MUS as well as EAS of each of the Pokemon's moves against the target Pokemon:

```ts
export interface PokemonScoreData {
  matchupScore?: number;
  expectedAttackScores: Map<MoveId, number>;
}
```

This cached data is populated by `Pokemon.getExpectedAttackScore` and `Pokemon.getMatchupScore`, which also return the appropriate cached data if it's already populated for the turn.

## Screenshots/Videos

## How to test the changes?

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [n/a] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?
