### PR TITLE
[Refactor] Rename `Arena#applyTagsForSide` to `Arena#applyTags`

### DIFF
--- a/src/data/arena-tags/arena-tag.ts
+++ b/src/data/arena-tags/arena-tag.ts
@@ -46,8 +46,7 @@ export abstract class ArenaTag {
   }
 
   /**
-   * Applies the tag's effect(s). Should be called via
-   * {@linkcode Arena.applyTagsForSide} or {@linkcode Arena.applyTags}.
+   * Applies the tag's effect(s). Should be called via {@linkcode Arena.applyTags}.
    * @param _simulated - If `true`, should suppress changes to game state
    * @param _args - Additional arguments
    * @returns `true` if effects are applied successfully.

--- a/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
+++ b/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
@@ -66,7 +66,7 @@ export abstract class ChanceBasedMoveEffectAttr extends MoveEffectAttr {
     );
 
     const userSide = user.getArenaTagSide();
-    globalScene.arena.applyTagsForSide(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
+    globalScene.arena.applyTags(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
 
     if (!this.selfTarget) {
       applyAbAttrs<IgnoreMoveEffectsAbAttr>(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);

--- a/src/data/moves/move-attrs/flinch-attr.ts
+++ b/src/data/moves/move-attrs/flinch-attr.ts
@@ -33,7 +33,7 @@ export class FlinchAttr extends AddBattlerTagAttr {
 
     if (moveChance.value <= move.chance) {
       const userSide = user.getArenaTagSide();
-      globalScene.arena.applyTagsForSide(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
+      globalScene.arena.applyTags(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
     }
 
     applyAbAttrs<IgnoreMoveEffectsAbAttr>(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -866,7 +866,13 @@ export abstract class Move {
     }
 
     if (!this.hasAttr(TypelessAttr)) {
-      globalScene.arena.applyTags([...WEAKEN_MOVE_TYPE_ARENA_TAG_TYPES], simulated, this.type, power);
+      globalScene.arena.applyTags(
+        [...WEAKEN_MOVE_TYPE_ARENA_TAG_TYPES],
+        ArenaTagSide.BOTH,
+        simulated,
+        this.type,
+        power,
+      );
       globalScene.applyModifiers(AttackTypeBoosterModifier, source.isPlayer(), source, this.type, power);
     }
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -765,35 +765,19 @@ export class Arena {
   }
 
   /**
-   * Applies each `ArenaTag` in this Arena, based on which side (self, enemy, or both) is passed in as a parameter
+   * Applies each `ArenaTag` in this Arena, based on which side (player, enemy, or both) is passed in as a parameter
    * @param tagTypes Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
    * @param side {@linkcode ArenaTagSide} which side's arena tags to apply
    * @param simulated if `true`, this applies arena tags without changing game state
    * @param args array of parameters that the called upon tags may need
    */
-  applyTagsForSide(
-    tagTypes: ArenaTagType | ArenaTagType[],
-    side: ArenaTagSide,
-    simulated: boolean,
-    ...args: unknown[]
-  ): void {
+  applyTags(tagTypes: ArenaTagType | ArenaTagType[], side: ArenaTagSide, simulated: boolean, ...args: unknown[]): void {
     const tagTypeArr = coerceArray(tagTypes);
     let tags = this.tags.filter((t) => tagTypeArr.includes(t.tagType));
     if (side !== ArenaTagSide.BOTH) {
       tags = tags.filter((t) => t.side === side);
     }
     tags.forEach((t) => t.apply(simulated, ...args));
-  }
-
-  /**
-   * Applies the specified tag to both sides (ie: both user and trainer's tag that match the Tag specified)
-   * by calling {@linkcode applyTagsForSide()}
-   * @param tagType Either an {@linkcode ArenaTagType} string, or an actual {@linkcode ArenaTag} class to filter which ones to apply
-   * @param simulated if `true`, this applies arena tags without changing game state
-   * @param args array of parameters that the called upon tags may need
-   */
-  applyTags(tagType: ArenaTagType | ArenaTagType[], simulated: boolean, ...args: unknown[]): void {
-    this.applyTagsForSide(tagType, ArenaTagSide.BOTH, simulated, ...args);
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1875,7 +1875,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     applyMoveAttrs(VariableMoveTypeAttr, this, null, move, moveTypeHolder);
     applyAbAttrs<MoveTypeChangeAbAttr>(AbAttrFlag.MOVE_TYPE_CHANGE, this, simulated, move, undefined, moveTypeHolder);
 
-    globalScene.arena.applyTags(ArenaTagType.ION_DELUGE, simulated, moveTypeHolder);
+    globalScene.arena.applyTags(ArenaTagType.ION_DELUGE, ArenaTagSide.BOTH, simulated, moveTypeHolder);
     if (this.hasTag(BattlerTagType.ELECTRIFIED)) {
       moveTypeHolder.value = ElementalType.ELECTRIC;
     }
@@ -3218,7 +3218,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     /** Critical hits ignore the damage reduction from screens */
     if (!isCritical) {
-      globalScene.arena.applyTagsForSide(
+      globalScene.arena.applyTags(
         [...WEAKEN_MOVE_SCREEN_ARENA_TAG_TYPES],
         defendingSide,
         simulated,

--- a/src/phases/base/hit-check-phase.ts
+++ b/src/phases/base/hit-check-phase.ts
@@ -111,7 +111,7 @@ export abstract class HitCheckPhase extends PokemonPhase {
     const hasConditionalProtectApplied = new BooleanHolder(false);
     /** If the move is not targeting a Pokemon on the user's side, try to apply conditional protection effects */
     if (!this.move.getMove().isAllyTarget()) {
-      globalScene.arena.applyTagsForSide(
+      globalScene.arena.applyTags(
         [...CONDITIONAL_PROTECT_ARENA_TAG_TYPES],
         targetSide,
         simulated,

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -4,6 +4,7 @@ import type { PostSummonAbAttr } from "#abilities/post-summon-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { ENTRY_HAZARD_ARENA_TAG_TYPES } from "#constants/arena-tag-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { StatusEffect } from "#enums/status-effect";
@@ -22,9 +23,9 @@ export class PostSummonPhase extends PokemonPhase {
     }
 
     // Apply pending heal effects from Healing Wish and Lunar Dance.
-    globalScene.arena.applyTags(ArenaTagType.PENDING_HEAL, false, pokemon);
+    globalScene.arena.applyTags(ArenaTagType.PENDING_HEAL, ArenaTagSide.BOTH, false, pokemon);
 
-    globalScene.arena.applyTags([...ENTRY_HAZARD_ARENA_TAG_TYPES], false, pokemon);
+    globalScene.arena.applyTags([...ENTRY_HAZARD_ARENA_TAG_TYPES], ArenaTagSide.BOTH, false, pokemon);
 
     // If this is mystery encounter and has post summon phase tag, apply post summon effects
     if (globalScene.currentBattle.isBattleMysteryEncounter()) {

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -140,7 +140,7 @@ export class StatStageChangePhase extends PokemonPhase {
       const cancelled = new BooleanHolder(false);
 
       if (!selfTarget && stages.value < 0) {
-        arena.applyTagsForSide(ArenaTagType.MIST, pokemon.getArenaTagSide(), false, this.source, cancelled);
+        arena.applyTags(ArenaTagType.MIST, pokemon.getArenaTagSide(), false, this.source, cancelled);
       }
 
       if (!cancelled.value && !selfTarget && stages.value < 0) {

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -8,6 +8,7 @@ import type { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-
 import { globalScene } from "#app/global-scene";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattleCommand } from "#enums/battle-command";
 import type { BattlerIndex } from "#enums/battler-index";
@@ -299,7 +300,7 @@ export class TurnCommandManager {
 
     /** 'true' if Trick Room is on the field. */
     const speedReversed = new BooleanHolder(false);
-    globalScene.arena.applyTags(ArenaTagType.TRICK_ROOM, false, speedReversed);
+    globalScene.arena.applyTags(ArenaTagType.TRICK_ROOM, ArenaTagSide.BOTH, false, speedReversed);
 
     if (speedReversed.value) {
       this.turnCommands = this.turnCommands.reverse();


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Missed it in the Arena Tag methods refactor.
Reduces the number of redundant methods.

## What are the changes from a developer perspective?
`Arena#applyTagsForSide` is renamed to `Arena#applyTags` and the old `Arena#applyTags` is removed.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?