### PR TITLE
ai-rework: Add Effect Scores for misc. status-effect-related attributes

### DIFF
--- a/src/data/moves/move-attrs/bypass-sleep-attr.ts
+++ b/src/data/moves/move-attrs/bypass-sleep-attr.ts
@@ -1,4 +1,3 @@
-import { BAD_MOVE_PENALTY } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { StatusEffect } from "#enums/status-effect";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
@@ -22,15 +21,12 @@ export class BypassSleepAttr extends MoveAttr {
   }
 
   /**
-   * @returns
-   * - (+6) if the user is asleep, minus (2) for each turn the user has already slept.
-   * - A {@linkcode BAD_MOVE_PENALTY} if the user is not asleep
-   * @todo Should the penalty be enforced by Snore/Sleep Talk's conditions instead?
+   * @returns (+6) if the user is asleep, minus (2) for each turn the user has already slept.
    */
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
-    if (user.hasStatusEffect(StatusEffect.SLEEP)) {
+    if (user.hasStatusEffect(StatusEffect.SLEEP, false, true)) {
       return 6 - 2 * user.turnsAsleep;
     }
-    return BAD_MOVE_PENALTY;
+    return 0;
   }
 }

--- a/src/data/moves/move-attrs/bypass-sleep-attr.ts
+++ b/src/data/moves/move-attrs/bypass-sleep-attr.ts
@@ -1,5 +1,7 @@
+import { BAD_MOVE_PENALTY } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { StatusEffect } from "#enums/status-effect";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveAttr } from "#moves/move-attr";
@@ -10,7 +12,7 @@ import { MoveAttr } from "#moves/move-attr";
  * and {@link https://bulbapedia.bulbagarden.net/wiki/Sleep_Talk_(move) | Sleep Talk}.
  */
 export class BypassSleepAttr extends MoveAttr {
-  override apply(user: Pokemon, _target: Pokemon | null, move: Move): boolean {
+  public override apply(user: Pokemon, _target: Pokemon | null, move: Move): boolean {
     if (user.hasStatusEffect(StatusEffect.SLEEP)) {
       user.addTag(BattlerTagType.BYPASS_SLEEP, 1, move.id, user.id);
       return true;
@@ -19,8 +21,16 @@ export class BypassSleepAttr extends MoveAttr {
     return false;
   }
 
-  /** Returns arbitrarily high score when Pokemon is asleep, otherwise shouldn't be used */
-  override getUserBenefitScore(user: Pokemon, _target: Pokemon, _move: Move): number {
-    return user.hasStatusEffect(StatusEffect.SLEEP) ? 200 : -10;
+  /**
+   * @returns
+   * - (+6) if the user is asleep, minus (2) for each turn the user has already slept.
+   * - A {@linkcode BAD_MOVE_PENALTY} if the user is not asleep
+   * @todo Should the penalty be enforced by Snore/Sleep Talk's conditions instead?
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    if (user.hasStatusEffect(StatusEffect.SLEEP)) {
+      return 6 - 2 * user.turnsAsleep;
+    }
+    return BAD_MOVE_PENALTY;
   }
 }

--- a/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
+++ b/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
@@ -98,7 +98,7 @@ export abstract class ChanceBasedMoveEffectAttr extends MoveEffectAttr {
      * This may be a decimal number; the final output is either
      * `floor(chanceWeightedScore)` or `floor(chanceWeightedScore) + 1`
      */
-    const chanceWeightedScore = chance * rawScore;
+    const chanceWeightedScore = (chance * rawScore) / 100;
     /** The minimum integer score this function can return */
     const minScore = Math.floor(chanceWeightedScore);
     /**

--- a/src/data/moves/move-attrs/heal-status-effect-attr.ts
+++ b/src/data/moves/move-attrs/heal-status-effect-attr.ts
@@ -1,8 +1,14 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import {
+  MAJOR_EFFECT_SCORE_BONUS,
+  MINOR_EFFECT_SCORE_BONUS,
+  MINOR_EFFECT_SCORE_PENALTY,
+} from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { MoveId } from "#enums/move-id";
 import type { StatusEffect } from "#enums/status-effect";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { getMoveTargets, type Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -21,11 +27,14 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
    * @param effects - status effect or list of status effects to cure
    */
   constructor(selfTarget: boolean, effects: StatusEffect | StatusEffect[]) {
-    super(selfTarget, { lastHitOnly: true });
+    super(selfTarget, {
+      lastHitOnly: true,
+      overridesAllyTargetPenalty: true,
+    });
     this.effects = [effects].flat(1);
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
     // Special edge case for shield dust blocking Sparkling Aria curing burn
     const moveTargets = getMoveTargets(user, move.id);
     if (
@@ -51,11 +60,26 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
     return false;
   }
 
-  isOfEffect(effect: StatusEffect): boolean {
+  public isOfEffect(effect: StatusEffect): boolean {
     return this.effects.includes(effect);
   }
 
-  override getUserBenefitScore(user: Pokemon, _target: Pokemon, _move: Move): number {
-    return user.hasNonVolatileStatusEffect(false, true) ? 10 : 0;
+  /**
+   * @returns This attribute's Effect Score modifier as follows:
+   * - If the affected Pokemon doesn't have a relevant status effect, grant (+0).
+   * - Otherwise, if the affected Pokemon is either the user or its ally, grant (+1) + 50%(+1)
+   * - Otherwise, grant (-1) [using the move would cure an opponent's status effect]
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const pokemon = this.selfTarget ? user : target;
+
+    if (!pokemon.hasStatusEffect(this.effects)) {
+      return 0;
+    }
+
+    if (!pokemon.isOpponent(user)) {
+      return this.getRandomScore(user, 50, MAJOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_BONUS);
+    }
+    return MINOR_EFFECT_SCORE_PENALTY;
   }
 }

--- a/src/data/moves/move-attrs/heal-status-effect-attr.ts
+++ b/src/data/moves/move-attrs/heal-status-effect-attr.ts
@@ -1,5 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { ANY_STATUS_SYNERGY_ABILITIES } from "#constants/ability-constants";
 import {
   MAJOR_EFFECT_SCORE_BONUS,
   MINOR_EFFECT_SCORE_BONUS,
@@ -7,7 +8,7 @@ import {
 } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { MoveId } from "#enums/move-id";
-import type { StatusEffect } from "#enums/status-effect";
+import { StatusEffect } from "#enums/status-effect";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { getMoveTargets, type Move } from "#moves/move";
@@ -66,14 +67,24 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
 
   /**
    * @returns This attribute's Effect Score modifier as follows:
-   * - If the affected Pokemon doesn't have a relevant status effect, grant (+0).
+   * - If the user has an ability that synergizes with their status effect, and the effects
+   * of this attribute would cure said status, grant (-1).
+   * - Otherwise, if the affected Pokemon doesn't have a relevant status effect OR it can't feasibly
+   * cure itself due to being asleep or frozen, grant (+0).
    * - Otherwise, if the affected Pokemon is either the user or its ally, grant (+1) + 50%(+1)
    * - Otherwise, grant (-1) [using the move would cure an opponent's status effect]
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
     const pokemon = this.selfTarget ? user : target;
 
-    if (!pokemon.hasStatusEffect(this.effects)) {
+    if (this.selfTarget && ANY_STATUS_SYNERGY_ABILITIES.some((abId) => pokemon.hasAbility(abId))) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+
+    if (
+      !pokemon.hasStatusEffect(this.effects, false, true)
+      || (this.selfTarget && pokemon.hasStatusEffect(StatusEffect.SLEEP, false, true))
+    ) {
       return 0;
     }
 

--- a/src/data/moves/move-attrs/heal-status-effect-attr.ts
+++ b/src/data/moves/move-attrs/heal-status-effect-attr.ts
@@ -3,6 +3,7 @@ import { getPokemonNameWithAffix } from "#app/messages";
 import { ANY_STATUS_SYNERGY_ABILITIES } from "#constants/ability-constants";
 import {
   MAJOR_EFFECT_SCORE_BONUS,
+  MAJOR_EFFECT_SCORE_PENALTY,
   MINOR_EFFECT_SCORE_BONUS,
   MINOR_EFFECT_SCORE_PENALTY,
 } from "#constants/ai-constants";
@@ -70,9 +71,9 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
    * - If the user has an ability that synergizes with their status effect, and the effects
    * of this attribute would cure said status, grant (-1).
    * - Otherwise, if the affected Pokemon doesn't have a relevant status effect OR it can't feasibly
-   * cure itself due to being asleep or frozen, grant (+0).
+   * cure itself due to being asleep, grant (+0).
    * - Otherwise, if the affected Pokemon is either the user or its ally, grant (+1) + 50%(+1)
-   * - Otherwise, grant (-1) [using the move would cure an opponent's status effect]
+   * - Otherwise, grant (-2) [using the move would cure an opponent's status effect]
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
     const pokemon = this.selfTarget ? user : target;
@@ -91,6 +92,6 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
     if (!pokemon.isOpponent(user)) {
       return this.getRandomScore(user, 50, MAJOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_BONUS);
     }
-    return MINOR_EFFECT_SCORE_PENALTY;
+    return MAJOR_EFFECT_SCORE_PENALTY;
   }
 }

--- a/src/data/moves/move-attrs/party-status-cure-attr.ts
+++ b/src/data/moves/move-attrs/party-status-cure-attr.ts
@@ -37,16 +37,13 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
    * Tries to cure the status of the given {@linkcode Pokemon}
    * @param pokemon The {@linkcode Pokemon} to cure.
    * @param userId The ID of the (move) {@linkcode Pokemon | user}.
+   * @todo This doesn't actually apply abilities that negate the effect (i.e. Soundproof)
    */
   private cureStatus(pokemon: Pokemon, userId: number) {
-    if (!pokemon.isOnField() || pokemon.id === userId) {
-      // user always cures its own status, regardless of ability
+    if (this.hasRemovableStatusEffect(pokemon, userId)) {
       pokemon.resetStatus();
       pokemon.updateInfo();
-    } else if (!pokemon.hasAbility(this.abilityCondition)) {
-      pokemon.resetStatus();
-      pokemon.updateInfo();
-    } else {
+    } else if (pokemon.hasAbility(this.abilityCondition)) {
       globalScene.phaseManager.createAndUnshiftPhase(
         "ShowAbilityPhase",
         pokemon.id,
@@ -56,14 +53,26 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
   }
 
   /**
+   * Determines whether a given Pokemon has a non-volatile status effect that
+   * can be cured by this attribute's effect.
+   * @param pokemon - The {@linkcode Pokemon} to check
+   * @param userId - The ID of the Pokemon that originally used the move with this effect
+   * @returns `true` if the given {@linkcode pokemon} has a curable status effect
+   */
+  private hasRemovableStatusEffect(pokemon: Pokemon, userId: number): boolean {
+    return (
+      pokemon.hasNonVolatileStatusEffect(false, true)
+      && (!pokemon.isOnField() || pokemon.id === userId || !pokemon.hasAbility(this.abilityCondition))
+    );
+  }
+
+  /**
    * @returns (+1) for each party member that would have its status effect cured by this effect,
    * up to the {@linkcode SOFT_EFFECT_SCORE_LIMIT}.
    */
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
     const party = user.getParty();
-    const numPartyMembersWithRemovableStatus = party.filter(
-      (p) => p.hasNonVolatileStatusEffect(false, true) && (p.id === user.id || !p.hasAbility(this.abilityCondition)),
-    ).length;
+    const numPartyMembersWithRemovableStatus = party.filter((p) => this.hasRemovableStatusEffect(p, user.id)).length;
 
     return Math.min(numPartyMembersWithRemovableStatus, SOFT_EFFECT_SCORE_LIMIT);
   }

--- a/src/data/moves/move-attrs/party-status-cure-attr.ts
+++ b/src/data/moves/move-attrs/party-status-cure-attr.ts
@@ -1,5 +1,7 @@
 import { globalScene } from "#app/global-scene";
+import { SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
 import type { AbilityId } from "#enums/ability-id";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -20,7 +22,7 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
     this.abilityCondition = abilityCondition;
   }
 
-  override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     const partyPokemon = user.getParty();
     partyPokemon.forEach((p) => this.cureStatus(p, user.id));
 
@@ -36,7 +38,7 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
    * @param pokemon The {@linkcode Pokemon} to cure.
    * @param userId The ID of the (move) {@linkcode Pokemon | user}.
    */
-  public cureStatus(pokemon: Pokemon, userId: number) {
+  private cureStatus(pokemon: Pokemon, userId: number) {
     if (!pokemon.isOnField() || pokemon.id === userId) {
       // user always cures its own status, regardless of ability
       pokemon.resetStatus();
@@ -51,5 +53,18 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
         pokemon.getPassiveAbility()?.id === this.abilityCondition,
       );
     }
+  }
+
+  /**
+   * @returns (+1) for each party member that would have its status effect cured by this effect,
+   * up to the {@linkcode SOFT_EFFECT_SCORE_LIMIT}.
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    const party = user.getParty();
+    const numPartyMembersWithRemovableStatus = party.filter(
+      (p) => p.hasNonVolatileStatusEffect(false, true) && (p.id === user.id || !p.hasAbility(this.abilityCondition)),
+    ).length;
+
+    return Math.min(numPartyMembersWithRemovableStatus, SOFT_EFFECT_SCORE_LIMIT);
   }
 }

--- a/src/data/moves/move-attrs/party-status-cure-attr.ts
+++ b/src/data/moves/move-attrs/party-status-cure-attr.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
+import { BAD_MOVE_PENALTY, SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
 import type { AbilityId } from "#enums/ability-id";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -73,6 +73,10 @@ export class PartyStatusCureAttr extends MoveEffectAttr {
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
     const party = user.getParty();
     const numPartyMembersWithRemovableStatus = party.filter((p) => this.hasRemovableStatusEffect(p, user.id)).length;
+
+    if (numPartyMembersWithRemovableStatus === 0) {
+      return BAD_MOVE_PENALTY;
+    }
 
     return Math.min(numPartyMembersWithRemovableStatus, SOFT_EFFECT_SCORE_LIMIT);
   }

--- a/src/data/moves/move-attrs/psycho-shift-effect-attr.ts
+++ b/src/data/moves/move-attrs/psycho-shift-effect-attr.ts
@@ -1,5 +1,9 @@
+import { BAD_MOVE_PENALTY } from "#constants/ai-constants";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -9,8 +13,8 @@ import { MoveEffectAttr } from "#moves/move-effect-attr";
  * Passes the user's status effect onto the target, then heals the user.
  */
 export class PsychoShiftEffectAttr extends MoveEffectAttr {
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
-    const statusToApply = this.getStatusToApply(user);
+  public override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
+    const statusToApply = user.getStatusEffect();
 
     if (!statusToApply) {
       return false;
@@ -30,16 +34,54 @@ export class PsychoShiftEffectAttr extends MoveEffectAttr {
     return trySetStatus;
   }
 
-  override getTargetBenefitScore(user: Pokemon, target: Pokemon, _move: Move): number {
-    const statusToApply = this.getStatusToApply(user);
-    return !target.hasNonVolatileStatusEffect()
-      && statusToApply !== StatusEffect.NONE
-      && target.canSetStatus(statusToApply, true, false, user)
-      ? -10
-      : 0;
+  /**
+   * @returns An Effect Score based on the {@linkcode StatusEffect} that would be transferred
+   * to the target when using this move.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const statusToApply = user.getStatusEffect();
+    if (!target.canSetStatus(statusToApply, true, false, user)) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    return this.getStatusEffectScore(user, target, statusToApply);
   }
 
-  private getStatusToApply(user: Pokemon): StatusEffect {
-    return user.getStatusEffect();
+  /**
+   * @returns The Effect Score given for transferring the given {@linkcode effect}
+   * from the {@linkcode user} to the {@linkcode target}:
+   * - Poison and Toxic Poison grant (+2)/(+3) respectively.
+   * - Paralysis grants (+2) if the user outspeeds the target, and (+3) otherwise.
+   * - Burn grants (+3) if the target has a physical affinity (ATK > SPATK), and (+2) otherwise.
+   * - Sleep and Freeze grant a {@linkcode BAD_MOVE_PENALTY}. Psycho Shift can't normally be used
+   * while the user is under these status effects.
+   */
+  private getStatusEffectScore(user: EnemyPokemon, target: Pokemon, effect: StatusEffect): number {
+    switch (effect) {
+      case StatusEffect.POISON:
+        return 2;
+      case StatusEffect.TOXIC:
+        return 3;
+      case StatusEffect.PARALYSIS:
+        return user.outspeeds(target, true) ? 2 : 3;
+      case StatusEffect.BURN: {
+        const effectiveStatOptions = {
+          abilityApplyMode: AbilityApplyMode.REVEALED,
+          simulated: true,
+        };
+        return target.getEffectiveStat(Stat.ATK, effectiveStatOptions)
+          > target.getEffectiveStat(Stat.SPATK, effectiveStatOptions)
+          ? 3
+          : 2;
+      }
+      case StatusEffect.SLEEP:
+      case StatusEffect.FREEZE:
+        return BAD_MOVE_PENALTY;
+      default:
+        // This will cause a type error if more status effects are added in the future,
+        // ensuring they are not forgotten to be accounted for.
+        effect satisfies StatusEffect.NONE;
+        return 0;
+    }
   }
 }

--- a/test/ai/move-effect-scores/heal-bell.test.ts
+++ b/test/ai/move-effect-scores/heal-bell.test.ts
@@ -5,7 +5,7 @@ import { StatusEffect } from "#enums/status-effect";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-describe("Move Effect Scores - Snore", () => {
+describe("Move Effect Scores - Heal Bell", () => {
   let phaserGame: Phaser.Game;
   let game: GameManager;
 
@@ -23,36 +23,44 @@ describe("Move Effect Scores - Snore", () => {
     game = new GameManager(phaserGame);
     game.override
       .battleType("single")
+      .startingWave(8) // Forces a Trainer battle w/ 2 Pokemon
       .enemySpecies(SpeciesId.MAGIKARP)
       .enemyAbility(AbilityId.BALL_FETCH)
-      .enemyMoveset([MoveId.SNORE, MoveId.TACKLE, MoveId.SPLASH])
+      .enemyMoveset([MoveId.HEAL_BELL, MoveId.TACKLE, MoveId.SPLASH])
       .ability(AbilityId.BALL_FETCH)
       .startingLevel(100)
       .enemyLevel(100);
   });
 
-  it("should be avoided when the user is not asleep", async () => {
+  it("should be avoided when none of the user's party are afflicted with a status", async () => {
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
     const enemy = game.field.getEnemyPokemon();
-    expect(enemy).toNeverSelectMove(MoveId.SNORE);
+    expect(enemy).toNeverSelectMove(MoveId.HEAL_BELL);
   });
 
-  it("should be strongly preferred when the user is asleep", async () => {
-    game.override.enemyStatusEffect(StatusEffect.SLEEP);
+  it("should be strongly preferred when the user and a party member are afflicted with a status", async () => {
+    game.override.enemyStatusEffect(StatusEffect.BURN);
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
     const enemy = game.field.getEnemyPokemon();
-    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SNORE);
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.HEAL_BELL);
   });
 
-  it("should not be avoided when the user has Comatose", async () => {
-    game.override.enemyAbility(AbilityId.COMATOSE);
+  it("should not count active allies with Soundproof towards effect score", async () => {
+    game.override
+      .battleType("double")
+      .enemyAbility(AbilityId.SOUNDPROOF)
+      .enemyStatusEffect(StatusEffect.BURN)
+      .startingWave(1);
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    const enemy = game.field.getEnemyPokemon();
-    expect(enemy).not.toNeverSelectMove(MoveId.SNORE);
+    const [enemy] = game.scene.getEnemyField();
+    // Heal Bell should have exactly (+1) ES
+    expect(enemy).toPreferSelectingMove(MoveId.HEAL_BELL);
+    // Tackle's ES is in the interval [0, 1], so it should still be used sometimes
+    expect(enemy).not.toNeverSelectMove(MoveId.TACKLE);
   });
 });

--- a/test/ai/move-effect-scores/psycho-shift.test.ts
+++ b/test/ai/move-effect-scores/psycho-shift.test.ts
@@ -1,0 +1,134 @@
+import { AbilityId } from "#enums/ability-id";
+import { ArenaTagSide } from "#enums/arena-tag-side";
+import { ArenaTagType } from "#enums/arena-tag-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
+import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Psycho Shift", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.PSYCHO_SHIFT, MoveId.TACKLE, MoveId.SPLASH])
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be avoided when the user does not have a status effect", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PSYCHO_SHIFT);
+  });
+
+  it.each([
+    ["asleep", StatusEffect.SLEEP],
+    ["frozen", StatusEffect.FREEZE],
+  ])("should be avoided when the user is %s", async (_, effect) => {
+    game.override.enemyStatusEffect(effect);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PSYCHO_SHIFT);
+  });
+
+  describe.each([
+    {
+      effectName: "Poison",
+      effect: StatusEffect.POISON,
+      controlMove: MoveId.POISON_GAS,
+      immuneTypeName: "Poison",
+      immuneSpecies: SpeciesId.GRIMER,
+      immuneAbilityName: "Immunity",
+      immuneAbilityId: AbilityId.IMMUNITY,
+    },
+    {
+      effectName: "Burn",
+      effect: StatusEffect.BURN,
+      controlMove: MoveId.WILL_O_WISP,
+      immuneTypeName: "Fire",
+      immuneSpecies: SpeciesId.SLUGMA,
+      immuneAbilityName: "Water Veil",
+      immuneAbilityId: AbilityId.WATER_VEIL,
+    },
+    {
+      effectName: "Paralysis",
+      effect: StatusEffect.PARALYSIS,
+      controlMove: MoveId.THUNDER_WAVE,
+      immuneTypeName: "Electric",
+      immuneSpecies: SpeciesId.PIKACHU,
+      immuneAbilityName: "Limber",
+      immuneAbilityId: AbilityId.LIMBER,
+    },
+  ])(
+    "Transferring $effectName",
+    ({ effectName, effect, controlMove, immuneTypeName, immuneSpecies, immuneAbilityName, immuneAbilityId }) => {
+      beforeEach(() => {
+        game.override.enemyStatusEffect(effect).enemyMoveset([MoveId.PSYCHO_SHIFT, controlMove, MoveId.TACKLE]);
+      });
+
+      it(`should be strongly preferred when the user can transfer ${effectName} to an opponent`, async () => {
+        await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+        const enemy = game.field.getEnemyPokemon();
+        expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.PSYCHO_SHIFT);
+      });
+
+      it(`should be avoided when the opponent is ${immuneTypeName}-type`, async () => {
+        await game.classicMode.startBattle(immuneSpecies);
+
+        const enemy = game.field.getEnemyPokemon();
+        expect(enemy).toNeverSelectMove(MoveId.PSYCHO_SHIFT);
+      });
+
+      it(`should be avoided when the opponent has ${immuneAbilityName}`, async () => {
+        game.override.ability(immuneAbilityId);
+
+        await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+        revealAllAbilities(game.scene);
+
+        const enemy = game.field.getEnemyPokemon();
+        expect(enemy).toNeverSelectMove(MoveId.PSYCHO_SHIFT);
+      });
+
+      it(`should be avoided when the opponent is already afflicted with ${effectName}`, async () => {
+        game.override.statusEffect(effect);
+
+        await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+        const enemy = game.field.getEnemyPokemon();
+        expect(enemy).toNeverSelectMove(MoveId.PSYCHO_SHIFT);
+      });
+
+      it("should be avoided when the opponent is under the effects of Safeguard", async () => {
+        await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+        game.scene.arena.addTag(ArenaTagType.SAFEGUARD, 0, 1, MoveId.NONE, ArenaTagSide.PLAYER, true);
+
+        const enemy = game.field.getEnemyPokemon();
+        expect(enemy).toNeverSelectMove(MoveId.PSYCHO_SHIFT);
+      });
+    },
+  );
+});

--- a/test/ai/move-effect-scores/refresh.test.ts
+++ b/test/ai/move-effect-scores/refresh.test.ts
@@ -1,0 +1,75 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Refresh", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.REFRESH, MoveId.TACKLE, MoveId.SPLASH])
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be avoided when the user does not have a status effect", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.REFRESH);
+  });
+
+  it.each([
+    ["poisoned", StatusEffect.POISON],
+    ["badly poisoned", StatusEffect.TOXIC],
+    ["paralyzed", StatusEffect.PARALYSIS],
+    ["burned", StatusEffect.BURN],
+  ])("should be preferred when the user is %s", async (_, effect) => {
+    game.override.enemyStatusEffect(effect);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.REFRESH);
+  });
+
+  it.each([
+    ["asleep", StatusEffect.SLEEP],
+    ["frozen", StatusEffect.FREEZE],
+  ])("should be avoided when the user is %s", async (_, effect) => {
+    game.override.enemyStatusEffect(effect);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.REFRESH);
+  });
+
+  it("should be avoided when the user is burned, but has Guts", async () => {
+    game.override.enemyStatusEffect(StatusEffect.BURN).enemyAbility(AbilityId.GUTS);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.REFRESH);
+  });
+});

--- a/test/ai/move-effect-scores/snore.test.ts
+++ b/test/ai/move-effect-scores/snore.test.ts
@@ -1,0 +1,58 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Refresh", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SNORE, MoveId.TACKLE, MoveId.SPLASH])
+      .ability(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be avoided when the user is not asleep", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SNORE);
+  });
+
+  it("should be strongly preferred when the user is asleep", async () => {
+    game.override.enemyStatusEffect(StatusEffect.SLEEP);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SNORE);
+  });
+
+  it("should not be avoided when the user has Comatose", async () => {
+    game.override.enemyAbility(AbilityId.COMATOSE);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toNeverSelectMove(MoveId.SNORE);
+  });
+});

--- a/test/ai/move-effect-scores/will-o-wisp.test.ts
+++ b/test/ai/move-effect-scores/will-o-wisp.test.ts
@@ -24,7 +24,7 @@ describe("Move Effect Scores - Will-O-Wisp", () => {
     game = new GameManager(phaserGame);
     game.override
       .battleType("single")
-      .enemySpecies(SpeciesId.GYARADOS)
+      .enemySpecies(SpeciesId.MAGIKARP)
       .enemyAbility(AbilityId.BALL_FETCH)
       .enemyMoveset([MoveId.WILL_O_WISP, MoveId.SUPER_FANG])
       .ability(AbilityId.BALL_FETCH)


### PR DESCRIPTION
## What are the changes the user will see?

The AI should now properly evaluate and use the following moves:
- Psycho Shift
- Status-curing moves (e.g. Refresh)
- Snore
- Sleep Talk (partially, the random move selection isn't taken into account yet)
- Heal Bell, Aromatherapy, Sparkly Swirl

## Why am I making these changes?

Part of the AI Rework.

## What are the changes from a developer perspective?

Added effect score method overrides for the following attributes:
- `PsychoShiftEffectAttr`
- `HealStatusEffectAttr`
- `BypassSleepAttr`
- `PartyStatusCureAttr`

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`

New unit tests (can run with `pnpm test move-effect-scores/testName`):
- `psycho-shift`
- `refresh`
- `snore`
- `heal-bell`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
