### PR TITLE
[AI-Rework] Re-implement Instant Tera commands

### DIFF
--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -312,16 +312,17 @@ export class EnemyPokemon extends Pokemon {
       }
     }
 
-    const nextMove = this.getNextMove();
+    const command = this.shouldTera() ? BattleCommand.TERA : BattleCommand.FIGHT;
+    const turnMove = this.getNextMove();
     console.log(
-      `${BattlerIndex[this.getBattlerIndex()]}: selecting ${MoveId[nextMove.move.id]} against ${nextMove.targets.map((i) => BattlerIndex[i])}`,
+      `${BattlerIndex[this.getBattlerIndex()]}: selecting ${MoveId[turnMove.move.id]} against ${turnMove.targets.map((i) => BattlerIndex[i])}`,
     );
 
     return {
       pokemon: this,
-      command: BattleCommand.FIGHT,
-      turnMove: nextMove,
-      targets: nextMove.targets,
+      command,
+      turnMove,
+      targets: turnMove.targets,
     };
   }
 
@@ -522,6 +523,16 @@ export class EnemyPokemon extends Pokemon {
       targets: [optTarget[0]],
       score: optTarget[1],
     };
+  }
+
+  /** @returns `true` if this Pokemon should Terastallize on its next action */
+  private shouldTera(): boolean {
+    if (this.isTerastallized) {
+      return false;
+    }
+
+    const { trainer } = globalScene.currentBattle;
+    return Overrides.FORCE_ENEMY_TERA_OVERRIDE || (!isNil(trainer) && trainer.shouldTera(this));
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?

Enemy Pokemon should once again be able to Terastallize on their first move action if configured to do so via their Trainer's config or the `FORCE_ENEMY_TERA` override

## Why am I making these changes?

Previous Tera command functionality was overwritten by changes from this branch. This is mainly meant to resolve conflicts and fix some tests.

## What are the changes from a developer perspective?

`EnemyPokemon.getNextMove` now has logic to differentiate from selecting a `TERA` command vs. a `FIGHT` command with help from a new `shouldTera` helper method.

## Screenshots/Videos

## How to test the changes?

`pnpm test:silent tera-blast`

> [!NOTE]
> Some tests are currently failing in the `ai-rework` branch. The remaining failing tests are to be addressed in #1219.

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [?] Are all unit tests still passing? (`pnpm test:silent`)
  - [?] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [?] Have I provided screenshots/videos of the changes (if applicable)?
  - [?] Have I made sure that any UI change works for both UI themes (dark and light)?
