### PR TITLE
[Refactor] Remove unnecessary `arena` params

### DIFF
--- a/src/@types/move-types.ts
+++ b/src/@types/move-types.ts
@@ -59,6 +59,7 @@ export type MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => 
  * A function to check if a move with the given {@linkcode MoveId}
  * can have its effects negated by a {@linkcode ConditionalProtectTag | conditional protection}
  * field effect (e.g. Wide Guard).
+ * @todo Remove `arena` param
  */
 export type ProtectConditionFunc = (arena: Arena, moveId: MoveId) => boolean;
 

--- a/src/@types/move-types.ts
+++ b/src/@types/move-types.ts
@@ -7,7 +7,6 @@ import type { ElementalType } from "#enums/elemental-type";
 import type { HitResult } from "#enums/hit-result";
 import type { MoveId } from "#enums/move-id";
 import type { MoveResult } from "#enums/move-result";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 
@@ -59,9 +58,8 @@ export type MoveConditionFunc = (user: Pokemon, target: Pokemon, move: Move) => 
  * A function to check if a move with the given {@linkcode MoveId}
  * can have its effects negated by a {@linkcode ConditionalProtectTag | conditional protection}
  * field effect (e.g. Wide Guard).
- * @todo Remove `arena` param
  */
-export type ProtectConditionFunc = (arena: Arena, moveId: MoveId) => boolean;
+export type ProtectConditionFunc = (moveId: MoveId) => boolean;
 
 export type UserMoveConditionFunc = (user: Pokemon, move: Move) => boolean;
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1256,7 +1256,7 @@ export class BattleScene extends SceneBase {
       if (!this.gameMode.hasTrainers) {
         newBattleType = BattleType.WILD;
       } else if (battleType === undefined) {
-        newBattleType = this.gameMode.isWaveTrainer(newWaveIndex, this.arena) ? BattleType.TRAINER : BattleType.WILD;
+        newBattleType = this.gameMode.isWaveTrainer(newWaveIndex) ? BattleType.TRAINER : BattleType.WILD;
       } else {
         newBattleType = battleType;
       }

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1438,13 +1438,11 @@ export class BattleScene extends SceneBase {
     return this.currentBattle;
   }
 
-  newArena(biomeId: BiomeId): Arena {
+  newArena(biomeId: BiomeId): void {
     this.arena = new Arena(biomeId);
     this.eventTarget.dispatchEvent(new NewArenaEvent());
 
     this.arenaBg.pipelineData = { terrainColorRatio: this.arena.getBgTerrainColorRatioForBiome() };
-
-    return this.arena;
   }
 
   updateFieldScale(): Promise<void> {

--- a/src/data/arena-tags/arena-room-tag.ts
+++ b/src/data/arena-tags/arena-room-tag.ts
@@ -1,11 +1,11 @@
+import { globalScene } from "#app/global-scene";
 import { ArenaTag } from "#arena-tags/arena-tag";
-import type { Arena } from "#field/arena";
 
 /**
  * Base class for moves like Trick Room which should negate their effect when used a second time.
  */
 export abstract class ArenaRoomTag extends ArenaTag {
-  override onOverlap(arena: Arena): void {
-    arena.removeTag(this.tagType);
+  override onOverlap(): void {
+    globalScene.arena.removeTag(this.tagType);
   }
 }

--- a/src/data/arena-tags/arena-tag.ts
+++ b/src/data/arena-tags/arena-tag.ts
@@ -3,7 +3,6 @@ import { allMoves } from "#data/data-lists";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import i18next from "i18next";
 
@@ -49,30 +48,27 @@ export abstract class ArenaTag {
   /**
    * Applies the tag's effect(s). Should be called via
    * {@linkcode Arena.applyTagsForSide} or {@linkcode Arena.applyTags}.
-   * @param _arena - The {@linkcode Arena} to which the tag belongs
    * @param _simulated - If `true`, should suppress changes to game state
    * @param _args - Additional arguments
    * @returns `true` if effects are applied successfully.
    */
-  public apply(_arena: Arena, _simulated: boolean, ..._args: unknown[]): boolean {
+  public apply(_simulated: boolean, ..._args: unknown[]): boolean {
     return true;
   }
 
   /**
    * Applies effects when the tag is first added to the field.
-   * @param _arena - The {@linkcode Arena} to which the tag belongs
    * @param _quiet - (Default `false`) If `true`, should suppress game messages during execution
    * @see {@linkcode Arena.addTag}
    */
-  public onAdd(_arena: Arena, _quiet: boolean = false): void {}
+  public onAdd(_quiet: boolean = false): void {}
 
   /**
    * Applies effects when the tag is removed from the field.
    * By default, this queues a localized on-remove message.
-   * @param _arena - The {@linkcode Arena} to which the tag belongs
    * @param quiet - (Default `false`) If `true`, should suppress game messages during execution
    */
-  public onRemove(_arena: Arena, quiet: boolean = false): void {
+  public onRemove(quiet: boolean = false): void {
     if (!quiet) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",
@@ -84,20 +80,18 @@ export abstract class ArenaTag {
   /**
    * Applies effects when a tag of the same {@linkcode ArenaTagType | type}
    * and {@linkcode ArenaTagSide | side} would be added to the field.
-   * @param _arena - The {@linkcode Arena} to which the tag belongs
    */
-  public onOverlap(_arena: Arena): void {}
+  public onOverlap(): void {}
 
   /**
    * Applies effects at the end of each turn.
    * If this returns `false`, the tag is removed from the field
    * after these effects are applied.
-   * @param _arena - The {@linkcode Arena} to which the tag belongs
    * @returns `true` to retain the tag on the field after this call;
    * `false` to remove the tag.
    * @see {@linkcode Arena.lapseTags}
    */
-  public lapse(_arena: Arena): boolean {
+  public lapse(): boolean {
     return this.turnCount < 1 || --this.turnCount !== 0;
   }
 

--- a/src/data/arena-tags/aurora-veil-tag.ts
+++ b/src/data/arena-tags/aurora-veil-tag.ts
@@ -4,7 +4,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveCategory } from "#enums/move-category";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -19,7 +18,7 @@ export class AuroraVeilTag extends WeakenMoveScreenTag {
     ]);
   }
 
-  override onAdd(_arena: Arena, quiet: boolean = false): void {
+  override onAdd(quiet: boolean = false): void {
     if (!quiet) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",

--- a/src/data/arena-tags/conditional-protect-tag.ts
+++ b/src/data/arena-tags/conditional-protect-tag.ts
@@ -67,7 +67,7 @@ export abstract class ConditionalProtectTag extends ArenaTag {
   ): boolean {
     if (
       (this.side === ArenaTagSide.PLAYER) === defender.isPlayer()
-      && this.protectConditionFunc(globalScene.arena, moveId)
+      && this.protectConditionFunc(moveId)
       && (this.ignoresBypass || !allMoves.get(moveId).checkFlag(MoveFlags.IGNORE_PROTECT, attacker, defender))
     ) {
       if (!isProtected.value) {

--- a/src/data/arena-tags/conditional-protect-tag.ts
+++ b/src/data/arena-tags/conditional-protect-tag.ts
@@ -8,7 +8,6 @@ import type { ArenaTagType } from "#enums/arena-tag-type";
 import { CommonAnim } from "#enums/common-anim";
 import { MoveFlags } from "#enums/move-flags";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import type { ProtectConditionFunc } from "#types/move-types";
 import type { BooleanHolder } from "#utils/common-utils";
@@ -38,7 +37,7 @@ export abstract class ConditionalProtectTag extends ArenaTag {
     this.ignoresBypass = ignoresBypass;
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t(`arenaTag:conditionalProtectOnAdd${this.i18nSideKey}`, { moveName: super.getMoveName() }),
@@ -46,12 +45,11 @@ export abstract class ConditionalProtectTag extends ArenaTag {
   }
 
   // Removes default message for effect removal
-  override onRemove(_arena: Arena): void {}
+  override onRemove(): void {}
 
   /**
    * Checks incoming moves against the condition function
    * and protects the target if conditions are met
-   * @param arena the {@linkcode Arena} containing this tag
    * @param simulated `true` if the tag is applied quietly; `false` otherwise.
    * @param isProtected a {@linkcode BooleanHolder} used to flag if the move is protected against
    * @param attacker the attacking {@linkcode Pokemon}
@@ -61,7 +59,6 @@ export abstract class ConditionalProtectTag extends ArenaTag {
    * @returns `true` if this tag protected against the attack; `false` otherwise
    */
   override apply(
-    arena: Arena,
     simulated: boolean,
     isProtected: BooleanHolder,
     attacker: Pokemon,
@@ -70,7 +67,7 @@ export abstract class ConditionalProtectTag extends ArenaTag {
   ): boolean {
     if (
       (this.side === ArenaTagSide.PLAYER) === defender.isPlayer()
-      && this.protectConditionFunc(arena, moveId)
+      && this.protectConditionFunc(globalScene.arena, moveId)
       && (this.ignoresBypass || !allMoves.get(moveId).checkFlag(MoveFlags.IGNORE_PROTECT, attacker, defender))
     ) {
       if (!isProtected.value) {

--- a/src/data/arena-tags/crafty-shield-tag.ts
+++ b/src/data/arena-tags/crafty-shield-tag.ts
@@ -10,12 +10,11 @@ import type { ProtectConditionFunc } from "#types/move-types";
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Crafty_Shield_(move) Crafty Shield's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect
  * @param moveId {@linkcode MoveId} The move to check against this condition
  * @returns `true` if the incoming move is a Status move, is not a hazard, and does not target all
  * Pokemon or sides of the field.
  */
-const CraftyShieldConditionFunc: ProtectConditionFunc = (_arena, moveId) => {
+const CraftyShieldConditionFunc: ProtectConditionFunc = (moveId) => {
   const move = allMoves.get(moveId);
   return (
     move.category === MoveCategory.STATUS

--- a/src/data/arena-tags/delayed-attack-tag.ts
+++ b/src/data/arena-tags/delayed-attack-tag.ts
@@ -3,7 +3,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import type { FieldBattlerIndex } from "#enums/battler-index";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { PokemonMove } from "#field/pokemon-move";
 import { isNil } from "#utils/common-utils";
@@ -45,7 +44,7 @@ export class DelayedAttackTag extends ArenaTag {
     this.delayedAttacks.push({ sourceId: source.id, moveId: moveId, targetIndex, turnCount: 3 });
   }
 
-  override lapse(_arena: Arena): boolean {
+  override lapse(): boolean {
     this.delayedAttacks.forEach((attack) => {
       attack.turnCount--;
 
@@ -76,7 +75,7 @@ export class DelayedAttackTag extends ArenaTag {
     return this.delayedAttacks.length > 0;
   }
 
-  override onRemove(_arena: Arena): void {}
+  override onRemove(): void {}
 
   override loadTag(source: ArenaTag | any): void {
     super.loadTag(source);

--- a/src/data/arena-tags/entry-hazard-tag.ts
+++ b/src/data/arena-tags/entry-hazard-tag.ts
@@ -2,7 +2,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import { ArenaTagSide } from "#enums/arena-tag-side";
 import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 
 /**
@@ -26,22 +25,21 @@ export abstract class EntryHazardTag extends ArenaTag {
     this.maxLayers = maxLayers;
   }
 
-  override onOverlap(arena: Arena): void {
+  override onOverlap(): void {
     if (this.layers < this.maxLayers) {
       this.layers++;
 
-      this.onAdd(arena);
+      this.onAdd();
     }
   }
 
   /**
    * Activates the hazard effect onto a Pokemon when it enters the field
-   * @param _arena the {@linkcode Arena} containing this tag
    * @param simulated if `true`, only checks if the hazard would activate.
    * @param pokemon the {@linkcode Pokemon} triggering this hazard
    * @returns `true` if this hazard affects the given Pokemon; `false` otherwise.
    */
-  override apply(_arena: Arena, simulated: boolean, pokemon: Pokemon): boolean {
+  override apply(simulated: boolean, pokemon: Pokemon): boolean {
     if (this.side !== ArenaTagSide.BOTH && (this.side === ArenaTagSide.PLAYER) !== pokemon.isPlayer()) {
       return false;
     }

--- a/src/data/arena-tags/fairy-lock-tag.ts
+++ b/src/data/arena-tags/fairy-lock-tag.ts
@@ -2,7 +2,6 @@ import { globalScene } from "#app/global-scene";
 import { ArenaTag } from "#arena-tags/arena-tag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -17,7 +16,7 @@ export class FairyLockTag extends ArenaTag {
     super(ArenaTagType.FAIRY_LOCK, turnCount, MoveId.FAIRY_LOCK, sourceId);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:fairyLockOnAdd"));
   }
 }

--- a/src/data/arena-tags/fire-grass-pledge-tag.ts
+++ b/src/data/arena-tags/fire-grass-pledge-tag.ts
@@ -9,7 +9,6 @@ import { ArenaTagType } from "#enums/arena-tag-type";
 import { CommonAnim } from "#enums/common-anim";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { BooleanHolder, toDmgValue } from "#utils/common-utils";
 import i18next from "i18next";
@@ -26,7 +25,7 @@ export class FireGrassPledgeTag extends ArenaTag {
     super(ArenaTagType.FIRE_GRASS_PLEDGE, 4, MoveId.FIRE_PLEDGE, sourceId, side);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     // "A sea of fire enveloped your/the opposing team!"
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
@@ -34,7 +33,7 @@ export class FireGrassPledgeTag extends ArenaTag {
     );
   }
 
-  override lapse(arena: Arena): boolean {
+  override lapse(): boolean {
     const field: Pokemon[] =
       this.side === ArenaTagSide.PLAYER ? globalScene.getPlayerField() : globalScene.getEnemyField();
 
@@ -62,6 +61,6 @@ export class FireGrassPledgeTag extends ArenaTag {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 8));
       });
 
-    return super.lapse(arena);
+    return super.lapse();
   }
 }

--- a/src/data/arena-tags/grass-water-pledge-tag.ts
+++ b/src/data/arena-tags/grass-water-pledge-tag.ts
@@ -3,7 +3,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -17,7 +16,7 @@ export class GrassWaterPledgeTag extends ArenaTag {
     super(ArenaTagType.GRASS_WATER_PLEDGE, 4, MoveId.GRASS_PLEDGE, sourceId, side);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     // "A swamp enveloped your/the opposing team!"
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",

--- a/src/data/arena-tags/gravity-tag.ts
+++ b/src/data/arena-tags/gravity-tag.ts
@@ -4,7 +4,6 @@ import type { SkyDropTag } from "#battler-tags/sky-drop-tag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -17,7 +16,7 @@ export class GravityTag extends ArenaTag {
     super(ArenaTagType.GRAVITY, turnCount, MoveId.GRAVITY);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:gravityOnAdd"));
     globalScene.getField(true).forEach((pokemon) => {
       if (pokemon) {
@@ -31,7 +30,7 @@ export class GravityTag extends ArenaTag {
     });
   }
 
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:gravityOnRemove"));
   }
 }

--- a/src/data/arena-tags/happy-hour-tag.ts
+++ b/src/data/arena-tags/happy-hour-tag.ts
@@ -3,7 +3,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -15,11 +14,11 @@ export class HappyHourTag extends ArenaTag {
     super(ArenaTagType.HAPPY_HOUR, 0, MoveId.HAPPY_HOUR, sourceId, side);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:happyHourOnAdd"));
   }
 
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:happyHourOnRemove"));
   }
 }

--- a/src/data/arena-tags/ion-deluge-tag.ts
+++ b/src/data/arena-tags/ion-deluge-tag.ts
@@ -3,7 +3,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { NumberHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
@@ -18,20 +17,19 @@ export class IonDelugeTag extends ArenaTag {
   }
 
   /** Queues an on-add message */
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:plasmaFistsOnAdd"));
   }
 
-  override onRemove(_arena: Arena): void {} // Removes default on-remove message
+  override onRemove(): void {} // Removes default on-remove message
 
   /**
    * Converts Normal-type moves to Electric type
-   * @param _arena n/a
    * @param _simulated n/a
    * @param moveType a {@linkcode NumberHolder} containing a move's {@linkcode ElementalType}
    * @returns `true` if the given move type changed; `false` otherwise.
    */
-  override apply(_arena: Arena, _simulated: boolean, moveType: NumberHolder): boolean {
+  override apply(_simulated: boolean, moveType: NumberHolder): boolean {
     if (moveType.value === ElementalType.NORMAL) {
       moveType.value = ElementalType.ELECTRIC;
       return true;

--- a/src/data/arena-tags/light-screen-tag.ts
+++ b/src/data/arena-tags/light-screen-tag.ts
@@ -4,7 +4,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveCategory } from "#enums/move-category";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -16,7 +15,7 @@ export class LightScreenTag extends WeakenMoveScreenTag {
     super(ArenaTagType.LIGHT_SCREEN, turnCount, MoveId.LIGHT_SCREEN, sourceId, side, [MoveCategory.SPECIAL]);
   }
 
-  override onAdd(_arena: Arena, quiet: boolean = false): void {
+  override onAdd(quiet: boolean = false): void {
     if (!quiet) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",

--- a/src/data/arena-tags/mat-block-tag.ts
+++ b/src/data/arena-tags/mat-block-tag.ts
@@ -12,11 +12,10 @@ import i18next from "i18next";
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Mat_Block_(move) Mat Block's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect.
  * @param moveId {@linkcode MoveId} The move to check against this condition.
  * @returns `true` if the incoming move is not a Status move.
  */
-const MatBlockConditionFunc: ProtectConditionFunc = (_arena, moveId): boolean => {
+const MatBlockConditionFunc: ProtectConditionFunc = (moveId): boolean => {
   const move = allMoves.get(moveId);
   return move.category !== MoveCategory.STATUS;
 };

--- a/src/data/arena-tags/mat-block-tag.ts
+++ b/src/data/arena-tags/mat-block-tag.ts
@@ -6,7 +6,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveCategory } from "#enums/move-category";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { ProtectConditionFunc } from "#types/move-types";
 import i18next from "i18next";
 
@@ -31,7 +30,7 @@ export class MatBlockTag extends ConditionalProtectTag {
     super(ArenaTagType.MAT_BLOCK, MoveId.MAT_BLOCK, sourceId, side, MatBlockConditionFunc);
   }
 
-  override onAdd(_arena: Arena) {
+  override onAdd() {
     if (this.sourceId) {
       const source = globalScene.getPokemonById(this.sourceId);
       if (source) {

--- a/src/data/arena-tags/mist-tag.ts
+++ b/src/data/arena-tags/mist-tag.ts
@@ -7,7 +7,6 @@ import { AbAttrFlag } from "#enums/ab-attr-flag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { BooleanHolder } from "#utils/common-utils";
 import i18next from "i18next";
@@ -21,8 +20,8 @@ export class MistTag extends ArenaTag {
     super(ArenaTagType.MIST, turnCount, MoveId.MIST, sourceId, side);
   }
 
-  override onAdd(arena: Arena, quiet: boolean = false): void {
-    super.onAdd(arena);
+  override onAdd(quiet: boolean = false): void {
+    super.onAdd();
 
     if (this.sourceId) {
       const source = globalScene.getPokemonById(this.sourceId);
@@ -40,14 +39,13 @@ export class MistTag extends ArenaTag {
 
   /**
    * Cancels the lowering of stats
-   * @param _arena the {@linkcode Arena} containing this effect
    * @param simulated `true` if the effect should be applied quietly
    * @param attacker the {@linkcode Pokemon} using a move into this effect.
    * @param cancelled a {@linkcode BooleanHolder} whose value is set to `true`
    * to flag the stat reduction as cancelled
    * @returns `true` if a stat reduction was cancelled; `false` otherwise
    */
-  override apply(_arena: Arena, simulated: boolean, attacker: Pokemon, cancelled: BooleanHolder): boolean {
+  override apply(simulated: boolean, attacker: Pokemon, cancelled: BooleanHolder): boolean {
     if (attacker?.isActive(true)) {
       const bypassed = new BooleanHolder(false);
       applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, simulated, bypassed);

--- a/src/data/arena-tags/mud-sport-tag.ts
+++ b/src/data/arena-tags/mud-sport-tag.ts
@@ -3,7 +3,6 @@ import { WeakenMoveTypeTag } from "#arena-tags/weaken-move-type-tag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -15,11 +14,11 @@ export class MudSportTag extends WeakenMoveTypeTag {
     super(ArenaTagType.MUD_SPORT, turnCount, ElementalType.ELECTRIC, MoveId.MUD_SPORT, sourceId);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:mudSportOnAdd"));
   }
 
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:mudSportOnRemove"));
   }
 }

--- a/src/data/arena-tags/no-crit-tag.ts
+++ b/src/data/arena-tags/no-crit-tag.ts
@@ -4,7 +4,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -24,7 +23,7 @@ export class NoCritTag extends ArenaTag {
   }
 
   /** Queues a message upon adding this effect to the field */
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t(`arenaTag:noCritOnAdd${this.i18nSideKey}`, {
@@ -34,7 +33,7 @@ export class NoCritTag extends ArenaTag {
   }
 
   /** Queues a message upon removing this effect from the field */
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     const source = globalScene.getPokemonById(this.sourceId!); // TODO: is this bang correct?
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",

--- a/src/data/arena-tags/pending-heal-tag.ts
+++ b/src/data/arena-tags/pending-heal-tag.ts
@@ -5,7 +5,6 @@ import { allMoves } from "#data/data-lists";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import type { FieldBattlerIndex } from "#enums/battler-index";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { isNil } from "#utils/common-utils";
 import i18next from "i18next";
@@ -60,10 +59,10 @@ export class PendingHealTag extends ArenaTag {
   }
 
   /** Removes default on-remove message */
-  override onRemove(_arena: Arena): void {}
+  override onRemove(): void {}
 
   /** This arena tag is removed at the end of the turn if no pending healing effects are on the field */
-  override lapse(_arena: Arena): boolean {
+  override lapse(): boolean {
     for (const key in this.pendingHeals) {
       if (this.pendingHeals[key].length > 0) {
         return true;
@@ -76,13 +75,12 @@ export class PendingHealTag extends ArenaTag {
    * Applies a pending healing effect on the given target index. If an effect is found for
    * the index, the Pokemon at that index is healed to full HP, is cured of any non-volatile status,
    * and has its PP fully restored (if the effect is from Lunar Dance).
-   * @param arena - The {@linkcode Arena} containing this tag
    * @param simulated - If `true`, suppresses changes to game state
    * @param pokemon - The {@linkcode Pokemon} receiving the healing effect
    * @returns `true` if the target Pokemon was healed by this effect
    * @todo This should also be called when a Pokemon moves into a new position via Ally Switch
    */
-  override apply(arena: Arena, simulated: boolean, pokemon: Pokemon): boolean {
+  override apply(simulated: boolean, pokemon: Pokemon): boolean {
     const targetIndex = pokemon.getBattlerIndex();
     const targetEffects = this.pendingHeals[targetIndex];
 
@@ -98,7 +96,7 @@ export class PendingHealTag extends ArenaTag {
         console.warn(`Source of pending ${allMoves.get(moveId).name} effect is undefined!`);
         targetEffects.splice(targetEffects.indexOf(healEffect), 1);
         // Re-evaluate after the invalid heal effect is removed
-        return this.apply(arena, simulated, pokemon);
+        return this.apply(simulated, pokemon);
       }
 
       globalScene.phaseManager.createAndUnshiftPhase("PokemonHealPhase", targetIndex, pokemon.getMaxHp(), {

--- a/src/data/arena-tags/quick-guard-tag.ts
+++ b/src/data/arena-tags/quick-guard-tag.ts
@@ -9,12 +9,11 @@ import type { ProtectConditionFunc } from "#types/move-types";
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Quick_Guard_(move) Quick Guard's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect
  * @param moveId {@linkcode MoveId} The move to check against this condition
  * @returns `true` if the incoming move's priority is greater than 0.
  *   This includes moves with modified priorities from abilities (e.g. Prankster)
  */
-const QuickGuardConditionFunc: ProtectConditionFunc = (_arena, moveId) => {
+const QuickGuardConditionFunc: ProtectConditionFunc = (moveId) => {
   const move = allMoves.get(moveId);
   const effectPhase = globalScene.phaseManager.getCurrentPhase();
 

--- a/src/data/arena-tags/reflect-tag.ts
+++ b/src/data/arena-tags/reflect-tag.ts
@@ -4,7 +4,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveCategory } from "#enums/move-category";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -16,7 +15,7 @@ export class ReflectTag extends WeakenMoveScreenTag {
     super(ArenaTagType.REFLECT, turnCount, MoveId.REFLECT, sourceId, side, [MoveCategory.PHYSICAL]);
   }
 
-  override onAdd(_arena: Arena, quiet: boolean = false): void {
+  override onAdd(quiet: boolean = false): void {
     if (!quiet) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",

--- a/src/data/arena-tags/safeguard-tag.ts
+++ b/src/data/arena-tags/safeguard-tag.ts
@@ -3,7 +3,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -17,14 +16,14 @@ export class SafeguardTag extends ArenaTag {
     super(ArenaTagType.SAFEGUARD, turnCount, MoveId.SAFEGUARD, sourceId, side);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t(`arenaTag:safeguardOnAdd${this.i18nSideKey}`),
     );
   }
 
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t(`arenaTag:safeguardOnRemove${this.i18nSideKey}`),

--- a/src/data/arena-tags/spikes-tag.ts
+++ b/src/data/arena-tags/spikes-tag.ts
@@ -8,7 +8,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { HitResult } from "#enums/hit-result";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { BooleanHolder, toDmgValue } from "#utils/common-utils";
 import i18next from "i18next";
@@ -23,8 +22,8 @@ export class SpikesTag extends EntryHazardTag {
     super(ArenaTagType.SPIKES, MoveId.SPIKES, sourceId, side, 3);
   }
 
-  override onAdd(arena: Arena, quiet: boolean = false): void {
-    super.onAdd(arena);
+  override onAdd(quiet: boolean = false): void {
+    super.onAdd();
 
     const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
     if (!quiet && source) {

--- a/src/data/arena-tags/sticky-web-tag.ts
+++ b/src/data/arena-tags/sticky-web-tag.ts
@@ -7,7 +7,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
 import { Stat } from "#enums/stat";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { BooleanHolder, NumberHolder } from "#utils/common-utils";
 import i18next from "i18next";
@@ -23,8 +22,8 @@ export class StickyWebTag extends EntryHazardTag {
   }
 
   /** @todo Should `quiet` ever be `true`? */
-  override onAdd(arena: Arena, quiet: boolean = false): void {
-    super.onAdd(arena);
+  override onAdd(quiet: boolean = false): void {
+    super.onAdd();
     const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
     if (!quiet && source) {
       globalScene.phaseManager.createAndUnshiftPhase(

--- a/src/data/arena-tags/tailwind-tag.ts
+++ b/src/data/arena-tags/tailwind-tag.ts
@@ -7,7 +7,6 @@ import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { Stat } from "#enums/stat";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -20,7 +19,7 @@ export class TailwindTag extends ArenaTag {
     super(ArenaTagType.TAILWIND, turnCount, MoveId.TAILWIND, sourceId, side);
   }
 
-  override onAdd(_arena: Arena, quiet: boolean = false): void {
+  override onAdd(quiet: boolean = false): void {
     if (!quiet) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",
@@ -57,7 +56,7 @@ export class TailwindTag extends ArenaTag {
     }
   }
 
-  override onRemove(_arena: Arena, quiet: boolean = false): void {
+  override onRemove(quiet: boolean = false): void {
     if (!quiet) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",

--- a/src/data/arena-tags/toxic-spikes-tag.ts
+++ b/src/data/arena-tags/toxic-spikes-tag.ts
@@ -6,7 +6,6 @@ import { ArenaTagType } from "#enums/arena-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { StatusEffect } from "#enums/status-effect";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import i18next from "i18next";
 
@@ -24,8 +23,8 @@ export class ToxicSpikesTag extends EntryHazardTag {
     this.neutralized = false;
   }
 
-  override onAdd(arena: Arena, quiet: boolean = false): void {
-    super.onAdd(arena);
+  override onAdd(quiet: boolean = false): void {
+    super.onAdd();
 
     const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
     if (!quiet && source) {
@@ -39,9 +38,9 @@ export class ToxicSpikesTag extends EntryHazardTag {
     }
   }
 
-  override onRemove(arena: Arena): void {
+  override onRemove(): void {
     if (!this.neutralized) {
-      super.onRemove(arena);
+      super.onRemove();
     }
   }
 

--- a/src/data/arena-tags/trick-room-tag.ts
+++ b/src/data/arena-tags/trick-room-tag.ts
@@ -3,7 +3,6 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { ArenaRoomTag } from "#arena-tags/arena-room-tag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { BooleanHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
@@ -21,12 +20,12 @@ export class TrickRoomTag extends ArenaRoomTag {
    * turn order should be reversed.
    * @returns `true`
    */
-  override apply(_arena: Arena, _simulated: boolean, speedReversed: BooleanHolder): boolean {
+  override apply(_simulated: boolean, speedReversed: BooleanHolder): boolean {
     speedReversed.value = !speedReversed.value;
     return true;
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
     if (source) {
       globalScene.phaseManager.createAndUnshiftPhase(
@@ -36,7 +35,7 @@ export class TrickRoomTag extends ArenaRoomTag {
     }
   }
 
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:trickRoomOnRemove"));
   }
 }

--- a/src/data/arena-tags/type-hazard-tag.ts
+++ b/src/data/arena-tags/type-hazard-tag.ts
@@ -9,7 +9,6 @@ import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { ElementalType } from "#enums/elemental-type";
 import { HitResult } from "#enums/hit-result";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { BooleanHolder, toDmgValue } from "#utils/common-utils";
 import i18next from "i18next";
@@ -39,8 +38,8 @@ export abstract class TypeHazardTag extends EntryHazardTag {
     this.activateTrapKey = activateTrapKey;
   }
 
-  override onAdd(arena: Arena, quiet: boolean = false): void {
-    super.onAdd(arena);
+  override onAdd(quiet: boolean = false): void {
+    super.onAdd();
 
     const source = this.sourceId ? globalScene.getPokemonById(this.sourceId) : null;
     if (!quiet && source) {

--- a/src/data/arena-tags/type-immune-damage-over-time-tag.ts
+++ b/src/data/arena-tags/type-immune-damage-over-time-tag.ts
@@ -8,7 +8,6 @@ import { ArenaTagSide } from "#enums/arena-tag-side";
 import { CommonAnim } from "#enums/common-anim";
 import { ElementalType } from "#enums/elemental-type";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { BooleanHolder, enumValueToKey, toDmgValue } from "#utils/common-utils";
 import i18next from "i18next";
@@ -46,7 +45,7 @@ export class TypeImmuneDamageOverTimeTag extends ArenaTag {
     }
   }
 
-  override onAdd(_arena: Arena) {
+  override onAdd() {
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t(
@@ -55,7 +54,7 @@ export class TypeImmuneDamageOverTimeTag extends ArenaTag {
     );
   }
 
-  override lapse(arena: Arena): boolean {
+  override lapse(): boolean {
     const field: Pokemon[] =
       this.side === ArenaTagSide.PLAYER ? globalScene.getPlayerField() : globalScene.getEnemyField();
 
@@ -84,6 +83,6 @@ export class TypeImmuneDamageOverTimeTag extends ArenaTag {
         pokemon.damageAndUpdate(toDmgValue(pokemon.getMaxHp() / 6));
       });
 
-    return super.lapse(arena);
+    return super.lapse();
   }
 }

--- a/src/data/arena-tags/water-fire-pledge-tag.ts
+++ b/src/data/arena-tags/water-fire-pledge-tag.ts
@@ -3,7 +3,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { NumberHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
@@ -19,7 +18,7 @@ export class WaterFirePledgeTag extends ArenaTag {
     super(ArenaTagType.WATER_FIRE_PLEDGE, 4, MoveId.WATER_PLEDGE, sourceId, side);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     // "A rainbow appeared in the sky on your/the opposing team's side!"
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
@@ -29,13 +28,12 @@ export class WaterFirePledgeTag extends ArenaTag {
 
   /**
    * Doubles the chance for the given move's secondary effect(s) to trigger
-   * @param _arena the {@linkcode Arena} containing this tag
    * @param _simulated n/a
    * @param moveChance a {@linkcode NumberHolder} containing
    * the move's current effect chance
    * @returns `true` if the move's effect chance was doubled (currently always `true`)
    */
-  override apply(_arena: Arena, _simulated: boolean, moveChance: NumberHolder): boolean {
+  override apply(_simulated: boolean, moveChance: NumberHolder): boolean {
     moveChance.value *= 2;
     return true;
   }

--- a/src/data/arena-tags/water-sport-tag.ts
+++ b/src/data/arena-tags/water-sport-tag.ts
@@ -3,7 +3,6 @@ import { WeakenMoveTypeTag } from "#arena-tags/weaken-move-type-tag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import i18next from "i18next";
 
 /**
@@ -15,11 +14,11 @@ export class WaterSportTag extends WeakenMoveTypeTag {
     super(ArenaTagType.WATER_SPORT, turnCount, ElementalType.FIRE, MoveId.WATER_SPORT, sourceId);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:waterSportOnAdd"));
   }
 
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("arenaTag:waterSportOnRemove"));
   }
 }

--- a/src/data/arena-tags/weaken-move-screen-tag.ts
+++ b/src/data/arena-tags/weaken-move-screen-tag.ts
@@ -8,7 +8,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { MoveCategory } from "#enums/move-category";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { Pokemon } from "#field/pokemon";
 import { BooleanHolder, type NumberHolder } from "#utils/common-utils";
 
@@ -44,7 +43,6 @@ export abstract class WeakenMoveScreenTag extends ArenaTag {
   /**
    * Applies the weakening effect to the move.
    *
-   * @param _arena the {@linkcode Arena} where the move is applied.
    * @param _simulated n/a
    * @param attacker the attacking {@linkcode Pokemon}
    * @param moveCategory the attacking move's {@linkcode MoveCategory}.
@@ -52,7 +50,6 @@ export abstract class WeakenMoveScreenTag extends ArenaTag {
    * @returns `true` if the attacking move was weakened; `false` otherwise.
    */
   override apply(
-    _arena: Arena,
     simulated: boolean,
     attacker: Pokemon,
     moveCategory: MoveCategory,

--- a/src/data/arena-tags/weaken-move-type-tag.ts
+++ b/src/data/arena-tags/weaken-move-type-tag.ts
@@ -2,7 +2,6 @@ import { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { ElementalType } from "#enums/elemental-type";
 import type { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import type { NumberHolder } from "#utils/common-utils";
 
 /**
@@ -28,13 +27,12 @@ export abstract class WeakenMoveTypeTag extends ArenaTag {
 
   /**
    * Reduces an attack's power by 0.33x if it matches this tag's weakened type.
-   * @param _arena n/a
    * @param _simulated n/a
    * @param type the attack's {@linkcode ElementalType}
    * @param power a {@linkcode NumberHolder} containing the attack's power
    * @returns `true` if the attack's power was reduced; `false` otherwise.
    */
-  override apply(_arena: Arena, _simulated: boolean, type: ElementalType, power: NumberHolder): boolean {
+  override apply(_simulated: boolean, type: ElementalType, power: NumberHolder): boolean {
     if (type === this.weakenedType) {
       power.value *= 0.33;
       return true;

--- a/src/data/arena-tags/wide-guard-tag.ts
+++ b/src/data/arena-tags/wide-guard-tag.ts
@@ -9,11 +9,10 @@ import type { ProtectConditionFunc } from "#types/move-types";
 /**
  * Condition function for {@link https://bulbapedia.bulbagarden.net/wiki/Wide_Guard_(move) Wide Guard's}
  * protection effect.
- * @param _arena {@linkcode Arena} The arena containing the protection effect
  * @param moveId {@linkcode MoveId} The move to check against this condition
  * @returns `true` if the incoming move is multi-targeted (even if it's only used against one Pokemon).
  */
-const WideGuardConditionFunc: ProtectConditionFunc = (_arena, moveId): boolean => {
+const WideGuardConditionFunc: ProtectConditionFunc = (moveId): boolean => {
   const move = allMoves.get(moveId);
 
   switch (move.moveTarget) {

--- a/src/data/arena-tags/wish-tag.ts
+++ b/src/data/arena-tags/wish-tag.ts
@@ -5,7 +5,6 @@ import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import type { FieldBattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
-import type { Arena } from "#field/arena";
 import { toDmgValue } from "#utils/common-utils";
 import i18next from "i18next";
 
@@ -22,7 +21,7 @@ export class WishTag extends ArenaTag {
     super(ArenaTagType.WISH, turnCount, MoveId.WISH, sourceId, side);
   }
 
-  override onAdd(_arena: Arena): void {
+  override onAdd(): void {
     if (this.sourceId) {
       const user = globalScene.getPokemonById(this.sourceId);
       if (user) {
@@ -37,7 +36,7 @@ export class WishTag extends ArenaTag {
     }
   }
 
-  override onRemove(_arena: Arena): void {
+  override onRemove(): void {
     const target = globalScene.getPokemonByBattlerIndex(this.battlerIndex);
     if (target?.isActive(true)) {
       globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", this.triggerMessage);

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -1027,7 +1027,6 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
     const encountersByBiome = new Map<string, number>(biomes.map((b) => [b, 0]));
     const validMEfloorsByBiome = new Map<string, number>(biomes.map((b) => [b, 0]));
     let currentBiome: BiomeId = BiomeId.TOWN;
-    let currentArena = globalScene.newArena(currentBiome);
     globalScene.setSeed(randomString(24));
     globalScene.resetSeed();
     for (let i = 10; i < 180; i++) {
@@ -1066,7 +1065,7 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
           }
         }
 
-        currentArena = globalScene.newArena(currentBiome);
+        globalScene.newArena(currentBiome);
       }
 
       // Fixed battle
@@ -1075,7 +1074,7 @@ export function calculateMEAggregateStats(baseSpawnWeight: number) {
       }
 
       // Trainer
-      if (globalScene.gameMode.isWaveTrainer(i, currentArena)) {
+      if (globalScene.gameMode.isWaveTrainer(i)) {
         continue;
       }
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -782,7 +782,7 @@ export class Arena {
     if (side !== ArenaTagSide.BOTH) {
       tags = tags.filter((t) => t.side === side);
     }
-    tags.forEach((t) => t.apply(this, simulated, ...args));
+    tags.forEach((t) => t.apply(simulated, ...args));
   }
 
   /**
@@ -818,7 +818,7 @@ export class Arena {
   ): boolean {
     const existingTag = this.findTag(tagType, side);
     if (existingTag) {
-      existingTag.onOverlap(this);
+      existingTag.onOverlap();
 
       if (ENTRY_HAZARD_ARENA_TAG_TYPES.includes(existingTag.tagType)) {
         const { tagType, side, turnCount, layers, maxLayers } = existingTag as EntryHazardTag;
@@ -832,7 +832,7 @@ export class Arena {
     const newTag = getArenaTag(tagType, sourceId, turnCount, sourceMove, side);
     if (newTag) {
       this.tags.push(newTag);
-      newTag.onAdd(this, quiet);
+      newTag.onAdd(quiet);
 
       const { layers = 0, maxLayers = 0 } = ENTRY_HAZARD_ARENA_TAG_TYPES.includes(newTag.tagType)
         ? (newTag as EntryHazardTag)
@@ -889,9 +889,9 @@ export class Arena {
 
   lapseTags(): void {
     this.tags
-      .filter((t) => !t.lapse(this))
+      .filter((t) => !t.lapse())
       .forEach((t) => {
-        t.onRemove(this);
+        t.onRemove();
         this.tags.splice(this.tags.indexOf(t), 1);
 
         this.eventTarget.dispatchEvent(new TagRemovedEvent(t.tagType, t.side, t.turnCount));
@@ -902,7 +902,7 @@ export class Arena {
     const tags = this.tags;
     const tag = tags.find((t) => t.tagType === tagType);
     if (tag) {
-      tag.onRemove(this);
+      tag.onRemove();
       tags.splice(tags.indexOf(tag), 1);
 
       this.eventTarget.dispatchEvent(new TagRemovedEvent(tag.tagType, tag.side, tag.turnCount));
@@ -913,7 +913,7 @@ export class Arena {
   removeTagOnSide(tagType: ArenaTagType, side: ArenaTagSide, quiet: boolean = false): boolean {
     const tag = this.findTag(tagType, side);
     if (tag) {
-      tag.onRemove(this, quiet);
+      tag.onRemove(quiet);
       this.tags.splice(this.tags.indexOf(tag), 1);
 
       this.eventTarget.dispatchEvent(new TagRemovedEvent(tag.tagType, tag.side, tag.turnCount));
@@ -923,7 +923,7 @@ export class Arena {
 
   removeAllTags(): void {
     while (this.tags.length) {
-      this.tags[0].onRemove(this);
+      this.tags[0].onRemove();
       this.eventTarget.dispatchEvent(
         new TagRemovedEvent(this.tags[0].tagType, this.tags[0].side, this.tags[0].turnCount),
       );

--- a/src/game-mode.ts
+++ b/src/game-mode.ts
@@ -16,7 +16,6 @@ import { ChallengeType } from "#enums/challenge-type";
 import { Challenges } from "#enums/challenges";
 import { GameModes } from "#enums/game-modes";
 import { SpeciesId } from "#enums/species-id";
-import type { Arena } from "#field/arena";
 import { applyChallenges } from "#utils/challenge-utils";
 import { randSeedInt, randSeedItem } from "#utils/random-utils";
 import i18next from "i18next";
@@ -142,10 +141,9 @@ export class GameMode implements GameModeConfig {
   /**
    * Determines whether or not to generate a trainer
    * @param waveIndex the current floor the player is on (trainer sprites fail to generate on X1 floors)
-   * @param arena the current {@linkcode Arena}
    * @returns `true` if a trainer should be generated, `false` otherwise
    */
-  isWaveTrainer(waveIndex: number, arena: Arena): boolean {
+  isWaveTrainer(waveIndex: number): boolean {
     // Daily spawns trainers on floors 5, 15, 20, 25, 30, 35, 40, and 45
     if (this.isDaily) {
       return waveIndex % 10 === 5 || (!(waveIndex % 10) && waveIndex > 10 && !this.isWaveFinal(waveIndex));
@@ -158,7 +156,7 @@ export class GameMode implements GameModeConfig {
     // Trainers must not appear on X1 waves due to a bug that prevents trainer sprites from appearing
     // after the full party heal that happens between X0 and X1 waves
     if (waveIndex % 10 > 1) {
-      const trainerChance = arena.getTrainerChance();
+      const trainerChance = globalScene.arena.getTrainerChance();
       let allowTrainerBattle = true;
       if (trainerChance) {
         const waveBase = Math.floor(waveIndex / 10) * 10;
@@ -175,7 +173,7 @@ export class GameMode implements GameModeConfig {
 
           if (w < waveIndex) {
             globalScene.executeWithSeedOffset(() => {
-              const waveTrainerChance = arena.getTrainerChance();
+              const waveTrainerChance = globalScene.arena.getTrainerChance();
               if (!randSeedInt(waveTrainerChance)) {
                 allowTrainerBattle = false;
               }

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -255,9 +255,9 @@ export class TitlePhase extends Phase {
         Promise.all(loadPokemonAssets).then(() => {
           time.delayedCall(500, () => globalScene.audioManager.playBgm());
           gameData.gameStats.dailyRunSessionsPlayed++;
-          const arena = globalScene.newArena(gameMode.getStartingBiome());
+          globalScene.newArena(gameMode.getStartingBiome());
           globalScene.newBattle();
-          arena.init();
+          globalScene.arena.init();
           globalScene.sessionPlayTime = 0;
           globalScene.lastSavePlayTime = 0;
           this.end();

--- a/test/game-modes/game-mode.test.ts
+++ b/test/game-modes/game-mode.test.ts
@@ -32,15 +32,15 @@ describe("game-mode", () => {
       vi.spyOn(classicGameMode, "isFixedBattle").mockImplementation((n: number) => n === 16);
       vi.spyOn(arena, "getTrainerChance").mockReturnValue(1);
       vi.spyOn(RandomUtils, "randSeedInt").mockReturnValue(0);
-      expect(classicGameMode.isWaveTrainer(11, arena)).toBeFalsy();
-      expect(classicGameMode.isWaveTrainer(12, arena)).toBeTruthy();
-      expect(classicGameMode.isWaveTrainer(13, arena)).toBeFalsy();
-      expect(classicGameMode.isWaveTrainer(14, arena)).toBeFalsy();
-      expect(classicGameMode.isWaveTrainer(15, arena)).toBeFalsy();
+      expect(classicGameMode.isWaveTrainer(11)).toBeFalsy();
+      expect(classicGameMode.isWaveTrainer(12)).toBeTruthy();
+      expect(classicGameMode.isWaveTrainer(13)).toBeFalsy();
+      expect(classicGameMode.isWaveTrainer(14)).toBeFalsy();
+      expect(classicGameMode.isWaveTrainer(15)).toBeFalsy();
       // Wave 16 is a fixed trainer battle
-      expect(classicGameMode.isWaveTrainer(17, arena)).toBeFalsy();
-      expect(classicGameMode.isWaveTrainer(18, arena)).toBeFalsy();
-      expect(classicGameMode.isWaveTrainer(19, arena)).toBeFalsy();
+      expect(classicGameMode.isWaveTrainer(17)).toBeFalsy();
+      expect(classicGameMode.isWaveTrainer(18)).toBeFalsy();
+      expect(classicGameMode.isWaveTrainer(19)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Basically just cleaning up leftovers from the global scene refactor.

## What are the changes from a developer perspective?
All params used to pass around the arena were removed from various `ArenaTag` methods (and `ProtectConditionFunc` and `GameMode#isWaveTrainer`).

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?