### PR TITLE
[P2] Fix instant-charged attacks checking status, etc. twice

### DIFF
--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -75,7 +75,7 @@ export class MoveChargePhase extends HitCheckPhase {
           pokemon: user,
           targets: this.targets,
           move: this.move,
-          followUp: false,
+          followUp: true,
           when: "eager",
         });
       } else {


### PR DESCRIPTION
## What are the changes the user will see?

Two-turn moves with "instant charge" conditions (e.g. Solar Beam) no longer perform checks for status effects like paralysis, non-volatile status effects like confusion, and some other things when said conditions are met.

## Why am I making these changes?

Closes #592 

## What are the changes from a developer perspective?

The attack phase of instant-charge moves during a one-turn execution is now considered a "follow-up" move. With this change, the following checks are ignored within `MovePhase`:
- All non-volatile status effect checks (the only relevant effect in this case is Paralysis)
- All effects implemented via a `MOVE` battler tag lapse, including:
  - Confusion
  - Infatuation
  - Truant (i.e. a Pokemon with Truant will now be able to use Electro Shot, etc. as long as it can charge instantly)
- Irrelevant / unreachable effects:
  - Imprison's move-cancelling effect
  - The effects of other Pokemon's Dancer ability (none of the instant-charge moves are dance moves)

## Screenshots/Videos

## How to test the changes?

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [?] Have I provided screenshots/videos of the changes (if applicable)?
  - [?] Have I made sure that any UI change works for both UI themes (dark and light)?
