### PR TITLE
[P2] Fix Disable reversing the target's move history on condition check

### DIFF
--- a/src/data/battler-tags/move-restriction-battler-tag.ts
+++ b/src/data/battler-tags/move-restriction-battler-tag.ts
@@ -90,9 +90,9 @@ export abstract class MoveRestrictionBattlerTag extends BattlerTag implements Re
    * @param pokemon {@linkcode Pokemon} to get the last valid move from
    * @returns the last valid move from the pokemon's move history
    */
-  public getLastValidMove(pokemon: Pokemon): Move | undefined {
+  protected getLastValidMove(pokemon: Pokemon): Move | undefined {
     const turnMove = pokemon
-      .getLastXMoves()
+      .getLastXMoves(-1)
       .find((m) => m.move.id !== MoveId.NONE && m.move.id !== MoveId.STRUGGLE && !m.virtual);
 
     return turnMove?.move;

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -402,8 +402,7 @@ export function initMoves() {
       .condition(
         (_user, target, _move) =>
           target
-            .getMoveHistory()
-            .reverse()
+            .getLastXMoves(-1)
             .find((m) => m.move.id !== MoveId.NONE && m.move.id !== MoveId.STRUGGLE && !m.virtual) !== undefined,
       )
       .ignoresSubstitute()

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3798,7 +3798,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (moveCount >= 0) {
       return moveHistory.slice(Math.max(moveHistory.length - moveCount, 0)).reverse();
     }
-    return moveHistory.slice(0).reverse();
+    return moveHistory.slice().reverse();
   }
 
   getMoveQueue(): TurnMove[] {

--- a/test/moves/disable.test.ts
+++ b/test/moves/disable.test.ts
@@ -28,56 +28,80 @@ describe("Moves - Disable", () => {
       .battleType("single")
       .ability(AbilityId.BALL_FETCH)
       .enemyAbility(AbilityId.BALL_FETCH)
-      .moveset([MoveId.DISABLE, MoveId.SPLASH])
+      .moveset([MoveId.DISABLE, MoveId.SPLASH, MoveId.CELEBRATE])
       .enemyMoveset(MoveId.SPLASH)
       .enemySpecies(SpeciesId.SHUCKLE);
   });
 
-  it("restricts moves", async () => {
-    await game.classicMode.startBattle(SpeciesId.PIKACHU);
+  it("should restrict the target's last used move, and only that move", async () => {
+    game.override.battleType("double");
 
-    const enemyMon = game.scene.getEnemyPokemon()!;
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
 
-    game.move.select(MoveId.DISABLE);
-    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+    game.move.select(MoveId.SPLASH, 0);
+    game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
 
-    expect(enemyMon.getMoveHistory()).toHaveLength(1);
-    expect(enemyMon.isMoveRestricted(MoveId.SPLASH)).toBe(true);
+    game.move.select(MoveId.CELEBRATE, 0);
+    game.move.select(MoveId.CELEBRATE, 1);
+    await game.toNextTurn();
+
+    game.move.select(MoveId.DISABLE, 0, BattlerIndex.PLAYER_2);
+    game.move.select(MoveId.SPLASH, 1);
+    await game.toEndOfTurn();
+
+    const [, player2] = game.scene.getPlayerField();
+
+    expect(player2.isMoveRestricted(MoveId.CELEBRATE)).toBeTruthy();
+    expect(player2.isMoveRestricted(MoveId.SPLASH)).toBeFalsy();
+  });
+
+  it("should restrict the move used by the target on the same turn", async () => {
+    await game.classicMode.startBattle(SpeciesId.PIKACHU);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.select(MoveId.DISABLE);
+    await game.toNextTurn();
+
+    expect(enemy.getMoveHistory()).toHaveLength(1);
+    expect(enemy.isMoveRestricted(MoveId.SPLASH)).toBeTruthy();
   });
 
   it("fails if enemy has no move history", async () => {
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
-    const playerMon = game.scene.getPlayerPokemon()!;
-    const enemyMon = game.scene.getEnemyPokemon()!;
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
 
-    game.move.select(MoveId.DISABLE);
     game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    game.move.select(MoveId.DISABLE);
     await game.toNextTurn();
 
-    expect(playerMon.getMoveHistory()[0]).toMatchObject<TurnMove>({
+    expect(player.getMoveHistory()[0]).toMatchObject<TurnMove>({
       move: expect.objectContaining({ id: MoveId.DISABLE }),
       result: MoveResult.FAIL,
       type: ElementalType.NORMAL,
       targets: [2],
     });
-    expect(enemyMon.isMoveRestricted(MoveId.SPLASH)).toBe(false);
+    expect(enemy.isMoveRestricted(MoveId.SPLASH)).toBeFalsy();
   }, 20000);
 
   it("causes STRUGGLE if all usable moves are disabled", async () => {
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
-    const enemyMon = game.scene.getEnemyPokemon()!;
+    const enemy = game.field.getEnemyPokemon();
 
-    game.move.select(MoveId.DISABLE);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.select(MoveId.DISABLE);
     await game.toNextTurn();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
-    const enemyHistory = enemyMon.getMoveHistory();
+    const enemyHistory = enemy.getMoveHistory();
     expect(enemyHistory).toHaveLength(2);
     expect(enemyHistory[0].move.id).toBe(MoveId.SPLASH);
     expect(enemyHistory[1].move.id).toBe(MoveId.STRUGGLE);
@@ -87,32 +111,32 @@ describe("Moves - Disable", () => {
     game.override.enemyMoveset([MoveId.STRUGGLE]);
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
-    const playerMon = game.scene.getPlayerPokemon()!;
-    const enemyMon = game.scene.getEnemyPokemon()!;
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
 
-    game.move.select(MoveId.DISABLE);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.select(MoveId.DISABLE);
     await game.toNextTurn();
 
-    expect(playerMon).toHaveMoveResult(MoveResult.FAIL);
-    expect(enemyMon).toHaveUsedMove(MoveId.STRUGGLE);
-    expect(enemyMon.isMoveRestricted(MoveId.STRUGGLE)).toBe(false);
+    expect(player).toHaveMoveResult(MoveResult.FAIL);
+    expect(enemy).toHaveUsedMove(MoveId.STRUGGLE);
+    expect(enemy.isMoveRestricted(MoveId.STRUGGLE)).toBeFalsy();
   }, 20000);
 
   it("interrupts target's move when target moves after", async () => {
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
-    const enemyMon = game.scene.getEnemyPokemon()!;
+    const enemy = game.field.getEnemyPokemon();
 
     game.move.select(MoveId.SPLASH);
     await game.toNextTurn();
 
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     // Both mons just used Splash last turn; now have player use Disable.
     game.move.select(MoveId.DISABLE);
-    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
     await game.toNextTurn();
 
-    const enemyHistory = enemyMon.getMoveHistory();
+    const enemyHistory = enemy.getMoveHistory();
     expect(enemyHistory).toHaveLength(2);
     expect(enemyHistory[0]).toMatchObject<TurnMove>({
       move: expect.objectContaining({ id: MoveId.SPLASH }),
@@ -123,17 +147,16 @@ describe("Moves - Disable", () => {
     expect(enemyHistory[1].result).toBe(MoveResult.FAIL);
   }, 20000);
 
-  it("disables NATURE POWER, not the move invoked by it", async () => {
+  it("should disable Nature Power, not the move invoked by it", async () => {
     game.override.enemyMoveset([MoveId.NATURE_POWER]);
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
-    const enemyMon = game.scene.getEnemyPokemon()!;
+    const enemy = game.field.getEnemyPokemon();
 
-    game.move.select(MoveId.DISABLE);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.select(MoveId.DISABLE);
     await game.toNextTurn();
 
-    expect(enemyMon.isMoveRestricted(MoveId.NATURE_POWER)).toBe(true);
-    expect(enemyMon.isMoveRestricted(enemyMon.getLastXMoves(2)[1].move.id)).toBe(false);
+    expect(enemy.isMoveRestricted(MoveId.NATURE_POWER)).toBeTruthy();
   }, 20000);
 });

--- a/test/moves/disable.test.ts
+++ b/test/moves/disable.test.ts
@@ -70,7 +70,7 @@ describe("Moves - Disable", () => {
     expect(enemy.isMoveRestricted(MoveId.SPLASH)).toBeTruthy();
   });
 
-  it("fails if enemy has no move history", async () => {
+  it("should fail if enemy has no move history", async () => {
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
     const player = game.field.getPlayerPokemon();
@@ -89,7 +89,7 @@ describe("Moves - Disable", () => {
     expect(enemy.isMoveRestricted(MoveId.SPLASH)).toBeFalsy();
   }, 20000);
 
-  it("causes STRUGGLE if all usable moves are disabled", async () => {
+  it("should force the target to use Struggle if all usable moves are disabled", async () => {
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
     const enemy = game.field.getEnemyPokemon();
@@ -107,7 +107,7 @@ describe("Moves - Disable", () => {
     expect(enemyHistory[1].move.id).toBe(MoveId.STRUGGLE);
   }, 20000);
 
-  it("cannot disable STRUGGLE", async () => {
+  it("should fail if the target's last move was Struggle", async () => {
     game.override.enemyMoveset([MoveId.STRUGGLE]);
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
@@ -123,7 +123,7 @@ describe("Moves - Disable", () => {
     expect(enemy.isMoveRestricted(MoveId.STRUGGLE)).toBeFalsy();
   }, 20000);
 
-  it("interrupts target's move when target moves after", async () => {
+  it("should interrupt the target's move if it matches the disabled move", async () => {
     await game.classicMode.startBattle(SpeciesId.PIKACHU);
 
     const enemy = game.field.getEnemyPokemon();

--- a/test/moves/disable.test.ts
+++ b/test/moves/disable.test.ts
@@ -38,7 +38,6 @@ describe("Moves - Disable", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
 
-    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     game.move.select(MoveId.SPLASH, 0);
     game.move.select(MoveId.SPLASH, 1);
     await game.toNextTurn();
@@ -47,6 +46,7 @@ describe("Moves - Disable", () => {
     game.move.select(MoveId.CELEBRATE, 1);
     await game.toNextTurn();
 
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
     game.move.select(MoveId.DISABLE, 0, BattlerIndex.PLAYER_2);
     game.move.select(MoveId.SPLASH, 1);
     await game.toEndOfTurn();


### PR DESCRIPTION
## What are the changes the user will see?

Disable should now restrict the correct move in most situations.

## Why am I making these changes?

Closes #612 

## What are the changes from a developer perspective?

- Disable's condition now uses `getLastXMoves(-1)` instead of reversing the target's move history in-place
- Updated `MoveRestrictionBattlerTag.getLastValidMove`'s visibility and access to move history (it could only evaluate the most recent move)
- Updated `disable.test.ts` with a new test + style changes

## Screenshots/Videos



## How to test the changes?

`pnpm test disable`

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (dark and light)?
