### PR TITLE
[Refactor] Remove `PhaseManager.queueMovePhase`

### DIFF
--- a/src/data/abilities/ab-attrs/post-dancing-move-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-dancing-move-ab-attr.ts
@@ -24,24 +24,16 @@ export class PostDancingMoveAbAttr extends PostMoveUsedAbAttr {
       if (!simulated) {
         if (move.getMove().isSelfStatusMove()) {
           // If the move is a SelfStatusMove (ie. Swords Dance), the Dancer should replicate it on itself
-          globalScene.phaseManager.queueMovePhase({
-            pokemon,
-            targets: [pokemon.getBattlerIndex()],
-            move,
+          globalScene.phaseManager.createAndUnshiftPhase("MovePhase", pokemon, [pokemon.getBattlerIndex()], move, {
             followUp: true,
             ignorePp: true,
-            when: "eager",
           });
         } else {
           // Otherwise, the Dancer must replicate the move on the source of the Dance
           const target = this.getTarget(pokemon, source, targets);
-          globalScene.phaseManager.queueMovePhase({
-            pokemon,
-            targets: target,
-            move,
+          globalScene.phaseManager.createAndUnshiftPhase("MovePhase", pokemon, target, move, {
             followUp: true,
             ignorePp: true,
-            when: "eager",
           });
         }
       }

--- a/src/data/moves/move-attrs/call-move-attr.ts
+++ b/src/data/moves/move-attrs/call-move-attr.ts
@@ -47,13 +47,9 @@ export abstract class CallMoveAttr extends OverrideMoveEffectAttr {
 
     user.getMoveQueue().push({ move: move, targets, virtual: true, ignorePP: true, type: user.getMoveType(move) });
     globalScene.phaseManager.createAndUnshiftPhase("LoadMoveAnimPhase", move.id);
-    globalScene.phaseManager.queueMovePhase({
-      pokemon: user,
-      targets,
-      move: move.id,
+    globalScene.phaseManager.createAndUnshiftPhase("MovePhase", user, targets, move.id, {
       followUp: true,
       ignorePp: true,
-      when: "eager",
     });
 
     overridden.value = true;

--- a/src/data/moves/move-attrs/repeat-move-attr.ts
+++ b/src/data/moves/move-attrs/repeat-move-attr.ts
@@ -34,12 +34,7 @@ export class RepeatMoveAttr extends MoveEffectAttr {
     target
       .getMoveQueue()
       .unshift({ move: lastMove.move, targets: moveTargets, ignorePP: false, type: target.getMoveType(lastMove.move) });
-    globalScene.phaseManager.queueMovePhase({
-      pokemon: target,
-      targets: moveTargets,
-      move: movesetMove,
-      when: "eager",
-    });
+    globalScene.phaseManager.createAndUnshiftPhase("MovePhase", target, moveTargets, movesetMove);
     return true;
   }
 

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -969,13 +969,10 @@ export function handleMysteryEncounterBattleStartEffects() {
       } else {
         source = globalScene.getEnemyField()[0];
       }
-      globalScene.phaseManager.queueMovePhase({
-        pokemon: source,
-        targets: effect.targets,
-        move: effect.move,
-        followUp: effect.followUp,
-        ignorePp: effect.ignorePp,
-        when: "defer",
+      const { targets, move, followUp, ignorePp } = effect;
+      globalScene.phaseManager.createAndPushPhase("MovePhase", source, targets, move, {
+        followUp,
+        ignorePp,
       });
     });
 

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -1,10 +1,8 @@
 import type { Phase } from "#app/phase";
 import type { DestinyBondTag } from "#battler-tags/destiny-bond-tag";
 import type { GrudgeTag } from "#battler-tags/grudge-tag";
-import type { BattlerIndex, FieldBattlerIndex } from "#enums/battler-index";
-import type { MoveId } from "#enums/move-id";
+import type { FieldBattlerIndex } from "#enums/battler-index";
 import type { Pokemon } from "#field/pokemon";
-import type { PokemonMove } from "#field/pokemon-move";
 import { AttemptCapturePhase } from "#phases/attempt-capture-phase";
 import { AttemptRunPhase } from "#phases/attempt-run-phase";
 import { BattleEndPhase } from "#phases/battle-end-phase";
@@ -195,19 +193,6 @@ const PHASES = {
 } as const;
 
 export type PhaseConstructorMap = typeof PHASES;
-
-interface UseMoveInit {
-  pokemon: Pokemon;
-  targets: BattlerIndex[];
-  move: PokemonMove | MoveId;
-  /** Whether to add the {@linkcode MovePhase} to the front of the phase queue or defer it. */
-  when: "eager" | "defer" | "before" | "after";
-  targetPhaseKey?: PhaseKey;
-  followUp?: boolean;
-  ignorePp?: boolean;
-  reflected?: boolean;
-  snatched?: boolean;
-}
 
 interface GameOverInit {
   isVictory?: boolean;
@@ -626,46 +611,6 @@ export class PhaseManager {
   ): void {
     this.setPhaseQueueSplice();
     this.createAndUnshiftPhase("FaintPhase", battlerIndex, preventEndure, destinyTag, grudgeTag, source);
-  }
-
-  public queueMovePhase({
-    pokemon,
-    targets,
-    move,
-    followUp = false,
-    ignorePp = false,
-    reflected = false,
-    snatched = false,
-    when,
-    targetPhaseKey,
-  }: UseMoveInit) {
-    const builderParams = ["MovePhase", pokemon, targets, move, followUp, ignorePp, reflected, snatched] as const;
-
-    const validateTargetPhaseKey = () => {
-      if (!targetPhaseKey) {
-        throw new Error("targetPhaseKey is required for useMove.when === 'before' or 'after'");
-      }
-      return true;
-    };
-
-    switch (when) {
-      case "eager":
-        this.createAndUnshiftPhase(...builderParams);
-        break;
-      case "defer":
-        this.createAndPushPhase(...builderParams);
-        break;
-      case "before":
-        validateTargetPhaseKey();
-        this.createAndPrependPhase(targetPhaseKey!, ...builderParams);
-        break;
-      case "after":
-        validateTargetPhaseKey();
-        this.createAndAppendPhase(targetPhaseKey!, ...builderParams);
-        break;
-      default:
-        throw new Error(`Unknown useMove.when: ${when}`);
-    }
   }
 
   /**

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -586,8 +586,6 @@ export class PhaseManager {
 
   // #region Phase-Specific Utils
 
-  /**  @todo Are these utils still necessary? */
-
   /**
    * Unshifts a new {@linkcode FaintPhase} for the given {@linkcode BattlerIndex} to faint.
    *

--- a/src/phases/move-charge-phase.ts
+++ b/src/phases/move-charge-phase.ts
@@ -71,12 +71,8 @@ export class MoveChargePhase extends HitCheckPhase {
 
       if (instantCharge.value) {
         // queue a new MovePhase for this move's attack phase
-        globalScene.phaseManager.queueMovePhase({
-          pokemon: user,
-          targets: this.targets,
-          move: this.move,
+        globalScene.phaseManager.createAndUnshiftPhase("MovePhase", user, this.targets, this.move, {
           followUp: true,
-          when: "eager",
         });
       } else {
         user.getMoveQueue().push({ move, targets: this.targets, type: user.getMoveType(move) });

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -86,9 +86,12 @@ interface MovePhaseOptions {
 export class MovePhase extends BattlePhase {
   public override readonly phaseName = "MovePhase";
 
-  private _pokemon: Pokemon;
-  private _move: PokemonMove;
-  private _targets: BattlerIndex[];
+  /** The {@linkcode Pokemon} using the move */
+  public readonly pokemon: Pokemon;
+  /** The {@linkcode PokemonMove} to be used */
+  public readonly move: PokemonMove;
+  /** The {@linkcode BattlerIndex | indexes} of the move's targets on the field */
+  public readonly targets: BattlerIndex[];
   /**
    * If `true`, some condition checks are skipped for this use of the move:
    * - Effects from non-volatile status conditions (i.e. Sleep, Freeze, and Paralysis)
@@ -98,14 +101,14 @@ export class MovePhase extends BattlePhase {
    * - The move-cancelling effects of Imprison from any Pokemon other than the user
    * - The move-copying effects of Dancer from any Pokemon other than the user
    */
-  private followUp: boolean;
+  private readonly followUp: boolean;
   /** If `true`, this use of the move will not consume any PP */
   private ignorePp: boolean;
   /**
    * Whether or not this move is a "bounced" move as a result of
    * the Pokemon's ongoing Magic Coat effect or Magic Bounce ability.
    */
-  private reflected: boolean;
+  private readonly reflected: boolean;
   /**
    * Whether or not this move is a "stolen" move as
    * a result of the user previously using Snatch.
@@ -115,7 +118,7 @@ export class MovePhase extends BattlePhase {
    * However, whether or not the move was snatched cannot be verified without
    * peeking into the current phase.
    */
-  public snatched: boolean;
+  public readonly snatched: boolean;
   private failed: boolean = false;
   private cancelled: boolean = false;
 
@@ -138,33 +141,6 @@ export class MovePhase extends BattlePhase {
     this.ignorePp = ignorePp;
     this.reflected = reflected;
     this.snatched = snatched;
-  }
-
-  /** The {@linkcode Pokemon} using the move */
-  public get pokemon(): Pokemon {
-    return this._pokemon;
-  }
-
-  protected set pokemon(pokemon: Pokemon) {
-    this._pokemon = pokemon;
-  }
-
-  /** The {@linkcode PokemonMove} to be used */
-  public get move(): PokemonMove {
-    return this._move;
-  }
-
-  protected set move(move: PokemonMove) {
-    this._move = move;
-  }
-
-  /** The {@linkcode BattlerIndex | indexes} of the move's targets on the field */
-  public get targets(): BattlerIndex[] {
-    return this._targets;
-  }
-
-  protected set targets(targets: BattlerIndex[]) {
-    this._targets = targets;
   }
 
   /**

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -43,6 +43,31 @@ import { applyMoveAttrs, isFieldTargeted } from "#utils/move-utils";
 import { getStatusEffectActivationText, getStatusEffectHealText } from "#utils/status-effect-utils";
 import i18next from "i18next";
 
+interface MovePhaseOptions {
+  /**
+   * If `true`, some condition checks are skipped for this use of the move:
+   * - Effects from non-volatile status conditions (i.e. Sleep, Freeze, and Paralysis)
+   * - Volatile status effects; namely Confusion and Infatuation
+   * - The effects of the user's Truant ability. Truant will not cancel the move nor
+   * increment its turn counter.
+   * - The move-cancelling effects of Imprison from any Pokemon other than the user
+   * - The move-copying effects of Dancer from any Pokemon other than the user
+   */
+  followUp?: boolean;
+  /** If `true`, this use of the move will not consume any PP */
+  ignorePp?: boolean;
+  /**
+   * Whether or not this move is a "bounced" move as a result of
+   * the Pokemon's ongoing Magic Coat effect or Magic Bounce ability.
+   */
+  reflected?: boolean;
+  /**
+   * Whether or not this move is a "stolen" move as
+   * a result of the user previously using Snatch.
+   */
+  snatched?: boolean;
+}
+
 /**
  * Resolves the following:
  * - Checks if the move can be executed
@@ -61,15 +86,38 @@ import i18next from "i18next";
 export class MovePhase extends BattlePhase {
   public override readonly phaseName = "MovePhase";
 
-  protected _pokemon: Pokemon;
-  protected _move: PokemonMove;
-  protected _targets: BattlerIndex[];
-  protected followUp: boolean;
-  protected ignorePp: boolean;
-  protected reflected: boolean;
+  private _pokemon: Pokemon;
+  private _move: PokemonMove;
+  private _targets: BattlerIndex[];
+  /**
+   * If `true`, some condition checks are skipped for this use of the move:
+   * - Effects from non-volatile status conditions (i.e. Sleep, Freeze, and Paralysis)
+   * - Volatile status effects; namely Confusion and Infatuation
+   * - The effects of the user's Truant ability. Truant will not cancel the move nor
+   * increment its turn counter.
+   * - The move-cancelling effects of Imprison from any Pokemon other than the user
+   * - The move-copying effects of Dancer from any Pokemon other than the user
+   */
+  private followUp: boolean;
+  /** If `true`, this use of the move will not consume any PP */
+  private ignorePp: boolean;
+  /**
+   * Whether or not this move is a "bounced" move as a result of
+   * the Pokemon's ongoing Magic Coat effect or Magic Bounce ability.
+   */
+  private reflected: boolean;
+  /**
+   * Whether or not this move is a "stolen" move as
+   * a result of the user previously using Snatch.
+   * @privateRemarks
+   * This is only `public` because Swallow is meant to always succeed
+   * when snatched -- even when the user does not have Stockpile stacks.
+   * However, whether or not the move was snatched cannot be verified without
+   * peeking into the current phase.
+   */
   public snatched: boolean;
-  protected failed: boolean = false;
-  protected cancelled: boolean = false;
+  private failed: boolean = false;
+  private cancelled: boolean = false;
 
   /**
    * @param followUp Indicates that the move being used is a "follow-up" - for example, a move being used by Metronome or Dancer.
@@ -79,10 +127,7 @@ export class MovePhase extends BattlePhase {
     pokemon: Pokemon,
     targets: BattlerIndex[],
     move: PokemonMove | MoveId,
-    followUp: boolean = false,
-    ignorePp: boolean = false,
-    reflected: boolean = false,
-    snatched: boolean = false,
+    { followUp = false, ignorePp = false, reflected = false, snatched = false }: MovePhaseOptions = {},
   ) {
     super();
 
@@ -95,6 +140,7 @@ export class MovePhase extends BattlePhase {
     this.snatched = snatched;
   }
 
+  /** The {@linkcode Pokemon} using the move */
   public get pokemon(): Pokemon {
     return this._pokemon;
   }
@@ -103,6 +149,7 @@ export class MovePhase extends BattlePhase {
     this._pokemon = pokemon;
   }
 
+  /** The {@linkcode PokemonMove} to be used */
   public get move(): PokemonMove {
     return this._move;
   }
@@ -111,6 +158,7 @@ export class MovePhase extends BattlePhase {
     this._move = move;
   }
 
+  /** The {@linkcode BattlerIndex | indexes} of the move's targets on the field */
   public get targets(): BattlerIndex[] {
     return this._targets;
   }
@@ -289,7 +337,7 @@ export class MovePhase extends BattlePhase {
         );
         globalScene.phaseManager.createAndUnshiftPhase(
           "CommonAnimPhase",
-          CommonAnim.POISON + (statusEffect - 1) as CommonAnim,
+          (CommonAnim.POISON + (statusEffect - 1)) as CommonAnim,
           this.pokemon.getBattlerIndex(),
         );
       } else if (healed) {
@@ -375,14 +423,16 @@ export class MovePhase extends BattlePhase {
      */
     for (const p of otherPokemon) {
       if (applyBattlerTags<SnatchingTag>(BattlerTagType.SNATCHING, p, false, this.pokemon)) {
-        globalScene.phaseManager.queueMovePhase({
-          pokemon: p,
-          targets: getMoveTargets(p, this.move.moveId).targets,
-          move: this.move,
-          followUp: true,
-          snatched: true,
-          when: "eager",
-        });
+        globalScene.phaseManager.createAndUnshiftPhase(
+          "MovePhase",
+          p,
+          getMoveTargets(p, this.move.moveId).targets,
+          this.move,
+          {
+            followUp: true,
+            snatched: true,
+          },
+        );
 
         /**
          * Remove Snatch's effect from the Pokemon to prevent it from
@@ -444,14 +494,16 @@ export class MovePhase extends BattlePhase {
       applyAbAttrs<ReflectMovesAbAttr>(AbAttrFlag.REFLECT_MOVES, target, false, this.pokemon, move, reflected);
 
       if (reflected.value) {
-        globalScene.phaseManager.queueMovePhase({
-          pokemon: target,
-          targets: this.getReflectionTargets(target),
-          move: move.id,
-          followUp: true,
-          reflected: true,
-          when: "eager",
-        });
+        globalScene.phaseManager.createAndUnshiftPhase(
+          "MovePhase",
+          target,
+          this.getReflectionTargets(target),
+          move.id,
+          {
+            followUp: true,
+            reflected: true,
+          },
+        );
 
         // Only one Pokemon can reflect a field-targeting move (e.g. Spikes) at a time
         if (isFieldTargeted(this.targets)) {

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -428,14 +428,9 @@ export class TurnCommandManager {
 
     phaseManager.appendToPhase(
       "PostActionPhase",
-      phaseManager.createPhase(
-        "MovePhase",
-        pokemon,
-        targets ?? turnMove.targets,
-        move,
-        undefined,
-        cursor !== -1 && turnMove.ignorePP,
-      ),
+      phaseManager.createPhase("MovePhase", pokemon, targets ?? turnMove.targets, move, {
+        ignorePp: cursor !== -1 && turnMove.ignorePP,
+      }),
       phaseManager.createPhase("PostActionPhase", pokemon.getBattlerIndex(), true),
     );
 


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

After #1250, `queueMovePhase`'s only purpose is to reorganize `MovePhase`'s constructor parameters and add default parameter values. Reorganizing `MovePhase`'s parameters within its constructor instead makes `queueMovePhase` obsolete.

## What are the changes from a developer perspective?

`PhaseManager.queueMovePhase` and its interface have been completely removed. `MovePhase` now uses a `MovePhaseOptions` interface in its constructor (much like other Phases with several optional parameters)

## Screenshots/Videos

N/A

## How to test the changes?

`pnpm test:silent`

## Checklist

- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [n/a] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [n/a] Have I provided screenshots/videos of the changes (if applicable)?
  - [n/a] Have I made sure that any UI change works for both UI themes (dark and light)?
