### PR TITLE
github: add `misc` prefix for PR titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,6 +52,7 @@ List of valid "prefix(scope)" combinations:
   fix - All
   github - N/A
   i18n - N/A
+  misc - N/A
   refactor - All
   revert - N/A
   test - N/A

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ List of valid prefixes:
   fix - Fixing a bug
   github - Updating the CI pipeline or otherwise modifying something in the `./github/` directory
   i18n - Updating the localization submodule, adding new translatable text, etc
+  misc - A change that doesn't fit any other category
   refactor - A change that doesn't impact functionality or fix any bugs (except incidentally)
   revert - Reverting a previous commit
   test - Primarily adding/updating tests or modifying the test framework

--- a/.github/scripts/pr-title.ts
+++ b/.github/scripts/pr-title.ts
@@ -11,6 +11,7 @@ const PREFIXES = [
   "fix", // Fixing a bug
   "github", // Updating the CI pipeline or otherwise modifying something in the `./github/` directory
   "i18n", // Updating the localization submodule, adding new translatable text, etc
+  "misc", // A change that doesn't fit any other category
   "refactor", // A change that doesn't impact functionality or fix any bugs (except incidentally)
   "revert", // Reverting a previous commit
   "test", // Primarily adding/updating tests or modifying the test framework
@@ -41,6 +42,7 @@ const PREFIX_SCOPE_MAP = {
   fix: ALL_SCOPES,
   github: [],
   i18n: [],
+  misc: [],
   refactor: ALL_SCOPES,
   revert: [],
   test: [],


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Forgot to add it in the original PR.

## What are the changes from a developer perspective?
`misc` is now a valid prefix for PR titles.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?