### PR TITLE
[Refactor] Add type safety to `Arena#applyTags`

### DIFF
--- a/src/data/arena-tags/mist-tag.ts
+++ b/src/data/arena-tags/mist-tag.ts
@@ -45,7 +45,7 @@ export class MistTag extends ArenaTag {
    * to flag the stat reduction as cancelled
    * @returns `true` if a stat reduction was cancelled; `false` otherwise
    */
-  override apply(simulated: boolean, attacker: Pokemon, cancelled: BooleanHolder): boolean {
+  override apply(simulated: boolean, attacker: Pokemon | null, cancelled: BooleanHolder): boolean {
     if (attacker?.isActive(true)) {
       const bypassed = new BooleanHolder(false);
       applyAbAttrs<InfiltratorAbAttr>(AbAttrFlag.INFILTRATOR, attacker, simulated, bypassed);

--- a/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
+++ b/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
@@ -2,6 +2,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { IgnoreMoveEffectsAbAttr } from "#abilities/ignore-move-effects-ab-attr";
 import type { MoveEffectChanceMultiplierAbAttr } from "#abilities/move-effect-chance-multiplier-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { WaterFirePledgeTag } from "#arena-tags/water-fire-pledge-tag";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import type { Pokemon } from "#field/pokemon";
@@ -66,7 +67,7 @@ export abstract class ChanceBasedMoveEffectAttr extends MoveEffectAttr {
     );
 
     const userSide = user.getArenaTagSide();
-    globalScene.arena.applyTags(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
+    globalScene.arena.applyTags<WaterFirePledgeTag>(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
 
     if (!this.selfTarget) {
       applyAbAttrs<IgnoreMoveEffectsAbAttr>(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);

--- a/src/data/moves/move-attrs/flinch-attr.ts
+++ b/src/data/moves/move-attrs/flinch-attr.ts
@@ -2,6 +2,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { IgnoreMoveEffectsAbAttr } from "#abilities/ignore-move-effects-ab-attr";
 import type { MoveEffectChanceMultiplierAbAttr } from "#abilities/move-effect-chance-multiplier-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { WaterFirePledgeTag } from "#arena-tags/water-fire-pledge-tag";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -33,7 +34,7 @@ export class FlinchAttr extends AddBattlerTagAttr {
 
     if (moveChance.value <= move.chance) {
       const userSide = user.getArenaTagSide();
-      globalScene.arena.applyTags(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
+      globalScene.arena.applyTags<WaterFirePledgeTag>(ArenaTagType.WATER_FIRE_PLEDGE, userSide, false, moveChance);
     }
 
     applyAbAttrs<IgnoreMoveEffectsAbAttr>(AbAttrFlag.IGNORE_MOVE_EFFECTS, target, false, user, move, moveChance);

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -9,6 +9,7 @@ import type { UserFieldMoveTypePowerBoostAbAttr } from "#abilities/user-field-mo
 import type { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
 import type { WonderSkinAbAttr } from "#abilities/wonder-skin-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { WeakenMoveTypeTag } from "#arena-tags/weaken-move-type-tag";
 import { applyBattlerTags } from "#battler-tags/apply-battler-tags";
 import type { MeFirstPowerBoostTag } from "#battler-tags/me-first-power-boost-tag";
 import type { TypeBoostTag } from "#battler-tags/type-boost-tag";
@@ -866,7 +867,7 @@ export abstract class Move {
     }
 
     if (!this.hasAttr(TypelessAttr)) {
-      globalScene.arena.applyTags(
+      globalScene.arena.applyTags<WeakenMoveTypeTag>(
         [...WEAKEN_MOVE_TYPE_ARENA_TAG_TYPES],
         ArenaTagSide.BOTH,
         simulated,

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -771,13 +771,18 @@ export class Arena {
    * @param simulated if `true`, this applies arena tags without changing game state
    * @param args array of parameters that the called upon tags may need
    */
-  applyTags(tagTypes: ArenaTagType | ArenaTagType[], side: ArenaTagSide, simulated: boolean, ...args: unknown[]): void {
+  applyTags<T extends ArenaTag = never>(
+    tagTypes: ArenaTagType | ArenaTagType[],
+    side: ArenaTagSide,
+    ...args: Parameters<T["apply"]>
+  ): void {
     const tagTypeArr = coerceArray(tagTypes);
     let tags = this.tags.filter((t) => tagTypeArr.includes(t.tagType));
     if (side !== ArenaTagSide.BOTH) {
       tags = tags.filter((t) => t.side === side);
     }
-    tags.forEach((t) => t.apply(simulated, ...args));
+    const [simulated, ...params] = args;
+    tags.forEach((t) => t.apply(simulated, ...params));
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -44,6 +44,8 @@ import type { AnySound } from "#app/audio-manager";
 import { globalScene } from "#app/global-scene";
 import Overrides from "#app/overrides";
 import { timedEventManager } from "#app/timed-event-manager";
+import type { IonDelugeTag } from "#arena-tags/ion-deluge-tag";
+import type { WeakenMoveScreenTag } from "#arena-tags/weaken-move-screen-tag";
 import { applyBattlerTags } from "#battler-tags/apply-battler-tags";
 import type { AutotomizedTag } from "#battler-tags/autotomized-tag";
 import { BattlerTag } from "#battler-tags/battler-tag";
@@ -1875,7 +1877,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     applyMoveAttrs(VariableMoveTypeAttr, this, null, move, moveTypeHolder);
     applyAbAttrs<MoveTypeChangeAbAttr>(AbAttrFlag.MOVE_TYPE_CHANGE, this, simulated, move, undefined, moveTypeHolder);
 
-    globalScene.arena.applyTags(ArenaTagType.ION_DELUGE, ArenaTagSide.BOTH, simulated, moveTypeHolder);
+    globalScene.arena.applyTags<IonDelugeTag>(ArenaTagType.ION_DELUGE, ArenaTagSide.BOTH, simulated, moveTypeHolder);
     if (this.hasTag(BattlerTagType.ELECTRIFIED)) {
       moveTypeHolder.value = ElementalType.ELECTRIC;
     }
@@ -3218,7 +3220,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     /** Critical hits ignore the damage reduction from screens */
     if (!isCritical) {
-      globalScene.arena.applyTags(
+      globalScene.arena.applyTags<WeakenMoveScreenTag>(
         [...WEAKEN_MOVE_SCREEN_ARENA_TAG_TYPES],
         defendingSide,
         simulated,

--- a/src/phases/base/hit-check-phase.ts
+++ b/src/phases/base/hit-check-phase.ts
@@ -1,4 +1,5 @@
 import { globalScene } from "#app/global-scene";
+import type { ConditionalProtectTag } from "#arena-tags/conditional-protect-tag";
 import { applyBattlerTags } from "#battler-tags/apply-battler-tags";
 import type { ProtectedTag } from "#battler-tags/protected-tag";
 import { CONDITIONAL_PROTECT_ARENA_TAG_TYPES } from "#constants/arena-tag-constants";
@@ -111,7 +112,7 @@ export abstract class HitCheckPhase extends PokemonPhase {
     const hasConditionalProtectApplied = new BooleanHolder(false);
     /** If the move is not targeting a Pokemon on the user's side, try to apply conditional protection effects */
     if (!this.move.getMove().isAllyTarget()) {
-      globalScene.arena.applyTags(
+      globalScene.arena.applyTags<ConditionalProtectTag>(
         [...CONDITIONAL_PROTECT_ARENA_TAG_TYPES],
         targetSide,
         simulated,

--- a/src/phases/post-summon-phase.ts
+++ b/src/phases/post-summon-phase.ts
@@ -2,6 +2,8 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { CommanderAbAttr } from "#abilities/commander-ab-attr";
 import type { PostSummonAbAttr } from "#abilities/post-summon-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { EntryHazardTag } from "#arena-tags/entry-hazard-tag";
+import type { PendingHealTag } from "#arena-tags/pending-heal-tag";
 import { ENTRY_HAZARD_ARENA_TAG_TYPES } from "#constants/arena-tag-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -23,9 +25,9 @@ export class PostSummonPhase extends PokemonPhase {
     }
 
     // Apply pending heal effects from Healing Wish and Lunar Dance.
-    globalScene.arena.applyTags(ArenaTagType.PENDING_HEAL, ArenaTagSide.BOTH, false, pokemon);
+    globalScene.arena.applyTags<PendingHealTag>(ArenaTagType.PENDING_HEAL, ArenaTagSide.BOTH, false, pokemon);
 
-    globalScene.arena.applyTags([...ENTRY_HAZARD_ARENA_TAG_TYPES], ArenaTagSide.BOTH, false, pokemon);
+    globalScene.arena.applyTags<EntryHazardTag>([...ENTRY_HAZARD_ARENA_TAG_TYPES], ArenaTagSide.BOTH, false, pokemon);
 
     // If this is mystery encounter and has post summon phase tag, apply post summon effects
     if (globalScene.currentBattle.isBattleMysteryEncounter()) {

--- a/src/phases/stat-stage-change-phase.ts
+++ b/src/phases/stat-stage-change-phase.ts
@@ -7,6 +7,7 @@ import type { StatStageChangeMultiplierAbAttr } from "#abilities/stat-stage-chan
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { handleTutorial } from "#app/tutorial";
+import type { MistTag } from "#arena-tags/mist-tag";
 import { CANVAS_SCALE } from "#constants/ui-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -140,7 +141,7 @@ export class StatStageChangePhase extends PokemonPhase {
       const cancelled = new BooleanHolder(false);
 
       if (!selfTarget && stages.value < 0) {
-        arena.applyTags(ArenaTagType.MIST, pokemon.getArenaTagSide(), false, this.source, cancelled);
+        arena.applyTags<MistTag>(ArenaTagType.MIST, pokemon.getArenaTagSide(), false, this.source, cancelled);
       }
 
       if (!cancelled.value && !selfTarget && stages.value < 0) {

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -6,6 +6,7 @@ import type { MovePhase } from "#phases/move-phase";
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { TrickRoomTag } from "#arena-tags/trick-room-tag";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -300,7 +301,7 @@ export class TurnCommandManager {
 
     /** 'true' if Trick Room is on the field. */
     const speedReversed = new BooleanHolder(false);
-    globalScene.arena.applyTags(ArenaTagType.TRICK_ROOM, ArenaTagSide.BOTH, false, speedReversed);
+    globalScene.arena.applyTags<TrickRoomTag>(ArenaTagType.TRICK_ROOM, ArenaTagSide.BOTH, false, speedReversed);
 
     if (speedReversed.value) {
       this.turnCommands = this.turnCommands.reverse();


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Add additional type safety.

## What are the changes from a developer perspective?
`Arena#applyTags` changed to `applyTags<T extends ArenaTag = never>(...)` to enforce type safety with the tag `apply` function params.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?