### PR TITLE
[Tests] Increase timeout duration for Metronome RNG sweep test

### DIFF
--- a/test/moves/metronome.test.ts
+++ b/test/moves/metronome.test.ts
@@ -113,19 +113,23 @@ describe("Moves - Metronome", () => {
     await game.phaseInterceptor.to("CommandPhase");
   });
 
+  // The test is very long running at the moment on some machines
+  // because of the `getTSEnumValues(MoveId)` call in `randomMoveAttr.getRandomMove`
+  // TODO: remove the custom timeout once the MoveId enum gets converted (after checking it is indeed faster).
   it("should never call a G-Max move", async () => {
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
 
     const user = game.field.getPlayerPokemon();
 
-    const NUM_ROLLS = 2000; // As long as this is greater than total number of moves, this should cover all possible RNG rolls
+    // As long as this is greater than total number of moves, this should cover all possible RNG rolls
+    const NUM_ROLLS = allMoves.size + 1;
 
     await game.rng.equalSample(NUM_ROLLS, () => {
       const moveId = randomMoveAttr.getRandomMove(user);
       const move = allMoves.get(moveId);
       // @ts-expect-error - `hasFlag()` is private but we want to validate the flag is set
       expect(move.hasFlag(MoveFlags.G_MAX_MOVE)).toBe(false);
-      expect(allMoves.get(moveId).checkFlag(MoveFlags.G_MAX_MOVE, user)).toBe(false);
+      expect(move.checkFlag(MoveFlags.G_MAX_MOVE, user)).toBe(false);
     });
-  });
+  }, 50000);
 });


### PR DESCRIPTION
<!-- (Once you have read these comments, you are free to remove them) -->
<!-- Feel free to look at other PRs for examples -->
<!--
Make sure the title includes categorization (choose the one that best fits):
-       [Bug]: If the PR is primarily a bug fix
-      [Move]: If a move has new or changed functionality
-   [Ability]: If an ability has new or changed functionality
-      [Item]: For new or modified items
-   [Mystery]: For new or modified Mystery Encounters
-      [Test]: If the PR is primarily adding or modifying tests
-     [UI/UX]: If the PR is changing UI/UX elements
-     [Audio]: If the PR is adding or changing music/sfx
-    [Sprite]: If the PR is adding or changing sprites
-   [Balance]: If the PR is related to game balance
- [Challenge]: If the PR is adding or modifying challenges
-  [Refactor]: If the PR is primarily rewriting existing code
-      [Docs]: If the PR is just adding or modifying documentation (such as tsdocs/code comments)
-    [GitHub]: For changes to GitHub workflows/templates/etc
-      [Misc]: If no other category fits the PR
-->
<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

## What are the changes the user will see?

potato computers can run the test without it timing out
<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

The "Metronome should never call a G-Max move" test is making an RNG sweep, calling `metronomeAttr.getRandomMove` 2000 times, which in turn calls `getTSEnumValues(MoveId)`.

My computer is potato and the test times out because of those calls.

By saving the result of the getTSEnumValue call in a variable and reusing it I confirmed that this is the bottleneck for the test, as in this case the test ends in 500ms.
It's not something we want to do for the game since it would be using too much memory for a move that is very rarely going to be relevant, this should mostly be an issue for this test.
<details><summary>For reference:</summary>

 (to compare with the execution times in the screenshots below)
<img width="719" height="151" alt="image" src="https://github.com/user-attachments/assets/f3e2e808-5801-48f9-b12c-03a64e5a84a9" />

</details> 

Of note, the test wasn't timing out for me in the past, I am not sure when it started failing but it's likely a change we made could have caused it. Since the effort to move away from enums is still ongoing this PR is merely patching away the timeout issue for now. If porting MoveId to a const does not drastically help the performance of this test we may have to look deeper into when the issue started, to check for the potential introduction of a major performance issue. This could be important since many players use devices with limited performance, like phones or chromebooks.

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

- The sweep was reduced from 2000 to the actual number of moves (so, right now, a bit less than 1000).
- This reduces the execution time on my machine from ~60s to ~30s, which is still more than the default timeout of 20s, so a temporary 50s timeout was put in place.

When the the `MoveId` enum gets converted, we should revisit this test.

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

Execution time on 🥔 💻 before and after:

<img width="979" height="327" alt="metronome" src="https://github.com/user-attachments/assets/a051867f-f9dd-4109-ae43-69dbb9fa6826" />


<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?
`pnpm test:silent metronome`
<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
- [X] Otherwise: **I'm using `beta` as my base branch**
- [X] There is no overlap with another PR?
- [X] The PR is self-contained and cannot be split into smaller PRs?
- [X] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [X] Are all unit tests still passing? (`pnpm test:silent`)
  - [] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [X] Have I provided screenshots/videos of the changes (if applicable)?
  - [] Have I made sure that any UI change works for both UI themes (dark and light)?

#### If there are no locale changes:
- [X] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->
