### PR TITLE
Review suggestions for PR1260

### DIFF
--- a/src/field/pokemon-move.ts
+++ b/src/field/pokemon-move.ts
@@ -102,10 +102,6 @@ export class PokemonMove {
     return 1 - this.ppUsed / this.getMovePp();
   }
 
-  getName(): string {
-    return this.getMove().name;
-  }
-
   /**
    * Copies an existing move or creates a valid PokemonMove object from json representing one
    * @param source The data for the {@linkcode PokemonMove | move} to copy

--- a/test/moves/powder.test.ts
+++ b/test/moves/powder.test.ts
@@ -5,7 +5,6 @@ import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-import { PokemonMove } from "#field/pokemon-move";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -43,7 +42,7 @@ describe("Moves - Powder", () => {
     await game.classicMode.startBattle(SpeciesId.CHARIZARD);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
-    enemyPokemon.moveset = [new PokemonMove(enemyPokemon, MoveId.EMBER)];
+    game.move.changeMoveset(enemyPokemon, MoveId.EMBER);
 
     game.move.select(MoveId.POWDER);
 

--- a/test/moves/sketch.test.ts
+++ b/test/moves/sketch.test.ts
@@ -5,7 +5,6 @@ import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-import { PokemonMove } from "#field/pokemon-move";
 import { MetronomeAttr } from "#moves/metronome-attr";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
@@ -40,10 +39,7 @@ describe("Moves - Sketch", () => {
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
     const playerPokemon = game.scene.getPlayerPokemon()!;
     // can't use normal moveset override because we need to check moveset changes
-    playerPokemon.moveset = [
-      new PokemonMove(playerPokemon, MoveId.SKETCH),
-      new PokemonMove(playerPokemon, MoveId.SKETCH),
-    ];
+    game.move.changeMoveset(playerPokemon, [MoveId.SKETCH, MoveId.SKETCH]);
 
     game.move.select(MoveId.SKETCH);
     await game.toEndOfTurn();
@@ -65,10 +61,7 @@ describe("Moves - Sketch", () => {
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
     const playerPokemon = game.scene.getPlayerPokemon()!;
     const enemyPokemon = game.scene.getEnemyPokemon()!;
-    playerPokemon.moveset = [
-      new PokemonMove(playerPokemon, MoveId.SKETCH),
-      new PokemonMove(playerPokemon, MoveId.GROWL),
-    ];
+    game.move.changeMoveset(playerPokemon, [MoveId.SKETCH, MoveId.GROWL]);
 
     game.move.select(MoveId.GROWL);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
@@ -95,7 +88,7 @@ describe("Moves - Sketch", () => {
     game.override.enemyMoveset([MoveId.METRONOME]);
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
     const playerPokemon = game.scene.getPlayerPokemon()!;
-    playerPokemon.moveset = [new PokemonMove(playerPokemon, MoveId.SKETCH)];
+    game.move.changeMoveset(playerPokemon, MoveId.SKETCH);
 
     // Opponent uses Metronome -> False Swipe, then player uses Sketch, which should sketch Metronome
     game.move.select(MoveId.SKETCH);

--- a/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -8,7 +8,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { PlayerPokemon } from "#field/player-pokemon";
-import { PokemonMove } from "#field/pokemon-move";
 import { AnOfferYouCantRefuseEncounter } from "#mystery-encounters/an-offer-you-cant-refuse-encounter";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -213,7 +212,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.AN_OFFER_YOU_CANT_REFUSE, [SpeciesId.ABRA]);
       const party = scene.getPlayerParty();
       const abra = party.find((pkm) => pkm.species.speciesId === SpeciesId.ABRA)!;
-      abra.moveset = [new PokemonMove(abra, MoveId.BEAT_UP)];
+      game.move.changeMoveset(abra, MoveId.BEAT_UP);
       const expBefore = abra.exp;
 
       await runMysteryEncounterToEnd(game, 2);

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -13,7 +13,6 @@ import { SpeciesId } from "#enums/species-id";
 import { TrainerType } from "#enums/trainer-type";
 import { UiMode } from "#enums/ui-mode";
 import type { Pokemon } from "#field/pokemon";
-import { PokemonMove } from "#field/pokemon-move";
 import * as InitMoveAnim from "#init/init-move-anim";
 import type { PokemonHeldItemModifier } from "#modifier/modifier";
 import type { PokemonHeldItemModifierType } from "#modifier/modifier-type";
@@ -170,18 +169,18 @@ describe("Clowning Around - Mystery Encounter", () => {
       [enemy1, enemy2].forEach((p) => expect(p).toBeDefined());
       expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
       expect(enemy1.species.speciesId).toBe(SpeciesId.MR_MIME);
-      expect(enemy1.moveset).toEqual([
-        new PokemonMove(enemy1, MoveId.TEETER_DANCE),
-        new PokemonMove(enemy1, MoveId.ALLY_SWITCH),
-        new PokemonMove(enemy1, MoveId.DAZZLING_GLEAM),
-        new PokemonMove(enemy1, MoveId.PSYCHIC),
+      expect(enemy1.moveset.map((m) => m.moveId)).toEqual([
+        MoveId.TEETER_DANCE,
+        MoveId.ALLY_SWITCH,
+        MoveId.DAZZLING_GLEAM,
+        MoveId.PSYCHIC,
       ]);
       expect(enemy2.species.speciesId).toBe(SpeciesId.BLACEPHALON);
-      expect(enemy2.moveset).toEqual([
-        new PokemonMove(enemy2, MoveId.TRICK),
-        new PokemonMove(enemy2, MoveId.HYPNOSIS),
-        new PokemonMove(enemy2, MoveId.SHADOW_BALL),
-        new PokemonMove(enemy2, MoveId.MIND_BLOWN),
+      expect(enemy2.moveset.map((m) => m.moveId)).toEqual([
+        MoveId.TRICK,
+        MoveId.HYPNOSIS,
+        MoveId.SHADOW_BALL,
+        MoveId.MIND_BLOWN,
       ]);
 
       // Should have used moves pre-battle
@@ -267,8 +266,8 @@ describe("Clowning Around - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, defaultParty);
 
       // Set some moves on party for attack type booster generation
-      const player = scene.getPlayerParty()[0];
-      player.moveset = [new PokemonMove(player, MoveId.TACKLE), new PokemonMove(player, MoveId.THIEF)];
+      const player = game.field.getPlayerPokemon();
+      game.move.changeMoveset(player, [MoveId.TACKLE, MoveId.THIEF]);
 
       // 2 Sitrus Berries on lead
       scene.modifiers = [];
@@ -355,9 +354,9 @@ describe("Clowning Around - Mystery Encounter", () => {
       const [player1, player2, player3] = scene.getPlayerParty();
 
       // Same type moves on lead
-      player1.moveset = [new PokemonMove(player1, MoveId.ICE_BEAM), new PokemonMove(player1, MoveId.SURF)];
+      game.move.changeMoveset(player1, [MoveId.ICE_BEAM, MoveId.SURF]);
       // Different type moves on second
-      player2.moveset = [new PokemonMove(player2, MoveId.GRASS_KNOT), new PokemonMove(player2, MoveId.ELECTRO_BALL)];
+      game.move.changeMoveset(player2, [MoveId.GRASS_KNOT, MoveId.ELECTRO_BALL]);
       // No moves on third
       player3.moveset = [];
       await runMysteryEncounterToEnd(game, 3);

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -6,7 +6,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { PokemonMove } from "#field/pokemon-move";
 import { DancingLessonsEncounter } from "#mystery-encounters/dancing-lessons-encounter";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -194,8 +193,8 @@ describe("Dancing Lessons - Mystery Encounter", () => {
     it("should add Oricorio to the party", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
       const partyCountBefore = scene.getPlayerParty().length;
-      const [player] = scene.getPlayerParty();
-      player.moveset = [new PokemonMove(player, MoveId.DRAGON_DANCE)];
+      const player = game.field.getPlayerPokemon();
+      game.move.changeMoveset(player, MoveId.DRAGON_DANCE);
       await runMysteryEncounterToEnd(game, 3, { partySlot: 1, optionNumber: 1 });
       const partyCountAfter = scene.getPlayerParty().length;
 
@@ -234,8 +233,8 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
-      const [player] = scene.getPlayerParty();
-      player.moveset = [new PokemonMove(player, MoveId.DRAGON_DANCE)];
+      const player = game.field.getPlayerPokemon();
+      game.move.changeMoveset(player, MoveId.DRAGON_DANCE);
       await runMysteryEncounterToEnd(game, 3, { partySlot: 1, optionNumber: 1 });
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -6,7 +6,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { PokemonMove } from "#field/pokemon-move";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import { FightOrFlightEncounter } from "#mystery-encounters/fight-or-flight-encounter";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -172,8 +171,8 @@ describe("Fight or Flight - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIGHT_OR_FLIGHT, defaultParty);
 
       // Mock moveset
-      const [player] = scene.getPlayerParty();
-      player.moveset = [new PokemonMove(player, MoveId.KNOCK_OFF)];
+      const player = game.field.getPlayerPokemon();
+      game.move.changeMoveset(player, MoveId.KNOCK_OFF);
       const item = game.scene.currentBattle.mysteryEncounter!.misc;
 
       await runMysteryEncounterToEnd(game, 2);

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -6,7 +6,6 @@ import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { PokemonMove } from "#field/pokemon-move";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
 import { PartTimerEncounter } from "#mystery-encounters/part-timer-encounter";
@@ -256,8 +255,8 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       await game.runToMysteryEncounter(MysteryEncounterType.PART_TIMER, defaultParty);
       // Mock moveset
-      const [player] = scene.getPlayerParty();
-      player.moveset = [new PokemonMove(player, MoveId.ATTRACT)];
+      const player = game.field.getPlayerPokemon();
+      game.move.changeMoveset(player, MoveId.ATTRACT);
       await runMysteryEncounterToEnd(game, 3);
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(2.5), true, false);

--- a/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -11,7 +11,6 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { Nature } from "#enums/nature";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { PokemonMove } from "#field/pokemon-move";
 import * as InitMoveAnim from "#init/init-move-anim";
 import { PokemonBaseStatTotalModifier } from "#modifier/modifier";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
@@ -193,7 +192,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.THE_STRONG_STUFF, defaultParty);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
-      const [enemy] = scene.getEnemyField();
+      const enemy = game.field.getEnemyPokemon();
       expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
       expect(enemy.species.speciesId).toBe(SpeciesId.SHUCKLE);
       expect(enemy.summonData.statStages).toEqual([0, 2, 0, 2, 0, 0, 0]);
@@ -204,11 +203,11 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       expect(shuckleItems.find((m) => m.isBerryModifier() && m.berryType === BerryType.GANLON)?.stackCount).toBe(1);
       expect(shuckleItems.find((m) => m.isBerryModifier() && m.berryType === BerryType.APICOT)?.stackCount).toBe(1);
       expect(shuckleItems.find((m) => m.isBerryModifier() && m.berryType === BerryType.LUM)?.stackCount).toBe(2);
-      expect(enemy.moveset).toEqual([
-        new PokemonMove(enemy, MoveId.INFESTATION),
-        new PokemonMove(enemy, MoveId.SALT_CURE),
-        new PokemonMove(enemy, MoveId.GASTRO_ACID),
-        new PokemonMove(enemy, MoveId.HEAL_ORDER),
+      expect(enemy.moveset.map((m) => m.moveId)).toEqual([
+        MoveId.INFESTATION,
+        MoveId.SALT_CURE,
+        MoveId.GASTRO_ACID,
+        MoveId.HEAL_ORDER,
       ]);
 
       // Should have used moves pre-battle

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -7,7 +7,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { PokemonMove } from "#field/pokemon-move";
 import * as InitMoveAnim from "#init/init-move-anim";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -168,14 +167,14 @@ describe("Trash to Treasure - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TRASH_TO_TREASURE, defaultParty);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
-      const [enemy] = scene.getEnemyField();
+      const enemy = game.field.getEnemyPokemon();
       expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
       expect(enemy.species.speciesId).toBe(SpeciesId.GARBODOR);
-      expect(enemy.moveset).toEqual([
-        new PokemonMove(enemy, MoveId.PAYBACK),
-        new PokemonMove(enemy, MoveId.GUNK_SHOT),
-        new PokemonMove(enemy, MoveId.STOMPING_TANTRUM),
-        new PokemonMove(enemy, MoveId.DRAIN_PUNCH),
+      expect(enemy.moveset.map((m) => m.moveId)).toEqual([
+        MoveId.PAYBACK,
+        MoveId.GUNK_SHOT,
+        MoveId.STOMPING_TANTRUM,
+        MoveId.DRAIN_PUNCH,
       ]);
 
       // Should have used moves pre-battle

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -9,7 +9,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
-import { PokemonMove } from "#field/pokemon-move";
 import type { BerryModifier } from "#modifier/modifier";
 import { modifierTypes } from "#modifier/modifier-types";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
@@ -270,8 +269,8 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
       await game.runToMysteryEncounter(MysteryEncounterType.UNCOMMON_BREED, defaultParty);
       // Mock moveset
-      const [player] = scene.getPlayerParty();
-      player.moveset = [new PokemonMove(player, MoveId.CHARM)];
+      const player = game.field.getPlayerPokemon();
+      game.move.changeMoveset(player, MoveId.CHARM);
       await runMysteryEncounterToEnd(game, 3);
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();


### PR DESCRIPTION
- Remove obsolete `PokemonMove#getName`

- Tests use `game.move.changeMoveset(pkmn, ...)`
instead of `pkmn.moveset = [...]`

- Tests use `expect(pkmn.moveset.map(m => m.moveId).toEqual([...])`
instead of `expect(pkmn.moveset).toEqual([new PokemonMove(...), ...])`

Note that you could instead do this:
```ts
expect(pkmn.moveset).toEqual([
  expect.objectContaining({moveId: MoveId.MOVE_NAME}),
  // ...
]);
```
but that makes the error message harder to interpret.

In the future we could add a custom `toHaveMoveset` matcher.