### PR TITLE
ai-rework: Rewrite Ally Target scoring logic

### DIFF
--- a/src/constants/ai-constants.ts
+++ b/src/constants/ai-constants.ts
@@ -1,5 +1,6 @@
 /* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
+import type { MoveAttr } from "#moves/move-attr";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 /** The {@link Pokemon.getAttackScore | Attack Score} granted to moves that KO an opponent. */
@@ -62,7 +63,7 @@ export const BAD_MOVE_PENALTY = -5;
 /**
  * The score penalty granted by default when targeting an ally in a double battle.
  * This should prevent the AI from deciding to attack their ally, for example.
- * Certain move attributes may {@link MoveAttrOptions.overridesAllyTargetPenalty | override this penalty}.
+ * Certain move attributes may {@link MoveAttr.getAllyTargetScore | override this penalty}.
  */
 export const ALLY_TARGET_PENALTY = -20;
 

--- a/src/data/moves/move-attrs/faint-countdown-attr.ts
+++ b/src/data/moves/move-attrs/faint-countdown-attr.ts
@@ -16,7 +16,6 @@ export class FaintCountdownAttr extends AddBattlerTagAttr {
     super(BattlerTagType.PERISH_SONG, false, {
       failOnOverlap: true,
       turnCountMin: 4,
-      overridesAllyTargetPenalty: true,
     });
   }
 
@@ -44,5 +43,10 @@ export class FaintCountdownAttr extends AddBattlerTagAttr {
   public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
     const allyTargetMultiplier = target.isOpponent(user) ? 1 : -1;
     return allyTargetMultiplier * (target.isTrapped() ? MINOR_EFFECT_SCORE_BONUS : 0);
+  }
+
+  /** @returns The inverted output of {@linkcode getRawEffectScore} */
+  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    return -this.getRawEffectScore(user, target, move);
   }
 }

--- a/src/data/moves/move-attrs/heal-attr.ts
+++ b/src/data/moves/move-attrs/heal-attr.ts
@@ -22,7 +22,7 @@ export class HealAttr extends MoveEffectAttr {
   private showAnim: boolean;
 
   constructor(healRatio: number = 1, showAnim: boolean = false, selfTarget: boolean = true) {
-    super(selfTarget, { overridesAllyTargetPenalty: true });
+    super(selfTarget);
 
     this.healRatio = healRatio;
     this.showAnim = showAnim;
@@ -88,7 +88,7 @@ export class HealAttr extends MoveEffectAttr {
    * @param move - The {@linkcode Move} being evaluated
    * @returns The ES for using the given move against the given target
    */
-  protected getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     if (target.hasTag(BattlerTagType.HEAL_BLOCK) || target.isFullHp()) {
       return BAD_MOVE_PENALTY;
     }

--- a/src/data/moves/move-attrs/heal-status-effect-attr.ts
+++ b/src/data/moves/move-attrs/heal-status-effect-attr.ts
@@ -1,12 +1,7 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { ANY_STATUS_SYNERGY_ABILITIES } from "#constants/ability-constants";
-import {
-  MAJOR_EFFECT_SCORE_BONUS,
-  MAJOR_EFFECT_SCORE_PENALTY,
-  MINOR_EFFECT_SCORE_BONUS,
-  MINOR_EFFECT_SCORE_PENALTY,
-} from "#constants/ai-constants";
+import { BURN_SYNERGY_ABILITIES, POISON_SYNERGY_ABILITIES } from "#constants/ability-constants";
+import { MAJOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { MoveId } from "#enums/move-id";
 import { StatusEffect } from "#enums/status-effect";
@@ -14,6 +9,7 @@ import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { getMoveTargets, type Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
+import { coerceArray } from "#utils/common-utils";
 import { getStatusEffectHealText } from "#utils/status-effect-utils";
 
 /**
@@ -29,11 +25,8 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
    * @param effects - status effect or list of status effects to cure
    */
   constructor(selfTarget: boolean, effects: StatusEffect | StatusEffect[]) {
-    super(selfTarget, {
-      lastHitOnly: true,
-      overridesAllyTargetPenalty: true,
-    });
-    this.effects = [effects].flat(1);
+    super(selfTarget, { lastHitOnly: true });
+    this.effects = coerceArray(effects);
   }
 
   public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
@@ -68,30 +61,48 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
 
   /**
    * @returns This attribute's Effect Score modifier as follows:
-   * - If the user has an ability that synergizes with their status effect, and the effects
-   * of this attribute would cure said status, grant (-1).
-   * - Otherwise, if the affected Pokemon doesn't have a relevant status effect OR it can't feasibly
-   * cure itself due to being asleep, grant (+0).
-   * - Otherwise, if the affected Pokemon is either the user or its ally, grant (+1) + 50%(+1)
-   * - Otherwise, grant (-2) [using the move would cure an opponent's status effect]
+   * - If the target of this effect is the user, defer scoring to {@linkcode getAllyTargetScore}
+   * (*unless the user is asleep, and therefore cannot cure its own status*).
+   * - Otherwise, grant a {@link MAJOR_EFFECT_SCORE_PENALTY | major penalty}
+   * (*using the move would cure an opponent's status effect*)
    */
-  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
-    const pokemon = this.selfTarget ? user : target;
-
-    if (this.selfTarget && ANY_STATUS_SYNERGY_ABILITIES.some((abId) => pokemon.hasAbility(abId))) {
-      return MINOR_EFFECT_SCORE_PENALTY;
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (this.selfTarget) {
+      if (user.hasStatusEffect(StatusEffect.SLEEP, false, true)) {
+        return 0;
+      }
+      return this.getAllyTargetScore(user, user, move);
     }
 
-    if (
-      !pokemon.hasStatusEffect(this.effects, false, true)
-      || (this.selfTarget && pokemon.hasStatusEffect(StatusEffect.SLEEP, false, true))
-    ) {
+    if (!target.hasStatusEffect(this.effects, false, true)) {
       return 0;
     }
 
-    if (!pokemon.isOpponent(user)) {
-      return this.getRandomScore(user, 50, MAJOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_BONUS);
-    }
     return MAJOR_EFFECT_SCORE_PENALTY;
+  }
+
+  /**
+   * @returns This attribute's Ally Target Score modifier as follows:
+   * - If the target doesn't have a relevant status effect for this effect, grant (+0).
+   * - If the target is burned or poisoned, and it has an ability that synergizes with that
+   * status effect, grant a {@link MAJOR_EFFECT_SCORE_PENALTY | major penalty}.
+   * - Otherwise, grant (+1) + 50%(+1)
+   */
+  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const effect = target.getStatusEffect(true);
+
+    if (!this.effects.includes(effect)) {
+      return 0;
+    }
+
+    if (
+      (effect === StatusEffect.BURN && BURN_SYNERGY_ABILITIES.some((abId) => target.hasAbility(abId)))
+      || ([StatusEffect.POISON, StatusEffect.TOXIC].includes(effect)
+        && POISON_SYNERGY_ABILITIES.some((abId) => target.hasAbility(abId)))
+    ) {
+      return MAJOR_EFFECT_SCORE_PENALTY;
+    }
+
+    return this.getRandomScore(user, 50, 2, 1);
   }
 }

--- a/src/data/moves/move-attrs/helping-hand-attr.ts
+++ b/src/data/moves/move-attrs/helping-hand-attr.ts
@@ -13,18 +13,23 @@ import { isBetween } from "#utils/common-utils";
  */
 export class HelpingHandAttr extends AddBattlerTagAttr {
   constructor() {
-    super(BattlerTagType.HELPING_HAND, false, { overridesAllyTargetPenalty: true });
+    super(BattlerTagType.HELPING_HAND, false);
+  }
+
+  /** @returns 0. The score for this effect is entirely implemented in {@linkcode getAllyTargetScore} */
+  public override getRawEffectScore(_user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    return 0;
   }
 
   /**
-   * Grants a {@link MAJOR_EFFECT_SCORE_BONUS | major bonus} if the targeted ally
+   * @returns a {@link MAJOR_EFFECT_SCORE_BONUS | major bonus} if the targeted ally
    * has an attack with a high {@linkcode Pokemon.getExpectedAttackScore | EAS} against at least one opponent,
    * but cannot KO any opponent with any of its attacks.
    *
    * **NOTE:** In this method, {@linkcode target} is assumed to be the user's ally.
    * this is guaranteed via Helping Hand's {@linkcode Move.moveTarget | target restriction}.
    */
-  public override getRawEffectScore(_user: EnemyPokemon, target: Pokemon, _move: Move): number {
+  public override getAllyTargetScore(_user: EnemyPokemon, target: Pokemon, _move: Move): number | null {
     /** The target's highest EAS against any opposing Pokemon */
     const targetMaxEAS = Math.max(
       ...target

--- a/src/data/moves/move-attrs/helping-hand-attr.ts
+++ b/src/data/moves/move-attrs/helping-hand-attr.ts
@@ -29,7 +29,7 @@ export class HelpingHandAttr extends AddBattlerTagAttr {
    * **NOTE:** In this method, {@linkcode target} is assumed to be the user's ally.
    * this is guaranteed via Helping Hand's {@linkcode Move.moveTarget | target restriction}.
    */
-  public override getAllyTargetScore(_user: EnemyPokemon, target: Pokemon, _move: Move): number | null {
+  public override getAllyTargetScore(_user: EnemyPokemon, target: Pokemon, _move: Move): number {
     /** The target's highest EAS against any opposing Pokemon */
     const targetMaxEAS = Math.max(
       ...target

--- a/src/data/moves/move-attrs/move-attr.ts
+++ b/src/data/moves/move-attrs/move-attr.ts
@@ -1,3 +1,7 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { ALLY_TARGET_PENALTY } from "#constants/ai-constants";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
@@ -8,8 +12,6 @@ import type { BooleanHolder } from "#utils/common-utils";
 export interface MoveAttrOptions {
   /** Does this attribute contribute to AI effect score when the move fails or has no effect? */
   appliesScoreOnFail?: boolean;
-  /** Does this attribute override the AI's (-20) penalty when targeting an ally? */
-  overridesAllyTargetPenalty?: boolean;
 }
 
 /**
@@ -35,16 +37,6 @@ export abstract class MoveAttr {
    */
   public get appliesScoreOnFail(): boolean {
     return this.options?.appliesScoreOnFail ?? false;
-  }
-
-  /**
-   * Defines whether or not this attribute overrides the generic ally target penalty of
-   * (-20) and implements its own effect score against allies.
-   * @default false
-   * @see {@linkcode Move.getEffectScore}
-   */
-  public get overridesAllyTargetPenalty(): boolean {
-    return this.options?.overridesAllyTargetPenalty ?? false;
   }
 
   /**
@@ -115,6 +107,21 @@ export abstract class MoveAttr {
    */
   public getEffectScore(_user: EnemyPokemon, _target: Pokemon, _move: Move): number {
     return 0;
+  }
+
+  /**
+   * Defines the integer Effect Score bonus (or penalty) granted by this attribute based on the
+   * current game state when targeting an ally.
+   * @param user - The {@linkcode EnemyPokemon} evaluating the move
+   * @param target - The {@linkcode Pokemon} the move is evaluated against. This can be assumed to be
+   * the {@linkcode user}'s ally.
+   * @param move - The {@linkcode Move} being evaluated. This can be assumed to be a Status move since
+   * all Attack moves are automatically given an {@linkcode ALLY_TARGET_PENALTY}.
+   * @returns `null` by default. `null` scores do not contribute to Effect Score, but can warrant an
+   * {@linkcode ALLY_TARGET_PENALTY} if none of the move's other attributes have a defined score.
+   */
+  public getAllyTargetScore(_user: EnemyPokemon, _target: Pokemon, _move: Move): number | null {
+    return null;
   }
 
   /**

--- a/src/data/moves/move-attrs/move-attr.ts
+++ b/src/data/moves/move-attrs/move-attr.ts
@@ -113,8 +113,7 @@ export abstract class MoveAttr {
    * Defines the integer Effect Score bonus (or penalty) granted by this attribute based on the
    * current game state when targeting an ally.
    * @param user - The {@linkcode EnemyPokemon} evaluating the move
-   * @param target - The {@linkcode Pokemon} the move is evaluated against. This can be assumed to be
-   * the {@linkcode _user | user}'s ally.
+   * @param target - The {@linkcode Pokemon} the move is evaluated against. This can be assumed to be the user's ally.
    * @param move - The {@linkcode Move} being evaluated. This can be assumed to be a Status move since
    * all Attack moves are automatically given an {@linkcode ALLY_TARGET_PENALTY}.
    * @returns `null` by default. `null` scores do not contribute to Effect Score, but can warrant an

--- a/src/data/moves/move-attrs/move-attr.ts
+++ b/src/data/moves/move-attrs/move-attr.ts
@@ -114,7 +114,7 @@ export abstract class MoveAttr {
    * current game state when targeting an ally.
    * @param user - The {@linkcode EnemyPokemon} evaluating the move
    * @param target - The {@linkcode Pokemon} the move is evaluated against. This can be assumed to be
-   * the {@linkcode user}'s ally.
+   * the {@linkcode _user | user}'s ally.
    * @param move - The {@linkcode Move} being evaluated. This can be assumed to be a Status move since
    * all Attack moves are automatically given an {@linkcode ALLY_TARGET_PENALTY}.
    * @returns `null` by default. `null` scores do not contribute to Effect Score, but can warrant an

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -11,7 +11,7 @@ import {
   POISON_SYNERGY_ABILITIES,
   POISONING_SYNERGY_ABILITIES,
 } from "#constants/ability-constants";
-import { ALLY_TARGET_PENALTY, BAD_MOVE_PENALTY, MAJOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
+import { BAD_MOVE_PENALTY, MAJOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { MoveCategory } from "#enums/move-category";
@@ -40,10 +40,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
     overrideStatus: boolean = false,
     effectChanceOverride?: number,
   ) {
-    super(selfTarget, {
-      effectChanceOverride: effectChanceOverride,
-      overridesAllyTargetPenalty: true,
-    });
+    super(selfTarget, { effectChanceOverride });
 
     this.effect = effect;
     this.turnsRemaining = turnsRemaining;
@@ -94,26 +91,20 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * This score is inverted for self-targeted effects (i.e. Rest).
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
-    if (target === user.getAlly()) {
-      return this.getAllyTargetScore(user, target, move);
-    }
-
     return (this.selfTarget ? -1 : 1) * super.getEffectScore(user, target, move);
   }
 
   /**
-   * Computes the Effect Score from this attribute when targeting the user's ally.
-   * This accounts for the ally's abilties, which may benefit from the ally being afflicted with
-   * certain status effects. In these cases, the move is generally awarded a X%(+2) bonus, where
-   * the bonus chance X reflects the damage per turn of the status effect.
-   * @param user - The {@linkcode Pokemon} evaluating the move
-   * @param ally - The user's ally
-   * @param move - The {@linkcode Move} being evaluated
-   * @returns The overriding Effect Score when targeting the given ally.
+   * @returns An Effect Score bonus to incentivize afflicting allies with status effects under certain conditions.
+   * These bonuses only apply to {@linkcode StatusEffect.BURN | BURN}, {@linkcode StatusEffect.POISON | POISON}, and
+   * {@linkcode StatusEffect.TOXIC | TOXIC}, and only when the ally has an ability that synergizes with being afflicted
+   * by that effect.
+   * @see {@linkcode BURN_SYNERGY_ABILITIES}
+   * @see {@linkcode POISON_SYNERGY_ABILITIES}
    */
-  private getAllyTargetScore(user: EnemyPokemon, ally: Pokemon, move: Move): number {
-    if (!move.isStatusMove() || !ally.canSetStatus(this.effect, true, this.overrideStatus, user)) {
-      return ALLY_TARGET_PENALTY;
+  public override getAllyTargetScore(user: EnemyPokemon, ally: Pokemon, _move: Move): number | null {
+    if (!ally.canSetStatus(this.effect, true, this.overrideStatus, user)) {
+      return null;
     }
 
     if (this.effect === StatusEffect.BURN && BURN_SYNERGY_ABILITIES.some((abId) => ally.hasAbility(abId))) {
@@ -133,7 +124,7 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
       return this.getRandomScore(user, bonusChance, MAJOR_EFFECT_SCORE_BONUS);
     }
 
-    return ALLY_TARGET_PENALTY;
+    return null;
   }
 
   /**

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -55,7 +55,7 @@ import { VariablePowerAttr } from "#moves/variable-power-attr";
 import { VariableTargetAttr } from "#moves/variable-target-attr";
 import type { MoveConditionFunc } from "#types/move-types";
 import type { AbstractConstructor, Constructor, nil } from "#types/utility-types";
-import { BooleanHolder, NumberHolder } from "#utils/common-utils";
+import { BooleanHolder, isNil, NumberHolder } from "#utils/common-utils";
 import { applyMoveAttrs } from "#utils/move-utils";
 import { toCamelCaseString } from "#utils/string-utils";
 import i18next from "i18next";
@@ -823,27 +823,37 @@ export abstract class Move {
     isFail: boolean,
   ): number {
     if (target === user.getAlly()) {
+      /*
+       * Attacks (other than Pollen Puff) are always penalized against allies
+       * TODO:
+       * - Reduce this penalty for multi-target moves
+       * - Use attribute flags instead of specific move IDs for more flexibility
+       */
+      if (this.id !== MoveId.POLLEN_PUFF && !this.isStatusMove()) {
+        return ALLY_TARGET_PENALTY;
+      }
+
       /**
        * ALLY TARGET PENALTY:
        *
        * If the user is the target's ally, a {@link ALLY_TARGET_PENALTY | massive score penalty} is applied
        * unless the move has at least one attribute that overrides the penalty.
-       * In that case, the total score is the sum of effect scores from those
+       * In that case, the total score is the sum of {@link MoveAttr.getAllyTargetScore | ally target scores} from those
        * overriding attributes.
        *
        * **NOTE:** if at least one attribute overrides the Ally Target Penalty, ONLY
        * the overriding attributes are accounted for in scoring. Score contributions
        * from other non-overriding attributes are ignored.
        */
-      const allyTargetAttrs = this.attrs.filter((attr) => attr.overridesAllyTargetPenalty);
+      const allyTargetScores = this.attrs
+        .map((attr) => attr.getAllyTargetScore(user, target, this))
+        .filter((score) => !isNil(score));
 
-      if (allyTargetAttrs.length === 0) {
+      if (allyTargetScores.length === 0) {
         return ALLY_TARGET_PENALTY;
       }
 
-      return allyTargetAttrs
-        .map((attr) => attr.getEffectScore(user, target, this))
-        .reduce((total, score) => total + score, 0);
+      return allyTargetScores.reduce((total, score) => total + score, 0);
     }
 
     let attrs: MoveAttr[] = this.attrs;


### PR DESCRIPTION
## What are the changes the user will see?

The AI should no longer be incentivized to use attacks with secondary effects (e.g. Flamethrower) on their allies)

## Why am I making these changes?

The `overridesAllyTargetPenalty` option for move attributes has proven to be a bit too cumbersome, with it requiring the option to be enabled and a private helper method to be defined in most cases. These changes should make it easier to distinguish ES calculations against opponents from those against allies

## What are the changes from a developer perspective?

- All attacks (other than Pollen Puff) are now automatically assigned the Ally Target Penalty when targeting an ally.
- `MoveAttr` now has a public `getAllyTargetScore` function, which is used to compute Effect Score when an enemy Pokemon targets its ally with a move with the attribute (aka ATS). This can either return an integer score or `null`. If `null` is returned, the attribute does not contribute to ATS in the given game state, deferring to other attributes with a defined ATS. If none of the move's attributes have a defined ATS, then the move is given an Ally Target Penalty.
- The `overridesAllyTargetPenalty` option is removed. Attributes that previously used the option have been adjusted to override `getAllyTargetScore` instead.

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  