### PR TITLE
ai-rework: Add Effect Scores for healing effects

### DIFF
--- a/src/data/moves/move-attrs/heal-attr.ts
+++ b/src/data/moves/move-attrs/heal-attr.ts
@@ -89,7 +89,7 @@ export class HealAttr extends MoveEffectAttr {
    * @returns The ES for using the given move against the given target
    */
   protected getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
-    if (target.hasTag(BattlerTagType.HEAL_BLOCK)) {
+    if (target.hasTag(BattlerTagType.HEAL_BLOCK) || target.isFullHp()) {
       return BAD_MOVE_PENALTY;
     }
 

--- a/src/data/moves/move-attrs/heal-attr.ts
+++ b/src/data/moves/move-attrs/heal-attr.ts
@@ -2,7 +2,10 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { RecoveryBoostAbAttr } from "#abilities/recovery-boost-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { BAD_MOVE_PENALTY } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -19,7 +22,7 @@ export class HealAttr extends MoveEffectAttr {
   private showAnim: boolean;
 
   constructor(healRatio: number = 1, showAnim: boolean = false, selfTarget: boolean = true) {
-    super(selfTarget);
+    super(selfTarget, { overridesAllyTargetPenalty: true });
 
     this.healRatio = healRatio;
     this.showAnim = showAnim;
@@ -44,7 +47,7 @@ export class HealAttr extends MoveEffectAttr {
    * Creates a new {@linkcode PokemonHealPhase}.
    * This heals the target and shows the appropriate message.
    */
-  addHealPhase(target: Pokemon, healRatio: number) {
+  private addHealPhase(target: Pokemon, healRatio: number): void {
     globalScene.phaseManager.createAndUnshiftPhase(
       "PokemonHealPhase",
       target.getBattlerIndex(),
@@ -56,9 +59,48 @@ export class HealAttr extends MoveEffectAttr {
     );
   }
 
-  override getTargetBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    const score =
-      (1 - (this.selfTarget ? user : target).getHpRatio()) * 20 - this.getHealRatio(user, target, move) * 10;
-    return Math.round(score / (1 - this.healRatio / 2));
+  /**
+   * @returns An Effect Score modifier for the given move action as follows:
+   * - If the target is an opponent to the user, grant double the {@linkcode BAD_MOVE_PENALTY}
+   * - Otherwise, grant a bonus as defined in {@linkcode getAllyTargetScore}
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    const pokemon = this.selfTarget ? user : target;
+
+    if (pokemon.isOpponent(user)) {
+      return 2 * BAD_MOVE_PENALTY;
+    }
+
+    return this.getAllyTargetScore(user, target, move);
+  }
+
+  /**
+   * Obtains the Effect Score bonus for healing an allied Pokemon with this effect:
+   * - If the target is afflicted with Heal Block, grants a {@linkcode BAD_MOVE_PENALTY}
+   * - Otherwise, check the following conditions:
+   *   - Any opposing Pokemon is faster than the user
+   *   - The target's missing HP ratio is greater than or equal to this effect's heal ratio
+   *
+   *   If either of the above conditions are met, grant (+1) + C(+1), where the chance C is equal to
+   *   this effect's heal ratio.
+   * @param user - The {@linkcode Pokemon} evaluating the move
+   * @param target - The {@linkcode Pokemon} the move is evaluated against. This is assumed to be either the user or its ally.
+   * @param move - The {@linkcode Move} being evaluated
+   * @returns The ES for using the given move against the given target
+   */
+  protected getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (target.hasTag(BattlerTagType.HEAL_BLOCK)) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    /** `true` if at least one opponent outspeeds the user */
+    const opponentOutspeeds = user.getOpponents().some((opp) => !user.outspeeds(opp, true));
+    const healRatio = this.getHealRatio(user, target, move);
+
+    if (opponentOutspeeds || 1 - target.getHpRatio() >= healRatio) {
+      return this.getRandomScore(user, healRatio * 100, 2, 1);
+    }
+
+    return 0;
   }
 }

--- a/src/data/moves/move-attrs/heal-on-ally-attr.ts
+++ b/src/data/moves/move-attrs/heal-on-ally-attr.ts
@@ -1,3 +1,4 @@
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { HealAttr } from "#moves/heal-attr";
 import type { Move } from "#moves/move";
@@ -7,7 +8,7 @@ import type { Move } from "#moves/move";
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Pollen_Puff_(move) | Pollen Puff}.
  */
 export class HealOnAllyAttr extends HealAttr {
-  override apply(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override apply(user: Pokemon, target: Pokemon, move: Move): boolean {
     if (user.getAlly() === target) {
       user.stopMultiHit();
       super.apply(user, target, move);
@@ -15,5 +16,17 @@ export class HealOnAllyAttr extends HealAttr {
     }
 
     return false;
+  }
+
+  /**
+   * This is the same scoring logic as in {@linkcode HealAttr.getEffectScore}, except
+   * that the penalty for targeting an opponent with the effect is removed.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (target.isOpponent(user)) {
+      return 0;
+    }
+
+    return this.getAllyTargetScore(user, target, move);
   }
 }

--- a/src/data/moves/move-attrs/hit-heal-attr.ts
+++ b/src/data/moves/move-attrs/hit-heal-attr.ts
@@ -1,11 +1,16 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { MAJOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
 import type { EffectiveStat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
-import { toDmgValue } from "#utils/common-utils";
+import { isNil, toDmgValue } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -60,17 +65,32 @@ export class HitHealAttr extends MoveEffectAttr {
   }
 
   /**
-   * Used by the Enemy AI to rank an attack based on a given user
-   * @param user {@linkcode Pokemon} using this move
-   * @param target {@linkcode Pokemon} target of this move
-   * @param move {@linkcode Move} being used
-   * @returns an integer. Higher means enemy is more likely to use that move.
+   * @returns An Effect Score modifier as follows:
+   * - If any of the user's opponents has Liquid Ooze, grant a {@linkcode MAJOR_EFFECT_SCORE_PENALTY}.
+   * - Otherwise, if the user is under the effects of Heal Block, grant no bonus.
+   * - Otherwise, grant a bonus based on the expected HP restored by this move action.
+   *   This bonus is "tiered" based on the expected heal ratio similarly to {@linkcode ChanceBasedMoveEffectAttr}'s scoring.
+   *   Given expected heal ratio H = 0.5m + c, the resulting minimum score is m, and the chance to grant the maximum
+   *   score (m + 1) is (c / 0.5)
    */
-  override getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    if (this.healStat) {
-      const healAmount = target.getEffectiveStat(this.healStat);
-      return Math.floor(Math.max(0, Math.min(1, (healAmount + user.hp) / user.getMaxHp() - 0.33)) / user.getHpRatio());
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (user.getOpponents().some((opp) => opp.hasRevealedAbility(AbilityId.LIQUID_OOZE))) {
+      return MAJOR_EFFECT_SCORE_PENALTY;
     }
-    return Math.floor(Math.max(1 - user.getHpRatio() - 0.33, 0) * (move.power / 4));
+
+    if (user.hasTag(BattlerTagType.HEAL_BLOCK)) {
+      return 0;
+    }
+
+    const expectedDamage = !isNil(this.healStat)
+      ? target.getEffectiveStat(this.healStat, { abilityApplyMode: AbilityApplyMode.REVEALED })
+      : target.getAttackDamage(user, move, AbilityApplyMode.REVEALED, false, true).damage;
+    const expectedHealRatio = Math.min(expectedDamage * this.healRatio, user.getInverseHp()) / user.getMaxHp();
+
+    const healBonusThreshold = 0.5;
+    const minScore = Math.floor(expectedHealRatio / healBonusThreshold);
+    const tierUpChance = (expectedHealRatio % healBonusThreshold) / healBonusThreshold;
+
+    return minScore + this.getRandomScore(user, tierUpChance);
   }
 }

--- a/src/data/moves/move-attrs/hit-heal-attr.ts
+++ b/src/data/moves/move-attrs/hit-heal-attr.ts
@@ -1,3 +1,7 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { ChanceBasedMoveEffectAttr } from "#moves/chance-based-move-effect-attr";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { MAJOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
@@ -70,8 +74,8 @@ export class HitHealAttr extends MoveEffectAttr {
    * - Otherwise, if the user is under the effects of Heal Block, grant no bonus.
    * - Otherwise, grant a bonus based on the expected HP restored by this move action.
    *   This bonus is "tiered" based on the expected heal ratio similarly to {@linkcode ChanceBasedMoveEffectAttr}'s scoring.
-   *   Given expected heal ratio H = 0.4m + c, the resulting minimum score is m, and the chance to grant the maximum
-   *   score (m + 1) is (c / 0.4)
+   *   Given expected heal ratio `H = 0.4m + c`, the resulting minimum score is `m`, and the chance to grant the maximum
+   *   score `(m + 1)` is `(c / 0.4)`
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     if (user.getOpponents().some((opp) => opp.hasRevealedAbility(AbilityId.LIQUID_OOZE))) {

--- a/src/data/moves/move-attrs/hit-heal-attr.ts
+++ b/src/data/moves/move-attrs/hit-heal-attr.ts
@@ -70,8 +70,8 @@ export class HitHealAttr extends MoveEffectAttr {
    * - Otherwise, if the user is under the effects of Heal Block, grant no bonus.
    * - Otherwise, grant a bonus based on the expected HP restored by this move action.
    *   This bonus is "tiered" based on the expected heal ratio similarly to {@linkcode ChanceBasedMoveEffectAttr}'s scoring.
-   *   Given expected heal ratio H = 0.5m + c, the resulting minimum score is m, and the chance to grant the maximum
-   *   score (m + 1) is (c / 0.5)
+   *   Given expected heal ratio H = 0.4m + c, the resulting minimum score is m, and the chance to grant the maximum
+   *   score (m + 1) is (c / 0.4)
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     if (user.getOpponents().some((opp) => opp.hasRevealedAbility(AbilityId.LIQUID_OOZE))) {
@@ -85,9 +85,10 @@ export class HitHealAttr extends MoveEffectAttr {
     const expectedDamage = !isNil(this.healStat)
       ? target.getEffectiveStat(this.healStat, { abilityApplyMode: AbilityApplyMode.REVEALED })
       : target.getAttackDamage(user, move, AbilityApplyMode.REVEALED, false, true).damage;
-    const expectedHealRatio = Math.min(expectedDamage * this.healRatio, user.getInverseHp()) / user.getMaxHp();
+    const expectedHealRatio =
+      Math.min(Math.floor(expectedDamage * this.healRatio), user.getInverseHp()) / user.getMaxHp();
 
-    const healBonusThreshold = 0.5;
+    const healBonusThreshold = 0.4;
     const minScore = Math.floor(expectedHealRatio / healBonusThreshold);
     const tierUpChance = (expectedHealRatio % healBonusThreshold) / healBonusThreshold;
 

--- a/src/data/moves/move-attrs/hp-split-attr.ts
+++ b/src/data/moves/move-attrs/hp-split-attr.ts
@@ -31,15 +31,16 @@ export class HpSplitAttr extends MoveEffectAttr {
 
   /**
    * @returns An Effect Score modifier as follows:
-   * - If the target has at least twice as much HP as the user, and the user is damaged, grant either
-   * a {@link MAJOR_EFFECT_SCORE_BONUS | major bonus} or a {@link MINOR_EFFECT_SCORE_BONUS | minor bonus}
+   * - If the expected HP gained from using this move is greater than a given {@linkcode scoringHpThreshold},
+   * grant either a {@link MAJOR_EFFECT_SCORE_BONUS | major bonus} or a {@link MINOR_EFFECT_SCORE_BONUS | minor bonus}
    * depending on whether or not the user outspeeds the target.
    * - Otherwise, grant a {@link MAJOR_EFFECT_SCORE_PENALTY | major penalty}.
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
-    const relativeHpRatio = target.hp / user.hp;
+    const relativeHpRatio = Math.min(target.hp - user.hp, user.getInverseHp()) / user.getMaxHp();
+    const scoringHpThreshold = 0.3;
 
-    if (!user.isFullHp() && relativeHpRatio >= 2) {
+    if (!user.isFullHp() && relativeHpRatio >= scoringHpThreshold) {
       return user.outspeeds(target, true) ? MAJOR_EFFECT_SCORE_BONUS : MINOR_EFFECT_SCORE_BONUS;
     }
 

--- a/src/data/moves/move-attrs/hp-split-attr.ts
+++ b/src/data/moves/move-attrs/hp-split-attr.ts
@@ -1,3 +1,9 @@
+import {
+  MAJOR_EFFECT_SCORE_BONUS,
+  MAJOR_EFFECT_SCORE_PENALTY,
+  MINOR_EFFECT_SCORE_BONUS,
+} from "#constants/ai-constants";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -21,5 +27,22 @@ export class HpSplitAttr extends MoveEffectAttr {
     });
 
     return true;
+  }
+
+  /**
+   * @returns An Effect Score modifier as follows:
+   * - If the target has at least twice as much HP as the user, and the user is damaged, grant either
+   * a {@link MAJOR_EFFECT_SCORE_BONUS | major bonus} or a {@link MINOR_EFFECT_SCORE_BONUS | minor bonus}
+   * depending on whether or not the user outspeeds the target.
+   * - Otherwise, grant a {@link MAJOR_EFFECT_SCORE_PENALTY | major penalty}.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const relativeHpRatio = target.hp / user.hp;
+
+    if (!user.isFullHp() && relativeHpRatio >= 2) {
+      return user.outspeeds(target, true) ? MAJOR_EFFECT_SCORE_BONUS : MINOR_EFFECT_SCORE_BONUS;
+    }
+
+    return MAJOR_EFFECT_SCORE_PENALTY;
   }
 }

--- a/test/ai/move-effect-scores/drain-punch.test.ts
+++ b/test/ai/move-effect-scores/drain-punch.test.ts
@@ -1,0 +1,75 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Drain Punch", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MACHOP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.DRAIN_PUNCH, MoveId.SKY_UPPERCUT, MoveId.SPLASH])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred over moves with slightly higher power when the user is damaged", async () => {
+    await game.classicMode.startBattle(SpeciesId.SNORLAX);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp * 0.5);
+
+    expect(enemy).toPreferSelectingMove(MoveId.DRAIN_PUNCH);
+  });
+
+  it("should not be preferred over higher-power moves when the user is healthy", async () => {
+    await game.classicMode.startBattle(SpeciesId.SNORLAX);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp * 0.95);
+
+    expect(enemy).not.toPreferSelectingMove(MoveId.DRAIN_PUNCH);
+  });
+
+  it("should not be preferred over higher-power moves when the user is afflicted with Heal Block", async () => {
+    await game.classicMode.startBattle(SpeciesId.SNORLAX);
+
+    game.move.use(MoveId.HEAL_BLOCK);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.toNextTurn();
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = 1;
+
+    expect(enemy).not.toPreferSelectingMove(MoveId.DRAIN_PUNCH);
+  });
+
+  it("should be avoided when the target is known to have Liquid Ooze", async () => {
+    game.override.ability(AbilityId.LIQUID_OOZE);
+
+    await game.classicMode.startBattle(SpeciesId.SNORLAX);
+
+    revealAllAbilities(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = 1;
+    expect(enemy).toNeverSelectMove(MoveId.DRAIN_PUNCH);
+  });
+});

--- a/test/ai/move-effect-scores/heal-pulse.test.ts
+++ b/test/ai/move-effect-scores/heal-pulse.test.ts
@@ -1,0 +1,79 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Heal Pulse", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("double")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.HEAL_PULSE, MoveId.SPLASH, MoveId.SUPER_FANG])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user's ally is at low HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.hp = 1;
+
+    expect(enemy1).toPreferSelectingMove(MoveId.HEAL_PULSE);
+  });
+
+  it("should be preferred when the user's ally is above half HP and the user is slower than an opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.REGIELEKI, SpeciesId.MUNCHLAX);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.hp = Math.floor(enemy2.hp * 0.75);
+
+    expect(enemy1).toPreferSelectingMove(MoveId.HEAL_PULSE);
+  });
+
+  it("should be avoided when the user's ally is at full HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.MUNCHLAX, SpeciesId.SNORLAX);
+
+    const [enemy1] = game.scene.getEnemyField();
+    expect(enemy1).toNeverSelectMove(MoveId.HEAL_PULSE);
+  });
+
+  it("should be avoided when the user's ally is afflicted with Heal Block", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.SPLASH, 0);
+    game.move.use(MoveId.HEAL_BLOCK, 1);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.toNextTurn();
+
+    const [enemy1] = game.scene.getEnemyField();
+    expect(enemy1).toNeverSelectMove(MoveId.HEAL_PULSE);
+  });
+
+  it("should be avoided in single battles even when all other moves fail", async () => {
+    game.override.battleType("single").enemyMoveset([MoveId.HEAL_PULSE, MoveId.SPIT_UP, MoveId.SWALLOW]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.HEAL_PULSE);
+  });
+});

--- a/test/ai/move-effect-scores/pain-split.test.ts
+++ b/test/ai/move-effect-scores/pain-split.test.ts
@@ -1,0 +1,55 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Pain Split", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.PAIN_SPLIT, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be avoided when the user is at full HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PAIN_SPLIT);
+  });
+
+  it("should be preferred when the user is critically damaged", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = 1;
+    expect(enemy).toPreferSelectingMove(MoveId.PAIN_SPLIT);
+  });
+
+  it("should be avoided when both the user and target are critically damaged", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    game.scene.getField(true).forEach((p) => (p.hp = 1));
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PAIN_SPLIT);
+  });
+});

--- a/test/ai/move-effect-scores/pollen-puff.test.ts
+++ b/test/ai/move-effect-scores/pollen-puff.test.ts
@@ -1,0 +1,79 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Pollen Puff", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("double")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.POLLEN_PUFF, MoveId.SPLASH, MoveId.SUPER_FANG])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user's ally is at low HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.hp = 1;
+
+    expect(enemy1).toPreferSelectingMove(MoveId.POLLEN_PUFF);
+  });
+
+  it("should be preferred when the user's ally is above half HP and the user is slower than an opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.REGIELEKI, SpeciesId.MAGIKARP);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.hp = Math.floor(enemy2.hp * 0.75);
+
+    expect(enemy1).toPreferSelectingMove(MoveId.POLLEN_PUFF);
+  });
+
+  it("should not be preferred when the user's ally is at full HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGMAR, SpeciesId.MAGMORTAR);
+
+    const [enemy1] = game.scene.getEnemyField();
+    expect(enemy1).not.toPreferSelectingMove(MoveId.POLLEN_PUFF);
+  });
+
+  it("should not be preferred when the user's ally is afflicted with Heal Block", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGMAR, SpeciesId.MAGMORTAR);
+
+    game.move.use(MoveId.HEAL_BLOCK, 0);
+    game.move.use(MoveId.SPLASH, 1);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.toNextTurn();
+
+    const [enemy1] = game.scene.getEnemyField();
+    expect(enemy1).not.toPreferSelectingMove(MoveId.POLLEN_PUFF);
+  });
+
+  it("should not be penalized in single battles", async () => {
+    game.override.battleType("single").enemyMoveset([MoveId.POLLEN_PUFF, MoveId.SPLASH, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.POLLEN_PUFF);
+  });
+});

--- a/test/ai/move-effect-scores/recover.test.ts
+++ b/test/ai/move-effect-scores/recover.test.ts
@@ -1,0 +1,76 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Recover", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.RECOVER, MoveId.SPLASH, MoveId.SUPER_FANG])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user is at low HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.MUNCHLAX);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = 1;
+    expect(enemy).toPreferSelectingMove(MoveId.RECOVER);
+  });
+
+  it("should be preferred when the user is above half HP and is slower than the target", async () => {
+    await game.classicMode.startBattle(SpeciesId.BARRASKEWDA);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp * 0.75);
+    expect(enemy).toPreferSelectingMove(MoveId.RECOVER);
+  });
+
+  it("should not be preferred when the user is above half HP and is faster than the target", async () => {
+    await game.classicMode.startBattle(SpeciesId.MUNCHLAX);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp * 0.75);
+    expect(enemy).not.toPreferSelectingMove(MoveId.RECOVER);
+  });
+
+  it("should be avoided when the user is at full HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.BARRASKEWDA);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.RECOVER);
+  });
+
+  it("should be avoided when the user is under the effects of Heal Block", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = 1;
+
+    game.move.use(MoveId.HEAL_BLOCK);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.toNextTurn();
+
+    expect(enemy).toNeverSelectMove(MoveId.RECOVER);
+  });
+});

--- a/test/ai/move-effect-scores/strength-sap.test.ts
+++ b/test/ai/move-effect-scores/strength-sap.test.ts
@@ -1,0 +1,65 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Strength Sap", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.STRENGTH_SAP, MoveId.GROWL, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user is damaged", async () => {
+    await game.classicMode.startBattle(SpeciesId.EXCADRILL);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp / 2);
+
+    expect(enemy).toPreferSelectingMove(MoveId.STRENGTH_SAP);
+  });
+
+  it("should be avoided when the opponent has Liquid Ooze", async () => {
+    game.override.ability(AbilityId.LIQUID_OOZE);
+
+    await game.classicMode.startBattle(SpeciesId.EXCADRILL);
+
+    revealAllAbilities(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp / 2);
+
+    expect(enemy).toNeverSelectMove(MoveId.STRENGTH_SAP);
+  });
+
+  // TODO: the AI should be aware of Clear Body once stat stage changes are scored
+  it.todo("should be avoided when the opponent has Clear Body", async () => {
+    game.override.ability(AbilityId.CLEAR_BODY);
+
+    await game.classicMode.startBattle(SpeciesId.EXCADRILL);
+
+    revealAllAbilities(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.STRENGTH_SAP);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

The Enemy AI should now properly evaluate moves with the following effects for command selection:
- Healing effects for either the user (e.g. Recover) or a selected target (e.g. Heal Pulse)
- Pollen Puff
- Draining moves (e.g. Drain Punch)
- Strength Sap
- Pain Split

## Why am I making these changes?

Part of the AI Rework.

## What are the changes from a developer perspective?

Added scoring logic for the following move attributes:
- `HealAttr`
- `HealOnAllyAttr` (an extension of `HealAttr`'s logic)
- `HitHealAttr`
- `HpSplitAttr`

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [ ] `pnpm test:silent`
  - Some test issues from #1312 are still present, but are fixed in #1324  

New unit tests (can be run with `pnpm test move-effect-scores/testName`):

- [x] `recover`
- [x] `heal-pulse`
- [x] `pollen-puff`
- [x] `drain-punch`
- [x] `strength-sap`
- [x] `pain-split`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
