### PR TITLE
github: title lint workflow now only runs on PRs to main/beta

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,6 +1,9 @@
 name: PR Title Validation
 on:
   pull_request:
+    branches:
+      - main
+      - beta
     types: [opened, edited, reopened, synchronize]
 
 jobs:


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Forgot to restrict the workflow to only run on PRs targeted at `main` or `beta`.

## What are the changes from a developer perspective?
PRs to branches other than `main` and `beta` should no longer trigger the PR title linting workflow.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?