### PR TITLE
misc: replace `n / 4096` with readable fractions

### DIFF
--- a/src/constants/game-constants.ts
+++ b/src/constants/game-constants.ts
@@ -53,7 +53,7 @@ export const FOG_ACCURACY_MULTIPLIER = 0.9;
 export const SCREEN_SINGLES_DMG_FACTOR = 0.5;
 
 /** The damage multiplier applied by Reflect, Light Screen, and Aurora Veil in double battles.*/
-export const SCREEN_DOUBLES_DMG_FACTOR = 2732 / 4096;
+export const SCREEN_DOUBLES_DMG_FACTOR = 2 / 3;
 
 /** The scaling factor by how much higher the level cap is compared to the average Pokemon of a wave */
 export const LEVEL_CAP_SCALE_FACTOR = 1.2;

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -3356,12 +3356,12 @@ export function initMoves() {
       .attr(TargetHalfHpDamageAttr),
     new AttackMove(MoveId.COLLISION_COURSE, ElementalType.FIGHTING, MoveCategory.PHYSICAL, 100, 100, 5, -1, 0, 9)
       .attr(
-        MovePowerMultiplierAttr, // TODO: replace fraction with decimal
-        (user, target, move) => (target.getAttackTypeEffectiveness(move.type, user) >= 2 ? 5461 / 4096 : 1),
+        MovePowerMultiplierAttr,
+        (user, target, move) => (target.getAttackTypeEffectiveness(move.type, user) >= 2 ? 4 / 3 : 1),
       ),
     new AttackMove(MoveId.ELECTRO_DRIFT, ElementalType.ELECTRIC, MoveCategory.SPECIAL, 100, 100, 5, -1, 0, 9)
       .attr(MovePowerMultiplierAttr, (user, target, move) =>
-        target.getAttackTypeEffectiveness(move.type, user) >= 2 ? 5461 / 4096 : 1,
+        target.getAttackTypeEffectiveness(move.type, user) >= 2 ? 4 / 3 : 1,
       )
       .makesContact(),
     new SelfStatusMove(MoveId.SHED_TAIL, ElementalType.NORMAL, -1, 10, -1, 0, 9)


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
We already replaced most of these, there were just a couple left. There's no need for us to use Gamefreak's FP-avoiding approximations when we're not constrained by old/weak handheld hardware.

## What are the changes from a developer perspective?
Remaining `n / 4096` fractions replaced with readable alternatives.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?