### PR TITLE
[Dev] Use Biome for unused imports rule

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -49,15 +49,14 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true, // see https://biomejs.dev/linter/rules/#recommended-rules
+      "recommended": true, // see https://biomejs.dev/linter/javascript/rules/#recommended-rules and https://biomejs.dev/linter/css/rules/#recommended-rules
       "correctness": {
         "noUndeclaredVariables": "off", // handled by TypeScript
         "noUnusedVariables": "error",
         "noSwitchDeclarations": "error",
         "noVoidTypeReturn": "warn", // TODO: Refactor and make this an error
         "noUnusedImports": {
-          // TODO: replace the ESLint rule with this and swap the suppression comments
-          "level": "off",
+          "level": "error",
           "fix": "safe"
         },
         "noUnusedFunctionParameters": "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,15 +22,6 @@ export default tseslint.config(
     },
     rules: {
       "no-undef": "off", // Disables the rule that disallows the use of undeclared variables (TypeScript handles this)
-      "@typescript-eslint/no-unused-vars": [
-        // TODO: Now that Biome is updated to 2.0, swap over this rule handling to Biome
-        "error",
-        {
-          args: "all", // Disallows unused variables
-          ignoreRestSiblings: true, // Allows unused variables that are part of a rest property in object destructuring. Useful for excluding certain properties from an object while using the others.
-          argsIgnorePattern: "^_", // Allows unused variables that start with an underscore
-        },
-      ],
       "@stylistic/ts/semi": ["error", "always"], // Requires semicolons for TypeScript-specific syntax
       semi: "off", // Disables the general semi rule for TypeScript files
       "no-extra-semi": "error", // Disallows unnecessary semicolons for TypeScript-specific syntax
@@ -75,15 +66,6 @@ export default tseslint.config(
     rules: {
       indent: ["error", 2, { SwitchCase: 1 }], // Enforces a 2-space indentation, enforces indentation of `case ...:` statements
       "no-undef": "off", // Disables the rule that disallows the use of undeclared variables (TypeScript handles this)
-      "@typescript-eslint/no-unused-vars": [
-        // Handled by ESLint for imports until Biome 2.0
-        "error",
-        {
-          args: "all", // Disallows unused variables
-          ignoreRestSiblings: true, // Allows unused variables that are part of a rest property in object destructuring. Useful for excluding certain properties from an object while using the others.
-          argsIgnorePattern: "^_", // Allows unused variables that start with an underscore
-        },
-      ],
       "eol-last": ["error", "always"], // Enforces at least one newline at the end of files
       "@stylistic/ts/semi": ["error", "always"], // Requires semicolons for TypeScript-specific syntax
       semi: "off", // Disables the general semi rule for TypeScript files

--- a/src/@types/ability-filter-options.ts
+++ b/src/@types/ability-filter-options.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { PokemonWaveData } from "#types/pokemon-wave-data";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 export interface AbilityFilterOptions {

--- a/src/@types/constructor.ts
+++ b/src/@types/constructor.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { AbstractConstructor } from "#types/abstract-constructor";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 /**

--- a/src/@types/language.ts
+++ b/src/@types/language.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { LoadingScene } from "#app/loading-scene";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 export type LanguageEvent = "language/change";

--- a/src/@types/pokemon-summon-data.ts
+++ b/src/@types/pokemon-summon-data.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports
 
 import type { BattlerTag } from "#battler-tags/battler-tag";

--- a/src/@types/timed-event.ts
+++ b/src/@types/timed-event.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { SupportedLanguage } from "#types/language";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 export interface EventBanner {

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -1,8 +1,6 @@
-// -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { BattleAnim } from "#animations/battle-anims";
-/* eslint-enable @typescript-eslint/no-unused-vars */
-// -- end tsdoc imports --
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 import type BattleScene from "#app/battle-scene";
 import type { Variant } from "#data/variant";

--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Ability } from "#abilities/ability";
 import type { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-effect-ab-attr";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { AbilityId } from "#enums/ability-id";

--- a/src/constants/arena-tag-constants.ts
+++ b/src/constants/arena-tag-constants.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { ElementalType } from "#enums/elemental-type";
 import type { Move } from "#moves/move";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { ArenaTagType } from "#enums/arena-tag-type";

--- a/src/constants/battler-tag-constants.ts
+++ b/src/constants/battler-tag-constants.ts
@@ -1,5 +1,5 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CritBoostTag } from "#battler-tags/crit-boost-tag";
 import type { DamagingTrapTag } from "#battler-tags/damaging-trap-tag";
 import type { ExposedTag } from "#battler-tags/exposed-tag";
@@ -14,7 +14,7 @@ import type { SemiInvulnerableTag } from "#battler-tags/semi-invulnerable-tag";
 import type { TrappedTag } from "#battler-tags/trapped-tag";
 import type { TypeBoostTag } from "#battler-tags/type-boost-tag";
 import type { ElementalType } from "#enums/elemental-type";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { BattlerTagType } from "#enums/battler-tag-type";

--- a/src/constants/friendship-constants.ts
+++ b/src/constants/friendship-constants.ts
@@ -1,11 +1,11 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { PokemonLevelIncrementModifier } from "#modifier/modifier";
 import type { FaintPhase } from "#phases/faint-phase";
 import type { LevelUpPhase } from "#phases/level-up-phase";
 import type { NextEncounterPhase } from "#phases/next-encounter-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 /** Each wave, all unfainted Pokemon gain this much happiness. Used in {@linkcode NextEncounterPhase} */

--- a/src/constants/game-constants.ts
+++ b/src/constants/game-constants.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { BattleStat } from "#enums/stat";
 import type { SystemSaveData } from "#types/system-data";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { SpeciesFormKey } from "#enums/species-form-key";

--- a/src/data/abilities/ab-attrs/ab-attr.ts
+++ b/src/data/abilities/ab-attrs/ab-attr.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { ShowAbilityPhase } from "#phases/show-ability-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { Ability } from "#abilities/ability";

--- a/src/data/abilities/ab-attrs/damage-boost-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/damage-boost-ab-attr.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { PreAttackAbAttr } from "#abilities/pre-attack-ab-attr";

--- a/src/data/abilities/ab-attrs/reflect-moves-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/reflect-moves-ab-attr.ts
@@ -1,7 +1,9 @@
 // -- start tsdoc imports
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { MovePhase } from "#phases/move-phase";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports
+
 import { PreDefendAbAttr } from "#abilities/pre-defend-ab-attr";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { AbAttrFlag } from "#enums/ab-attr-flag";

--- a/src/data/abilities/ab-attrs/stab-boost-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/stab-boost-ab-attr.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { AbilityId } from "#enums/ability-id";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { AbAttr } from "#abilities/ab-attr";

--- a/src/data/animations/anim-config.ts
+++ b/src/data/animations/anim-config.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { BattleAnim } from "#animations/battle-anims";

--- a/src/data/battler-tags/crit-boost-tag.ts
+++ b/src/data/battler-tags/crit-boost-tag.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CRIT_BOOST_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import type { ElementalType } from "#enums/elemental-type";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/damaging-trap-tag.ts
+++ b/src/data/battler-tags/damaging-trap-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { DAMAGING_TRAPPED_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";

--- a/src/data/battler-tags/disabled-tag.ts
+++ b/src/data/battler-tags/disabled-tag.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { AbilityId } from "#enums/ability-id";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/exposed-tag.ts
+++ b/src/data/battler-tags/exposed-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { EXPOSED_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { BattlerTag } from "#battler-tags/battler-tag";

--- a/src/data/battler-tags/floating-tag.ts
+++ b/src/data/battler-tags/floating-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TYPE_IMMUNE_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/highest-stat-boost-tag.ts
+++ b/src/data/battler-tags/highest-stat-boost-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { HIGHEST_STAT_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/move-lock-tag.ts
+++ b/src/data/battler-tags/move-lock-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { MOVE_LOCK_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/move-restriction-battler-tag.ts
+++ b/src/data/battler-tags/move-restriction-battler-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { RESTRICTING_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/protected-tag.ts
+++ b/src/data/battler-tags/protected-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { PROTECTION_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { CommonBattleAnim } from "#animations/common-battle-anim";

--- a/src/data/battler-tags/removed-type-tag.ts
+++ b/src/data/battler-tags/removed-type-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { REMOVE_TYPE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { BattlerTag } from "#battler-tags/battler-tag";

--- a/src/data/battler-tags/semi-invulnerable-tag.ts
+++ b/src/data/battler-tags/semi-invulnerable-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { SEMI_INVULNERABLE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/telekinesis-tag.ts
+++ b/src/data/battler-tags/telekinesis-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { FloatingTag } from "#battler-tags/floating-tag";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/battler-tags/type-boost-tag.ts
+++ b/src/data/battler-tags/type-boost-tag.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { BattlerTag } from "#battler-tags/battler-tag";

--- a/src/data/biome.ts
+++ b/src/data/biome.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Arena } from "#field/arena";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { BiomeId } from "#enums/biome-id";

--- a/src/data/moves/move-attrs/call-move-attr.ts
+++ b/src/data/moves/move-attrs/call-move-attr.ts
@@ -1,10 +1,10 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CopycatAttr } from "#moves/copycat-attr";
 import type { MetronomeAttr } from "#moves/metronome-attr";
 import type { NaturePowerAttr } from "#moves/nature-power-attr";
 import type { RandomMovesetMoveAttr } from "#moves/random-moveset-move-attr";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/moves/move-attrs/variable-def-attr.ts
+++ b/src/data/moves/move-attrs/variable-def-attr.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Stat } from "#enums/stat";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { Pokemon } from "#field/pokemon";

--- a/src/data/moves/move-attrs/weather-instant-charge-attr.ts
+++ b/src/data/moves/move-attrs/weather-instant-charge-attr.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { ChargingMove } from "#moves/move";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { IMysteryEncounter } from "#mystery-encounters/mystery-encounter";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type Battle from "#app/battle";

--- a/src/data/pokemon-form-level-moves.ts
+++ b/src/data/pokemon-form-level-moves.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { SpeciesFormChange } from "#data/pokemon-forms";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { PokemonSpeciesFormLevelMoves } from "#data/pokemon-level-moves";

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -1,9 +1,9 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { FORM_CHANGE_MOVE } from "#data/pokemon-level-moves";
 import type { FormChangePhase } from "#phases/form-change-phase";
 import type { QuietFormChangePhase } from "#phases/quiet-form-change-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/enums/ab-attr-flag.ts
+++ b/src/enums/ab-attr-flag.ts
@@ -1,5 +1,5 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { AbAttr } from "#abilities/ab-attr";
 import type { AddSecondStrikeAbAttr } from "#abilities/add-second-strike-ab-attr";
 import type { AlliedFieldDamageReductionAbAttr } from "#abilities/allied-field-damage-reduction-ab-attr";
@@ -108,7 +108,7 @@ import type { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-
 import type { WeightMultiplierAbAttr } from "#abilities/weight-multiplier-ab-attr";
 import type { WonderSkinAbAttr } from "#abilities/wonder-skin-ab-attr";
 import type { BadDreamsAbAttr } from "#abilities/bad-dreams-ab-attr";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 export const AbAttrFlag = {

--- a/src/enums/arena-tag-relative-side.ts
+++ b/src/enums/arena-tag-relative-side.ts
@@ -1,6 +1,6 @@
-// tsdoc imports
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 /**
  * Denotes which side of the field an effect applies,

--- a/src/enums/battle-command.ts
+++ b/src/enums/battle-command.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CommandPhase } from "#phases/command-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 /**

--- a/src/enums/battle-scene-event-type.ts
+++ b/src/enums/battle-scene-event-type.ts
@@ -1,5 +1,5 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type BattleScene from "#app/battle-scene";
 import type { Arena } from "#field/arena";
 import type {
@@ -11,7 +11,7 @@ import type {
   TurnEndEvent,
   TurnInitEvent,
 } from "#events/battle-scene";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 /** Alias for all {@linkcode BattleScene} events */

--- a/src/enums/challenge-type.ts
+++ b/src/enums/challenge-type.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Challenge } from "#data/challenge";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 /**

--- a/src/enums/egg-event-type.ts
+++ b/src/enums/egg-event-type.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { MoveUsedEvent } from "#events/battle-scene";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 export const EggEventType = {

--- a/src/enums/event-modifier-type.ts
+++ b/src/enums/event-modifier-type.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TimedEvent } from "#types/timed-event";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 /**

--- a/src/enums/item-rarity.ts
+++ b/src/enums/item-rarity.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { ModifierTier } from "#enums/modifier-tier";
 import type { Item } from "#types/item";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 /**

--- a/src/enums/move-flags.ts
+++ b/src/enums/move-flags.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { AbilityId } from "#enums/ability-id";
 import type { MoveId } from "#enums/move-id";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 export enum MoveFlags {

--- a/src/enums/phase-id.ts
+++ b/src/enums/phase-id.ts
@@ -1,5 +1,5 @@
 // -- start tsdocs imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Phase } from "#app/phase";
 import type { AttemptCapturePhase } from "#phases/attempt-capture-phase";
 import type { AttemptRunPhase } from "#phases/attempt-run-phase";
@@ -90,7 +90,7 @@ import type { UnavailablePhase } from "#phases/unavailable-phase";
 import type { UnlockPhase } from "#phases/unlock-phase";
 import type { VictoryPhase } from "#phases/victory-phase";
 import type { WeatherEffectPhase } from "#phases/weather-effect-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 export enum PhaseId {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1,9 +1,9 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type Battle from "#app/battle";
 import type BattleScene from "#app/battle-scene";
 import type { FaintPhase } from "#phases/faint-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { AbAttr } from "#abilities/ab-attr";

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -1,7 +1,6 @@
-// -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { UiWindowStyle } from "#enums/ui-window-style";
-// -- end tsdoc imports --
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 import { api } from "#api/api";
 import CacheBustedLoaderPlugin from "#app/plugins/cache-busted-loader-plugin";

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1614,13 +1614,13 @@ let modifierPoolThresholds = {};
 let ignoredPoolIndexes = {};
 
 let dailyStarterModifierPoolThresholds = {};
-let _ignoredDailyStarterPoolIndexes = {}; // eslint-disable-line @typescript-eslint/no-unused-vars
+let _ignoredDailyStarterPoolIndexes = {};
 
 let enemyModifierPoolThresholds = {};
-let _enemyIgnoredPoolIndexes = {}; // eslint-disable-line @typescript-eslint/no-unused-vars
+let _enemyIgnoredPoolIndexes = {};
 
 let enemyBuffModifierPoolThresholds = {};
-let _enemyBuffIgnoredPoolIndexes = {}; // eslint-disable-line @typescript-eslint/no-unused-vars
+let _enemyBuffIgnoredPoolIndexes = {};
 
 const tierWeights = [768 / 1024, 195 / 1024, 48 / 1024, 12 / 1024, 1 / 1024];
 /**

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { PokeballCounts } from "#app/battle-scene";
 import { Variant } from "#data/variant";
 import { AbilityId } from "#enums/ability-id";
@@ -28,8 +27,7 @@ import type { ModifierOverride } from "#modifier/modifier-type";
 
 /**
  * This comment block exists to prevent IDEs from automatically removing unused imports
- * {@linkcode BerryType}, {@linkcode ElementalType}, {@linkcode EvolutionItem}
- * {@linkcode FormChangeItem}, {@linkcode Stat}, {@linkcode Arena}
+ * {@linkcode BerryType}, {@linkcode EvolutionItem} {@linkcode FormChangeItem}, {@linkcode Stat}
  */
 /**
  * Overrides that are used to test different in game situations

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -1,9 +1,9 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { ChargeAnim } from "#enums/charge-anim";
 import type { MoveEffectPhase } from "#phases/move-effect-phase";
 import type { VictoryPhase } from "#phases/victory-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { MoveChargeAnim } from "#animations/move-charge-anim";

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { NewBiomeEncounterPhase } from "#phases/new-biome-encounter-phase";
 import type { NextEncounterPhase } from "#phases/next-encounter-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";

--- a/src/phases/enemy-command-phase.ts
+++ b/src/phases/enemy-command-phase.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { FormChangePhase } from "#phases/form-change-phase";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { AnySound } from "#app/audio-manager";

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -1,9 +1,9 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import type { GameOverPhase } from "#phases/game-over-phase";
 import type { MovePhase } from "#phases/move-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { EvolutionPhase } from "#phases/evolution-phase";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/mystery-encounter-phases/battle-phase.ts
+++ b/src/phases/mystery-encounter-phases/battle-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { PostSummonPhase } from "#phases/post-summon-phase";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/mystery-encounter-phases/battle-start-cleanup-phase.ts
+++ b/src/phases/mystery-encounter-phases/battle-start-cleanup-phase.ts
@@ -1,9 +1,9 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { handleMysteryEncounterBattleStartEffects } from "#mystery-encounters/encounter-phase-utils";
 import type MysteryEncounter from "#mystery-encounters/mystery-encounter";
 import type { TurnEndPhase } from "#phases/turn-end-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type MysteryEncounterDialogue from "#mystery-encounters/mystery-encounter-dialogue";
 import type { OptionTextDisplay } from "#mystery-encounters/mystery-encounter-dialogue";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/mystery-encounter-phases/option-selected-phase.ts
+++ b/src/phases/mystery-encounter-phases/option-selected-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type MysteryEncounterOption from "#mystery-encounters/mystery-encounter-option";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type MysteryEncounterOption from "#mystery-encounters/mystery-encounter-option";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/mystery-encounter-phases/rewards-phase.ts
+++ b/src/phases/mystery-encounter-phases/rewards-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type MysteryEncounter from "#mystery-encounters/mystery-encounter";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/post-action-phase.ts
+++ b/src/phases/post-action-phase.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TurnCommand } from "#app/turn-command-manager";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { globalScene } from "#app/global-scene";

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { GameOverPhase } from "#phases/game-over-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports--
 
 import { globalScene } from "#app/global-scene";

--- a/src/scene-base.ts
+++ b/src/scene-base.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import { UiTheme } from "#enums/ui-theme";
 import { UiWindowStyle } from "#enums/ui-window-style";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { ImagesFolder } from "#enums/images-folder";

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Phase } from "#app/phase";
 import type { MovePhase } from "#phases/move-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";

--- a/src/ui/interfaces/confirm-menu-config.ts
+++ b/src/ui/interfaces/confirm-menu-config.ts
@@ -1,7 +1,9 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { UiMode } from "#enums/ui-mode";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
+
 import type { OptionMenuSettings } from "#ui/option-select-config";
 
 /**

--- a/src/ui/interfaces/option-select-config.ts
+++ b/src/ui/interfaces/option-select-config.ts
@@ -1,7 +1,9 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { UiMode } from "#enums/ui-mode";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
+
 import type { TextStyle } from "#enums/text-style";
 
 /**

--- a/src/ui/interfaces/option-select-ui-item.ts
+++ b/src/ui/interfaces/option-select-ui-item.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import { BaseOptionSelectUiHandler } from "#ui/base-option-select-ui-handler";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { OptionSelectItem } from "#ui/option-select-config";

--- a/src/ui/settings/settings-ui-items.ts
+++ b/src/ui/settings/settings-ui-items.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { GeneralSettingsUiHandler } from "#ui/general-settings-ui-handler";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { GAME_SPEEDS } from "#constants/app-constants";

--- a/src/utils/anim-utils.ts
+++ b/src/utils/anim-utils.ts
@@ -1,8 +1,8 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { initCommonAnims } from "#init/init-common-anims";
 import type { initEncounterAnims } from "#init/init-encounter-anims";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { LegacyAnimConfig } from "#animations/anim-config";

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { initGameSpeed } from "#system/game-speed";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { MAX_STAT_STAGE, MIN_STAT_STAGE } from "#constants/game-constants";

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { AbilityId } from "#enums/ability-id";

--- a/test/abilities/unburden.test.ts
+++ b/test/abilities/unburden.test.ts
@@ -231,7 +231,6 @@ describe("Abilities - Unburden", () => {
     game.override.battleType("double").ability(AbilityId.NONE).moveset(MoveId.FALSE_SWIPE); // Disable ability override so that we can properly set abilities below
     await game.classicMode.startBattle(SpeciesId.TREECKO, SpeciesId.MEOWTH, SpeciesId.WEEZING);
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [treecko, _meowth, weezing] = game.scene.getPlayerParty();
     treecko.abilityIndex = 2; // Treecko has Unburden
     weezing.abilityIndex = 1; // Weezing has Neutralizing Gas

--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -1,9 +1,9 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CommandPhase } from "#phases/command-phase";
 import type { TurnEndPhase } from "#phases/turn-end-phase";
 import type { TurnStartPhase } from "#phases/turn-start-phase";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { updateUserInfo } from "#app/account";

--- a/test/test-utils/helpers/field-helper.ts
+++ b/test/test-utils/helpers/field-helper.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { globalScene } from "#app/global-scene";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { Ability } from "#abilities/ability";

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -1,9 +1,9 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { NewArenaEvent } from "#events/battle-scene";
 import type { Arena } from "#field/arena";
 import type { GameManager } from "#test/test-utils/game-manager";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import type { BattleStyle } from "#app/overrides";

--- a/test/test-utils/matchers/to-have-ability-applied-matcher.ts
+++ b/test/test-utils/matchers/to-have-ability-applied-matcher.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { getPokemonNameWithAffix } from "#app/messages";

--- a/test/test-utils/matchers/to-have-battler-tag-type-matcher.ts
+++ b/test/test-utils/matchers/to-have-battler-tag-type-matcher.ts
@@ -1,7 +1,7 @@
 // -- start tsdoc imports --
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
-/* eslint-enable @typescript-eslint/no-unused-vars */
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { getPokemonNameWithAffix } from "#app/messages";

--- a/test/test-utils/matchers/to-have-status-effect-matcher.ts
+++ b/test/test-utils/matchers/to-have-status-effect-matcher.ts
@@ -1,6 +1,7 @@
 // -- start tsdoc imports --
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 // -- end tsdoc imports --
 
 import { getPokemonNameWithAffix } from "#app/messages";


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Reducing reliance on ESLint.

## What are the changes from a developer perspective?
When adding imports for TSDocs, we now use the following:
```ts
/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
import ...;
/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
```
instead of:
```ts
/* eslint-disable @typescript-eslint/no-unused-vars */
import ...;
/* eslint-enable @typescript-eslint/no-unused-vars */
```

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?