### PR TITLE
[Refactor] Change `Pokemon#moveset` to `protected`

### DIFF
--- a/src/data/abilities/ab-attrs/forewarn-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/forewarn-ab-attr.ts
@@ -4,6 +4,7 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
 import type { PokemonMove } from "#field/pokemon-move";
+import type { Move } from "#moves/move";
 import { OneHitKOAttr } from "#moves/one-hit-ko-attr";
 import i18next from "i18next";
 
@@ -18,27 +19,25 @@ export class ForewarnAbAttr extends PostSummonAbAttr {
       movesets.push(...opponent.getMoveset());
     }
 
-    for (const move of movesets) {
-      if (move.getMove().isStatusMove()) {
+    for (const pokemonMove of movesets) {
+      const move = pokemonMove.getMove();
+      // TS incorrectly narrows `move` from `Move` to `never` if `move.isStatusMove()` is used here
+      if ((move as Move).isStatusMove()) {
         movePower = 1;
-      } else if (move.getMove().hasAttr(OneHitKOAttr)) {
+      } else if (move.hasAttr(OneHitKOAttr)) {
         movePower = 150;
-      } else if (
-        move.getMove().id === MoveId.COUNTER
-        || move.getMove().id === MoveId.MIRROR_COAT
-        || move.getMove().id === MoveId.METAL_BURST
-      ) {
+      } else if (move.id === MoveId.COUNTER || move.id === MoveId.MIRROR_COAT || move.id === MoveId.METAL_BURST) {
         movePower = 120;
-      } else if (move.getMove().power === -1) {
+      } else if (move.power === -1) {
         movePower = 80;
       } else {
-        movePower = move.getMove().power;
+        movePower = move.power;
       }
 
       // TODO: if multiple moves have the same effective power, one should be randomly chosen from them
       if (movePower > maxPowerSeen) {
         maxPowerSeen = movePower;
-        moveName = move.getName();
+        moveName = move.name;
       }
     }
 

--- a/src/data/abilities/ab-attrs/forewarn-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/forewarn-ab-attr.ts
@@ -15,8 +15,7 @@ export class ForewarnAbAttr extends PostSummonAbAttr {
     const movesets: PokemonMove[] = [];
 
     for (const opponent of pokemon.getOpponents()) {
-      // TODO: should this consider summon data movesets (such as from Transform)?
-      movesets.push(...opponent.getMoveset(true));
+      movesets.push(...opponent.getMoveset());
     }
 
     for (const move of movesets) {

--- a/src/data/abilities/ab-attrs/forewarn-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/forewarn-ab-attr.ts
@@ -3,47 +3,56 @@ import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
+import type { PokemonMove } from "#field/pokemon-move";
 import { OneHitKOAttr } from "#moves/one-hit-ko-attr";
 import i18next from "i18next";
 
 export class ForewarnAbAttr extends PostSummonAbAttr {
   public override apply(pokemon: Pokemon, simulated: boolean): boolean {
     let maxPowerSeen = 0;
-    let maxMove = "";
+    let moveName = "";
     let movePower = 0;
-    for (const opponent of pokemon.getOpponents()) {
-      for (const move of opponent.moveset) {
-        if (move.getMove().isStatusMove()) {
-          movePower = 1;
-        } else if (move.getMove().hasAttr(OneHitKOAttr)) {
-          movePower = 150;
-        } else if (
-          move.getMove().id === MoveId.COUNTER
-          || move.getMove().id === MoveId.MIRROR_COAT
-          || move.getMove().id === MoveId.METAL_BURST
-        ) {
-          movePower = 120;
-        } else if (move.getMove().power === -1) {
-          movePower = 80;
-        } else {
-          movePower = move.getMove().power;
-        }
+    const movesets: PokemonMove[] = [];
 
-        if (movePower > maxPowerSeen) {
-          maxPowerSeen = movePower;
-          maxMove = move.getName();
-        }
+    for (const opponent of pokemon.getOpponents()) {
+      // TODO: should this consider summon data movesets (such as from Transform)?
+      movesets.push(...opponent.getMoveset(true));
+    }
+
+    for (const move of movesets) {
+      if (move.getMove().isStatusMove()) {
+        movePower = 1;
+      } else if (move.getMove().hasAttr(OneHitKOAttr)) {
+        movePower = 150;
+      } else if (
+        move.getMove().id === MoveId.COUNTER
+        || move.getMove().id === MoveId.MIRROR_COAT
+        || move.getMove().id === MoveId.METAL_BURST
+      ) {
+        movePower = 120;
+      } else if (move.getMove().power === -1) {
+        movePower = 80;
+      } else {
+        movePower = move.getMove().power;
+      }
+
+      // TODO: if multiple moves have the same effective power, one should be randomly chosen from them
+      if (movePower > maxPowerSeen) {
+        maxPowerSeen = movePower;
+        moveName = move.getName();
       }
     }
+
     if (!simulated) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",
         i18next.t("abilityTriggers:forewarn", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-          moveName: maxMove,
+          moveName,
         }),
       );
     }
+
     return true;
   }
 }

--- a/src/data/berry.ts
+++ b/src/data/berry.ts
@@ -139,7 +139,7 @@ export function getBerryEffectFunc(berryType: BerryType): BerryEffectFunc {
           ? pokemon.getMoveset().find((m) => !m.getPpRatio())
           : pokemon.getMoveset().find((m) => m.getPpRatio() < 1);
         if (ppRestoreMove !== undefined) {
-          ppRestoreMove!.ppUsed = Math.max(ppRestoreMove!.ppUsed - 10, 0);
+          ppRestoreMove.ppUsed = Math.max(ppRestoreMove.ppUsed - 10, 0);
           globalScene.phaseManager.createAndUnshiftPhase(
             "MessagePhase",
             i18next.t("battle:ppHealBerry", {

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -673,9 +673,7 @@ export class FreshStartChallenge extends Challenge {
       .filter((m) => m[0] <= 5)
       .map((lm) => lm[1])
       .slice(0, 4); // No egg moves
-    moveset.forEach((m, i) => {
-      pokemon.setMove(i, m);
-    });
+    pokemon.setMoveset(...moveset);
     pokemon.luck = 0; // No luck
     pokemon.shiny = false; // Not shiny
     pokemon.variant = 0; // Not shiny

--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -16,7 +16,6 @@ import { SpeciesId } from "#enums/species-id";
 import { TrainerType } from "#enums/trainer-type";
 import { TrainerVariant } from "#enums/trainer-variant";
 import type { Pokemon } from "#field/pokemon";
-import { PokemonMove } from "#field/pokemon-move";
 import { Trainer } from "#field/trainer";
 import { pokemonEvolutions } from "#init/init-pokemon-evolutions";
 import type { DexAttrProps, GameData } from "#system/game-data";
@@ -669,12 +668,14 @@ export class FreshStartChallenge extends Challenge {
     pokemon.abilityIndex = 0; // Always base ability, not hidden ability
     pokemon.passive = false; // Passive isn't unlocked
     pokemon.nature = Nature.HARDY; // Neutral nature
-    pokemon.moveset = pokemon.species
+    const moveset = pokemon.species
       .getLevelMoves()
       .filter((m) => m[0] <= 5)
       .map((lm) => lm[1])
-      .slice(0, 4)
-      .map((m) => new PokemonMove(m)); // No egg moves
+      .slice(0, 4); // No egg moves
+    moveset.forEach((m, i) => {
+      pokemon.setMove(i, m);
+    });
     pokemon.luck = 0; // No luck
     pokemon.shiny = false; // Not shiny
     pokemon.variant = 0; // Not shiny

--- a/src/data/moves/move-attrs/less-pp-more-power-attr.ts
+++ b/src/data/moves/move-attrs/less-pp-more-power-attr.ts
@@ -10,10 +10,10 @@ import type { NumberHolder } from "#utils/common-utils";
 export class LessPPMorePowerAttr extends VariablePowerAttr {
   override apply(user: Pokemon, _target: Pokemon, move: Move, power: NumberHolder): boolean {
     const ppMax = move.pp;
-    const ppUsed = user.moveset.find((m) => m.moveId === move.id)?.ppUsed ?? 0;
+    const ppUsed = user.getMoveset(true).find((m) => m.moveId === move.id)?.ppUsed ?? 0;
 
     let ppRemains = ppMax - ppUsed;
-    /** Reduce to 0 to avoid negative numbers if user has 1PP before attack and target has Ability.PRESSURE */
+    // Reduce to 0 to avoid negative numbers if user has 1PP before attack and target has Pressure
     if (ppRemains < 0) {
       ppRemains = 0;
     }

--- a/src/data/moves/move-attrs/less-pp-more-power-attr.ts
+++ b/src/data/moves/move-attrs/less-pp-more-power-attr.ts
@@ -10,7 +10,7 @@ import type { NumberHolder } from "#utils/common-utils";
 export class LessPPMorePowerAttr extends VariablePowerAttr {
   override apply(user: Pokemon, _target: Pokemon, move: Move, power: NumberHolder): boolean {
     const ppMax = move.pp;
-    const ppUsed = user.getMoveset(true).find((m) => m.moveId === move.id)?.ppUsed ?? 0;
+    const ppUsed = user.getMoveset().find((m) => m.moveId === move.id)?.ppUsed ?? 0;
 
     let ppRemains = ppMax - ppUsed;
     // Reduce to 0 to avoid negative numbers if user has 1PP before attack and target has Pressure

--- a/src/data/moves/move-attrs/random-moveset-move-attr.ts
+++ b/src/data/moves/move-attrs/random-moveset-move-attr.ts
@@ -48,7 +48,7 @@ export class RandomMovesetMoveAttr extends CallMoveAttr {
         allies = [user];
       }
 
-      const partyMoveset = allies.flatMap((p) => p.moveset);
+      const partyMoveset = allies.flatMap((p) => p.getMoveset(true));
       const moves = partyMoveset.filter((m) => !this.invalidMoves.has(m.moveId) && !m.getMove().name.endsWith(" (N)"));
 
       if (moves.length === 0) {
@@ -62,6 +62,8 @@ export class RandomMovesetMoveAttr extends CallMoveAttr {
   }
 }
 
+// TODO: these lists should be moved to their own file (e.g. `invalid-moves.ts`)
+// so that importing them doesn't import anything else
 export const invalidAssistMoves: ReadonlySet<MoveId> = Object.freeze(
   new Set([
     ...getMaxMoveList(),

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -377,12 +377,10 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
         // Greedent joins the team, level equal to 2 below highest party member (shiny locked)
         const level = getHighestLevelPlayerPokemon(false, true).level - 2;
         const greedent = new EnemyPokemon(getPokemonSpecies(SpeciesId.GREEDENT), level, TrainerSlot.NONE, false, true);
-        greedent.moveset = [
-          new PokemonMove(MoveId.THRASH),
-          new PokemonMove(MoveId.BODY_PRESS),
-          new PokemonMove(MoveId.STUFF_CHEEKS),
-          new PokemonMove(MoveId.SLACK_OFF),
-        ];
+        greedent.setMove(0, MoveId.THRASH);
+        greedent.setMove(1, MoveId.BODY_PRESS);
+        greedent.setMove(2, MoveId.STUFF_CHEEKS);
+        greedent.setMove(3, MoveId.SLACK_OFF);
         greedent.passive = true;
 
         await transitionMysteryEncounterIntroVisuals(true, true, 500);

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -377,10 +377,7 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
         // Greedent joins the team, level equal to 2 below highest party member (shiny locked)
         const level = getHighestLevelPlayerPokemon(false, true).level - 2;
         const greedent = new EnemyPokemon(getPokemonSpecies(SpeciesId.GREEDENT), level, TrainerSlot.NONE, false, true);
-        greedent.setMove(0, MoveId.THRASH);
-        greedent.setMove(1, MoveId.BODY_PRESS);
-        greedent.setMove(2, MoveId.STUFF_CHEEKS);
-        greedent.setMove(3, MoveId.SLACK_OFF);
+        greedent.setMoveset(MoveId.THRASH, MoveId.BODY_PRESS, MoveId.STUFF_CHEEKS, MoveId.SLACK_OFF);
         greedent.passive = true;
 
         await transitionMysteryEncounterIntroVisuals(true, true, 500);

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -367,12 +367,12 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
 
           // If the Pokemon has non-status moves that don't match the Pokemon's type, prioritizes those as the new type
           // Makes the "randomness" of the shuffle slightly less punishing
-          let priorityTypes = pokemon.moveset
+          let priorityTypes = pokemon
+            .getMoveset(true)
             .filter(
-              (move) =>
-                move && !originalTypes.includes(move.getMove().type) && move.getMove().category !== MoveCategory.STATUS,
+              (move) => !originalTypes.includes(move.getMove().type) && move.getMove().category !== MoveCategory.STATUS,
             )
-            .map((move) => move!.getMove().type);
+            .map((move) => move?.getMove().type);
           if (priorityTypes?.length > 0) {
             priorityTypes = [...new Set(priorityTypes)].sort();
             priorityTypes = randSeedShuffle(priorityTypes);

--- a/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
@@ -83,11 +83,12 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
     const species = getPokemonSpecies(SpeciesId.ORICORIO);
     const level = getEncounterPokemonLevelForWave(STANDARD_ENCOUNTER_BOOSTED_LEVEL_MODIFIER);
     const enemyPokemon = new EnemyPokemon(species, level, TrainerSlot.NONE, false);
-    if (!enemyPokemon.moveset.some((m) => m && m.getMove().id === MoveId.REVELATION_DANCE)) {
-      if (enemyPokemon.moveset.length < 4) {
-        enemyPokemon.moveset.push(new PokemonMove(MoveId.REVELATION_DANCE));
+    const moveset = enemyPokemon.getMoveset(true);
+    if (!moveset.some((m) => m && m.getMove().id === MoveId.REVELATION_DANCE)) {
+      if (moveset.length < 4) {
+        enemyPokemon.setMove(moveset.length, MoveId.REVELATION_DANCE);
       } else {
-        enemyPokemon.moveset[0] = new PokemonMove(MoveId.REVELATION_DANCE);
+        enemyPokemon.setMove(0, MoveId.REVELATION_DANCE);
       }
     }
 
@@ -225,9 +226,10 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
         const encounter = globalScene.currentBattle.mysteryEncounter!;
         const onPokemonSelected = (pokemon: PlayerPokemon) => {
           // Return the options for nature selection
-          return pokemon.moveset
-            .filter((move) => move && DANCING_MOVES.includes(move.getMove().id))
-            .map((move: PokemonMove) => {
+          return pokemon
+            .getMoveset(true)
+            .filter((move) => DANCING_MOVES.includes(move.getMove().id))
+            .map((move) => {
               const option: OptionSelectItem = {
                 label: move.getName(),
                 handler: () => {

--- a/src/data/mystery-encounters/encounters/field-trip-encounter.ts
+++ b/src/data/mystery-encounters/encounters/field-trip-encounter.ts
@@ -74,7 +74,7 @@ export const FieldTripEncounter: MysteryEncounter = MysteryEncounterBuilder.with
         const encounter = globalScene.currentBattle.mysteryEncounter!;
         const onPokemonSelected = (pokemon: PlayerPokemon) => {
           // Return the options for Pokemon move valid for this option
-          return pokemon.moveset.map((move: PokemonMove) => {
+          return pokemon.getMoveset(true).map((move) => {
             const option: OptionSelectItem = {
               label: move.getName(),
               handler: () => {
@@ -119,7 +119,7 @@ export const FieldTripEncounter: MysteryEncounter = MysteryEncounterBuilder.with
         const encounter = globalScene.currentBattle.mysteryEncounter!;
         const onPokemonSelected = (pokemon: PlayerPokemon) => {
           // Return the options for Pokemon move valid for this option
-          return pokemon.moveset.map((move: PokemonMove) => {
+          return pokemon.getMoveset(true).map((move) => {
             const option: OptionSelectItem = {
               label: move.getName(),
               handler: () => {
@@ -164,7 +164,7 @@ export const FieldTripEncounter: MysteryEncounter = MysteryEncounterBuilder.with
         const encounter = globalScene.currentBattle.mysteryEncounter!;
         const onPokemonSelected = (pokemon: PlayerPokemon) => {
           // Return the options for Pokemon move valid for this option
-          return pokemon.moveset.map((move: PokemonMove) => {
+          return pokemon.getMoveset(true).map((move) => {
             const option: OptionSelectItem = {
               label: move.getName(),
               handler: () => {

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -22,7 +22,6 @@ import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
-import { PokemonMove } from "#field/pokemon-move";
 import {
   HiddenAbilityRateBoosterModifier,
   type PokemonHeldItemModifier,
@@ -47,7 +46,7 @@ import { PokemonData } from "#system/pokemon-data";
 import type { OptionSelectItem } from "#ui/option-select-config";
 import { isNil, NumberHolder } from "#utils/common-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
-import { randInt, randItem, randSeedInt, randSeedShuffle } from "#utils/random-utils";
+import { randInt, randItem, randSeedInt, randSeedItem, randSeedShuffle } from "#utils/random-utils";
 import i18next from "i18next";
 
 /** the i18n namespace for the encounter */
@@ -252,16 +251,17 @@ export const GlobalTradeSystemEncounter: MysteryEncounter = MysteryEncounterBuil
 
           // If Pokemon is still not shiny or with HA, give the Pokemon a random Common egg move in its moveset
           if (!tradePokemon.shiny && (!tradePokemon.species.abilityHidden || tradePokemon.abilityIndex < hiddenIndex)) {
-            const eggMoves = tradePokemon.getEggMoves();
+            // Cannot gen the rare egg move, only 1 of the first 3 common moves
+            const eggMoves = tradePokemon.getEggMoves()?.slice(0, 2);
             if (eggMoves) {
-              // Cannot gen the rare egg move, only 1 of the first 3 common moves
-              const eggMove = eggMoves[randSeedInt(3)];
-              if (!tradePokemon.moveset.some((m) => m.moveId === eggMove)) {
-                if (tradePokemon.moveset.length < 4) {
-                  tradePokemon.moveset.push(new PokemonMove(eggMove));
+              const eggMove = randSeedItem(eggMoves);
+              const moveset = tradePokemon.getMoveset(true);
+              if (!moveset.some((m) => m.moveId === eggMove)) {
+                if (moveset.length < 4) {
+                  tradePokemon.setMove(moveset.length, eggMove);
                 } else {
                   const eggMoveIndex = randSeedInt(4);
-                  tradePokemon.moveset[eggMoveIndex] = new PokemonMove(eggMove);
+                  tradePokemon.setMove(eggMoveIndex, eggMove);
                 }
               }
             }

--- a/src/data/mystery-encounters/encounters/part-timer-encounter.ts
+++ b/src/data/mystery-encounters/encounters/part-timer-encounter.ts
@@ -110,7 +110,7 @@ export const PartTimerEncounter: MysteryEncounter = MysteryEncounterBuilder.with
           };
 
           // Reduce all PP to 2 (if they started at greater than 2)
-          pokemon.moveset.forEach((move) => {
+          pokemon.getMoveset(true).forEach((move) => {
             if (move) {
               const newPpUsed = move.getMovePp() - 2;
               move.ppUsed = move.ppUsed < newPpUsed ? newPpUsed : move.ppUsed;
@@ -188,7 +188,7 @@ export const PartTimerEncounter: MysteryEncounter = MysteryEncounterBuilder.with
           };
 
           // Reduce all PP to 2 (if they started at greater than 2)
-          pokemon.moveset.forEach((move) => {
+          pokemon.getMoveset(true).forEach((move) => {
             if (move) {
               const newPpUsed = move.getMovePp() - 2;
               move.ppUsed = move.ppUsed < newPpUsed ? newPpUsed : move.ppUsed;
@@ -252,7 +252,7 @@ export const PartTimerEncounter: MysteryEncounter = MysteryEncounterBuilder.with
         encounter.setDialogueToken("selectedPokemon", selectedPokemon.getNameToRender());
 
         // Reduce all PP to 2 (if they started at greater than 2)
-        selectedPokemon.moveset.forEach((move) => {
+        selectedPokemon.getMoveset(true).forEach((move) => {
           if (move) {
             const newPpUsed = move.getMovePp() - 2;
             move.ppUsed = move.ppUsed < newPpUsed ? newPpUsed : move.ppUsed;

--- a/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
+++ b/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
@@ -7,7 +7,7 @@ import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PokeballType } from "#enums/pokeball-type";
-import { Stat } from "#enums/stat";
+import { type BattleStat, Stat } from "#enums/stat";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -33,7 +33,7 @@ import { MoveRequirement, PersistentModifierRequirement } from "#mystery-encount
 import { CHARMING_MOVES } from "#mystery-encounters/requirement-groups";
 import { PokemonData } from "#system/pokemon-data";
 import { isNil } from "#utils/common-utils";
-import { randSeedInt } from "#utils/random-utils";
+import { randSeedInt, randSeedItem } from "#utils/random-utils";
 
 /** the i18n namespace for the encounter */
 const namespace = "mysteryEncounters/uncommonBreed";
@@ -73,23 +73,23 @@ export const UncommonBreedEncounter: MysteryEncounter = MysteryEncounterBuilder.
     // Pokemon will always have one of its egg moves in its moveset
     const eggMoves = pokemon.getEggMoves();
     if (eggMoves) {
-      const eggMoveIndex = randSeedInt(4);
-      const randomEggMoveId: MoveId = eggMoves[eggMoveIndex];
+      const randomEggMoveId = randSeedItem(eggMoves);
       encounter.misc = {
         eggMove: randomEggMoveId,
         pokemon: pokemon,
       };
-      if (pokemon.moveset.length < 4) {
-        pokemon.moveset.push(new PokemonMove(randomEggMoveId));
+      const moveset = pokemon.getMoveset(true);
+      if (moveset.length < 4) {
+        pokemon.setMove(moveset.length, randomEggMoveId);
       } else {
-        pokemon.moveset[0] = new PokemonMove(randomEggMoveId);
+        pokemon.setMove(0, randomEggMoveId);
       }
     } else {
       encounter.misc.pokemon = pokemon;
     }
 
     // Defense/Spd buffs below wave 50, +1 to all stats otherwise
-    const statChangesForBattle: (Stat.ATK | Stat.DEF | Stat.SPATK | Stat.SPDEF | Stat.SPD | Stat.ACC | Stat.EVA)[] =
+    const statChangesForBattle: BattleStat[] =
       globalScene.currentBattle.waveIndex < 50
         ? [Stat.DEF, Stat.SPDEF, Stat.SPD]
         : [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD];
@@ -280,10 +280,11 @@ function givePokemonExtraEggMove(pokemon: EnemyPokemon, previousEggMoveId: MoveI
     while (randomEggMoveId === previousEggMoveId) {
       randomEggMoveId = eggMoves[randSeedInt(4)];
     }
-    if (pokemon.moveset.length < 4) {
-      pokemon.moveset.push(new PokemonMove(randomEggMoveId));
+    const moveset = pokemon.getMoveset(true);
+    if (moveset.length < 4) {
+      pokemon.setMove(moveset.length, randomEggMoveId);
     } else {
-      pokemon.moveset[1] = new PokemonMove(randomEggMoveId);
+      pokemon.setMove(1, randomEggMoveId);
     }
   }
 }

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -500,7 +500,8 @@ async function postProcessTransformedPokemon(
   const newPokemonGeneratedMoveset = newPokemon.getMoveset(true);
 
   // @ts-expect-error - `Pokemon#moveset` is private
-  newPokemon.moveset = previousPokemon.moveset.slice(0);
+  const previousMoveset = previousPokemon.moveset.slice(0).map((m) => m.getMove().id);
+  newPokemon.setMoveset(...previousMoveset);
 
   const newEggMoveIndex = await addEggMoveToNewPokemonMoveset(newPokemon, speciesRootForm, forBattle);
 

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -21,7 +21,7 @@ import { TrainerType } from "#enums/trainer-type";
 import { TransformationScreenPosition } from "#enums/transformation-screen-position";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
-import { PokemonMove } from "#field/pokemon-move";
+import type { PokemonMove } from "#field/pokemon-move";
 import { HiddenAbilityRateBoosterModifier, type PokemonHeldItemModifier } from "#modifier/modifier";
 import type { PokemonHeldItemModifierType } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
@@ -497,8 +497,9 @@ async function postProcessTransformedPokemon(
   // Set the moveset of the new pokemon to be the same as previous, but with 1 egg move and 1 (attempted) STAB move of the new species
   newPokemon.generateAndPopulateMoveset();
   // Store a copy of a "standard" generated moveset for the new pokemon, will be used later for finding a favored move
-  const newPokemonGeneratedMoveset = newPokemon.moveset;
+  const newPokemonGeneratedMoveset = newPokemon.getMoveset(true);
 
+  // @ts-expect-error - `Pokemon#moveset` is private
   newPokemon.moveset = previousPokemon.moveset.slice(0);
 
   const newEggMoveIndex = await addEggMoveToNewPokemonMoveset(newPokemon, speciesRootForm, forBattle);
@@ -708,7 +709,7 @@ async function addEggMoveToNewPokemonMoveset(
     let randomEggMoveIndex = eggMoveIndices.pop();
     let randomEggMove = !isNil(randomEggMoveIndex) ? eggMoves[randomEggMoveIndex] : null;
     let retries = 0;
-    while (retries < 3 && (!randomEggMove || newPokemon.moveset.some((m) => m.moveId === randomEggMove))) {
+    while (retries < 3 && (!randomEggMove || newPokemon.getMoveset(true).some((m) => m.moveId === randomEggMove))) {
       // If Pokemon already knows this move, roll for another egg move
       randomEggMoveIndex = eggMoveIndices.pop();
       randomEggMove = !isNil(randomEggMoveIndex) ? eggMoves[randomEggMoveIndex] : null;
@@ -716,12 +717,13 @@ async function addEggMoveToNewPokemonMoveset(
     }
 
     if (randomEggMove) {
-      if (!newPokemon.moveset.some((m) => m.moveId === randomEggMove)) {
-        if (newPokemon.moveset.length < 4) {
-          newPokemon.moveset.push(new PokemonMove(randomEggMove));
+      const moveset = newPokemon.getMoveset(true);
+      if (!moveset.some((m) => m.moveId === randomEggMove)) {
+        if (moveset.length < 4) {
+          newPokemon.setMove(moveset.length, randomEggMove);
         } else {
           eggMoveIndex = randSeedInt(4);
-          newPokemon.moveset[eggMoveIndex] = new PokemonMove(randomEggMove);
+          newPokemon.setMove(eggMoveIndex, randomEggMove);
         }
       }
 
@@ -748,13 +750,16 @@ async function addEggMoveToNewPokemonMoveset(
  */
 function addFavoredMoveToNewPokemonMoveset(
   newPokemon: PlayerPokemon,
-  newPokemonGeneratedMoveset: PokemonMove[],
+  newPokemonGeneratedMoveset: readonly PokemonMove[],
   newEggMoveIndex: number | null,
 ) {
   let favoredMove: PokemonMove | null = null;
   for (const move of newPokemonGeneratedMoveset) {
     // Needs to match first type, second type will be replaced
-    if (move.getMove().type === newPokemon.getTypes()[0] && !newPokemon.moveset.some((m) => m.moveId === move.moveId)) {
+    if (
+      move.getMove().type === newPokemon.getTypes()[0]
+      && !newPokemon.getMoveset(true).some((m) => m.moveId === move.moveId)
+    ) {
       favoredMove = move;
       break;
     }
@@ -764,7 +769,7 @@ function addFavoredMoveToNewPokemonMoveset(
   if (!favoredMove) {
     for (const move of newPokemonGeneratedMoveset) {
       // Needs to match first type, second type will be replaced
-      if (!newPokemon.moveset.some((m) => m.moveId === move.moveId)) {
+      if (!newPokemon.getMoveset(true).some((m) => m.moveId === move.moveId)) {
         favoredMove = move;
         break;
       }
@@ -772,15 +777,15 @@ function addFavoredMoveToNewPokemonMoveset(
   }
   // Finally, assign favored move to random index that isn't the new egg move index
   if (favoredMove) {
-    if (newPokemon.moveset.length < 4) {
-      newPokemon.moveset.push(favoredMove);
+    if (newPokemon.getMoveset(true).length < 4) {
+      newPokemon.setMove(newPokemon.getMoveset(true).length, favoredMove.getMove().id);
     } else {
       let favoredMoveIndex = randSeedInt(4);
       while (newEggMoveIndex !== null && favoredMoveIndex === newEggMoveIndex) {
         favoredMoveIndex = randSeedInt(4);
       }
 
-      newPokemon.moveset[favoredMoveIndex] = favoredMove;
+      newPokemon.setMove(favoredMoveIndex, favoredMove.getMove().id);
     }
   }
 }

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -499,8 +499,7 @@ async function postProcessTransformedPokemon(
   // Store a copy of a "standard" generated moveset for the new pokemon, will be used later for finding a favored move
   const newPokemonGeneratedMoveset = newPokemon.getMoveset(true);
 
-  // @ts-expect-error - `Pokemon#moveset` is private
-  const previousMoveset = previousPokemon.moveset.slice(0).map((m) => m.getMove().id);
+  const previousMoveset = previousPokemon.getMoveset(true).map((m) => m.getMove().id);
   newPokemon.setMoveset(...previousMoveset);
 
   const newEggMoveIndex = await addEggMoveToNewPokemonMoveset(newPokemon, speciesRootForm, forBattle);

--- a/src/data/mystery-encounters/mystery-encounter-requirements.ts
+++ b/src/data/mystery-encounters/mystery-encounter-requirements.ts
@@ -573,14 +573,21 @@ export class MoveRequirement extends EncounterPokemonRequirement {
 
   override queryParty(partyPokemon: PlayerPokemon[]): PlayerPokemon[] {
     return partyPokemon.filter((pokemon) => {
-      const movesetFilter = pokemon.moveset.some((move) => move.moveId && this.requiredMoves.includes(move.moveId));
+      const movesetFilter = pokemon
+        .getMoveset(true)
+        .some((move) => move.moveId && this.requiredMoves.includes(move.moveId));
       const pokemonIsAllowed = !this.excludeDisallowedPokemon || pokemon.isAllowedInBattle();
       return pokemonIsAllowed && (this.invertQuery ? !movesetFilter : movesetFilter);
     });
   }
 
   override getDialogueToken(pokemon?: PlayerPokemon): [string, string] {
-    const includedMoves = pokemon?.moveset.filter((move) => move?.moveId && this.requiredMoves.includes(move.moveId));
+    if (!pokemon) {
+      return ["move", ""];
+    }
+    const includedMoves = pokemon
+      .getMoveset(true)
+      .filter((move) => move.moveId && this.requiredMoves.includes(move.moveId));
     if (includedMoves && includedMoves.length > 0 && includedMoves[0]) {
       return ["move", includedMoves[0].getName()];
     }
@@ -616,7 +623,9 @@ export class CompatibleMoveRequirement extends EncounterPokemonRequirement {
       return partyPokemon.filter(
         (pokemon) =>
           this.requiredMoves.filter((learnableMove) =>
-            pokemon.compatibleTms.filter((tm) => !pokemon.moveset.find((m) => m.moveId === tm)).includes(learnableMove),
+            pokemon.compatibleTms
+              .filter((tm) => !pokemon.getMoveset(true).find((m) => m.moveId === tm))
+              .includes(learnableMove),
           ).length > 0,
       );
     }
@@ -624,14 +633,19 @@ export class CompatibleMoveRequirement extends EncounterPokemonRequirement {
     return partyPokemon.filter(
       (pokemon) =>
         this.requiredMoves.filter((learnableMove) =>
-          pokemon.compatibleTms.filter((tm) => !pokemon.moveset.find((m) => m.moveId === tm)).includes(learnableMove),
+          pokemon.compatibleTms
+            .filter((tm) => !pokemon.getMoveset(true).find((m) => m.moveId === tm))
+            .includes(learnableMove),
         ).length === 0,
     );
   }
 
   override getDialogueToken(pokemon?: PlayerPokemon): [string, string] {
+    if (!pokemon) {
+      return ["compatibleMove", ""];
+    }
     const includedCompatMoves = this.requiredMoves.filter((reqMove) =>
-      pokemon?.compatibleTms.filter((tm) => !pokemon.moveset.find((m) => m.moveId === tm)).includes(reqMove),
+      pokemon.compatibleTms.filter((tm) => !pokemon.getMoveset(true).find((m) => m.moveId === tm)).includes(reqMove),
     );
     if (includedCompatMoves.length > 0) {
       return ["compatibleMove", MoveId[includedCompatMoves[0]]];

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -366,9 +366,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
       // Set moves
       if (config?.moveSet && config.moveSet.length > 0) {
         enemyPokemon.summonData.moveset = [];
-        config.moveSet.forEach((m, i) => {
-          enemyPokemon.setMove(i, m);
-        });
+        enemyPokemon.setMoveset(...config.moveSet);
       }
 
       // Set tags

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -37,7 +37,6 @@ import { TrainerVariant } from "#enums/trainer-variant";
 import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
-import { PokemonMove } from "#field/pokemon-move";
 import { Trainer } from "#field/trainer";
 import { initMoveAnim } from "#init/init-move-anim";
 import {
@@ -366,9 +365,10 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
 
       // Set moves
       if (config?.moveSet && config.moveSet.length > 0) {
-        const moves = config.moveSet.map((m) => new PokemonMove(m));
-        enemyPokemon.moveset = moves;
-        enemyPokemon.summonData.moveset = moves;
+        enemyPokemon.summonData.moveset = [];
+        config.moveSet.forEach((m, i) => {
+          enemyPokemon.setMove(i, m);
+        });
       }
 
       // Set tags

--- a/src/data/pokemon-evolutions.ts
+++ b/src/data/pokemon-evolutions.ts
@@ -198,7 +198,7 @@ export class NightEvolutionCondition extends SpeciesEvolutionCondition {
  */
 export class TypeKnownEvoCondition extends SpeciesEvolutionCondition {
   constructor(requiredType: ElementalType) {
-    super((p) => p.moveset.filter((m) => m.getMove().type === requiredType).length > 0);
+    super((p) => p.getMoveset(true).filter((m) => m.getMove().type === requiredType).length > 0);
     this.description = "Needs to know a type move";
   }
 }
@@ -223,7 +223,7 @@ export class TypeKnownEvoCondition extends SpeciesEvolutionCondition {
  */
 export class MoveKnownEvoCondition extends SpeciesEvolutionCondition {
   constructor(requiredMoveId: MoveId) {
-    super((p) => p.moveset.filter((m) => m.moveId === requiredMoveId).length > 0);
+    super((p) => p.getMoveset(true).filter((m) => m.moveId === requiredMoveId).length > 0);
     // TODO: Needs to load call initMoves befeore this
     this.description = "needs to know "; // + allMoves.get(requiredMoveId).name;
   }

--- a/src/data/species-form-change-triggers/species-form-change-move-learned-trigger.ts
+++ b/src/data/species-form-change-triggers/species-form-change-move-learned-trigger.ts
@@ -13,6 +13,6 @@ export class SpeciesFormChangeMoveLearnedTrigger extends SpeciesFormChangeTrigge
   }
 
   override canChange(pokemon: Pokemon): boolean {
-    return pokemon.moveset.some((m) => m.moveId === this.move) === this.known;
+    return pokemon.getMoveset(true).some((m) => m.moveId === this.move) === this.known;
   }
 }

--- a/src/data/trainer-configs/evil-team-trainer-configs.ts
+++ b/src/data/trainer-configs/evil-team-trainer-configs.ts
@@ -9,7 +9,6 @@ import { SpeciesId } from "#enums/species-id";
 import { TrainerPoolTier } from "#enums/trainer-pool-tier";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { TrainerType } from "#enums/trainer-type";
-import { PokemonMove } from "#field/pokemon-move";
 
 let t = TrainerType.ROCKET_GRUNT;
 export const evilTeamTrainerConfigs: TrainerConfigs = {
@@ -597,12 +596,10 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 1; // Segin Starmobile
-        p.moveset = [
-          new PokemonMove(MoveId.WICKED_TORQUE),
-          new PokemonMove(MoveId.SPIN_OUT),
-          new PokemonMove(MoveId.SHIFT_GEAR),
-          new PokemonMove(MoveId.HIGH_HORSEPOWER),
-        ];
+        p.setMove(0, MoveId.WICKED_TORQUE);
+        p.setMove(1, MoveId.SPIN_OUT);
+        p.setMove(2, MoveId.SHIFT_GEAR);
+        p.setMove(3, MoveId.HIGH_HORSEPOWER);
       }),
     ),
   [TrainerType.MELA]: new TrainerConfig(++t)
@@ -616,12 +613,10 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 2; // Schedar Starmobile
-        p.moveset = [
-          new PokemonMove(MoveId.BLAZING_TORQUE),
-          new PokemonMove(MoveId.SPIN_OUT),
-          new PokemonMove(MoveId.SHIFT_GEAR),
-          new PokemonMove(MoveId.HIGH_HORSEPOWER),
-        ];
+        p.setMove(0, MoveId.BLAZING_TORQUE);
+        p.setMove(1, MoveId.SPIN_OUT);
+        p.setMove(2, MoveId.SHIFT_GEAR);
+        p.setMove(3, MoveId.HIGH_HORSEPOWER);
       }),
     ),
   [TrainerType.ATTICUS]: new TrainerConfig(++t)
@@ -635,12 +630,10 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 3; // Navi Starmobile
-        p.moveset = [
-          new PokemonMove(MoveId.NOXIOUS_TORQUE),
-          new PokemonMove(MoveId.SPIN_OUT),
-          new PokemonMove(MoveId.SHIFT_GEAR),
-          new PokemonMove(MoveId.HIGH_HORSEPOWER),
-        ];
+        p.setMove(0, MoveId.NOXIOUS_TORQUE);
+        p.setMove(1, MoveId.SPIN_OUT);
+        p.setMove(2, MoveId.SHIFT_GEAR);
+        p.setMove(3, MoveId.HIGH_HORSEPOWER);
       }),
     ),
   [TrainerType.ORTEGA]: new TrainerConfig(++t)
@@ -654,12 +647,10 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 4; // Ruchbah Starmobile
-        p.moveset = [
-          new PokemonMove(MoveId.MAGICAL_TORQUE),
-          new PokemonMove(MoveId.SPIN_OUT),
-          new PokemonMove(MoveId.SHIFT_GEAR),
-          new PokemonMove(MoveId.HIGH_HORSEPOWER),
-        ];
+        p.setMove(0, MoveId.MAGICAL_TORQUE);
+        p.setMove(1, MoveId.SPIN_OUT);
+        p.setMove(2, MoveId.SHIFT_GEAR);
+        p.setMove(3, MoveId.HIGH_HORSEPOWER);
       }),
     ),
   [TrainerType.ERI]: new TrainerConfig(++t)
@@ -673,12 +664,10 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 5; // Caph Starmobile
-        p.moveset = [
-          new PokemonMove(MoveId.COMBAT_TORQUE),
-          new PokemonMove(MoveId.SPIN_OUT),
-          new PokemonMove(MoveId.SHIFT_GEAR),
-          new PokemonMove(MoveId.HIGH_HORSEPOWER),
-        ];
+        p.setMove(0, MoveId.COMBAT_TORQUE);
+        p.setMove(1, MoveId.SPIN_OUT);
+        p.setMove(2, MoveId.SHIFT_GEAR);
+        p.setMove(3, MoveId.HIGH_HORSEPOWER);
       }),
     ),
 };

--- a/src/data/trainer-configs/evil-team-trainer-configs.ts
+++ b/src/data/trainer-configs/evil-team-trainer-configs.ts
@@ -10,6 +10,8 @@ import { TrainerPoolTier } from "#enums/trainer-pool-tier";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { TrainerType } from "#enums/trainer-type";
 
+const teamStarCommonMoveset = [MoveId.SPIN_OUT, MoveId.SHIFT_GEAR, MoveId.HIGH_HORSEPOWER] as const;
+
 let t = TrainerType.ROCKET_GRUNT;
 export const evilTeamTrainerConfigs: TrainerConfigs = {
   [TrainerType.ROCKET_GRUNT]: new TrainerConfig(t)
@@ -596,10 +598,7 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 1; // Segin Starmobile
-        p.setMove(0, MoveId.WICKED_TORQUE);
-        p.setMove(1, MoveId.SPIN_OUT);
-        p.setMove(2, MoveId.SHIFT_GEAR);
-        p.setMove(3, MoveId.HIGH_HORSEPOWER);
+        p.setMoveset(MoveId.WICKED_TORQUE, ...teamStarCommonMoveset);
       }),
     ),
   [TrainerType.MELA]: new TrainerConfig(++t)
@@ -613,10 +612,7 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 2; // Schedar Starmobile
-        p.setMove(0, MoveId.BLAZING_TORQUE);
-        p.setMove(1, MoveId.SPIN_OUT);
-        p.setMove(2, MoveId.SHIFT_GEAR);
-        p.setMove(3, MoveId.HIGH_HORSEPOWER);
+        p.setMoveset(MoveId.BLAZING_TORQUE, ...teamStarCommonMoveset);
       }),
     ),
   [TrainerType.ATTICUS]: new TrainerConfig(++t)
@@ -630,10 +626,7 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 3; // Navi Starmobile
-        p.setMove(0, MoveId.NOXIOUS_TORQUE);
-        p.setMove(1, MoveId.SPIN_OUT);
-        p.setMove(2, MoveId.SHIFT_GEAR);
-        p.setMove(3, MoveId.HIGH_HORSEPOWER);
+        p.setMoveset(MoveId.NOXIOUS_TORQUE, ...teamStarCommonMoveset);
       }),
     ),
   [TrainerType.ORTEGA]: new TrainerConfig(++t)
@@ -647,10 +640,7 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 4; // Ruchbah Starmobile
-        p.setMove(0, MoveId.MAGICAL_TORQUE);
-        p.setMove(1, MoveId.SPIN_OUT);
-        p.setMove(2, MoveId.SHIFT_GEAR);
-        p.setMove(3, MoveId.HIGH_HORSEPOWER);
+        p.setMoveset(MoveId.MAGICAL_TORQUE, ...teamStarCommonMoveset);
       }),
     ),
   [TrainerType.ERI]: new TrainerConfig(++t)
@@ -664,10 +654,7 @@ export const evilTeamTrainerConfigs: TrainerConfigs = {
       3,
       getRandomPartyMemberFunc([SpeciesId.REVAVROOM], TrainerSlot.TRAINER, true, (p) => {
         p.formIndex = 5; // Caph Starmobile
-        p.setMove(0, MoveId.COMBAT_TORQUE);
-        p.setMove(1, MoveId.SPIN_OUT);
-        p.setMove(2, MoveId.SHIFT_GEAR);
-        p.setMove(3, MoveId.HIGH_HORSEPOWER);
+        p.setMoveset(MoveId.COMBAT_TORQUE, ...teamStarCommonMoveset);
       }),
     ),
 };

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1417,6 +1417,40 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.moveset;
   }
 
+  /**
+   * Sets the move in the specified move slot to the specified move. Does nothing if `moveId` is `MoveId.NONE`.
+   * @param moveIndex - Which move slot to set
+   * @param moveId - The move to set the slot to
+   * @todo Should it remove the move from the moveset if `moveId` is `MoveId.NONE` instead of doing nothing?
+   */
+  public setMove(moveIndex: number, moveId: MoveId): void {
+    if (moveId === MoveId.NONE) {
+      return;
+    }
+    const move = new PokemonMove(moveId);
+    this.moveset[moveIndex] = move;
+  }
+
+  /** Sets the pokemon's moveset to the specified moves, deleting the old moveset. */
+  public setMoveset(...moves: MoveId[]): void {
+    this.moveset = [];
+    if (moves.length === 0) {
+      return;
+    }
+    for (const move of moves) {
+      this.moveset.push(new PokemonMove(move));
+    }
+  }
+
+  /** Swaps 2 moves in the pokemon's moveset. Does nothing if one of the slots is empty. */
+  public swapMoves(firstIndex: number, secondIndex: number): void {
+    if (!this.moveset[firstIndex] || !this.moveset[secondIndex]) {
+      return;
+    }
+    [this.moveset[firstIndex], this.moveset[secondIndex]] = [this.moveset[secondIndex], this.moveset[firstIndex]];
+  }
+
+  /** Resets the used PP of all moves in the pokemon's moveset to 0 */
   public restoreMovePP(): void {
     for (const move of this.moveset) {
       move.ppUsed = 0;
@@ -2258,18 +2292,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /** @returns A list of the pokemon's egg moves */
   public getEggMoves(): MoveId[] | undefined {
     return speciesEggMoves[this.getSpeciesForm().getRootSpeciesId()];
-  }
-
-  public setMove(moveIndex: number, moveId: MoveId): void {
-    if (moveId === MoveId.NONE) {
-      return;
-    }
-    const move = new PokemonMove(moveId);
-    this.moveset[moveIndex] = move;
-  }
-
-  public swapMoves(firstIndex: number, secondIndex: number): void {
-    [this.moveset[firstIndex], this.moveset[secondIndex]] = [this.moveset[secondIndex], this.moveset[firstIndex]];
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1392,7 +1392,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   abstract getBossSegmentIndex(): number;
 
   /**
-   * @param bypassSummonData - Whether to get the Pokemon's actual moveset
+   * @param bypassSummonData - (Default `true`) Whether to get the Pokemon's actual/unmodified moveset (`true`)
+   *   or the Pokemon's temporary/modified moveset (such as due to Transform) (`false`).
    * @returns The Pokemon's active moveset
    */
   public getMoveset(bypassSummonData: boolean = false): readonly PokemonMove[] {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -259,7 +259,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public stats: number[];
   public ivs: number[];
   public nature: Nature;
-  public moveset: PokemonMove[];
+  protected moveset: PokemonMove[];
   protected status: Status | null = null;
   public friendship: number;
   public metLevel: number;
@@ -353,8 +353,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
       this.nature = dataSource.nature || (0 as Nature);
       this.nickname = dataSource.nickname;
+      // @ts-expect-error - `Pokemon#moveset` is `protected`
       this.moveset = dataSource.moveset;
-      // @ts-expect-error - `Pokemon#status` is protected
+      // @ts-expect-error - `Pokemon#status` is `protected`
       this.status = dataSource.status;
       this.friendship = dataSource.friendship !== undefined ? dataSource.friendship : this.species.baseFriendship;
       this.metLevel = dataSource.metLevel || 5;
@@ -1390,7 +1391,11 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   abstract getBossSegmentIndex(): number;
 
-  getMoveset(bypassSummonData: boolean = false): PokemonMove[] {
+  /**
+   * @param bypassSummonData - Whether to get the Pokemon's actual moveset
+   * @returns The Pokemon's active moveset
+   */
+  public getMoveset(bypassSummonData: boolean = false): readonly PokemonMove[] {
     const ret = !bypassSummonData && this.summonData.moveset.length > 0 ? this.summonData.moveset : this.moveset;
 
     // Overrides moveset based on arrays specified in overrides.ts
@@ -1410,6 +1415,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.moveset[index] = new PokemonMove(moveId, Math.min(ppUsed, allMoves.get(moveId).pp));
     });
     return this.moveset;
+  }
+
+  public restoreMovePP(): void {
+    for (const move of this.moveset) {
+      move.ppUsed = 0;
+    }
   }
 
   /**
@@ -2244,21 +2255,21 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
-  /**
-   * Get a list of all egg moves
-   *
-   * @returns list of egg moves
-   */
-  getEggMoves(): MoveId[] | undefined {
+  /** @returns A list of the pokemon's egg moves */
+  public getEggMoves(): MoveId[] | undefined {
     return speciesEggMoves[this.getSpeciesForm().getRootSpeciesId()];
   }
 
-  setMove(moveIndex: number, moveId: MoveId): void {
+  public setMove(moveIndex: number, moveId: MoveId): void {
     if (moveId === MoveId.NONE) {
       return;
     }
     const move = new PokemonMove(moveId);
     this.moveset[moveIndex] = move;
+  }
+
+  public swapMoves(firstIndex: number, secondIndex: number): void {
+    [this.moveset[firstIndex], this.moveset[secondIndex]] = [this.moveset[secondIndex], this.moveset[firstIndex]];
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1431,7 +1431,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.moveset[moveIndex] = move;
   }
 
-  /** Sets the pokemon's moveset to the specified moves, deleting the old moveset. */
+  /** Overwrites the pokemon's moveset to the specified set of moves, deleting the old moveset. */
   public setMoveset(...moves: MoveId[]): void {
     this.moveset = [];
     if (moves.length === 0) {

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -1363,7 +1363,7 @@ export class TmModifierTypeGenerator extends ModifierTypeGenerator {
         return new TmModifierType(pregenArgs[0] as MoveId);
       }
       const partyMemberCompatibleTms = party.map((p) =>
-        (p as PlayerPokemon).compatibleTms.filter((tm) => !p.moveset.find((m) => m.moveId === tm)),
+        (p as PlayerPokemon).compatibleTms.filter((tm) => !p.getMoveset(true).find((m) => m.moveId === tm)),
       );
       const tierUniqueCompatibleTms = partyMemberCompatibleTms
         .flat()

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -54,7 +54,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
     }
 
     const move = allMoves.get(this.moveId);
-    const currentMoveset = pokemon.getMoveset();
+    const currentMoveset = pokemon.getMoveset(true);
 
     // The game first checks if the Pokemon already has the move and ends the phase if it does.
     const hasMoveAlready = currentMoveset.some((m) => m.moveId === move.id) && this.moveId !== MoveId.SKETCH;

--- a/src/phases/learn-move-phase.ts
+++ b/src/phases/learn-move-phase.ts
@@ -146,7 +146,7 @@ export class LearnMovePhase extends PlayerPartyMemberPokemonPhase {
 
         const forgetSuccessText = i18next.t("battle:learnMoveForgetSuccess", {
           pokemonName: getPokemonNameWithAffix(pokemon),
-          moveName: pokemon.moveset[moveIndex]!.getName(),
+          moveName: pokemon.getMoveset(true)[moveIndex]?.getName() ?? "Unknown",
         });
         const fullText = [i18next.t("battle:countdownPoof"), forgetSuccessText, i18next.t("battle:learnMoveAnd")].join(
           "$",

--- a/src/phases/party-heal-phase.ts
+++ b/src/phases/party-heal-phase.ts
@@ -29,9 +29,7 @@ export class PartyHealPhase extends BattlePhase {
       for (const pokemon of globalScene.getPlayerParty()) {
         pokemon.hp = pokemon.getMaxHp();
         pokemon.resetStatus();
-        for (const move of pokemon.moveset) {
-          move.ppUsed = 0;
-        }
+        pokemon.restoreMovePP();
         pokemon.updateInfo(true);
       }
       globalScene.playerTerasUsed = 0;

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -110,6 +110,7 @@ export class PokemonData {
     }
 
     if (isPokemon(source)) {
+      // @ts-expect-error - `Pokemon#moveset` is `protected`
       this.moveset = source.moveset;
       this.summonData = source.summonData;
       return;

--- a/src/ui/components/pokemon-info-container.ts
+++ b/src/ui/components/pokemon-info-container.ts
@@ -385,7 +385,7 @@ export class PokemonInfoContainer extends Phaser.GameObjects.Container {
 
       for (let m = 0; m < 4; m++) {
         const moveset = pokemon.getMoveset(true);
-        const move = m < moveset.length && moveset[m] ? moveset[m]!.getMove() : null;
+        const move = m < moveset.length && moveset[m] ? moveset[m].getMove() : null;
         this.pokemonMoveBgs[m].setFrame(
           enumValueToKey(ElementalType, move ? move.type : ElementalType.UNKNOWN).toLowerCase(),
         );

--- a/src/ui/components/pokemon-info-container.ts
+++ b/src/ui/components/pokemon-info-container.ts
@@ -384,7 +384,8 @@ export class PokemonInfoContainer extends Phaser.GameObjects.Container {
       }
 
       for (let m = 0; m < 4; m++) {
-        const move = m < pokemon.moveset.length && pokemon.moveset[m] ? pokemon.moveset[m]!.getMove() : null;
+        const moveset = pokemon.getMoveset(true);
+        const move = m < moveset.length && moveset[m] ? moveset[m]!.getMove() : null;
         this.pokemonMoveBgs[m].setFrame(
           enumValueToKey(ElementalType, move ? move.type : ElementalType.UNKNOWN).toLowerCase(),
         );

--- a/src/ui/handlers/party-ui-handler.ts
+++ b/src/ui/handlers/party-ui-handler.ts
@@ -353,7 +353,7 @@ export class PartyUiHandler extends MessageUiHandler {
               filterResult = this.FilterChallengeLegal(pokemon);
             }
             if (filterResult === null && this.partyUiMode === PartyUiMode.MOVE_MODIFIER) {
-              filterResult = this.moveSelectFilter(pokemon.moveset[this.optionsCursor]);
+              filterResult = this.moveSelectFilter(pokemon.getMoveset(true)[this.optionsCursor]);
             }
           } else {
             filterResult = (this.selectFilter as PokemonModifierTransferSelectFilter)(
@@ -900,7 +900,7 @@ export class PartyUiHandler extends MessageUiHandler {
         this.options.push(PartyOption.RELEASE);
       }
     } else if (this.partyUiMode === PartyUiMode.MOVE_MODIFIER) {
-      for (let m = 0; m < pokemon.moveset.length; m++) {
+      for (let m = 0; m < pokemon.getMoveset(true).length; m++) {
         this.options.push(PartyOption.MOVE_1 + m);
       }
     } else if (this.partyUiMode === PartyUiMode.REMEMBER_MOVE_MODIFIER) {
@@ -968,7 +968,7 @@ export class PartyUiHandler extends MessageUiHandler {
           case PartyOption.MOVE_2:
           case PartyOption.MOVE_3:
           case PartyOption.MOVE_4: {
-            const move = pokemon.moveset[option - PartyOption.MOVE_1];
+            const move = pokemon.getMoveset(true)[option - PartyOption.MOVE_1];
             if (this.showMovePp) {
               const maxPP = move.getMovePp();
               const currPP = maxPP - move.ppUsed;

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -466,7 +466,7 @@ export class SummaryUiHandler extends UiHandler {
 
     if (this.moveSelect) {
       if (button === Button.ACTION) {
-        if (this.pokemon && this.moveCursor < this.pokemon.moveset.length) {
+        if (this.pokemon && this.moveCursor < this.pokemon.getMoveset(true).length) {
           if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE) {
             this.moveSelectFunction?.(this.moveCursor);
           } else {
@@ -475,9 +475,7 @@ export class SummaryUiHandler extends UiHandler {
               this.setCursor(this.moveCursor);
             } else {
               if (this.selectedMoveIndex !== this.moveCursor) {
-                const tempMove = this.pokemon?.moveset[this.selectedMoveIndex];
-                this.pokemon.moveset[this.selectedMoveIndex] = this.pokemon.moveset[this.moveCursor];
-                this.pokemon.moveset[this.moveCursor] = tempMove;
+                this.pokemon.swapMoves(this.selectedMoveIndex, this.moveCursor);
 
                 const selectedMoveRow = this.moveRowsContainer.getAt(
                   this.selectedMoveIndex,
@@ -1053,7 +1051,7 @@ export class SummaryUiHandler extends UiHandler {
 
         for (let m = 0; m < 4; m++) {
           const move: PokemonMove | null =
-            this.pokemon && this.pokemon.moveset.length > m ? this.pokemon?.moveset[m] : null;
+            this.pokemon && this.pokemon.getMoveset(true).length > m ? this.pokemon.getMoveset(true)[m] : null;
           const moveRowContainer = globalScene.add.container(0, 16 * m);
           this.moveRowsContainer.add(moveRowContainer);
 
@@ -1134,8 +1132,8 @@ export class SummaryUiHandler extends UiHandler {
       return null;
     }
 
-    if (this.moveCursor < 4 && this.pokemon && this.moveCursor < this.pokemon.moveset.length) {
-      return this.pokemon.moveset[this.moveCursor].getMove();
+    if (this.moveCursor < 4 && this.pokemon && this.moveCursor < this.pokemon.getMoveset(true).length) {
+      return this.pokemon.getMoveset(true)[this.moveCursor].getMove();
     }
     if (this.summaryUiMode === SummaryUiMode.LEARN_MOVE && this.moveCursor === 4) {
       return this.newMove;

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -23,7 +23,6 @@ import { SummaryUiPage } from "#enums/summary-ui-page";
 import { TextStyle } from "#enums/text-style";
 import { UiMode } from "#enums/ui-mode";
 import type { Pokemon } from "#field/pokemon";
-import type { PokemonMove } from "#field/pokemon-move";
 import { modifierSortFunc, type PokemonHeldItemModifier } from "#modifier/modifier";
 import type { Move } from "#moves/move";
 import { settings } from "#system/settings-manager";
@@ -1049,9 +1048,12 @@ export class SummaryUiHandler extends UiHandler {
         this.moveRowsContainer = globalScene.add.container(0, 0);
         this.movesContainer.add(this.moveRowsContainer);
 
+        // TODO: is it even possible to reach this `for` loop if `this.pokemon` is `null`?
+        // what about the rest of this method? in what situation is `this.pokemon` `null`?
+        const moveset = this.pokemon?.getMoveset(true);
         for (let m = 0; m < 4; m++) {
-          const move: PokemonMove | null =
-            this.pokemon && this.pokemon.getMoveset(true).length > m ? this.pokemon.getMoveset(true)[m] : null;
+          // `!`s are safe because `moveset` isn't `undefined` if `this.pokemon` is defined
+          const move = this.pokemon && moveset!.length > m ? moveset![m] : null;
           const moveRowContainer = globalScene.add.container(0, 16 * m);
           this.moveRowsContainer.add(moveRowContainer);
 

--- a/test/abilities/dancer.test.ts
+++ b/test/abilities/dancer.test.ts
@@ -59,6 +59,6 @@ describe("Abilities - Dancer", () => {
     await game.toEndOfTurn();
 
     // doesn't use PP if copied move is also in moveset
-    expect(oricorio.moveset[0]?.ppUsed).toBe(0);
+    expect(oricorio.getMoveset(true)[0]?.ppUsed).toBe(0);
   });
 });

--- a/test/game-modes/daily-mode.test.ts
+++ b/test/game-modes/daily-mode.test.ts
@@ -36,7 +36,7 @@ describe("Daily Mode", () => {
     expect(party).toHaveLength(3);
     party.forEach((pkm) => {
       expect(pkm.level).toBe(20);
-      expect(pkm.moveset.length).toBeGreaterThan(0);
+      expect(pkm.getMoveset(true).length).toBeGreaterThan(0);
     });
     expect(game.scene.getModifiers(MapModifier).length).toBeGreaterThan(0);
   });

--- a/test/moves/instruct.test.ts
+++ b/test/moves/instruct.test.ts
@@ -141,7 +141,7 @@ describe("Moves - Instruct", () => {
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
     game.move.changeMoveset(enemyPokemon, MoveId.HIDDEN_POWER);
-    const moveUsed = enemyPokemon.moveset.find((m) => m?.moveId === MoveId.HIDDEN_POWER)!;
+    const moveUsed = enemyPokemon.getMoveset(true).find((m) => m.moveId === MoveId.HIDDEN_POWER)!;
     moveUsed.ppUsed = moveUsed.getMovePp() - 1;
 
     game.move.select(MoveId.INSTRUCT);

--- a/test/moves/powder.test.ts
+++ b/test/moves/powder.test.ts
@@ -5,7 +5,6 @@ import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-import { PokemonMove } from "#field/pokemon-move";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -42,15 +41,15 @@ describe("Moves - Powder", () => {
     game.override.enemyMoveset([]);
     await game.classicMode.startBattle(SpeciesId.CHARIZARD);
 
-    const enemyPokemon = game.scene.getEnemyPokemon()!;
-    enemyPokemon.moveset = [new PokemonMove(MoveId.EMBER)];
+    const enemyPokemon = game.field.getEnemyPokemon();
+    game.move.changeMoveset(enemyPokemon, MoveId.EMBER);
 
     game.move.select(MoveId.POWDER);
 
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.FAIL);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
-    expect(enemyPokemon.moveset[0]!.ppUsed).toBe(1);
+    expect(enemyPokemon.getMoveset(true)[0].ppUsed).toBe(1);
 
     await game.toNextTurn();
 
@@ -59,7 +58,7 @@ describe("Moves - Powder", () => {
     await game.phaseInterceptor.to("BerryPhase", false);
     expect(enemyPokemon).toHaveMoveResult(MoveResult.SUCCESS);
     expect(enemyPokemon.hp).toBe(Math.ceil((3 * enemyPokemon.getMaxHp()) / 4));
-    expect(enemyPokemon.moveset[0]!.ppUsed).toBe(2);
+    expect(enemyPokemon.getMoveset(true)[0].ppUsed).toBe(2);
   });
 
   it("should have no effect against Grass-type Pokemon", async () => {

--- a/test/moves/sketch.test.ts
+++ b/test/moves/sketch.test.ts
@@ -5,7 +5,6 @@ import { MoveId } from "#enums/move-id";
 import { MoveResult } from "#enums/move-result";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-import { PokemonMove } from "#field/pokemon-move";
 import { MetronomeAttr } from "#moves/metronome-attr";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
@@ -38,9 +37,9 @@ describe("Moves - Sketch", () => {
 
   it("Sketch should not fail even if a previous Sketch failed to retrieve a valid move and ran out of PP", async () => {
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
-    const playerPokemon = game.scene.getPlayerPokemon()!;
+    const playerPokemon = game.field.getPlayerPokemon();
     // can't use normal moveset override because we need to check moveset changes
-    playerPokemon.moveset = [new PokemonMove(MoveId.SKETCH), new PokemonMove(MoveId.SKETCH)];
+    game.move.changeMoveset(playerPokemon, [MoveId.SKETCH, MoveId.SKETCH]);
 
     game.move.select(MoveId.SKETCH);
     await game.toEndOfTurn();
@@ -53,16 +52,16 @@ describe("Moves - Sketch", () => {
     game.move.select(MoveId.SKETCH);
     await game.toEndOfTurn();
     expect(playerPokemon).toHaveMoveResult(MoveResult.SUCCESS);
-    expect(playerPokemon.moveset[0]?.moveId).toBe(MoveId.SPLASH);
-    expect(playerPokemon.moveset[1]?.moveId).toBe(MoveId.SKETCH);
+    expect(playerPokemon.getMoveset(true)[0].moveId).toBe(MoveId.SPLASH);
+    expect(playerPokemon.getMoveset(true)[1].moveId).toBe(MoveId.SKETCH);
   });
 
   it("Sketch should retrieve the most recent valid move from its target history", async () => {
     game.override.enemyStatusEffect(StatusEffect.PARALYSIS);
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
-    const playerPokemon = game.scene.getPlayerPokemon()!;
-    const enemyPokemon = game.scene.getEnemyPokemon()!;
-    playerPokemon.moveset = [new PokemonMove(MoveId.SKETCH), new PokemonMove(MoveId.GROWL)];
+    const playerPokemon = game.field.getPlayerPokemon();
+    const enemyPokemon = game.field.getEnemyPokemon();
+    game.move.changeMoveset(playerPokemon, [MoveId.SKETCH, MoveId.GROWL]);
 
     game.move.select(MoveId.GROWL);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
@@ -76,8 +75,8 @@ describe("Moves - Sketch", () => {
     await game.move.forceStatusActivation(true);
     await game.toEndOfTurn();
     expect(playerPokemon).toHaveMoveResult(MoveResult.SUCCESS);
-    expect(playerPokemon.moveset[0]?.moveId).toBe(MoveId.SPLASH);
-    expect(playerPokemon.moveset[1]?.moveId).toBe(MoveId.GROWL);
+    expect(playerPokemon.getMoveset(true)[0].moveId).toBe(MoveId.SPLASH);
+    expect(playerPokemon.getMoveset(true)[1].moveId).toBe(MoveId.GROWL);
   });
 
   it("should sketch moves that call other moves", async () => {
@@ -88,15 +87,15 @@ describe("Moves - Sketch", () => {
 
     game.override.enemyMoveset([MoveId.METRONOME]);
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
-    const playerPokemon = game.scene.getPlayerPokemon()!;
-    playerPokemon.moveset = [new PokemonMove(MoveId.SKETCH)];
+    const playerPokemon = game.field.getPlayerPokemon();
+    game.move.changeMoveset(playerPokemon, MoveId.SKETCH);
 
     // Opponent uses Metronome -> False Swipe, then player uses Sketch, which should sketch Metronome
     game.move.select(MoveId.SKETCH);
     game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     await game.toEndOfTurn();
     expect(playerPokemon).toHaveMoveResult(MoveResult.SUCCESS);
-    expect(playerPokemon.moveset[0]?.moveId).toBe(MoveId.METRONOME);
+    expect(playerPokemon.getMoveset(true)[0].moveId).toBe(MoveId.METRONOME);
     expect(playerPokemon.hp).toBeLessThan(playerPokemon.getMaxHp()); // Make sure opponent actually used False Swipe
   });
 });

--- a/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
+++ b/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
@@ -134,8 +134,8 @@ describe("Absolute Avarice - Mystery Encounter", () => {
       expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(SpeciesId.GREEDENT);
-      const moveset = enemyField[0].moveset.map((m) => m.moveId);
-      expect(moveset?.length).toBe(4);
+      const moveset = enemyField[0].getMoveset(true).map((m) => m.moveId);
+      expect(moveset.length).toBe(4);
       expect(moveset).toEqual([MoveId.THRASH, MoveId.BODY_PRESS, MoveId.STUFF_CHEEKS, MoveId.CRUNCH]);
 
       const movePhases = phaseSpy.mock.calls.filter((p) => p[0].is("MovePhase")).map((p) => p[0]);
@@ -257,8 +257,8 @@ describe("Absolute Avarice - Mystery Encounter", () => {
       expect(partyCountBefore + 1).toBe(partyCountAfter);
       const greedent = scene.getPlayerParty()[scene.getPlayerParty().length - 1];
       expect(greedent.species.speciesId).toBe(SpeciesId.GREEDENT);
-      const moveset = greedent.moveset.map((m) => m.moveId);
-      expect(moveset?.length).toBe(4);
+      const moveset = greedent.getMoveset(true).map((m) => m.moveId);
+      expect(moveset.length).toBe(4);
       expect(moveset).toEqual([MoveId.THRASH, MoveId.BODY_PRESS, MoveId.STUFF_CHEEKS, MoveId.SLACK_OFF]);
     });
 

--- a/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
+++ b/test/mystery-encounter/encounters/an-offer-you-cant-refuse-encounter.test.ts
@@ -8,7 +8,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { PlayerPokemon } from "#field/player-pokemon";
-import { PokemonMove } from "#field/pokemon-move";
 import { AnOfferYouCantRefuseEncounter } from "#mystery-encounters/an-offer-you-cant-refuse-encounter";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -213,7 +212,7 @@ describe("An Offer You Can't Refuse - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.AN_OFFER_YOU_CANT_REFUSE, [SpeciesId.ABRA]);
       const party = scene.getPlayerParty();
       const abra = party.find((pkm) => pkm.species.speciesId === SpeciesId.ABRA)!;
-      abra.moveset = [new PokemonMove(MoveId.BEAT_UP)];
+      game.move.changeMoveset(abra, MoveId.BEAT_UP);
       const expBefore = abra.exp;
 
       await runMysteryEncounterToEnd(game, 2);

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -169,14 +169,14 @@ describe("Clowning Around - Mystery Encounter", () => {
       expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(2);
       expect(enemyField[0].species.speciesId).toBe(SpeciesId.MR_MIME);
-      expect(enemyField[0].moveset).toEqual([
+      expect(enemyField[0].getMoveset(true)).toEqual([
         new PokemonMove(MoveId.TEETER_DANCE),
         new PokemonMove(MoveId.ALLY_SWITCH),
         new PokemonMove(MoveId.DAZZLING_GLEAM),
         new PokemonMove(MoveId.PSYCHIC),
       ]);
       expect(enemyField[1].species.speciesId).toBe(SpeciesId.BLACEPHALON);
-      expect(enemyField[1].moveset).toEqual([
+      expect(enemyField[1].getMoveset(true)).toEqual([
         new PokemonMove(MoveId.TRICK),
         new PokemonMove(MoveId.HYPNOSIS),
         new PokemonMove(MoveId.SHADOW_BALL),
@@ -266,7 +266,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, defaultParty);
 
       // Set some moves on party for attack type booster generation
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.TACKLE), new PokemonMove(MoveId.THIEF)];
+      game.move.changeMoveset(scene.getPlayerParty()[0], [MoveId.TACKLE, MoveId.THIEF]);
 
       // 2 Sitrus Berries on lead
       scene.modifiers = [];
@@ -351,11 +351,11 @@ describe("Clowning Around - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.CLOWNING_AROUND, defaultParty);
 
       // Same type moves on lead
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.ICE_BEAM), new PokemonMove(MoveId.SURF)];
+      game.move.changeMoveset(scene.getPlayerParty()[0], [MoveId.ICE_BEAM, MoveId.SURF]);
       // Different type moves on second
-      scene.getPlayerParty()[1].moveset = [new PokemonMove(MoveId.GRASS_KNOT), new PokemonMove(MoveId.ELECTRO_BALL)];
+      game.move.changeMoveset(scene.getPlayerParty()[1], [MoveId.GRASS_KNOT, MoveId.ELECTRO_BALL]);
       // No moves on third
-      scene.getPlayerParty()[2].moveset = [];
+      game.move.changeMoveset(scene.getPlayerParty()[2], []);
       await runMysteryEncounterToEnd(game, 3);
 
       const leadTypesAfter = scene.getPlayerParty()[0].customPokemonData?.types;

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -6,7 +6,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { PokemonMove } from "#field/pokemon-move";
 import { DancingLessonsEncounter } from "#mystery-encounters/dancing-lessons-encounter";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -107,7 +106,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(SpeciesId.ORICORIO);
       expect(enemyField[0].summonData.statStages).toEqual([1, 1, 1, 1, 0, 0, 0]);
-      const moveset = enemyField[0].moveset.map((m) => m.moveId);
+      const moveset = enemyField[0].getMoveset(true).map((m) => m.moveId);
       expect(moveset.some((m) => m === MoveId.REVELATION_DANCE)).toBeTruthy();
 
       const movePhases = phaseSpy.mock.calls.filter((p) => p[0].is("MovePhase")).map((p) => p[0]);
@@ -154,7 +153,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       const phaseSpy = vi.spyOn(scene.phaseManager, "unshiftPhase");
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
-      scene.getPlayerParty()[0].moveset = [];
+      game.move.changeMoveset(scene.getPlayerParty()[0], []);
       await runMysteryEncounterToEnd(game, 2, { partySlot: 1 });
 
       const movePhases = phaseSpy.mock.calls.filter((p) => p[0].is("LearnMovePhase")).map((p) => p[0]);
@@ -166,7 +165,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
-      scene.getPlayerParty()[0].moveset = [];
+      game.move.changeMoveset(scene.getPlayerParty()[0], []);
       await runMysteryEncounterToEnd(game, 2, { partySlot: 1 });
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();
@@ -194,14 +193,14 @@ describe("Dancing Lessons - Mystery Encounter", () => {
     it("should add Oricorio to the party", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
       const partyCountBefore = scene.getPlayerParty().length;
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.DRAGON_DANCE)];
+      game.move.changeMoveset(scene.getPlayerParty()[0], MoveId.DRAGON_DANCE);
       await runMysteryEncounterToEnd(game, 3, { partySlot: 1, optionNumber: 1 });
       const partyCountAfter = scene.getPlayerParty().length;
 
       expect(partyCountBefore + 1).toBe(partyCountAfter);
       const oricorio = scene.getPlayerParty()[scene.getPlayerParty().length - 1];
       expect(oricorio.species.speciesId).toBe(SpeciesId.ORICORIO);
-      const moveset = oricorio.moveset.map((m) => m.moveId);
+      const moveset = oricorio.getMoveset(true).map((m) => m.moveId);
       expect(moveset?.some((m) => m === MoveId.REVELATION_DANCE)).toBeTruthy();
       expect(moveset?.some((m) => m === MoveId.DRAGON_DANCE)).toBeTruthy();
     });
@@ -209,7 +208,9 @@ describe("Dancing Lessons - Mystery Encounter", () => {
     it("should NOT be selectable if the player doesn't have a Dance type move", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
       const partyCountBefore = scene.getPlayerParty().length;
-      scene.getPlayerParty().forEach((p) => (p.moveset = []));
+      scene.getPlayerParty().forEach((p) => {
+        game.move.changeMoveset(p, []);
+      });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
@@ -233,7 +234,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
 
       await game.runToMysteryEncounter(MysteryEncounterType.DANCING_LESSONS, defaultParty);
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.DRAGON_DANCE)];
+      game.move.changeMoveset(scene.getPlayerParty()[0], MoveId.DRAGON_DANCE);
       await runMysteryEncounterToEnd(game, 3, { partySlot: 1, optionNumber: 1 });
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -6,7 +6,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { UiMode } from "#enums/ui-mode";
-import { PokemonMove } from "#field/pokemon-move";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import { FightOrFlightEncounter } from "#mystery-encounters/fight-or-flight-encounter";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
@@ -148,7 +147,9 @@ describe("Fight or Flight - Mystery Encounter", () => {
 
     it("should NOT be selectable if the player doesn't have a Stealing move", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIGHT_OR_FLIGHT, defaultParty);
-      scene.getPlayerParty().forEach((p) => (p.moveset = []));
+      scene.getPlayerParty().forEach((p) => {
+        game.move.changeMoveset(p, []);
+      });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
@@ -172,7 +173,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIGHT_OR_FLIGHT, defaultParty);
 
       // Mock moveset
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.KNOCK_OFF)];
+      game.move.changeMoveset(scene.getPlayerParty()[0], MoveId.KNOCK_OFF);
       const item = game.scene.currentBattle.mysteryEncounter!.misc;
 
       await runMysteryEncounterToEnd(game, 2);

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -6,7 +6,6 @@ import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
-import { PokemonMove } from "#field/pokemon-move";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
 import * as MysteryEncounters from "#mystery-encounters/mystery-encounters";
 import { PartTimerEncounter } from "#mystery-encounters/part-timer-encounter";
@@ -109,7 +108,7 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(1), true, false);
       // Expect PP of mon's moves to have been reduced to 2
-      const moves = scene.getPlayerParty()[0].moveset;
+      const moves = scene.getPlayerParty()[0].getMoveset(true);
       for (const move of moves) {
         expect((move?.getMovePp() ?? 0) - (move?.ppUsed ?? 0)).toBe(2);
       }
@@ -129,7 +128,7 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(4), true, false);
       // Expect PP of mon's moves to have been reduced to 2
-      const moves = scene.getPlayerParty()[1].moveset;
+      const moves = scene.getPlayerParty()[1].getMoveset(true);
       for (const move of moves) {
         expect((move?.getMovePp() ?? 0) - (move?.ppUsed ?? 0)).toBe(2);
       }
@@ -174,7 +173,7 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(1), true, false);
       // Expect PP of mon's moves to have been reduced to 2
-      const moves = scene.getPlayerParty()[2].moveset;
+      const moves = scene.getPlayerParty()[2].getMoveset(true);
       for (const move of moves) {
         expect((move?.getMovePp() ?? 0) - (move?.ppUsed ?? 0)).toBe(2);
       }
@@ -194,7 +193,7 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(4), true, false);
       // Expect PP of mon's moves to have been reduced to 2
-      const moves = scene.getPlayerParty()[3].moveset;
+      const moves = scene.getPlayerParty()[3].getMoveset(true);
       for (const move of moves) {
         expect((move?.getMovePp() ?? 0) - (move?.ppUsed ?? 0)).toBe(2);
       }
@@ -232,7 +231,9 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       await game.runToMysteryEncounter(MysteryEncounterType.PART_TIMER, defaultParty);
       // Mock movesets
-      scene.getPlayerParty().forEach((p) => (p.moveset = []));
+      scene.getPlayerParty().forEach((p) => {
+        game.move.changeMoveset(p, []);
+      });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
@@ -256,12 +257,12 @@ describe("Part-Timer - Mystery Encounter", () => {
 
       await game.runToMysteryEncounter(MysteryEncounterType.PART_TIMER, defaultParty);
       // Mock moveset
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.ATTRACT)];
+      game.move.changeMoveset(scene.getPlayerParty()[0], MoveId.ATTRACT);
       await runMysteryEncounterToEnd(game, 3);
 
       expect(EncounterPhaseUtils.updatePlayerMoney).toHaveBeenCalledWith(scene.getWaveMoneyAmount(2.5), true, false);
       // Expect PP of mon's moves to have been reduced to 2
-      const moves = scene.getPlayerParty()[0].moveset;
+      const moves = scene.getPlayerParty()[0].getMoveset(true);
       for (const move of moves) {
         expect((move?.getMovePp() ?? 0) - (move?.ppUsed ?? 0)).toBe(2);
       }

--- a/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
@@ -154,7 +154,7 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
 
       const newlyPurchasedPokemon = scene.getPlayerParty()[scene.getPlayerParty().length - 1];
       expect(newlyPurchasedPokemon.name).toBe(pokemonName);
-      expect(newlyPurchasedPokemon!.moveset.length > 0).toBeTruthy();
+      expect(newlyPurchasedPokemon.getMoveset(true).length).toBeGreaterThan(0);
     });
 
     it("should give the purchased Pokemon its HA or make it shiny", async () => {

--- a/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -205,7 +205,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       expect(shuckleItems.find((m) => m.isBerryModifier() && m.berryType === BerryType.GANLON)?.stackCount).toBe(1);
       expect(shuckleItems.find((m) => m.isBerryModifier() && m.berryType === BerryType.APICOT)?.stackCount).toBe(1);
       expect(shuckleItems.find((m) => m.isBerryModifier() && m.berryType === BerryType.LUM)?.stackCount).toBe(2);
-      expect(enemyField[0].moveset).toEqual([
+      expect(enemyField[0].getMoveset(true)).toEqual([
         new PokemonMove(MoveId.INFESTATION),
         new PokemonMove(MoveId.SALT_CURE),
         new PokemonMove(MoveId.GASTRO_ACID),

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -172,7 +172,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
       expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(SpeciesId.GARBODOR);
-      expect(enemyField[0].moveset).toEqual([
+      expect(enemyField[0].getMoveset(true)).toEqual([
         new PokemonMove(MoveId.PAYBACK),
         new PokemonMove(MoveId.GUNK_SHOT),
         new PokemonMove(MoveId.STOMPING_TANTRUM),

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -9,7 +9,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
-import { PokemonMove } from "#field/pokemon-move";
 import type { BerryModifier } from "#modifier/modifier";
 import { modifierTypes } from "#modifier/modifier-types";
 import * as EncounterPhaseUtils from "#mystery-encounters/encounter-phase-utils";
@@ -248,7 +247,9 @@ describe("Uncommon Breed - Mystery Encounter", () => {
 
     it("should NOT be selectable if the player doesn't have an Attracting move", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.UNCOMMON_BREED, defaultParty);
-      scene.getPlayerParty().forEach((p) => (p.moveset = []));
+      scene.getPlayerParty().forEach((p) => {
+        game.move.changeMoveset(p, []);
+      });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       const encounterPhase = scene.phaseManager.getCurrentPhase();
@@ -270,7 +271,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       const leaveEncounterWithoutBattleSpy = vi.spyOn(EncounterPhaseUtils, "leaveEncounterWithoutBattle");
       await game.runToMysteryEncounter(MysteryEncounterType.UNCOMMON_BREED, defaultParty);
       // Mock moveset
-      scene.getPlayerParty()[0].moveset = [new PokemonMove(MoveId.CHARM)];
+      game.move.changeMoveset(scene.getPlayerParty()[0], MoveId.CHARM);
       await runMysteryEncounterToEnd(game, 3);
 
       expect(leaveEncounterWithoutBattleSpy).toBeCalled();

--- a/test/phases/form-change-phase.test.ts
+++ b/test/phases/form-change-phase.test.ts
@@ -48,7 +48,7 @@ describe("Form Change Phase", () => {
     // Before the form change: Should be normal form
     const pokemon = game.scene.getPlayerParty()[0];
     expect(pokemon.getFormKey()).toBe("");
-    expect(pokemon.moveset.map((m) => m.moveId)).not.toContain(learnedMoveId);
+    expect(pokemon.getMoveset(true).map((m) => m.moveId)).not.toContain(learnedMoveId);
 
     // Give a form change item to activate the form change
     const formChangeItemType =
@@ -63,7 +63,12 @@ describe("Form Change Phase", () => {
     // After the form change: Should be the desired new form
     expect(game.phaseInterceptor.log.includes("FormChangePhase")).toBe(true);
     expect(pokemon.getFormKey()).toBe(newFormKey);
-    expect(pokemon.moveset.map((m) => m.moveId).includes(learnedMoveId)).toBe(expectedToLearn);
+    expect(
+      pokemon
+        .getMoveset(true)
+        .map((m) => m.moveId)
+        .includes(learnedMoveId),
+    ).toBe(expectedToLearn);
     expect(game.phaseInterceptor.log.includes("LearnMovePhase")).toBe(expectedToLearn);
   }
 
@@ -75,7 +80,7 @@ describe("Form Change Phase", () => {
     expect(zacian.getFormKey()).toBe("hero-of-many-battles");
     expect(zacian.getTypes()).toStrictEqual([ElementalType.FAIRY]);
     expect(zacian.calculateBaseStats()).toStrictEqual([92, 120, 115, 80, 115, 138]);
-    expect(zacian.moveset.map((m) => m.moveId)).not.toContain(MoveId.BEHEMOTH_BLADE);
+    expect(zacian.getMoveset(true).map((m) => m.moveId)).not.toContain(MoveId.BEHEMOTH_BLADE);
 
     // Prevent form change from finishing instantly, so that the player can attempt to cancel it
     const originalDoCycle = game.scene.animations.doCycle;
@@ -103,7 +108,7 @@ describe("Form Change Phase", () => {
     expect(zacian.getFormKey()).toBe("crowned");
     expect(zacian.getTypes()).toStrictEqual([ElementalType.FAIRY, ElementalType.STEEL]);
     expect(zacian.calculateBaseStats()).toStrictEqual([92, 150, 115, 80, 115, 148]);
-    expect(zacian.moveset.map((m) => m.moveId)).toContain(MoveId.BEHEMOTH_BLADE);
+    expect(zacian.getMoveset(true).map((m) => m.moveId)).toContain(MoveId.BEHEMOTH_BLADE);
   });
 
   it("should allow a G-Max Pokemon to learn its respective G-Max move at any level", async () => {
@@ -172,8 +177,8 @@ describe("Form Change Phase", () => {
     await game.toNextWave();
 
     // Expect no new moves to be learned
-    expect(rillaboom.moveset.map((m) => m.moveId)).not.toContain(MoveId.G_MAX_DRUM_SOLO);
-    expect(rillaboom.moveset.map((m) => m.moveId)).not.toContain(MoveId.DRUM_BEATING);
+    expect(rillaboom.getMoveset(true).map((m) => m.moveId)).not.toContain(MoveId.G_MAX_DRUM_SOLO);
+    expect(rillaboom.getMoveset(true).map((m) => m.moveId)).not.toContain(MoveId.DRUM_BEATING);
     expect(game.phaseInterceptor.log.includes("LearnMovePhase")).toBe(false);
   });
 });

--- a/test/test-utils/game-manager-utils.ts
+++ b/test/test-utils/game-manager-utils.ts
@@ -53,9 +53,9 @@ export function generateStarter(scene: BattleScene, species: SpeciesId[]): Start
       starter.nature,
     );
     const moveset: MoveId[] = [];
-    starterPokemon.moveset.forEach((move) => {
-      moveset.push(move!.getMove().id);
-    });
+    for (const move of starterPokemon.getMoveset(true)) {
+      moveset.push(move.getMove().id);
+    }
     starter.moveset = moveset as StarterMoveset;
   }
   return starters;

--- a/test/test-utils/helpers/move-helper.ts
+++ b/test/test-utils/helpers/move-helper.ts
@@ -7,7 +7,6 @@ import { Button } from "#enums/button";
 import { MoveId } from "#enums/move-id";
 import { UiMode } from "#enums/ui-mode";
 import type { Pokemon } from "#field/pokemon";
-import { PokemonMove } from "#field/pokemon-move";
 import { getMoveTargets } from "#moves/move";
 import type { CommandPhase } from "#phases/command-phase";
 import type { EnemyCommandPhase } from "#phases/enemy-command-phase";
@@ -114,8 +113,7 @@ export class MoveHelper extends GameManagerHelper {
     }
 
     const pokemon = this.game.scene.getPlayerField()[pkmIndex];
-    // @ts-expect-error - `Pokemon#moveset` is `protected`
-    pokemon.moveset = [new PokemonMove(moveId)];
+    pokemon.setMoveset(moveId);
 
     this.select(moveId, pkmIndex, targetIndex, useTera);
   }
@@ -153,15 +151,12 @@ export class MoveHelper extends GameManagerHelper {
       }
     }
 
-    moveset = coerceArray(moveset);
-    // @ts-expect-error - `Pokemon#moveset` is `protected`
-    pokemon.moveset = [];
-    for (const moveId of moveset) {
-      // @ts-expect-error - `Pokemon#moveset` is `protected`
-      pokemon.moveset.push(new PokemonMove(moveId));
-    }
-    const movesetStr = moveset.map((moveId) => MoveId[moveId]).join(", ");
-    console.log(`Pokemon ${pokemon.species.name}'s moveset manually set to ${movesetStr} (=[${moveset.join(", ")}])!`);
+    const newMoveset = coerceArray(moveset);
+    pokemon.setMoveset(...newMoveset);
+    const movesetStr = newMoveset.map((moveId) => MoveId[moveId]).join(", ");
+    console.log(
+      `Pokemon ${pokemon.species.name}'s moveset manually set to ${movesetStr} (=[${newMoveset.join(", ")}])!`,
+    );
   }
 
   /**
@@ -216,8 +211,8 @@ export class MoveHelper extends GameManagerHelper {
         "Warning: `forceEnemyMove` overwrites the Pokemon's moveset and disables the enemy moveset override!",
       );
     }
-    // @ts-expect-error - `Pokemon#moveset` is `protected`
-    enemy.moveset = [new PokemonMove(moveId)];
+
+    enemy.setMoveset(moveId);
     const legalTargets = getMoveTargets(enemy, moveId);
 
     vi.spyOn(enemy, "getNextMove").mockReturnValueOnce({

--- a/test/test-utils/helpers/move-helper.ts
+++ b/test/test-utils/helpers/move-helper.ts
@@ -114,6 +114,7 @@ export class MoveHelper extends GameManagerHelper {
     }
 
     const pokemon = this.game.scene.getPlayerField()[pkmIndex];
+    // @ts-expect-error - `Pokemon#moveset` is `protected`
     pokemon.moveset = [new PokemonMove(moveId)];
 
     this.select(moveId, pkmIndex, targetIndex, useTera);
@@ -153,10 +154,12 @@ export class MoveHelper extends GameManagerHelper {
     }
 
     moveset = coerceArray(moveset);
+    // @ts-expect-error - `Pokemon#moveset` is `protected`
     pokemon.moveset = [];
-    moveset.forEach((moveId) => {
+    for (const moveId of moveset) {
+      // @ts-expect-error - `Pokemon#moveset` is `protected`
       pokemon.moveset.push(new PokemonMove(moveId));
-    });
+    }
     const movesetStr = moveset.map((moveId) => MoveId[moveId]).join(", ");
     console.log(`Pokemon ${pokemon.species.name}'s moveset manually set to ${movesetStr} (=[${moveset.join(", ")}])!`);
   }
@@ -213,6 +216,7 @@ export class MoveHelper extends GameManagerHelper {
         "Warning: `forceEnemyMove` overwrites the Pokemon's moveset and disables the enemy moveset override!",
       );
     }
+    // @ts-expect-error - `Pokemon#moveset` is `protected`
     enemy.moveset = [new PokemonMove(moveId)];
     const legalTargets = getMoveTargets(enemy, moveId);
 


### PR DESCRIPTION
## What are the changes the user will see?
Transformed pokemon will be able to learn moves correctly again.

## Why am I making these changes?
Improved code safety.
- Fixes #1231

## What are the changes from a developer perspective?
- `Pokemon#moveset` changed to `protected` and all uses updated to use the appropriate helper methods.
- New helper method `Pokemon#swapMoves` added to swap two moves in a Pokémon's moveset.
- New helper method `Pokemon#restoreMovePP` added to reset PP usage of all moves in a Pokémon's moveset to `0`.
- New helper method `Pokemon#setMoveset` added to overwrite the Pokémon's current moveset with a new moveset.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?