### PR TITLE
[i18n] Map `biome` namespace to `biomes.json` file rename

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -91,6 +91,7 @@ const namespaceMap = {
   battleSpecDialogue: "dialogue-final-boss",
   splashMessages: "splash-texts",
   mysteryEncounterMessages: "mystery-encounter-texts",
+  biome: "biomes",
 };
 
 //#region Functions


### PR DESCRIPTION
## What are the changes the user will see?
An update to the locales submodule is included as it is necessary.

## Why am I making these changes?
Our code linter + formatter (Biome) expects that any file named `biome.json` is a config file, but our locales had files named `biome.json` that were not valid config files for Biome. They have been renamed `biomes.json` to prevent them from being erroneously considered as config files. This is an issue for Biome 2.0 which allows nesting of config files.

## What are the changes from a developer perspective?
There should be no change to the development experience, `"biome"` should still be a valid locales namespace as it has been mapped to the file rename to prevent the need for any change from developers.

## Screenshots/Videos
<details><summary>English</summary>
<p>

![image](https://github.com/user-attachments/assets/911f4bba-2ba3-42dd-8521-901bf39fcbf9)

</p>
</details> 
<details><summary>Spanish</summary>
<p>

![image](https://github.com/user-attachments/assets/32461365-b164-424d-947f-fc4db6f6c319)

</p>
</details> 

## How to test the changes?
Load up any run to ensure the biome name is still properly localized.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?

#### Are there any localization additions or changes? If so:
- [x] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [x] If so, please leave a link to it here: https://github.com/Despair-Games/poketernity-locales/pull/51
- [x] Have I added the `Localization` tag to this PR?