### PR TITLE
[Refactor] Put optional params of `Pokemon#getEffectiveStat` in object

### DIFF
--- a/src/data/abilities/ab-attrs/download-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/download-ab-attr.ts
@@ -23,8 +23,8 @@ export class DownloadAbAttr extends PostSummonAbAttr {
     this.enemySpDef = 0;
 
     for (const opponent of pokemon.getOpponents()) {
-      this.enemyDef += opponent.getEffectiveStat(Stat.DEF, undefined, undefined, AbilityApplyMode.IGNORE);
-      this.enemySpDef += opponent.getEffectiveStat(Stat.SPDEF, undefined, undefined, AbilityApplyMode.IGNORE);
+      this.enemyDef += opponent.getEffectiveStat(Stat.DEF, { abilityApplyMode: AbilityApplyMode.IGNORE });
+      this.enemySpDef += opponent.getEffectiveStat(Stat.SPDEF, { abilityApplyMode: AbilityApplyMode.IGNORE });
     }
 
     if (this.enemyDef < this.enemySpDef) {

--- a/src/data/battler-tags/confused-tag.ts
+++ b/src/data/battler-tags/confused-tag.ts
@@ -124,8 +124,8 @@ export class ConfusedTag extends BattlerTag {
       (pokemon.randSeedInt(100) < this.ACTIVATION_CHANCE && Overrides.STATUS_ACTIVATION_OVERRIDE !== false)
       || Overrides.STATUS_ACTIVATION_OVERRIDE === true
     ) {
-      const atk = pokemon.getEffectiveStat(Stat.ATK, undefined, undefined, AbilityApplyMode.IGNORE);
-      const def = pokemon.getEffectiveStat(Stat.DEF, undefined, undefined, AbilityApplyMode.IGNORE);
+      const atk = pokemon.getEffectiveStat(Stat.ATK, { abilityApplyMode: AbilityApplyMode.IGNORE });
+      const def = pokemon.getEffectiveStat(Stat.DEF, { abilityApplyMode: AbilityApplyMode.IGNORE });
 
       return toDmgValue(
         ((((2 * pokemon.level) / 5 + 2) * 40 * atk) / def / 50 + 2) * (pokemon.randSeedIntRange(85, 100) / 100),

--- a/src/data/battler-tags/highest-stat-boost-tag.ts
+++ b/src/data/battler-tags/highest-stat-boost-tag.ts
@@ -7,6 +7,7 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { AbilityBattlerTag } from "#battler-tags/ability-battler-tag";
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import { allAbilities } from "#data/data-lists";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import type { AbilityId } from "#enums/ability-id";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
@@ -45,13 +46,16 @@ export abstract class HighestStatBoostTag extends AbilityBattlerTag {
     super.onAdd(pokemon);
 
     let highestStat: EffectiveStat;
-    EFFECTIVE_STATS.map((s) => pokemon.getEffectiveStat(s)).reduce((highestValue: number, value: number, i: number) => {
-      if (value > highestValue) {
-        highestStat = EFFECTIVE_STATS[i];
-        return value;
-      }
-      return highestValue;
-    }, 0);
+    EFFECTIVE_STATS.map((s) => pokemon.getEffectiveStat(s, { abilityApplyMode: AbilityApplyMode.IGNORE })).reduce(
+      (highestValue: number, value: number, i: number) => {
+        if (value > highestValue) {
+          highestStat = EFFECTIVE_STATS[i];
+          return value;
+        }
+        return highestValue;
+      },
+      0,
+    );
 
     highestStat = highestStat!; // tell TS compiler it's defined!
     this.stat = highestStat;

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -1517,8 +1517,7 @@ export function initAbilities() {
       .attr(PostWeatherChangeAddBattlerTagAbAttr, BattlerTagType.PROTOSYNTHESIS, 0, WeatherType.SUNNY, WeatherType.HARSH_SUN)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
-      .attr(NoTransformAbilityAbAttr)
-      .partial(), // While setting the tag, the getbattlestat should ignore all modifiers to stats except stat stages
+      .attr(NoTransformAbilityAbAttr),
     new Ability(AbilityId.QUARK_DRIVE, 9)
       .conditionalAttr(
         getTerrainCondition(TerrainType.ELECTRIC),
@@ -1530,8 +1529,7 @@ export function initAbilities() {
       .attr(PostTerrainChangeAddBattlerTagAbAttr, BattlerTagType.QUARK_DRIVE, 0, TerrainType.ELECTRIC)
       .attr(UncopiableAbilityAbAttr)
       .attr(UnswappableAbilityAbAttr)
-      .attr(NoTransformAbilityAbAttr)
-      .partial(), // While setting the tag, the getbattlestat should ignore all modifiers to stats except stat stages
+      .attr(NoTransformAbilityAbAttr),
     new Ability(AbilityId.GOOD_AS_GOLD, 9)
       .attr(MoveImmunityAbAttr, (pokemon, attacker, move) => pokemon !== attacker && move.category === MoveCategory.STATUS)
       .ignorable(),

--- a/src/data/moves/move-attrs/tera-move-category-attr.ts
+++ b/src/data/moves/move-attrs/tera-move-category-attr.ts
@@ -13,8 +13,8 @@ export class TeraMoveCategoryAttr extends VariableMoveCategoryAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, category: NumberHolder): boolean {
     if (
       user.isTerastallized
-      && user.getEffectiveStat(Stat.ATK, target, move, AbilityApplyMode.IGNORE)
-        > user.getEffectiveStat(Stat.SPATK, target, move, AbilityApplyMode.IGNORE)
+      && user.getEffectiveStat(Stat.ATK, { opponent: target, move, abilityApplyMode: AbilityApplyMode.IGNORE })
+        > user.getEffectiveStat(Stat.SPATK, { opponent: target, move, abilityApplyMode: AbilityApplyMode.IGNORE })
     ) {
       category.value = MoveCategory.PHYSICAL;
       return true;

--- a/src/data/moves/move-attrs/use-higher-attacking-stat-attr.ts
+++ b/src/data/moves/move-attrs/use-higher-attacking-stat-attr.ts
@@ -16,8 +16,8 @@ export class UseHigherAttackingStatAttr extends VariableMoveCategoryAttr {
   override apply(user: Pokemon, target: Pokemon, move: Move, category: NumberHolder): boolean {
     let returnVal = false;
     if (
-      user.getEffectiveStat(Stat.ATK, target, move, AbilityApplyMode.IGNORE)
-      > user.getEffectiveStat(Stat.SPATK, target, move, AbilityApplyMode.IGNORE)
+      user.getEffectiveStat(Stat.ATK, { opponent: target, move, abilityApplyMode: AbilityApplyMode.IGNORE })
+      > user.getEffectiveStat(Stat.SPATK, { opponent: target, move, abilityApplyMode: AbilityApplyMode.IGNORE })
     ) {
       if (category.value === MoveCategory.SPECIAL) {
         returnVal = true;

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -963,9 +963,9 @@ export class AttackMove extends Move {
     attackScore = Math.pow(effectiveness - 1, 2) * effectiveness < 1 ? -2 : 2;
     if (attackScore) {
       if (this.category === MoveCategory.PHYSICAL) {
-        const atk = new NumberHolder(user.getEffectiveStat(Stat.ATK, target));
-        if (atk.value > user.getEffectiveStat(Stat.SPATK, target)) {
-          const statRatio = user.getEffectiveStat(Stat.SPATK, target) / atk.value;
+        const atk = new NumberHolder(user.getEffectiveStat(Stat.ATK, { opponent: target }));
+        if (atk.value > user.getEffectiveStat(Stat.SPATK, { opponent: target })) {
+          const statRatio = user.getEffectiveStat(Stat.SPATK, { opponent: target }) / atk.value;
           if (statRatio <= 0.75) {
             attackScore *= 2;
           } else if (statRatio <= 0.875) {
@@ -973,9 +973,9 @@ export class AttackMove extends Move {
           }
         }
       } else {
-        const spAtk = new NumberHolder(user.getEffectiveStat(Stat.SPATK, target));
-        if (spAtk.value > user.getEffectiveStat(Stat.ATK, target)) {
-          const statRatio = user.getEffectiveStat(Stat.ATK, target) / spAtk.value;
+        const spAtk = new NumberHolder(user.getEffectiveStat(Stat.SPATK, { opponent: target }));
+        if (spAtk.value > user.getEffectiveStat(Stat.ATK, { opponent: target })) {
+          const statRatio = user.getEffectiveStat(Stat.ATK, { opponent: target }) / spAtk.value;
           if (statRatio <= 0.75) {
             attackScore *= 2;
           } else if (statRatio <= 0.875) {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -216,7 +216,7 @@ interface DamageFunctionOptions {
 }
 
 interface EffectiveStatOptions {
-  /** The target {@linkcode Pokemon} */
+  /** The opposing {@linkcode Pokemon}, usually involved in an incoming or outgoing attack */
   opponent?: Pokemon;
   /** The {@linkcode Move} being used */
   move?: Move;
@@ -1135,11 +1135,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * Calculates and retrieves the final value of a stat considering any held items,
    * move effects, opponent abilities, and whether there was a critical hit.
    * @param stat - The desired {@linkcode EffectiveStat}
-   * @param opponent - The target {@linkcode Pokemon}
-   * @param move - The {@linkcode Move} being used
-   * @param abilityApplyMode - (Default {@linkcode AbilityApplyMode.DEFAULT}) The {@linkcode AbilityApplyMode} determining how abilities are applied
-   * @param isCritical - (Default `false`) Whether a critical hit has occurred or not
-   * @param simulated - (Default `true`) If `true`, nullifies any effects that produce any changes to game state from triggering
+   * @see {@linkcode EffectiveStatOptions} for optional params
    * @returns The final in-battle value of a stat
    */
   getEffectiveStat(

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1156,6 +1156,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
      * Variable Attack attributes are applied only to the raw stat
      * value and associated stat stage multiplier. Other stat modifiers,
      * e.g. items and abilities, apply based on the original stat.
+     * See https://bulbapedia.bulbagarden.net/wiki/Body_Press_(move)#Effect for more info
      */
     if (move && opponent && [Stat.ATK, Stat.SPATK].includes(stat)) {
       applyMoveAttrs(VariableAtkAttr, this, opponent, move, statValue, isCritical);

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -215,6 +215,28 @@ interface DamageFunctionOptions {
   source?: Pokemon;
 }
 
+interface EffectiveStatOptions {
+  /** The target {@linkcode Pokemon} */
+  opponent?: Pokemon;
+  /** The {@linkcode Move} being used */
+  move?: Move;
+  /**
+   * The {@linkcode AbilityApplyMode} determining how abilities are applied
+   * @defaultValue {@linkcode AbilityApplyMode.DEFAULT}
+   */
+  abilityApplyMode?: AbilityApplyMode;
+  /**
+   * Whether a critical hit has occurred or not
+   * @defaultValue `false`
+   */
+  isCritical?: boolean;
+  /**
+   * If `true`, nullifies any effects that produce any changes to game state from triggering
+   * @defaultValue `true`
+   */
+  simulated?: boolean;
+}
+
 export abstract class Pokemon extends Phaser.GameObjects.Container {
   public id: number;
   public override name: string;
@@ -1110,33 +1132,34 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Calculates and retrieves the final value of a stat considering any held
-   * items, move effects, opponent abilities, and whether there was a critical
-   * hit.
-   * @param stat the desired {@linkcode EffectiveStat}
-   * @param opponent the target {@linkcode Pokemon}
-   * @param move the {@linkcode Move} being used
-   * @param abilityApplyMode the {@linkcode AbilityApplyMode} determining how abilities are applied
-   * @param isCritical determines whether a critical hit has occurred or not (`false` by default)
-   * @param simulated if `true`, nullifies any effects that produce any changes to game state from triggering
-   * @returns the final in-battle value of a stat
+   * Calculates and retrieves the final value of a stat considering any held items,
+   * move effects, opponent abilities, and whether there was a critical hit.
+   * @param stat - The desired {@linkcode EffectiveStat}
+   * @param opponent - The target {@linkcode Pokemon}
+   * @param move - The {@linkcode Move} being used
+   * @param abilityApplyMode - (Default {@linkcode AbilityApplyMode.DEFAULT}) The {@linkcode AbilityApplyMode} determining how abilities are applied
+   * @param isCritical - (Default `false`) Whether a critical hit has occurred or not
+   * @param simulated - (Default `true`) If `true`, nullifies any effects that produce any changes to game state from triggering
+   * @returns The final in-battle value of a stat
    */
   getEffectiveStat(
     stat: EffectiveStat,
-    opponent?: Pokemon,
-    move?: Move,
-    abilityApplyMode: AbilityApplyMode = AbilityApplyMode.DEFAULT,
-    isCritical: boolean = false,
-    simulated: boolean = true,
+    {
+      opponent,
+      move,
+      abilityApplyMode = AbilityApplyMode.DEFAULT,
+      isCritical = false,
+      simulated = true,
+    }: EffectiveStatOptions = {},
   ): number {
     const applyAbFunc = getAbApplyFunc(abilityApplyMode);
 
     const statValue = new NumberHolder(-1);
 
-    /**
+    /*
      * Variable Attack attributes are applied only to the raw stat
      * value and associated stat stage multiplier. Other stat modifiers,
-     * e.g. items and abilities, apply based on the original {@linkcode stat}.
+     * e.g. items and abilities, apply based on the original stat.
      */
     if (move && opponent && [Stat.ATK, Stat.SPATK].includes(stat)) {
       applyMoveAttrs(VariableAtkAttr, this, opponent, move, statValue, isCritical);
@@ -1168,6 +1191,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     let ret = statValue.value;
 
+    const { arena } = globalScene;
     switch (stat) {
       case Stat.ATK:
         if (this.hasTag(BattlerTagType.SLOW_START)) {
@@ -1175,23 +1199,23 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         }
         break;
       case Stat.DEF:
-        if (this.isOfType(ElementalType.ICE) && globalScene.arena.hasWeather(WeatherType.SNOW)) {
+        if (this.isOfType(ElementalType.ICE) && arena.hasWeather(WeatherType.SNOW)) {
           ret *= 1.5;
         }
         break;
       case Stat.SPATK:
         break;
       case Stat.SPDEF:
-        if (this.isOfType(ElementalType.ROCK) && globalScene.arena.hasWeather(WeatherType.SANDSTORM)) {
+        if (this.isOfType(ElementalType.ROCK) && arena.hasWeather(WeatherType.SANDSTORM)) {
           ret *= 1.5;
         }
         break;
       case Stat.SPD: {
         const side = this.getArenaTagSide();
-        if (globalScene.arena.hasTag(ArenaTagType.TAILWIND, side)) {
+        if (arena.hasTag(ArenaTagType.TAILWIND, side)) {
           ret *= 2;
         }
-        if (globalScene.arena.hasTag(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
+        if (arena.hasTag(ArenaTagType.GRASS_WATER_PLEDGE, side)) {
           ret >>= 2;
         }
 
@@ -2073,8 +2097,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const enemyTypes = opponent.getTypes(true, true);
     /** Is this Pokemon faster than the opponent? */
     const outspeed =
-      (this.isActive(true) ? this.getEffectiveStat(Stat.SPD, opponent) : this.getStat(Stat.SPD, false))
-      >= opponent.getEffectiveStat(Stat.SPD, this);
+      (this.isActive(true) ? this.getEffectiveStat(Stat.SPD, { opponent }) : this.getStat(Stat.SPD, false))
+      >= opponent.getEffectiveStat(Stat.SPD, { opponent: this });
     /**
      * Based on how effective this Pokemon's types are offensively against the opponent's types.
      * This score is increased by 25 percent if this Pokemon is faster than the opponent.
@@ -2923,14 +2947,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
      * The attacker's offensive stat for the given move's category.
      * Critical hits cause negative stat stages to be ignored.
      */
-    const sourceAtk = source.getEffectiveStat(
-      isPhysical ? Stat.ATK : Stat.SPATK,
-      this,
+    const sourceAtk = source.getEffectiveStat(isPhysical ? Stat.ATK : Stat.SPATK, {
+      opponent: this,
       move,
       abilityApplyMode,
       isCritical,
       simulated,
-    );
+    });
 
     /**
      * The {@linkcode EffectiveStat} used to defend against the given move.
@@ -2943,7 +2966,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
      * This Pokemon's defensive stat for the given move's category.
      * Critical hits cause positive stat stages to be ignored.
      */
-    const targetDef = this.getEffectiveStat(defendingStat.value, source, move, abilityApplyMode, isCritical, simulated);
+    const targetDef = this.getEffectiveStat(defendingStat.value, {
+      opponent: source,
+      move,
+      abilityApplyMode,
+      isCritical,
+      simulated,
+    });
 
     /** This prevents a move with negative power from possibly dealing positive damage.
      * The issue can occur because the base damage is the result of the below equation plus 2.

--- a/test/abilities/unaware.test.ts
+++ b/test/abilities/unaware.test.ts
@@ -49,7 +49,7 @@ describe("Abilities - Unaware", () => {
         expectedStat = expectedStat * 2; // Should not ignore stat stages in Speed
       }
 
-      const actualStat = enemyPokemon.getEffectiveStat(stat, playerPokemon);
+      const actualStat = enemyPokemon.getEffectiveStat(stat, { opponent: playerPokemon });
       expect(actualStat).toBe(expectedStat);
     }
   });
@@ -71,7 +71,7 @@ describe("Abilities - Unaware", () => {
         expectedStat = Math.floor(expectedStat * (2 / 3));
       }
 
-      const actualStat = playerPokemon.getEffectiveStat(stat, enemyPokemon);
+      const actualStat = playerPokemon.getEffectiveStat(stat, { opponent: enemyPokemon });
       expect(actualStat).toBe(expectedStat);
     }
   });

--- a/test/test-utils/matchers/to-have-effective-stat-matcher.ts
+++ b/test/test-utils/matchers/to-have-effective-stat-matcher.ts
@@ -46,7 +46,12 @@ export function toHaveEffectiveStatMatcher(
     };
   }
 
-  const actualValue = received.getEffectiveStat(stat, enemy, move, AbilityApplyMode.DEFAULT, isCritical);
+  const actualValue = received.getEffectiveStat(stat, {
+    opponent: enemy,
+    move,
+    abilityApplyMode: AbilityApplyMode.DEFAULT,
+    isCritical,
+  });
   const pass = actualValue === expectedValue;
 
   const pkmName = getPokemonNameWithAffix(received);

--- a/test/test-utils/matchers/to-have-effective-stat-matcher.ts
+++ b/test/test-utils/matchers/to-have-effective-stat-matcher.ts
@@ -1,5 +1,4 @@
 import { getPokemonNameWithAffix } from "#app/messages";
-import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { type EffectiveStat, Stat } from "#enums/stat";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
@@ -49,7 +48,6 @@ export function toHaveEffectiveStatMatcher(
   const actualValue = received.getEffectiveStat(stat, {
     opponent: enemy,
     move,
-    abilityApplyMode: AbilityApplyMode.DEFAULT,
     isCritical,
   });
   const pass = actualValue === expectedValue;


### PR DESCRIPTION
## What are the changes the user will see?
Quark Drive and Protosynthesis now ignore abilities when calculating the highest stat and are no longer marked as "partial".

## Why am I making these changes?
No more `.getEffectiveStat(stat, undefined, undefined, ...)`.

## What are the changes from a developer perspective?
The optional parameters of `Pokemon#getEffectiveStat` are now passed via object.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?