### PR TITLE
ai-rework: Add Effect Scores for Status Effect inflicting moves

### DIFF
--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -43,3 +43,29 @@ export const ELECTRIC_IMMUNE_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
   AbilityId.LIGHTNING_ROD,
   AbilityId.MOTOR_DRIVE,
 ]);
+
+/** Abilities that grant a benefit when the source is under a non-volatile status effect */
+export const STATUS_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+  AbilityId.GUTS,
+  AbilityId.QUICK_FEET,
+  AbilityId.MARVEL_SCALE,
+  AbilityId.MAGIC_GUARD,
+]);
+
+/** Abilities that grant a benefit when the source is burned */
+export const BURN_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+  ...STATUS_SYNERGY_ABILITIES,
+  AbilityId.FLARE_BOOST,
+]);
+
+/** Abilities that grant a benefit when the source is poisoned (or badly poisoned) */
+export const POISON_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+  ...STATUS_SYNERGY_ABILITIES,
+  AbilityId.TOXIC_BOOST,
+  AbilityId.POISON_HEAL,
+]);
+
+export const POISONING_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+  AbilityId.MERCILESS,
+  AbilityId.POISON_PUPPETEER,
+]);

--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -45,7 +45,7 @@ export const ELECTRIC_IMMUNE_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
 ]);
 
 /** Abilities that grant a benefit when the source is under a non-volatile status effect */
-export const ANY_STATUS_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+export const ANY_STATUS_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
   AbilityId.GUTS,
   AbilityId.QUICK_FEET,
   AbilityId.MARVEL_SCALE,
@@ -53,20 +53,20 @@ export const ANY_STATUS_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze
 ]);
 
 /** Abilities that grant a benefit when the source is burned */
-export const BURN_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+export const BURN_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
   ...ANY_STATUS_SYNERGY_ABILITIES,
   AbilityId.FLARE_BOOST,
 ]);
 
 /** Abilities that grant a benefit when the source is poisoned (or badly poisoned) */
-export const POISON_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+export const POISON_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
   ...ANY_STATUS_SYNERGY_ABILITIES,
   AbilityId.TOXIC_BOOST,
   AbilityId.POISON_HEAL,
 ]);
 
 /** Abilities that grant a benefit when the source poisons another Pokemon */
-export const POISONING_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+export const POISONING_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
   AbilityId.MERCILESS,
   AbilityId.POISON_PUPPETEER,
 ]);

--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -45,7 +45,7 @@ export const ELECTRIC_IMMUNE_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
 ]);
 
 /** Abilities that grant a benefit when the source is under a non-volatile status effect */
-export const STATUS_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
+export const ANY_STATUS_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
   AbilityId.GUTS,
   AbilityId.QUICK_FEET,
   AbilityId.MARVEL_SCALE,
@@ -54,17 +54,18 @@ export const STATUS_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
 
 /** Abilities that grant a benefit when the source is burned */
 export const BURN_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
-  ...STATUS_SYNERGY_ABILITIES,
+  ...ANY_STATUS_SYNERGY_ABILITIES,
   AbilityId.FLARE_BOOST,
 ]);
 
 /** Abilities that grant a benefit when the source is poisoned (or badly poisoned) */
 export const POISON_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
-  ...STATUS_SYNERGY_ABILITIES,
+  ...ANY_STATUS_SYNERGY_ABILITIES,
   AbilityId.TOXIC_BOOST,
   AbilityId.POISON_HEAL,
 ]);
 
+/** Abilities that grant a benefit when the source poisons another Pokemon */
 export const POISONING_SYNERGY_ABILITIES: Readonly<AbilityId[]> = Object.freeze([
   AbilityId.MERCILESS,
   AbilityId.POISON_PUPPETEER,

--- a/src/constants/ai-constants.ts
+++ b/src/constants/ai-constants.ts
@@ -1,5 +1,6 @@
-/* eslint-enable @typescript-eslint/no-unused-vars */
-// -- end tsdoc imports --
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { Pokemon } from "#field/pokemon";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 /** The {@link Pokemon.getAttackScore | Attack Score} granted to moves that KO an opponent. */
 export const KO_ATTACK_SCORE = 4;

--- a/src/data/moves/move-attrs/move-effect-attr.ts
+++ b/src/data/moves/move-attrs/move-effect-attr.ts
@@ -71,13 +71,13 @@ export abstract class MoveEffectAttr extends MoveAttr {
 
   /**
    * Determines whether the {@linkcode Move}'s effects are valid to {@linkcode apply}
-   * @virtual
-   * @param user the {@linkcode Pokemon} using the move
-   * @param target the {@linkcode Pokemon} targeted by the move
-   * @param move the {@linkcode Move} being used
+   * @param user - The {@linkcode Pokemon} using the move
+   * @param target - The {@linkcode Pokemon} targeted by the move
+   * @param move - The {@linkcode Move} being used
+   * @param simulated - If `true`, suppresses changes to game state
    * @returns `true` if effects can apply
    */
-  canApply(user: Pokemon, target: Pokemon | null, _move: Move): boolean {
+  public canApply(user: Pokemon, target: Pokemon | null, _move: Move, _simulated: boolean = false): boolean {
     const affectedPokemon = this.selfTarget ? user : target;
     return !!affectedPokemon && !affectedPokemon.isFainted();
   }
@@ -91,7 +91,7 @@ export abstract class MoveEffectAttr extends MoveAttr {
    * @param move the {@linkcode Move} being used
    * @sealed
    */
-  override apply(user: Pokemon, target: Pokemon | null, move: Move): boolean {
+  public override apply(user: Pokemon, target: Pokemon | null, move: Move): boolean {
     if (this.canApply(user, target, move)) {
       return this.applyEffect(user, target, move);
     }
@@ -107,5 +107,5 @@ export abstract class MoveEffectAttr extends MoveAttr {
    * @param move the {@linkcode Move} being used
    * @returns `true` if effects successfully applied.
    */
-  abstract applyEffect(_user: Pokemon, _target: Pokemon | null, _move: Move): boolean;
+  public abstract applyEffect(_user: Pokemon, _target: Pokemon | null, _move: Move): boolean;
 }

--- a/src/data/moves/move-attrs/multi-status-effect-attr.ts
+++ b/src/data/moves/move-attrs/multi-status-effect-attr.ts
@@ -1,4 +1,5 @@
 import type { StatusEffect } from "#enums/status-effect";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { StatusEffectAttr } from "#moves/status-effect-attr";
@@ -18,16 +19,20 @@ export class MultiStatusEffectAttr extends StatusEffectAttr {
     this.effects = effects;
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
     this.effect = randSeedItem(this.effects);
     return super.applyEffect(user, target, move);
   }
 
-  override getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    const moveChance = this.getMoveChance(user, target, move);
-    const score = moveChance < 0 ? -10 : Math.floor(moveChance * -0.1);
-    const pokemon = this.selfTarget ? user : target;
-
-    return !pokemon.hasNonVolatileStatusEffect() && pokemon.canSetStatus(this.effect, true, false, user) ? score : 0;
+  /**
+   * @returns The average base Effect Score among each of this attribute's {@linkcode effects},
+   * according to {@linkcode getStatusEffectScore}
+   */
+  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const totalStatusEffectScore = this.effects.reduce(
+      (score, effect) => score + this.getStatusEffectScore(user, target, effect),
+      0,
+    );
+    return totalStatusEffectScore / this.effects.length;
   }
 }

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -112,7 +112,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * @returns The overriding Effect Score when targeting the given ally.
    */
   private getAllyTargetScore(user: EnemyPokemon, ally: Pokemon, move: Move): number {
-    if (!move.isStatusMove() || ally.isSafeguarded(user)) {
+    if (!move.isStatusMove() || !ally.canSetStatus(this.effect, true, this.overrideStatus, user)) {
       return ALLY_TARGET_PENALTY;
     }
 
@@ -141,7 +141,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * @see {@linkcode getStatusEffectScore}
    */
   public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
-    if (target.isSafeguarded(user)) {
+    if (!target.canSetStatus(this.effect, true, this.overrideStatus, user)) {
       return move.isStatusMove() ? BAD_MOVE_PENALTY : 0;
     }
     return this.getStatusEffectScore(user, target, this.effect);

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -2,9 +2,18 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { ConfusionOnStatusEffectAbAttr } from "#abilities/confusion-on-status-effect-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import {
+  BURN_SYNERGY_ABILITIES,
+  POISON_SYNERGY_ABILITIES,
+  POISONING_SYNERGY_ABILITIES,
+} from "#constants/ability-constants";
+import { ALLY_TARGET_PENALTY } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { MoveCategory } from "#enums/move-category";
-import type { StatusEffect } from "#enums/status-effect";
+import { Stat } from "#enums/stat";
+import { StatusEffect } from "#enums/status-effect";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { ChanceBasedMoveEffectAttr } from "#moves/chance-based-move-effect-attr";
 import type { Move } from "#moves/move";
@@ -27,16 +36,19 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
     overrideStatus: boolean = false,
     effectChanceOverride?: number,
   ) {
-    super(selfTarget, { effectChanceOverride: effectChanceOverride });
+    super(selfTarget, {
+      effectChanceOverride: effectChanceOverride,
+      overridesAllyTargetPenalty: true,
+    });
 
     this.effect = effect;
     this.turnsRemaining = turnsRemaining;
     this.overrideStatus = overrideStatus;
   }
 
-  override canApply(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override canApply(user: Pokemon, target: Pokemon, move: Move, simulated: boolean = false): boolean {
     if (user !== target && target.isSafeguarded(user)) {
-      if (move.category === MoveCategory.STATUS) {
+      if (move.category === MoveCategory.STATUS && !simulated) {
         globalScene.phaseManager.createAndUnshiftPhase(
           "MessagePhase",
           i18next.t("moveTriggers:safeguard", { targetName: getPokemonNameWithAffix(target) }),
@@ -47,7 +59,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
     return super.canApply(user, target, move);
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
     const pokemon = this.selfTarget ? user : target;
     if (pokemon.hasNonVolatileStatusEffect()) {
       if (this.overrideStatus) {
@@ -72,11 +84,80 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
     return false;
   }
 
-  override getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    const moveChance = this.getMoveChance(user, target, move);
-    const score = moveChance < 0 ? -10 : Math.floor(moveChance * -0.1);
-    const pokemon = this.selfTarget ? user : target;
+  /**
+   * @returns The output of {@linkcode getAllyTargetScore} when evaluating the move against the given user's
+   * ally, or the chance-adjusted {@linkcode getRawEffectScore | raw Effect Score} otherwise.
+   * This score is inverted for self-targeted effects (i.e. Rest).
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (target === user.getAlly()) {
+      return this.getAllyTargetScore(user, target, move);
+    }
 
-    return !pokemon.hasNonVolatileStatusEffect() && pokemon.canSetStatus(this.effect, true, false, user) ? score : 0;
+    return (this.selfTarget ? -1 : 1) * super.getEffectScore(user, target, move);
+  }
+
+  /**
+   * Computes the Effect Score from this attribute when targeting the user's ally.
+   * This accounts for the ally's abilties, which may benefit from the ally being afflicted with
+   * certain status effects. In these cases, the move is generally awarded a X%(+2) bonus, where
+   * the bonus chance X reflects the damage per turn of the status effect.
+   * @param user - The {@linkcode Pokemon} evaluating the move
+   * @param ally - The user's ally
+   * @param move - The {@linkcode Move} being evaluated
+   * @returns The overriding Effect Score when targeting the given ally.
+   */
+  private getAllyTargetScore(user: EnemyPokemon, ally: Pokemon, move: Move): number {
+    if (!move.isStatusMove() || !this.canApply(user, ally, move, true)) {
+      return ALLY_TARGET_PENALTY;
+    }
+
+    if (this.effect === StatusEffect.BURN && BURN_SYNERGY_ABILITIES.some((abId) => ally.hasAbility(abId))) {
+      return this.getRandomScore(user, 80, 2);
+    }
+
+    if (
+      [StatusEffect.POISON, StatusEffect.TOXIC].includes(this.effect)
+      && POISON_SYNERGY_ABILITIES.some((abId) => ally.hasAbility(abId))
+    ) {
+      const bonusChance = this.effect === StatusEffect.POISON ? 70 : 60;
+      return this.getRandomScore(user, bonusChance, 2);
+    }
+
+    return ALLY_TARGET_PENALTY;
+  }
+
+  /**
+   * @returns A base effect score depending on this attribute's {@linkcode effect}:
+   * - Poison and Toxic Poison grant (+1)/(+1.5) respectively. If the user has Poison Puppeteer or
+   * Merciless, this bonus is increased to (+2)/(+2.5).
+   * - Paralysis grants (+1) if the user outspeeds the target, and (+2) otherwise.
+   * - Sleep and Freeze grant (+2.5) in all cases
+   * - Burn grants (+2) if the target has a physical affinity (ATK > SPATK), and (+1) otherwise.
+   */
+  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    switch (this.effect) {
+      case StatusEffect.POISON:
+        return POISONING_SYNERGY_ABILITIES.some((abId) => user.hasAbility(abId)) ? 2 : 1;
+      case StatusEffect.TOXIC:
+        return POISONING_SYNERGY_ABILITIES.some((abId) => user.hasAbility(abId)) ? 2.5 : 1.5;
+      case StatusEffect.PARALYSIS:
+        return user.outspeeds(target, true) ? 1 : 2;
+      case StatusEffect.SLEEP:
+      case StatusEffect.FREEZE:
+        return 2.5;
+      case StatusEffect.BURN: {
+        const effectiveStatOptions = {
+          abilityApplyMode: AbilityApplyMode.REVEALED,
+          simulated: true,
+        };
+        return target.getEffectiveStat(Stat.ATK, effectiveStatOptions)
+          > target.getEffectiveStat(Stat.SPATK, effectiveStatOptions)
+          ? 2
+          : 1;
+      }
+      default:
+        return 0;
+    }
   }
 }

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -1,3 +1,7 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { MultiStatusEffectAttr } from "#moves/multi-status-effect-attr";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { ConfusionOnStatusEffectAbAttr } from "#abilities/confusion-on-status-effect-ab-attr";
 import { globalScene } from "#app/global-scene";
@@ -128,15 +132,27 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
   }
 
   /**
-   * @returns A base effect score depending on this attribute's {@linkcode effect}:
+   * @returns The base Effect Score corresponding to this attribute's {@linkcode effect}.
+   * @see {@linkcode getStatusEffectScore}
+   */
+  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    return this.getStatusEffectScore(user, target, this.effect);
+  }
+
+  /**
+   * @returns A base Effect Score depending on the given {@linkcode StatusEffect}:
    * - Poison and Toxic Poison grant (+1)/(+1.5) respectively. If the user has Poison Puppeteer or
    * Merciless, this bonus is increased to (+2)/(+2.5).
    * - Paralysis grants (+1) if the user outspeeds the target, and (+2) otherwise.
    * - Sleep and Freeze grant (+2.5) in all cases
    * - Burn grants (+2) if the target has a physical affinity (ATK > SPATK), and (+1) otherwise.
+   *
+   * @privateRemarks
+   * This is organized here (and not in {@linkcode getRawEffectScore}) so that
+   * {@linkcode MultiStatusEffectAttr} can reuse this method in its scoring.
    */
-  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
-    switch (this.effect) {
+  protected getStatusEffectScore(user: EnemyPokemon, target: Pokemon, effect: StatusEffect) {
+    switch (effect) {
       case StatusEffect.POISON:
         return POISONING_SYNERGY_ABILITIES.some((abId) => user.hasAbility(abId)) ? 2 : 1;
       case StatusEffect.TOXIC:

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -11,7 +11,7 @@ import {
   POISON_SYNERGY_ABILITIES,
   POISONING_SYNERGY_ABILITIES,
 } from "#constants/ability-constants";
-import { ALLY_TARGET_PENALTY, MAJOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
+import { ALLY_TARGET_PENALTY, BAD_MOVE_PENALTY, MAJOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { MoveCategory } from "#enums/move-category";
@@ -140,7 +140,10 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * @returns The base Effect Score corresponding to this attribute's {@linkcode effect}.
    * @see {@linkcode getStatusEffectScore}
    */
-  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (!this.canApply(user, target, move, true)) {
+      return move.isStatusMove() ? BAD_MOVE_PENALTY : 0;
+    }
     return this.getStatusEffectScore(user, target, this.effect);
   }
 

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -159,7 +159,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * This is organized here (and not in {@linkcode getRawEffectScore}) so that
    * {@linkcode MultiStatusEffectAttr} can reuse this method in its scoring.
    */
-  protected getStatusEffectScore(user: EnemyPokemon, target: Pokemon, effect: StatusEffect) {
+  protected getStatusEffectScore(user: EnemyPokemon, target: Pokemon, effect: StatusEffect): number {
     switch (effect) {
       case StatusEffect.POISON:
         return POISONING_SYNERGY_ABILITIES.some((abId) => user.hasAbility(abId)) ? 2 : 1;
@@ -181,6 +181,9 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
           : 1;
       }
       default:
+        // This will cause a type error if more status effects are added in the future,
+        // ensuring they are not forgotten to be accounted for.
+        effect satisfies StatusEffect.NONE;
         return 0;
     }
   }

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -11,7 +11,7 @@ import {
   POISON_SYNERGY_ABILITIES,
   POISONING_SYNERGY_ABILITIES,
 } from "#constants/ability-constants";
-import { ALLY_TARGET_PENALTY } from "#constants/ai-constants";
+import { ALLY_TARGET_PENALTY, MAJOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { MoveCategory } from "#enums/move-category";
@@ -117,15 +117,20 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
     }
 
     if (this.effect === StatusEffect.BURN && BURN_SYNERGY_ABILITIES.some((abId) => ally.hasAbility(abId))) {
-      return this.getRandomScore(user, 80, 2);
+      return this.getRandomScore(user, 80, MAJOR_EFFECT_SCORE_BONUS);
     }
 
     if (
       [StatusEffect.POISON, StatusEffect.TOXIC].includes(this.effect)
       && POISON_SYNERGY_ABILITIES.some((abId) => ally.hasAbility(abId))
     ) {
+      /**
+       * The chance to grant a bonus for poisoning the user's ally (with a status move).
+       * {@link StatusEffect.TOXIC | Badly poisoning} an ally is less likely to grant a bonus
+       * than {@link StatusEffect.POISON | poisoning} an ally.
+       */
       const bonusChance = this.effect === StatusEffect.POISON ? 70 : 60;
-      return this.getRandomScore(user, bonusChance, 2);
+      return this.getRandomScore(user, bonusChance, MAJOR_EFFECT_SCORE_BONUS);
     }
 
     return ALLY_TARGET_PENALTY;

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -51,7 +51,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
   }
 
   public override canApply(user: Pokemon, target: Pokemon, move: Move, simulated: boolean = false): boolean {
-    if (user !== target && target.isSafeguarded(user)) {
+    if (user !== target && target.isSafeguarded(user, simulated)) {
       if (move.category === MoveCategory.STATUS && !simulated) {
         globalScene.phaseManager.createAndUnshiftPhase(
           "MessagePhase",
@@ -112,7 +112,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * @returns The overriding Effect Score when targeting the given ally.
    */
   private getAllyTargetScore(user: EnemyPokemon, ally: Pokemon, move: Move): number {
-    if (!move.isStatusMove() || !this.canApply(user, ally, move, true)) {
+    if (!move.isStatusMove() || ally.isSafeguarded(user)) {
       return ALLY_TARGET_PENALTY;
     }
 
@@ -141,7 +141,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * @see {@linkcode getStatusEffectScore}
    */
   public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
-    if (!this.canApply(user, target, move, true)) {
+    if (target.isSafeguarded(user)) {
       return move.isStatusMove() ? BAD_MOVE_PENALTY : 0;
     }
     return this.getStatusEffectScore(user, target, this.effect);

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -908,10 +908,8 @@ export abstract class Move {
    * @see {@linkcode getEffectScore}
    */
   public getBattleAccuracyPenalty(user: EnemyPokemon, target: Pokemon): number {
-    /**
-     * If any ongoing effect would cause the move to bypass accuracy checks, assign no penalty.
-     * @todo the target's No Guard can be discovered prematurely here
-     */
+    // If any ongoing effect would cause the move to bypass accuracy checks, assign no penalty.
+    // TODO: the target's No Guard can be discovered prematurely here
     if (
       [user, target].some((p) => p.hasAbilityWithAttr(AbAttrFlag.ALWAYS_HIT))
       || user.getTag(BattlerTagType.IGNORE_ACCURACY)

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -212,7 +212,8 @@ export class EnemyPokemon extends Pokemon {
    */
   public getMoveScore(target: Pokemon, move: Move): number {
     // If the move is known to have no effect on the target, return a Bad Move Penalty.
-    // TODO: This is inefficient for attacks since effectiveness is calculated again for Attack Score.
+    // TODO: This is necessary for some status moves, but is inefficient for attacks
+    // since effectiveness is calculated again for Attack Score.
     if (target.getMoveEffectiveness(this, move, AbilityApplyMode.REVEALED) === 0) {
       return BAD_MOVE_PENALTY;
     }

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -211,10 +211,9 @@ export class EnemyPokemon extends Pokemon {
    * @returns the sum of this move's score components against the given target
    */
   public getMoveScore(target: Pokemon, move: Move): number {
-    // If the move is known to have no effect on the target, return a Bad Move Penalty.
-    // TODO: This is necessary for some status moves, but is inefficient for attacks
-    // since effectiveness is calculated again for Attack Score.
-    if (target.getMoveEffectiveness(this, move, AbilityApplyMode.REVEALED) === 0) {
+    // If the move is a Status move and is known to have no effect on the target,
+    // return a Bad Move Penalty.
+    if (move.isStatusMove() && target.getMoveEffectiveness(this, move, AbilityApplyMode.REVEALED) === 0) {
       return BAD_MOVE_PENALTY;
     }
 

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -211,6 +211,12 @@ export class EnemyPokemon extends Pokemon {
    * @returns the sum of this move's score components against the given target
    */
   public getMoveScore(target: Pokemon, move: Move): number {
+    // If the move is known to have no effect on the target, return a Bad Move Penalty.
+    // TODO: This is inefficient for attacks since effectiveness is calculated again for Attack Score.
+    if (target.getMoveEffectiveness(this, move, AbilityApplyMode.REVEALED) === 0) {
+      return BAD_MOVE_PENALTY;
+    }
+
     const conditionScore = move.getConditionScore(this, target);
     const attackScore = this.getAttackScore(target, move);
 

--- a/test/ai/move-effect-scores/spore.test.ts
+++ b/test/ai/move-effect-scores/spore.test.ts
@@ -6,7 +6,7 @@ import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-describe("Move Effect Scores - Smack Down", () => {
+describe("Move Effect Scores - Spore", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 

--- a/test/ai/move-effect-scores/spore.test.ts
+++ b/test/ai/move-effect-scores/spore.test.ts
@@ -60,7 +60,7 @@ describe("Move Effect Scores - Spore", () => {
   it("should be avoided if the opponent is under the effects of Safeguard", async () => {
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER);
+    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER, true);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.SPORE);

--- a/test/ai/move-effect-scores/spore.test.ts
+++ b/test/ai/move-effect-scores/spore.test.ts
@@ -1,0 +1,75 @@
+import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Smack Down", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SPORE, MoveId.SPLASH, MoveId.TACKLE])
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be strongly preferred over low-impact moves", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SPORE);
+  });
+
+  it("should be preferred over less accurate moves that inflict sleep", async () => {
+    game.override.enemyMoveset([MoveId.SPORE, MoveId.SLEEP_POWDER, MoveId.HYPNOSIS]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SPORE);
+  });
+
+  it("should be preferred over moves with a lower chance to inflict sleep", async () => {
+    game.override.enemyMoveset([MoveId.SPORE, MoveId.WICKED_TORQUE]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SPORE);
+  });
+
+  it("should be avoided if the opponent is under the effects of Safeguard", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SPORE);
+  });
+
+  it("should be avoided if the opponent is Grass-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.ODDISH);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SPORE);
+  });
+});

--- a/test/ai/move-effect-scores/thunder-wave.test.ts
+++ b/test/ai/move-effect-scores/thunder-wave.test.ts
@@ -1,0 +1,73 @@
+import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Thunder Wave", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.THUNDER_WAVE, MoveId.SUPER_FANG])
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred over Super Fang if the user is slower than the opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.PURUGLY);
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.THUNDER_WAVE);
+  });
+
+  it("should not be preferred over Super Fang if the user is faster than the opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.SNORLAX);
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.THUNDER_WAVE);
+  });
+
+  it("should be preferred over moves with a lower chance to paralyze", async () => {
+    game.override.enemyMoveset([MoveId.THUNDER_WAVE, MoveId.DRAGON_BREATH]);
+
+    await game.classicMode.startBattle(SpeciesId.SNORLAX);
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.THUNDER_WAVE);
+  });
+
+  it("should be avoided if the opponent is under the effects of Safeguard", async () => {
+    await game.classicMode.startBattle(SpeciesId.PURUGLY);
+
+    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER);
+
+    const enemy = game.scene.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.THUNDER_WAVE);
+  });
+
+  it("should be avoided if the opponent is Ground-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.DUGTRIO);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.THUNDER_WAVE);
+  });
+});

--- a/test/ai/move-effect-scores/thunder-wave.test.ts
+++ b/test/ai/move-effect-scores/thunder-wave.test.ts
@@ -58,7 +58,7 @@ describe("Move Effect Scores - Thunder Wave", () => {
   it("should be avoided if the opponent is under the effects of Safeguard", async () => {
     await game.classicMode.startBattle(SpeciesId.PURUGLY);
 
-    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER);
+    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER, true);
 
     const enemy = game.scene.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.THUNDER_WAVE);

--- a/test/ai/move-effect-scores/toxic.test.ts
+++ b/test/ai/move-effect-scores/toxic.test.ts
@@ -1,0 +1,101 @@
+import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { BattlerIndex } from "#enums/battler-index";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Toxic", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.TOXIC, MoveId.SUPER_FANG])
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred over Super Fang", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.TOXIC);
+  });
+
+  it.each([
+    { abilityName: "Poison Puppeteer", abilityId: AbilityId.POISON_PUPPETEER },
+    { abilityName: "Merciless", abilityId: AbilityId.MERCILESS },
+  ])("should be preferred over high-value moves if the user has $abilityName", async ({ abilityId }) => {
+    game.override.enemyAbility(abilityId).enemyMoveset([MoveId.TOXIC, MoveId.WILL_O_WISP]);
+
+    await game.classicMode.startBattle(SpeciesId.GYARADOS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.TOXIC);
+  });
+
+  it("should be preferred over normal Poison effects", async () => {
+    game.override.enemyMoveset([MoveId.TOXIC, MoveId.POISON_GAS]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.TOXIC);
+  });
+
+  it("should be avoided if the opponent is already poisoned", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.use(MoveId.SPLASH);
+    await game.move.selectEnemyMove(MoveId.TOXIC);
+    await game.move.forceHit();
+    await game.toNextTurn();
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.TOXIC);
+  });
+
+  it("should be avoided if the opponent is under the effects of Safeguard", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER, true);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.TOXIC);
+  });
+
+  it("should be avoided if the opponent is Poison-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.SKORUPI);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.TOXIC);
+  });
+
+  it("should still be preferred against Poison-type Pokemon if the user has Corrosion", async () => {
+    game.override.enemyAbility(AbilityId.CORROSION);
+
+    await game.classicMode.startBattle(SpeciesId.SKORUPI);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.TOXIC);
+  });
+});

--- a/test/ai/move-effect-scores/will-o-wisp.test.ts
+++ b/test/ai/move-effect-scores/will-o-wisp.test.ts
@@ -1,0 +1,74 @@
+import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Will-O-Wisp", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.GYARADOS)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.WILL_O_WISP, MoveId.SUPER_FANG])
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred over Super Fang if the opponent is a physical attacker", async () => {
+    await game.classicMode.startBattle(SpeciesId.EXCADRILL);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.WILL_O_WISP);
+  });
+
+  it("should not be preferred over Super Fang if the opponent is a special attacker", async () => {
+    await game.classicMode.startBattle(SpeciesId.ELECTRODE);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.WILL_O_WISP);
+  });
+
+  it("should be preferred over moves with a lower chance to burn", async () => {
+    game.override.enemyMoveset([MoveId.WILL_O_WISP, MoveId.EMBER]);
+
+    await game.classicMode.startBattle(SpeciesId.GYARADOS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.WILL_O_WISP);
+  });
+
+  it("should be avoided if the opponent is under the effects of Safeguard", async () => {
+    await game.classicMode.startBattle(SpeciesId.EXCADRILL);
+
+    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.WILL_O_WISP);
+  });
+
+  // TODO: Fix effectiveness logic for status effect moves to pass this test
+  it.todo("should be avoided if the opponent is Fire-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.INFERNAPE);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.WILL_O_WISP);
+  });
+});

--- a/test/ai/move-effect-scores/will-o-wisp.test.ts
+++ b/test/ai/move-effect-scores/will-o-wisp.test.ts
@@ -66,7 +66,7 @@ describe("Move Effect Scores - Will-O-Wisp", () => {
 
   // TODO: Fix effectiveness logic for status effect moves to pass this test
   it.todo("should be avoided if the opponent is Fire-type", async () => {
-    await game.classicMode.startBattle(SpeciesId.INFERNAPE);
+    await game.classicMode.startBattle(SpeciesId.CINDERACE);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.WILL_O_WISP);

--- a/test/ai/move-effect-scores/will-o-wisp.test.ts
+++ b/test/ai/move-effect-scores/will-o-wisp.test.ts
@@ -58,14 +58,13 @@ describe("Move Effect Scores - Will-O-Wisp", () => {
   it("should be avoided if the opponent is under the effects of Safeguard", async () => {
     await game.classicMode.startBattle(SpeciesId.EXCADRILL);
 
-    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER);
+    game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER, true);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.WILL_O_WISP);
   });
 
-  // TODO: Fix effectiveness logic for status effect moves to pass this test
-  it.todo("should be avoided if the opponent is Fire-type", async () => {
+  it("should be avoided if the opponent is Fire-type", async () => {
     await game.classicMode.startBattle(SpeciesId.CINDERACE);
 
     const enemy = game.field.getEnemyPokemon();


### PR DESCRIPTION
## What are the changes the user will see?

The Enemy AI should now evaluate moves that inflict non-volatile status effects more precisely.

## Why am I making these changes?

Part of the AI Rework.

## What are the changes from a developer perspective?

The following attributes now have Effect Score methods:
- `StatusEffectAttr`
- `MultiStatusEffectAttr`

> [!NOTE]
> These attributes use *chance-based* scores. To recap, the raw effect score is multiplied by `move.chance / 100`, then "tiered" based on the result. For example, an effect scored at 1.4 after the multiplier has a 40% chance to yield (+2) and a 60% chance to yield (+1). 

## Screenshots/Videos

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`

New unit tests  – can be run via `pnpm test[:silent] move-effect-scores/testName`:
- `spore`
- `thunder-wave`
- `will-o-wisp`
- `toxic`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
<!-- We have heavily optimized our test suite, so please actually run the tests :) -->
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
