### PR TITLE
github: rename "art" scope to "graphics"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,13 +31,13 @@ List of valid scopes:
   ability
   ai
   anomaly - Formerly "Mystery Encounters"
-  art
   audio
   battle - Relating to the general battle engine
   biomes
   challenge
   data - Data not covered by other scopes, such as TM lists
   event
+  graphics - Anything related to art/graphics (adding new sprites, fixing a sprite that isn't displaying, etc)
   item
   move
   ui - UI/UX

--- a/.github/scripts/pr-title.ts
+++ b/.github/scripts/pr-title.ts
@@ -20,13 +20,13 @@ const ALL_SCOPES = [
   "ability",
   "ai",
   "anomaly", // Formerly "Mystery Encounters"
-  "art",
   "audio",
   "battle", // Relating to the general battle engine
   "biomes",
   "challenge",
   "data", // Data not covered by other scopes, such as TM lists
   "event",
+  "graphics", // Anything related to art/graphics (adding new sprites, fixing a sprite that isn't displaying, etc)
   "item",
   "move",
   "ui", // UI/UX


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
To clarify the purpose of the label.

## What are the changes from a developer perspective?
The `art` scope for PR titles was renamed to `graphics`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?