### PR TITLE
ai-rework: Add scoring for `StatStageChangeAttr` + subclasses

### DIFF
--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -70,3 +70,9 @@ export const POISONING_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
   AbilityId.MERCILESS,
   AbilityId.POISON_PUPPETEER,
 ]);
+
+/** Abilities that grant a benefit when receiving a negative stat stage change */
+export const POST_STAT_STAGE_REDUCTION_ABILITIES = Object.freeze<AbilityId[]>([
+  AbilityId.DEFIANT,
+  AbilityId.COMPETITIVE,
+]);

--- a/src/constants/ai-constants.ts
+++ b/src/constants/ai-constants.ts
@@ -87,3 +87,22 @@ export const FAVORABLE_MATCHUP_SCORE_THRESHOLD = 3;
 
 /** The minimum accuracy a move can have before a Low Accuracy Penalty applies */
 export const LOW_ACCURACY_PENALTY_THRESHOLD = 80;
+
+/**
+ * The amount of stat stages an Enemy Pokemon can have before Defense- or
+ * Sp. Def-boosting moves (e.g. from Iron Defense) are significantly less
+ * incentivized by the AI
+ */
+export const DEFENSE_LOW_INCENTIVE_THRESHOLD = 2;
+
+/**
+ * The amount of stat stages an Enemy Pokemon can have before Evasion-boosting
+ * moves (e.g. Double Team) are no longer incentivized by the AI
+ */
+export const EVASION_BOOST_STAGE_LIMIT = 2;
+
+/**
+ * The amount of stat stages a Player Pokemon can have before Accuracy-reducing
+ * moves (e.g. Sand Attack) are no longer incentivized by the AI
+ */
+export const ACCURACY_REDUCTION_STAGE_LIMIT = -EVASION_BOOST_STAGE_LIMIT;

--- a/src/constants/ai-constants.ts
+++ b/src/constants/ai-constants.ts
@@ -84,3 +84,6 @@ export const STRONG_MATCHUP_SCORE_THRESHOLD = 4;
  * Pokemon is favored against its opponent
  */
 export const FAVORABLE_MATCHUP_SCORE_THRESHOLD = 3;
+
+/** The minimum accuracy a move can have before a Low Accuracy Penalty applies */
+export const LOW_ACCURACY_PENALTY_THRESHOLD = 80;

--- a/src/constants/ai-constants.ts
+++ b/src/constants/ai-constants.ts
@@ -1,7 +1,12 @@
 /* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { EnemyPokemon } from "#field/enemy-pokemon";
+import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { MoveAttr } from "#moves/move-attr";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import type { EffectiveStatOptions } from "#field/pokemon";
 
 /** The {@link Pokemon.getAttackScore | Attack Score} granted to moves that KO an opponent. */
 export const KO_ATTACK_SCORE = 4;
@@ -106,3 +111,18 @@ export const EVASION_BOOST_STAGE_LIMIT = 2;
  * moves (e.g. Sand Attack) are no longer incentivized by the AI
  */
 export const ACCURACY_REDUCTION_STAGE_LIMIT = -EVASION_BOOST_STAGE_LIMIT;
+
+/**
+ * The {@linkcode EffectiveStatOptions} to be passed to {@linkcode Pokemon.getEffectiveStat}
+ * when evaluating the effective stat of an allied {@linkcode EnemyPokemon}
+ */
+export const ALLY_EFFECTIVE_STAT_OPTIONS: EffectiveStatOptions = { simulated: true } as const;
+
+/**
+ * The {@linkcode EffectiveStatOptions} to be passed to {@linkcode Pokemon.getEffectiveStat}
+ * when evaluating the effective stat of an opposing {@linkcode PlayerPokemon}
+ */
+export const OPP_EFFECTIVE_STAT_OPTIONS: EffectiveStatOptions = {
+  abilityApplyMode: AbilityApplyMode.REVEALED,
+  simulated: true,
+} as const;

--- a/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
+++ b/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
@@ -81,16 +81,21 @@ export abstract class ChanceBasedMoveEffectAttr extends MoveEffectAttr {
    * and {@linkcode getMoveChance | chance to apply}.
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    /** The attribute's effect score, assuming its effect always applies */
+    const rawScore = this.getRawEffectScore(user, target, move);
+
+    return this.getTieredScore(user, target, move, rawScore);
+  }
+
+  protected getTieredScore(user: EnemyPokemon, target: Pokemon, move: Move, score: number): number {
     /**
      * The attribute's chance to apply its effect
      * @todo this chance calculation may prematurely reveal abilities
      */
     const chance = this.getMoveChance(user, target, move);
-    /** The attribute's effect score, assuming its effect always applies */
-    const rawScore = this.getRawEffectScore(user, target, move);
 
     if (chance < 0) {
-      return rawScore;
+      return score;
     }
 
     /**
@@ -98,7 +103,7 @@ export abstract class ChanceBasedMoveEffectAttr extends MoveEffectAttr {
      * This may be a decimal number; the final output is either
      * `floor(chanceWeightedScore)` or `floor(chanceWeightedScore) + 1`
      */
-    const chanceWeightedScore = (chance * rawScore) / 100;
+    const chanceWeightedScore = (chance * score) / 100;
     /** The minimum integer score this function can return */
     const minScore = Math.floor(chanceWeightedScore);
     /**

--- a/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
+++ b/src/data/moves/move-attrs/chance-based-move-effect-attr.ts
@@ -87,6 +87,22 @@ export abstract class ChanceBasedMoveEffectAttr extends MoveEffectAttr {
     return this.getTieredScore(user, target, move, rawScore);
   }
 
+  /**
+   * Translates the given "raw" decimal Effect Score into a final integer Effect Score, accounting for the
+   * effect's chance to apply. This is done by multiplying the raw score by the effect chance, then
+   * randomly "tiering" the product into either `floor(score)` or `floor(score) + 1`.
+   *
+   * **Example:**
+   *
+   * If an effect's raw score is `1.5`, and the chance to apply said effect is 50 percent, the resulting
+   * chance-adjusted score is `0.75`. In turn, the final score has a 25% chance of being (+0) and a 75%
+   * chance of being (+1)
+   * @param user - The {@linkcode EnemyPokemon} evaluating the move
+   * @param target - The {@linkcode Pokemon} the move is evaluated against
+   * @param move - The {@linkcode Move} being evaluated
+   * @param score - The previously calculated "raw" Effect Score for the move action
+   * @returns The final integer score after tiering
+   */
   protected getTieredScore(user: EnemyPokemon, target: Pokemon, move: Move, score: number): number {
     /**
      * The attribute's chance to apply its effect

--- a/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
+++ b/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
@@ -1,4 +1,4 @@
-import { ATTACK_SCORE_HP_THRESHOLD, MAJOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
+import { ATTACK_SCORE_HP_THRESHOLD, BAD_MOVE_PENALTY } from "#constants/ai-constants";
 import { HitResult } from "#enums/hit-result";
 import type { BattleStat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
@@ -48,6 +48,14 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
       user.getHpRatio() > 1 / this.cutRatio && this.stats.some((s) => user.getStatStage(s) < 6);
   }
 
+  /**
+   * @returns An additional penalty for reducing the user's HP to go with the score
+   * for this effect's stat stage changes. This checks each of the user's opponents'
+   * max {@link Pokemon.getExpectedAttackScore | EAS} among their estimated attacks
+   * to predict how much damage the user will receive this turn. If the user is
+   * projected to receive more damage than the effect's {@linkcode cutRatio}, this
+   * grants a {@linkcode BAD_MOVE_PENALTY}.
+   */
   public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     const oppMaxEas = user.getOpponents().map((opp) =>
       opp.estimateAttackMoves().reduce((maxEas, move) => {
@@ -58,7 +66,7 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
     );
 
     const meetsHpCutThreshold = oppMaxEas.every((eas) => eas < (this.cutRatio * 100) / ATTACK_SCORE_HP_THRESHOLD);
-    const hpCutPenalty = meetsHpCutThreshold ? 0 : MAJOR_EFFECT_SCORE_PENALTY;
+    const hpCutPenalty = meetsHpCutThreshold ? 0 : BAD_MOVE_PENALTY;
 
     return hpCutPenalty + super.getRawEffectScore(user, target, move);
   }

--- a/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
+++ b/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
@@ -58,8 +58,8 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
    */
   public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     const oppMaxEas = user.getOpponents().map((opp) =>
-      opp.estimateAttackMoves().reduce((maxEas, move) => {
-        const eas = opp.getExpectedAttackScore(user, move);
+      opp.estimateAttackMoves().reduce((maxEas, mv) => {
+        const eas = opp.getExpectedAttackScore(user, mv);
 
         return Math.max(maxEas, eas);
       }, 0),

--- a/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
+++ b/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
@@ -1,5 +1,7 @@
+import { ATTACK_SCORE_HP_THRESHOLD, MAJOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
 import { HitResult } from "#enums/hit-result";
 import type { BattleStat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { StatStageChangeAttr } from "#moves/stat-stage-change-attr";
@@ -28,7 +30,7 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
     this.messageCallback = messageCallback;
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
     user.damageAndUpdate(toDmgValue(user.getMaxHp() / this.cutRatio), {
       result: HitResult.OTHER,
       ignoreSegments: true,
@@ -41,8 +43,23 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
     return ret;
   }
 
-  override getCondition(): MoveConditionFunc {
+  public override getCondition(): MoveConditionFunc {
     return (user, _target, _move) =>
       user.getHpRatio() > 1 / this.cutRatio && this.stats.some((s) => user.getStatStage(s) < 6);
+  }
+
+  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    const oppMaxEas = user.getOpponents().map((opp) =>
+      opp.estimateAttackMoves().reduce((maxEas, move) => {
+        const eas = opp.getExpectedAttackScore(user, move);
+
+        return Math.max(maxEas, eas);
+      }, 0),
+    );
+
+    const meetsHpCutThreshold = oppMaxEas.every((eas) => eas < (this.cutRatio * 100) / ATTACK_SCORE_HP_THRESHOLD);
+    const hpCutPenalty = meetsHpCutThreshold ? 0 : MAJOR_EFFECT_SCORE_PENALTY;
+
+    return hpCutPenalty + super.getRawEffectScore(user, target, move);
   }
 }

--- a/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
+++ b/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
@@ -65,7 +65,9 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
       }, 0),
     );
 
-    const meetsHpCutThreshold = oppMaxEas.every((eas) => eas < (this.cutRatio * 100) / ATTACK_SCORE_HP_THRESHOLD);
+    const meetsHpCutThreshold = oppMaxEas.every(
+      (eas) => eas < ((user.getHpRatio() - 1 / this.cutRatio) * 100) / ATTACK_SCORE_HP_THRESHOLD,
+    );
     const hpCutPenalty = meetsHpCutThreshold ? 0 : BAD_MOVE_PENALTY;
 
     return hpCutPenalty + super.getRawEffectScore(user, target, move);

--- a/src/data/moves/move-attrs/faint-countdown-attr.ts
+++ b/src/data/moves/move-attrs/faint-countdown-attr.ts
@@ -46,7 +46,7 @@ export class FaintCountdownAttr extends AddBattlerTagAttr {
   }
 
   /** @returns The inverted output of {@linkcode getRawEffectScore} */
-  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, move: Move): number {
     return -this.getRawEffectScore(user, target, move);
   }
 }

--- a/src/data/moves/move-attrs/growth-stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/growth-stat-stage-change-attr.ts
@@ -14,7 +14,7 @@ export class GrowthStatStageChangeAttr extends StatStageChangeAttr {
     super([Stat.ATK, Stat.SPATK], 1, true);
   }
 
-  override getLevels(_user: Pokemon): number {
+  protected override getLevels(_user: Pokemon): number {
     if (
       !globalScene.arena.weather?.isEffectSuppressed()
       && globalScene.arena.hasWeather([WeatherType.SUNNY, WeatherType.HARSH_SUN])

--- a/src/data/moves/move-attrs/heal-attr.ts
+++ b/src/data/moves/move-attrs/heal-attr.ts
@@ -64,14 +64,12 @@ export class HealAttr extends MoveEffectAttr {
    * - If the target is an opponent to the user, grant double the {@linkcode BAD_MOVE_PENALTY}
    * - Otherwise, grant a bonus as defined in {@linkcode getAllyTargetScore}
    */
-  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
-    const pokemon = this.selfTarget ? user : target;
-
-    if (pokemon.isOpponent(user)) {
-      return 2 * BAD_MOVE_PENALTY;
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, move: Move): number {
+    if (this.selfTarget) {
+      return this.getAllyTargetScore(user, user, move);
     }
 
-    return this.getAllyTargetScore(user, target, move);
+    return 2 * BAD_MOVE_PENALTY;
   }
 
   /**
@@ -88,7 +86,7 @@ export class HealAttr extends MoveEffectAttr {
    * @param move - The {@linkcode Move} being evaluated
    * @returns The ES for using the given move against the given target
    */
-  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, move: Move): number {
     if (target.hasTag(BattlerTagType.HEAL_BLOCK) || target.isFullHp()) {
       return BAD_MOVE_PENALTY;
     }

--- a/src/data/moves/move-attrs/heal-on-ally-attr.ts
+++ b/src/data/moves/move-attrs/heal-on-ally-attr.ts
@@ -22,7 +22,7 @@ export class HealOnAllyAttr extends HealAttr {
    * This is the same scoring logic as in {@linkcode HealAttr.getEffectScore}, except
    * that the penalty for targeting an opponent with the effect is removed.
    */
-  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+  public override getEffectScore(user: EnemyPokemon, target: EnemyPokemon, move: Move): number {
     if (target.isOpponent(user)) {
       return 0;
     }

--- a/src/data/moves/move-attrs/heal-status-effect-attr.ts
+++ b/src/data/moves/move-attrs/heal-status-effect-attr.ts
@@ -88,7 +88,7 @@ export class HealStatusEffectAttr extends MoveEffectAttr {
    * status effect, grant a {@link MAJOR_EFFECT_SCORE_PENALTY | major penalty}.
    * - Otherwise, grant (+1) + 50%(+1)
    */
-  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, _move: Move): number {
     const effect = target.getStatusEffect(true);
 
     if (!this.effects.includes(effect)) {

--- a/src/data/moves/move-attrs/helping-hand-attr.ts
+++ b/src/data/moves/move-attrs/helping-hand-attr.ts
@@ -29,7 +29,7 @@ export class HelpingHandAttr extends AddBattlerTagAttr {
    * **NOTE:** In this method, {@linkcode target} is assumed to be the user's ally.
    * this is guaranteed via Helping Hand's {@linkcode Move.moveTarget | target restriction}.
    */
-  public override getAllyTargetScore(_user: EnemyPokemon, target: Pokemon, _move: Move): number {
+  public override getAllyTargetScore(_user: EnemyPokemon, target: EnemyPokemon, _move: Move): number {
     /** The target's highest EAS against any opposing Pokemon */
     const targetMaxEAS = Math.max(
       ...target

--- a/src/data/moves/move-attrs/move-attr.ts
+++ b/src/data/moves/move-attrs/move-attr.ts
@@ -119,7 +119,7 @@ export abstract class MoveAttr {
    * @returns `null` by default. `null` scores do not contribute to Effect Score, but can warrant an
    * {@linkcode ALLY_TARGET_PENALTY} if none of the move's other attributes have a defined score.
    */
-  public getAllyTargetScore(_user: EnemyPokemon, _target: Pokemon, _move: Move): number | null {
+  public getAllyTargetScore(_user: EnemyPokemon, _target: EnemyPokemon, _move: Move): number | null {
     return null;
   }
 

--- a/src/data/moves/move-attrs/psycho-shift-effect-attr.ts
+++ b/src/data/moves/move-attrs/psycho-shift-effect-attr.ts
@@ -1,5 +1,4 @@
-import { BAD_MOVE_PENALTY } from "#constants/ai-constants";
-import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import { BAD_MOVE_PENALTY, OPP_EFFECTIVE_STAT_OPTIONS } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
@@ -65,12 +64,8 @@ export class PsychoShiftEffectAttr extends MoveEffectAttr {
       case StatusEffect.PARALYSIS:
         return user.outspeeds(target, true) ? 2 : 3;
       case StatusEffect.BURN: {
-        const effectiveStatOptions = {
-          abilityApplyMode: AbilityApplyMode.REVEALED,
-          simulated: true,
-        };
-        return target.getEffectiveStat(Stat.ATK, effectiveStatOptions)
-          > target.getEffectiveStat(Stat.SPATK, effectiveStatOptions)
+        return target.getEffectiveStat(Stat.ATK, OPP_EFFECTIVE_STAT_OPTIONS)
+          > target.getEffectiveStat(Stat.SPATK, OPP_EFFECTIVE_STAT_OPTIONS)
           ? 3
           : 2;
       }

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -19,6 +19,7 @@ import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveCategory } from "#enums/move-category";
+import { MoveId } from "#enums/move-id";
 import { type BattleStat, Stat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -135,7 +136,8 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * on the stat changed:
    * - `ATK` / `SPATK`: If the target has a move of matching {@linkcode MoveCategory}, grant (+0.5) per stat stage.
    * - `DEF` / `SPDEF`: Check the offensive stat affinities of each opponent (i.e. which is higher between
-   * `ATK` and `SPATK`). This grants (+0.5) per stat stage, per opponent with a matching affinity.
+   * `ATK` and `SPATK`). This grants (+0.5) per stat stage, per opponent with a matching affinity. For `DEF`
+   * boosts, if the target has Body Press, this grants an additional (+1).
    * - `SPD`: Grants (+1) per opponent that the target would outspeed as a result of this effect.
    * - `ACC`: If the target has at least one move whose accuracy falls below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
    * grant, (+0.5) per stat stage.
@@ -183,7 +185,9 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
               > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
           ).length;
 
-        return 0.5 * numOppsWithMatchingAffinity * levels;
+        const bodyPressBonus = levels > 0 && target.hasMove(MoveId.BODY_PRESS) ? MINOR_EFFECT_SCORE_BONUS : 0;
+
+        return 0.5 * numOppsWithMatchingAffinity * levels + bodyPressBonus;
       }
       case Stat.SPD: {
         if (levels < 0) {

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -7,8 +7,10 @@ import type { ProtectStatAbAttr } from "#abilities/protect-stat-ab-attr";
 import type { StatStageChangeMultiplierAbAttr } from "#abilities/stat-stage-change-multiplier-ab-attr";
 import { globalScene } from "#app/global-scene";
 import type { MistTag } from "#arena-tags/mist-tag";
+import { POST_STAT_STAGE_REDUCTION_ABILITIES } from "#constants/ability-constants";
 import {
   LOW_ACCURACY_PENALTY_THRESHOLD,
+  MAJOR_EFFECT_SCORE_PENALTY,
   MINOR_EFFECT_SCORE_BONUS,
   MINOR_EFFECT_SCORE_PENALTY,
   SOFT_EFFECT_SCORE_LIMIT,
@@ -249,6 +251,10 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     const levels = this.getAdjustedLevels(user, target, stat);
     if (levels === 0) {
       return 0;
+    }
+
+    if (levels < 0 && POST_STAT_STAGE_REDUCTION_ABILITIES.some((abId) => target.hasRevealedAbility(abId))) {
+      return MAJOR_EFFECT_SCORE_PENALTY;
     }
 
     switch (stat) {

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -1,10 +1,19 @@
 import { globalScene } from "#app/global-scene";
+import {
+  LOW_ACCURACY_PENALTY_THRESHOLD,
+  MINOR_EFFECT_SCORE_BONUS,
+  MINOR_EFFECT_SCORE_PENALTY,
+  SOFT_EFFECT_SCORE_LIMIT,
+} from "#constants/ai-constants";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { MoveCategory } from "#enums/move-category";
 import { type BattleStat, Stat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { ChanceBasedMoveEffectAttr, type ChanceBasedMoveEffectAttrOptions } from "#moves/chance-based-move-effect-attr";
 import type { Move } from "#moves/move";
 import type { MoveConditionFunc } from "#types/move-types";
+import { isBetween } from "#utils/common-utils";
 
 /**
  * Set of optional parameters that may be applied to stat stage changing effects
@@ -76,49 +85,167 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     return true;
   }
 
-  getLevels(_user: Pokemon): number {
+  protected getLevels(_user: Pokemon): number {
     return this.stages;
   }
 
-  override getTargetBenefitScore(user: Pokemon, target: Pokemon, _move: Move): number {
-    let ret = 0;
-    const moveLevels = this.getLevels(user);
-    for (const stat of this.stats) {
-      let levels = moveLevels;
-      const statStage = target.getStatStage(stat);
-      if (levels > 0) {
-        levels = Math.min(statStage + levels, 6) - statStage;
-      } else {
-        levels = Math.max(statStage + levels, -6) - statStage;
-      }
-      let noEffect = false;
-      switch (stat) {
-        case Stat.ATK:
-          if (this.selfTarget) {
-            noEffect = !user.getMoveset().find((m) => m.getMove().category === MoveCategory.PHYSICAL);
-          }
-          break;
-        case Stat.DEF:
-          if (!this.selfTarget) {
-            noEffect = !user.getMoveset().find((m) => m.getMove().category === MoveCategory.PHYSICAL);
-          }
-          break;
-        case Stat.SPATK:
-          if (this.selfTarget) {
-            noEffect = !user.getMoveset().find((m) => m.getMove().category === MoveCategory.SPECIAL);
-          }
-          break;
-        case Stat.SPDEF:
-          if (!this.selfTarget) {
-            noEffect = !user.getMoveset().find((m) => m.getMove().category === MoveCategory.SPECIAL);
-          }
-          break;
-      }
-      if (noEffect) {
-        continue;
-      }
-      ret += levels * 4 + (levels > 0 ? -2 : 2);
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    return Math.min(super.getEffectScore(user, target, move), SOFT_EFFECT_SCORE_LIMIT);
+  }
+
+  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    if (this.selfTarget) {
+      return this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, user, stat), 0);
     }
-    return ret;
+
+    return this.stats.reduce((score, stat) => score + this.getOpposingTargetScoreByStat(user, target, stat), 0);
+  }
+
+  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    const rawScore = this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, target, stat), 0);
+
+    return Math.min(this.getTieredScore(user, target, move, rawScore), SOFT_EFFECT_SCORE_LIMIT);
+  }
+
+  private getAllyTargetScoreByStat(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
+    const effectiveStatOptions = { simulated: true };
+    const oppEffectiveStatOptions = {
+      abilityApplyMode: AbilityApplyMode.REVEALED,
+      simulated: true,
+    };
+
+    switch (stat) {
+      case Stat.ATK:
+      case Stat.SPATK: {
+        const category = stat === Stat.ATK ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
+        const moveset = target.getMoveset().map((mv) => mv.getMove());
+
+        if (moveset.some((mv) => mv.category === category)) {
+          return 0.5 * this.getLevels(user);
+        }
+        return 0;
+      }
+      case Stat.DEF:
+      case Stat.SPDEF: {
+        const [relevantStat, otherStat]: BattleStat[] =
+          stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
+
+        const numOppsWithMatchingAffinity = target
+          .getOpponents()
+          .filter(
+            (opp) =>
+              opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
+              > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
+          ).length;
+
+        return 0.5 * numOppsWithMatchingAffinity * this.getLevels(user);
+      }
+      case Stat.SPD: {
+        if (this.getLevels(user) < 0) {
+          return MINOR_EFFECT_SCORE_PENALTY;
+        }
+
+        const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
+        const startingSpdStage = target.getStatStage(stat);
+        const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
+
+        const finalSpdStage = startingSpdStage + this.getLevels(user);
+        const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
+
+        const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
+
+        const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
+          const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
+          return isBetween(oppSpd + 1, targetStartingSpd, targetStartingSpd * relativeSpdMultiplier);
+        }).length;
+
+        return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
+      }
+      case Stat.ACC: {
+        if (this.getLevels(user) < 0) {
+          return MINOR_EFFECT_SCORE_PENALTY;
+        }
+
+        const targetHasInaccurateMove = target
+          .getMoveset()
+          .some((pkmMove) => pkmMove.getMove().accuracy < LOW_ACCURACY_PENALTY_THRESHOLD);
+
+        return (targetHasInaccurateMove ? 0.5 : 0) * this.getLevels(user);
+      }
+      case Stat.EVA:
+        return 0.5 * this.getLevels(user);
+    }
+  }
+
+  private getOpposingTargetScoreByStat(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
+    const effectiveStatOptions = {
+      abilityApplyMode: AbilityApplyMode.REVEALED,
+      simulated: true,
+    };
+    const oppEffectiveStatOptions = { simulated: true };
+
+    switch (stat) {
+      case Stat.ATK:
+      case Stat.SPATK: {
+        const category = stat === Stat.ATK ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
+        const moveset = target.estimateAttackMoves();
+
+        if (moveset.some((mv) => mv.category === category)) {
+          return -0.5 * this.getLevels(user);
+        }
+        return 0;
+      }
+      case Stat.DEF:
+      case Stat.SPDEF: {
+        const [relevantStat, otherStat]: BattleStat[] =
+          stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
+
+        const numOppsWithMatchingAffinity = target
+          .getOpponents()
+          .filter(
+            (opp) =>
+              opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
+              > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
+          ).length;
+
+        return -0.5 * numOppsWithMatchingAffinity * this.getLevels(user);
+      }
+      case Stat.SPD: {
+        if (this.getLevels(user) > 0) {
+          return MINOR_EFFECT_SCORE_PENALTY;
+        }
+
+        const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
+        const startingSpdStage = target.getStatStage(stat);
+        const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
+
+        const finalSpdStage = startingSpdStage + this.getLevels(user);
+        const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
+
+        const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
+
+        const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
+          const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
+          return isBetween(oppSpd + 1, targetStartingSpd * relativeSpdMultiplier, targetStartingSpd);
+        }).length;
+
+        return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
+      }
+      case Stat.ACC:
+        return -0.5 * this.getLevels(user);
+      case Stat.EVA: {
+        if (this.getLevels(user) > 0) {
+          return MINOR_EFFECT_SCORE_PENALTY;
+        }
+
+        const oppHasInaccurateMove = target
+          .getOpponents()
+          .some((opp) =>
+            opp.getMoveset().some((pkmMove) => pkmMove.getMove().accuracy < LOW_ACCURACY_PENALTY_THRESHOLD),
+          );
+
+        return (oppHasInaccurateMove ? -0.5 : 0) * this.getLevels(user);
+      }
+    }
   }
 }

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -23,6 +23,7 @@ import { MoveCategory } from "#enums/move-category";
 import { MoveId } from "#enums/move-id";
 import { type BattleStat, Stat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
+import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { ChanceBasedMoveEffectAttr, type ChanceBasedMoveEffectAttrOptions } from "#moves/chance-based-move-effect-attr";
 import type { Move } from "#moves/move";
@@ -117,7 +118,10 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
       return this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, user, move, stat), 0);
     }
 
-    return this.stats.reduce((score, stat) => score + this.getOpposingTargetScoreByStat(user, target, move, stat), 0);
+    return this.stats.reduce(
+      (score, stat) => score + this.getOpposingTargetScoreByStat(user, target as PlayerPokemon, move, stat),
+      0,
+    );
   }
 
   /**
@@ -125,7 +129,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * upper-bounded by {@linkcode SOFT_EFFECT_SCORE_LIMIT} to yield the final score.
    * @see {@linkcode getAllyTargetScoreByStat}
    */
-  public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, move: Move): number {
     const rawScore = this.stats.reduce(
       (score, stat) => score + this.getAllyTargetScoreByStat(user, target, move, stat),
       0,
@@ -154,7 +158,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @returns The "raw" Effect Score bonus (or penalty) for the given stat. This score is combined with other
    * stats and {@link getTieredScore | tiered} to yield the final Effect Score.
    */
-  private getAllyTargetScoreByStat(user: EnemyPokemon, target: Pokemon, move: Move, stat: BattleStat): number {
+  private getAllyTargetScoreByStat(user: EnemyPokemon, target: EnemyPokemon, move: Move, stat: BattleStat): number {
     const effectiveStatOptions = { simulated: true };
     const oppEffectiveStatOptions = {
       abilityApplyMode: AbilityApplyMode.REVEALED,
@@ -251,7 +255,12 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @returns The "raw" Effect Score bonus (or penalty) for the given stat. This score is combined with other
    * stats and {@link getTieredScore | tiered} to yield the final Effect Score.
    */
-  private getOpposingTargetScoreByStat(user: EnemyPokemon, target: Pokemon, move: Move, stat: BattleStat): number {
+  private getOpposingTargetScoreByStat(
+    user: EnemyPokemon,
+    target: PlayerPokemon,
+    move: Move,
+    stat: BattleStat,
+  ): number {
     const effectiveStatOptions = {
       abilityApplyMode: AbilityApplyMode.REVEALED,
       simulated: true,

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -9,6 +9,7 @@ import { globalScene } from "#app/global-scene";
 import type { MistTag } from "#arena-tags/mist-tag";
 import { POST_STAT_STAGE_REDUCTION_ABILITIES } from "#constants/ability-constants";
 import {
+  BAD_MOVE_PENALTY,
   LOW_ACCURACY_PENALTY_THRESHOLD,
   MAJOR_EFFECT_SCORE_PENALTY,
   MINOR_EFFECT_SCORE_BONUS,
@@ -111,12 +112,12 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @see {@linkcode getAllyTargetScoreByStat}
    * @see {@linkcode getOpposingTargetScoreByStat}
    */
-  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+  public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     if (this.selfTarget) {
-      return this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, user, stat), 0);
+      return this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, user, move, stat), 0);
     }
 
-    return this.stats.reduce((score, stat) => score + this.getOpposingTargetScoreByStat(user, target, stat), 0);
+    return this.stats.reduce((score, stat) => score + this.getOpposingTargetScoreByStat(user, target, move, stat), 0);
   }
 
   /**
@@ -125,7 +126,10 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @see {@linkcode getAllyTargetScoreByStat}
    */
   public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
-    const rawScore = this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, target, stat), 0);
+    const rawScore = this.stats.reduce(
+      (score, stat) => score + this.getAllyTargetScoreByStat(user, target, move, stat),
+      0,
+    );
 
     return Math.min(this.getTieredScore(user, target, move, rawScore), SOFT_EFFECT_SCORE_LIMIT);
   }
@@ -145,11 +149,12 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @param user - The {@linkcode Pokemon} evaluating this effect
    * @param target - The {@linkcode Pokemon} this effect is evaluated against. This can be assumed to be either the
    * user or its ally.
+   * @param move - The {@linkcode Move} whose effect is evaluated.
    * @param stat - The {@linkcode BattleStat} being evaluated
    * @returns The "raw" Effect Score bonus (or penalty) for the given stat. This score is combined with other
    * stats and {@link getTieredScore | tiered} to yield the final Effect Score.
    */
-  private getAllyTargetScoreByStat(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
+  private getAllyTargetScoreByStat(user: EnemyPokemon, target: Pokemon, move: Move, stat: BattleStat): number {
     const effectiveStatOptions = { simulated: true };
     const oppEffectiveStatOptions = {
       abilityApplyMode: AbilityApplyMode.REVEALED,
@@ -158,7 +163,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
     const levels = this.getAdjustedLevels(user, target, stat);
     if (levels === 0) {
-      return 0;
+      return move.isStatusMove() ? BAD_MOVE_PENALTY : 0;
     }
 
     switch (stat) {
@@ -241,11 +246,12 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @param user - The {@linkcode Pokemon} evaluating this effect
    * @param target - The {@linkcode Pokemon} this effect is evaluated against. This can be assumed to be one of
    * the user's opponents.
+   * @param move - The {@linkcode Move} whose effect is evaluated
    * @param stat - The {@linkcode BattleStat} being evaluated
    * @returns The "raw" Effect Score bonus (or penalty) for the given stat. This score is combined with other
    * stats and {@link getTieredScore | tiered} to yield the final Effect Score.
    */
-  private getOpposingTargetScoreByStat(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
+  private getOpposingTargetScoreByStat(user: EnemyPokemon, target: Pokemon, move: Move, stat: BattleStat): number {
     const effectiveStatOptions = {
       abilityApplyMode: AbilityApplyMode.REVEALED,
       simulated: true,
@@ -254,7 +260,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
     const levels = this.getAdjustedLevels(user, target, stat);
     if (levels === 0) {
-      return 0;
+      return move.isStatusMove() ? BAD_MOVE_PENALTY : 0;
     }
 
     if (levels < 0 && POST_STAT_STAGE_REDUCTION_ABILITIES.some((abId) => target.hasRevealedAbility(abId))) {

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -10,6 +10,7 @@ import type { MistTag } from "#arena-tags/mist-tag";
 import { POST_STAT_STAGE_REDUCTION_ABILITIES } from "#constants/ability-constants";
 import {
   ACCURACY_REDUCTION_STAGE_LIMIT,
+  ALLY_EFFECTIVE_STAT_OPTIONS,
   BAD_MOVE_PENALTY,
   DEFENSE_LOW_INCENTIVE_THRESHOLD,
   EVASION_BOOST_STAGE_LIMIT,
@@ -17,6 +18,7 @@ import {
   MAJOR_EFFECT_SCORE_PENALTY,
   MINOR_EFFECT_SCORE_BONUS,
   MINOR_EFFECT_SCORE_PENALTY,
+  OPP_EFFECTIVE_STAT_OPTIONS,
   SOFT_EFFECT_SCORE_LIMIT,
 } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
@@ -208,11 +210,6 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @returns The raw Effect Score (can be a decimal value)
    */
   private getAllyDefenseStageChangeScore(target: EnemyPokemon, stat: Stat.DEF | Stat.SPDEF, levels: number): number {
-    const oppEffectiveStatOptions = {
-      abilityApplyMode: AbilityApplyMode.REVEALED,
-      simulated: true,
-    };
-
     const [relevantStat, otherStat]: BattleStat[] = stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
 
     const scoreMultiplier = target.getStatStage(stat) < DEFENSE_LOW_INCENTIVE_THRESHOLD ? 0.5 : 0.25;
@@ -221,8 +218,8 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
       .getOpponents()
       .filter(
         (opp) =>
-          opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
-          > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
+          opp.getEffectiveStat(relevantStat, OPP_EFFECTIVE_STAT_OPTIONS)
+          > opp.getEffectiveStat(otherStat, OPP_EFFECTIVE_STAT_OPTIONS),
       ).length;
 
     const bodyPressBonus = levels > 0 && target.hasMove(MoveId.BODY_PRESS) ? MINOR_EFFECT_SCORE_BONUS : 0;
@@ -241,17 +238,11 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @returns The raw Effect Score (can be a decimal value)
    */
   private getAllySpeedStageChangeScore(target: EnemyPokemon, stat: Stat.SPD, levels: number): number {
-    const effectiveStatOptions = { simulated: true };
-    const oppEffectiveStatOptions = {
-      abilityApplyMode: AbilityApplyMode.REVEALED,
-      simulated: true,
-    };
-
     if (levels < 0) {
       return MINOR_EFFECT_SCORE_PENALTY;
     }
 
-    const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
+    const targetStartingSpd = target.getEffectiveStat(stat, ALLY_EFFECTIVE_STAT_OPTIONS);
     const startingSpdStage = target.getStatStage(stat);
     const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
 
@@ -261,7 +252,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
 
     const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
-      const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
+      const oppSpd = opp.getEffectiveStat(stat, OPP_EFFECTIVE_STAT_OPTIONS);
       return isBetween(oppSpd + 1, targetStartingSpd, targetStartingSpd * relativeSpdMultiplier);
     }).length;
 
@@ -398,16 +389,14 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     stat: Stat.DEF | Stat.SPDEF,
     levels: number,
   ): number {
-    const oppEffectiveStatOptions = { simulated: true };
-
     const [relevantStat, otherStat]: BattleStat[] = stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
 
     const numOppsWithMatchingAffinity = target
       .getOpponents()
       .filter(
         (opp) =>
-          opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
-          > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
+          opp.getEffectiveStat(relevantStat, ALLY_EFFECTIVE_STAT_OPTIONS)
+          > opp.getEffectiveStat(otherStat, ALLY_EFFECTIVE_STAT_OPTIONS),
       ).length;
 
     return -0.5 * numOppsWithMatchingAffinity * levels;
@@ -424,17 +413,11 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * @returns The raw Effect Score (can be a decimal value)
    */
   private getOpponentSpeedStageChangeScore(target: PlayerPokemon, stat: Stat.SPD, levels: number): number {
-    const effectiveStatOptions = {
-      abilityApplyMode: AbilityApplyMode.REVEALED,
-      simulated: true,
-    };
-    const oppEffectiveStatOptions = { simulated: true };
-
     if (levels > 0) {
       return MINOR_EFFECT_SCORE_PENALTY;
     }
 
-    const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
+    const targetStartingSpd = target.getEffectiveStat(stat, OPP_EFFECTIVE_STAT_OPTIONS);
     const startingSpdStage = target.getStatStage(stat);
     const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
 
@@ -444,7 +427,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
 
     const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
-      const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
+      const oppSpd = opp.getEffectiveStat(stat, ALLY_EFFECTIVE_STAT_OPTIONS);
       return isBetween(oppSpd + 1, targetStartingSpd * relativeSpdMultiplier, targetStartingSpd);
     }).length;
 

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -301,15 +301,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
   /**
    * Calculates the Effect Score gained (before factoring in effect chance) from modifying a single
    * stat stage with this effect on one of the user's opponents. The heuristic for this scoring varies based
-   * on the stat changed:
-   * - `ATK` / `SPATK`: If the target has a move of matching {@linkcode MoveCategory}, grant (-0.5) per stat stage.
-   * - `DEF` / `SPDEF`: Check the offensive stat affinities (i.e. which is higher between
-   * `ATK` and `SPATK`) of each of the target's opponents (i.e. the user and its ally, if active).
-   * This grants (-0.5) per stat stage, per opponent with a matching affinity.
-   * - `SPD`: Grants (+1) for each of the target's opponents that would outspeed the target as a result of this effect.
-   * - `ACC`: Grants (-0.5) per stat stage unless the target's `ACC` stat stage is at or below the {@linkcode ACCURACY_REDUCTION_STAGE_LIMIT}.
-   * - `EVA`: If any of the target's opponents has at least one move whose accuracy falls below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
-   * grant (+0.5) per stat stage.
+   * on the stat changed.
    * @param user - The {@linkcode Pokemon} evaluating this effect
    * @param target - The {@linkcode Pokemon} this effect is evaluated against. This can be assumed to be one of
    * the user's opponents.

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -222,7 +222,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
         const targetHasInaccurateMove = target
           .getMoveset()
-          .some((pkmMove) => pkmMove.getMove().accuracy < LOW_ACCURACY_PENALTY_THRESHOLD);
+          .some((pkmMove) => isBetween(pkmMove.getMove().accuracy, 0, LOW_ACCURACY_PENALTY_THRESHOLD));
 
         return (targetHasInaccurateMove ? 0.5 : 0) * levels;
       }
@@ -324,7 +324,9 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         const oppHasInaccurateMove = target
           .getOpponents()
           .some((opp) =>
-            opp.getMoveset().some((pkmMove) => pkmMove.getMove().accuracy < LOW_ACCURACY_PENALTY_THRESHOLD),
+            opp
+              .getMoveset()
+              .some((pkmMove) => isBetween(pkmMove.getMove().accuracy, 0, LOW_ACCURACY_PENALTY_THRESHOLD)),
           );
 
         return (oppHasInaccurateMove ? -0.5 : 0) * levels;

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -144,17 +144,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
   /**
    * Calculates the Effect Score gained (before factoring in effect chance) from modifying a single
    * stat stage with this effect on either the user or its ally. The heuristic for this scoring varies based
-   * on the stat changed:
-   * - `ATK` / `SPATK`: If the target has a move of matching {@linkcode MoveCategory}, grant (+0.5) per stat stage.
-   * - `DEF` / `SPDEF`: Check the offensive stat affinities of each opponent (i.e. which is higher between
-   * `ATK` and `SPATK`). This grants (+0.5) per stat stage, per opponent with a matching affinity. If the
-   * target's stage for the affected stat is at or above the {@linkcode DEFENSE_LOW_INCENTIVE_THRESHOLD},
-   * this bonus is halved. For `DEF` boosts, if the target has Body Press, this grants an additional (+1).
-   * - `SPD`: Grants (+1) per opponent that the target would outspeed as a result of this effect.
-   * - `ACC`: If the target has at least one move whose accuracy falls below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
-   * grant, (+0.5) per stat stage.
-   * - `EVA`: Grants (+0.5) per stat stage unless the target's `EVA` stat stage is at or above the
-   * {@linkcode EVASION_BOOST_STAGE_LIMIT}.
+   * on the stat changed.
    * @param user - The {@linkcode Pokemon} evaluating this effect
    * @param target - The {@linkcode Pokemon} this effect is evaluated against. This can be assumed to be either the
    * user or its ally.
@@ -164,12 +154,6 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * stats and {@link getTieredScore | tiered} to yield the final Effect Score.
    */
   private getAllyTargetScoreByStat(user: EnemyPokemon, target: EnemyPokemon, move: Move, stat: BattleStat): number {
-    const effectiveStatOptions = { simulated: true };
-    const oppEffectiveStatOptions = {
-      abilityApplyMode: AbilityApplyMode.REVEALED,
-      simulated: true,
-    };
-
     const levels = this.getAdjustedLevels(user, target, stat);
     if (levels === 0) {
       return move.isStatusMove() ? BAD_MOVE_PENALTY : 0;
@@ -177,73 +161,150 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
     switch (stat) {
       case Stat.ATK:
-      case Stat.SPATK: {
-        const category = stat === Stat.ATK ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
-        const moveset = target.getMoveset().map((mv) => mv.getMove());
-
-        if (moveset.some((mv) => mv.category === category)) {
-          return 0.5 * levels;
-        }
-        return 0;
-      }
+      case Stat.SPATK:
+        return this.getAllyAttackStageChangeScore(target, stat, levels);
       case Stat.DEF:
-      case Stat.SPDEF: {
-        const [relevantStat, otherStat]: BattleStat[] =
-          stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
-
-        const scoreMultiplier = target.getStatStage(stat) < DEFENSE_LOW_INCENTIVE_THRESHOLD ? 0.5 : 0.25;
-
-        const numOppsWithMatchingAffinity = target
-          .getOpponents()
-          .filter(
-            (opp) =>
-              opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
-              > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
-          ).length;
-
-        const bodyPressBonus = levels > 0 && target.hasMove(MoveId.BODY_PRESS) ? MINOR_EFFECT_SCORE_BONUS : 0;
-
-        return scoreMultiplier * numOppsWithMatchingAffinity * levels + bodyPressBonus;
-      }
-      case Stat.SPD: {
-        if (levels < 0) {
-          return MINOR_EFFECT_SCORE_PENALTY;
-        }
-
-        const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
-        const startingSpdStage = target.getStatStage(stat);
-        const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
-
-        const finalSpdStage = startingSpdStage + levels;
-        const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
-
-        const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
-
-        const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
-          const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
-          return isBetween(oppSpd + 1, targetStartingSpd, targetStartingSpd * relativeSpdMultiplier);
-        }).length;
-
-        return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
-      }
-      case Stat.ACC: {
-        if (levels < 0) {
-          return MINOR_EFFECT_SCORE_PENALTY;
-        }
-
-        const targetHasInaccurateMove = target
-          .getMoveset()
-          .some((pkmMove) => isBetween(pkmMove.getMove().accuracy, 0, LOW_ACCURACY_PENALTY_THRESHOLD));
-
-        return (targetHasInaccurateMove ? 0.5 : 0) * levels;
-      }
-      case Stat.EVA: {
-        if (target.getStatStage(stat) < EVASION_BOOST_STAGE_LIMIT) {
-          return 0.5 * levels;
-        }
-        return 0;
-      }
+      case Stat.SPDEF:
+        return this.getAllyDefenseStageChangeScore(target, stat, levels);
+      case Stat.SPD:
+        return this.getAllySpeedStageChangeScore(target, stat, levels);
+      case Stat.ACC:
+        return this.getAllyAccuracyStageChangeScore(target, stat, levels);
+      case Stat.EVA:
+        return this.getAllyEvasivenessStageChangeScore(target, stat, levels);
     }
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Attack or Sp. Atk stage
+   * of an {@linkcode EnemyPokemon} with this attribute's effect. As long as the target
+   * Pokemon has a move that matches the stat's corresponding {@linkcode MoveCategory},
+   * this grants (+0.5) per stat stage.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getAllyAttackStageChangeScore(target: EnemyPokemon, stat: Stat.ATK | Stat.SPATK, levels: number): number {
+    const category = stat === Stat.ATK ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
+    const moveset = target.getMoveset().map((mv) => mv.getMove());
+
+    if (moveset.some((mv) => mv.category === category)) {
+      return 0.5 * levels;
+    }
+    return 0;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Defense or Sp. Def stage
+   * of an {@linkcode EnemyPokemon} with this attribute's effect. This checks the offensive stat affinities
+   * of each opponent (i.e. which is higher between `ATK` and `SPATK`).
+   * By default, this grants (+0.5) per stat stage, per opponent with a matching affinity. If the
+   * target's stage for the affected stat is at or above the {@linkcode DEFENSE_LOW_INCENTIVE_THRESHOLD},
+   * this bonus is halved. For `DEF` boosts, if the target has Body Press, this grants an additional (+1).
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getAllyDefenseStageChangeScore(target: EnemyPokemon, stat: Stat.DEF | Stat.SPDEF, levels: number): number {
+    const oppEffectiveStatOptions = {
+      abilityApplyMode: AbilityApplyMode.REVEALED,
+      simulated: true,
+    };
+
+    const [relevantStat, otherStat]: BattleStat[] = stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
+
+    const scoreMultiplier = target.getStatStage(stat) < DEFENSE_LOW_INCENTIVE_THRESHOLD ? 0.5 : 0.25;
+
+    const numOppsWithMatchingAffinity = target
+      .getOpponents()
+      .filter(
+        (opp) =>
+          opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
+          > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
+      ).length;
+
+    const bodyPressBonus = levels > 0 && target.hasMove(MoveId.BODY_PRESS) ? MINOR_EFFECT_SCORE_BONUS : 0;
+
+    return scoreMultiplier * numOppsWithMatchingAffinity * levels + bodyPressBonus;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Speed stage
+   * of an {@linkcode EnemyPokemon} with this attribute's effect. This grants
+   * (+1) for each opponent the target would surpass in turn order as a result of
+   * this effect.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getAllySpeedStageChangeScore(target: EnemyPokemon, stat: Stat.SPD, levels: number): number {
+    const effectiveStatOptions = { simulated: true };
+    const oppEffectiveStatOptions = {
+      abilityApplyMode: AbilityApplyMode.REVEALED,
+      simulated: true,
+    };
+
+    if (levels < 0) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+
+    const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
+    const startingSpdStage = target.getStatStage(stat);
+    const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
+
+    const finalSpdStage = startingSpdStage + levels;
+    const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
+
+    const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
+
+    const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
+      const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
+      return isBetween(oppSpd + 1, targetStartingSpd, targetStartingSpd * relativeSpdMultiplier);
+    }).length;
+
+    return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Accuracy stage of an
+   * {@linkcode EnemyPokemon} with this attribute's effect. If the target has a move with
+   * base accuracy below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD}, this grants
+   * (+0.5) per stat stage.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getAllyAccuracyStageChangeScore(target: EnemyPokemon, _stat: Stat.ACC, levels: number): number {
+    if (levels < 0) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+
+    const targetHasInaccurateMove = target
+      .getMoveset()
+      .some((pkmMove) => isBetween(pkmMove.getMove().accuracy, 0, LOW_ACCURACY_PENALTY_THRESHOLD));
+
+    return (targetHasInaccurateMove ? 0.5 : 0) * levels;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Evasiveness stage
+   * of an {@linkcode EnemyPokemon} with this attribute's effect. As long as the target's
+   * current Evasiveness stat stage is below the {@linkcode EVASION_BOOST_STAGE_LIMIT},
+   * this grants (+0.5) per stat stage.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getAllyEvasivenessStageChangeScore(target: EnemyPokemon, stat: Stat.EVA, levels: number): number {
+    if (target.getStatStage(stat) < EVASION_BOOST_STAGE_LIMIT) {
+      return 0.5 * levels;
+    }
+    return 0;
   }
 
   /**
@@ -272,12 +333,6 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     move: Move,
     stat: BattleStat,
   ): number {
-    const effectiveStatOptions = {
-      abilityApplyMode: AbilityApplyMode.REVEALED,
-      simulated: true,
-    };
-    const oppEffectiveStatOptions = { simulated: true };
-
     const levels = this.getAdjustedLevels(user, target, stat);
     if (levels === 0) {
       return move.isStatusMove() ? BAD_MOVE_PENALTY : 0;
@@ -289,79 +344,159 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
     switch (stat) {
       case Stat.ATK:
-      case Stat.SPATK: {
-        const category = stat === Stat.ATK ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
-        const moveset = target.estimateAttackMoves();
-
-        if (moveset.some((mv) => mv.category === category)) {
-          return -0.5 * levels;
-        }
-        return 0;
-      }
+      case Stat.SPATK:
+        return this.getOpponentAttackStageChangeScore(target, stat, levels);
       case Stat.DEF:
-      case Stat.SPDEF: {
-        const [relevantStat, otherStat]: BattleStat[] =
-          stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
-
-        const numOppsWithMatchingAffinity = target
-          .getOpponents()
-          .filter(
-            (opp) =>
-              opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
-              > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
-          ).length;
-
-        return -0.5 * numOppsWithMatchingAffinity * levels;
-      }
-      case Stat.SPD: {
-        if (levels > 0) {
-          return MINOR_EFFECT_SCORE_PENALTY;
-        }
-
-        const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
-        const startingSpdStage = target.getStatStage(stat);
-        const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
-
-        const finalSpdStage = startingSpdStage + levels;
-        const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
-
-        const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
-
-        const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
-          const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
-          return isBetween(oppSpd + 1, targetStartingSpd * relativeSpdMultiplier, targetStartingSpd);
-        }).length;
-
-        return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
-      }
-      case Stat.ACC: {
-        if (target.getStatStage(stat) > ACCURACY_REDUCTION_STAGE_LIMIT) {
-          return -0.5 * levels;
-        }
-        return 0;
-      }
-      case Stat.EVA: {
-        if (levels > 0) {
-          return MINOR_EFFECT_SCORE_PENALTY;
-        }
-
-        const oppHasInaccurateMove = target
-          .getOpponents()
-          .some((opp) =>
-            opp
-              .getMoveset()
-              .some((pkmMove) => isBetween(pkmMove.getMove().accuracy, 0, LOW_ACCURACY_PENALTY_THRESHOLD)),
-          );
-
-        return (oppHasInaccurateMove ? -0.5 : 0) * levels;
-      }
+      case Stat.SPDEF:
+        return this.getOpponentDefenseStageChangeScore(target, stat, levels);
+      case Stat.SPD:
+        return this.getOpponentSpeedStageChangeScore(target, stat, levels);
+      case Stat.ACC:
+        return this.getOpponentAccuracyStageChangeScore(target, stat, levels);
+      case Stat.EVA:
+        return this.getOpponentEvasivenessStageChangeScore(target, stat, levels);
     }
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Attack or Sp. Atk stage
+   * of a {@linkcode PlayerPokemon} with this attribute's effect. As long as the target
+   * Pokemon is expected to have a move that matches the stat's corresponding {@linkcode MoveCategory},
+   * this grants (-0.5) per stat stage.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getOpponentAttackStageChangeScore(
+    target: PlayerPokemon,
+    stat: Stat.ATK | Stat.SPATK,
+    levels: number,
+  ): number {
+    const category = stat === Stat.ATK ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
+    const moveset = target.estimateAttackMoves();
+
+    if (moveset.some((mv) => mv.category === category)) {
+      return -0.5 * levels;
+    }
+    return 0;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Defense or Sp. Def stage
+   * of a {@linkcode PlayerPokemon} with this attribute's effect. This checks the offensive stat
+   * affinities (i.e. which is higher between `ATK` and `SPATK`) of each of the target's
+   * opponents (i.e. the user and its ally, if active), and grants (-0.5) per stat stage,
+   * per opponent with a matching affinity.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getOpponentDefenseStageChangeScore(
+    target: PlayerPokemon,
+    stat: Stat.DEF | Stat.SPDEF,
+    levels: number,
+  ): number {
+    const oppEffectiveStatOptions = { simulated: true };
+
+    const [relevantStat, otherStat]: BattleStat[] = stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
+
+    const numOppsWithMatchingAffinity = target
+      .getOpponents()
+      .filter(
+        (opp) =>
+          opp.getEffectiveStat(relevantStat, oppEffectiveStatOptions)
+          > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
+      ).length;
+
+    return -0.5 * numOppsWithMatchingAffinity * levels;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Speed stage
+   * of a {@linkcode PlayerPokemon} with this attribute's effect. This grants (+1)
+   * for each opposing {@linkcode EnemyPokemon} that would surpass the target
+   * in turn order as a result of this effect.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getOpponentSpeedStageChangeScore(target: PlayerPokemon, stat: Stat.SPD, levels: number): number {
+    const effectiveStatOptions = {
+      abilityApplyMode: AbilityApplyMode.REVEALED,
+      simulated: true,
+    };
+    const oppEffectiveStatOptions = { simulated: true };
+
+    if (levels > 0) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+
+    const targetStartingSpd = target.getEffectiveStat(stat, effectiveStatOptions);
+    const startingSpdStage = target.getStatStage(stat);
+    const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
+
+    const finalSpdStage = startingSpdStage + levels;
+    const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
+
+    const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
+
+    const numOpponentsToOutspeed = target.getOpponents().filter((opp) => {
+      const oppSpd = opp.getEffectiveStat(stat, oppEffectiveStatOptions);
+      return isBetween(oppSpd + 1, targetStartingSpd * relativeSpdMultiplier, targetStartingSpd);
+    }).length;
+
+    return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Accuracy stage
+   * of a {@linkcode PlayerPokemon} with this attribute's effect. If the target's
+   * current Accuracy stat stage is above the {@linkcode ACCURACY_REDUCTION_STAGE_LIMIT},
+   * this grants (-0.5) per stat stage.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getOpponentAccuracyStageChangeScore(target: PlayerPokemon, stat: Stat.ACC, levels: number): number {
+    if (target.getStatStage(stat) > ACCURACY_REDUCTION_STAGE_LIMIT) {
+      return -0.5 * levels;
+    }
+    return 0;
+  }
+
+  /**
+   * Calculates the raw Effect Score gained from changing the Evasiveness stage
+   * of a {@linkcode PlayerPokemon} with this attribute's effect. If any of the opposing
+   * {@linkcode EnemyPokemon} know a move with base accuracy below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
+   * this grants (-0.5) per stat stage.
+   * @param target - The {@linkcode EnemyPokemon} to which the effect may apply
+   * @param stat - The {@linkcode Stat} being modified
+   * @param levels - The number of stages this attribute's effect will grant to the target
+   * @returns The raw Effect Score (can be a decimal value)
+   */
+  private getOpponentEvasivenessStageChangeScore(target: PlayerPokemon, _stat: Stat.EVA, levels: number): number {
+    if (levels > 0) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+
+    const oppHasInaccurateMove = target
+      .getOpponents()
+      .some((opp) =>
+        opp.getMoveset().some((pkmMove) => isBetween(pkmMove.getMove().accuracy, 0, LOW_ACCURACY_PENALTY_THRESHOLD)),
+      );
+
+    return (oppHasInaccurateMove ? -0.5 : 0) * levels;
   }
 
   /**
    * Computes the final amount of stat stages changed for the given stat based on
    * the target's known abilities. This accounts for cancelling effects such as
-   * Mist and Clear Body and multipliers such as Simple and Contrary.
+   * Mist and Clear Body, multipliers such as Simple and Contrary, and minimum and
+   * maximum total stat stage limits.
    * @param user - The {@linkcode EnemyPokemon} evaluating a move with this effect
    * @param target - The {@linkcode Pokemon} the effect is evaluated against
    * @param stat - The {@linkcode Stat} for which the stages are evaluated

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -1,11 +1,21 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { StatStageChangePhase } from "#phases/stat-stage-change-phase";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
+import { getAbApplyFunc } from "#abilities/apply-ab-attrs";
+import type { ProtectStatAbAttr } from "#abilities/protect-stat-ab-attr";
+import type { StatStageChangeMultiplierAbAttr } from "#abilities/stat-stage-change-multiplier-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { MistTag } from "#arena-tags/mist-tag";
 import {
   LOW_ACCURACY_PENALTY_THRESHOLD,
   MINOR_EFFECT_SCORE_BONUS,
   MINOR_EFFECT_SCORE_PENALTY,
   SOFT_EFFECT_SCORE_LIMIT,
 } from "#constants/ai-constants";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveCategory } from "#enums/move-category";
 import { type BattleStat, Stat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
@@ -13,7 +23,7 @@ import type { Pokemon } from "#field/pokemon";
 import { ChanceBasedMoveEffectAttr, type ChanceBasedMoveEffectAttrOptions } from "#moves/chance-based-move-effect-attr";
 import type { Move } from "#moves/move";
 import type { MoveConditionFunc } from "#types/move-types";
-import { isBetween } from "#utils/common-utils";
+import { BooleanHolder, isBetween, NumberHolder } from "#utils/common-utils";
 
 /**
  * Set of optional parameters that may be applied to stat stage changing effects
@@ -93,6 +103,11 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     return Math.min(super.getEffectScore(user, target, move), SOFT_EFFECT_SCORE_LIMIT);
   }
 
+  /**
+   * @returns The combined raw Effect Score for each of this attribute's stats.
+   * @see {@linkcode getAllyTargetScoreByStat}
+   * @see {@linkcode getOpposingTargetScoreByStat}
+   */
   public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
     if (this.selfTarget) {
       return this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, user, stat), 0);
@@ -101,18 +116,46 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     return this.stats.reduce((score, stat) => score + this.getOpposingTargetScoreByStat(user, target, stat), 0);
   }
 
+  /**
+   * @returns The combined Effect Score for each of this attribute's stats, {@link getTieredScore | tiered} and
+   * upper-bounded by {@linkcode SOFT_EFFECT_SCORE_LIMIT} to yield the final score.
+   * @see {@linkcode getAllyTargetScoreByStat}
+   */
   public override getAllyTargetScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     const rawScore = this.stats.reduce((score, stat) => score + this.getAllyTargetScoreByStat(user, target, stat), 0);
 
     return Math.min(this.getTieredScore(user, target, move, rawScore), SOFT_EFFECT_SCORE_LIMIT);
   }
 
+  /**
+   * Calculates the Effect Score gained (before factoring in effect chance) from modifying a single
+   * stat stage with this effect on either the user or its ally. The heuristic for this scoring varies based
+   * on the stat changed:
+   * - `ATK` / `SPATK`: If the target has a move of matching {@linkcode MoveCategory}, grant (+0.5) per stat stage.
+   * - `DEF` / `SPDEF`: Check the offensive stat affinities of each opponent (i.e. which is higher between
+   * `ATK` and `SPATK`). This grants (+0.5) per stat stage, per opponent with a matching affinity.
+   * - `SPD`: Grants (+1) per opponent that the target would outspeed as a result of this effect.
+   * - `ACC`: If the target has at least one move whose accuracy falls below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
+   * grant, (+0.5) per stat stage.
+   * - `EVA`: Grants (+0.5) per stat stage.
+   * @param user - The {@linkcode Pokemon} evaluating this effect
+   * @param target - The {@linkcode Pokemon} this effect is evaluated against. This can be assumed to be either the
+   * user or its ally.
+   * @param stat - The {@linkcode BattleStat} being evaluated
+   * @returns The "raw" Effect Score bonus (or penalty) for the given stat. This score is combined with other
+   * stats and {@link getTieredScore | tiered} to yield the final Effect Score.
+   */
   private getAllyTargetScoreByStat(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
     const effectiveStatOptions = { simulated: true };
     const oppEffectiveStatOptions = {
       abilityApplyMode: AbilityApplyMode.REVEALED,
       simulated: true,
     };
+
+    const levels = this.getAdjustedLevels(user, target, stat);
+    if (levels === 0) {
+      return 0;
+    }
 
     switch (stat) {
       case Stat.ATK:
@@ -121,7 +164,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         const moveset = target.getMoveset().map((mv) => mv.getMove());
 
         if (moveset.some((mv) => mv.category === category)) {
-          return 0.5 * this.getLevels(user);
+          return 0.5 * levels;
         }
         return 0;
       }
@@ -138,10 +181,10 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
               > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
           ).length;
 
-        return 0.5 * numOppsWithMatchingAffinity * this.getLevels(user);
+        return 0.5 * numOppsWithMatchingAffinity * levels;
       }
       case Stat.SPD: {
-        if (this.getLevels(user) < 0) {
+        if (levels < 0) {
           return MINOR_EFFECT_SCORE_PENALTY;
         }
 
@@ -149,7 +192,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         const startingSpdStage = target.getStatStage(stat);
         const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
 
-        const finalSpdStage = startingSpdStage + this.getLevels(user);
+        const finalSpdStage = startingSpdStage + levels;
         const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
 
         const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
@@ -162,7 +205,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
       }
       case Stat.ACC: {
-        if (this.getLevels(user) < 0) {
+        if (levels < 0) {
           return MINOR_EFFECT_SCORE_PENALTY;
         }
 
@@ -170,19 +213,43 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
           .getMoveset()
           .some((pkmMove) => pkmMove.getMove().accuracy < LOW_ACCURACY_PENALTY_THRESHOLD);
 
-        return (targetHasInaccurateMove ? 0.5 : 0) * this.getLevels(user);
+        return (targetHasInaccurateMove ? 0.5 : 0) * levels;
       }
       case Stat.EVA:
-        return 0.5 * this.getLevels(user);
+        return 0.5 * levels;
     }
   }
 
+  /**
+   * Calculates the Effect Score gained (before factoring in effect chance) from modifying a single
+   * stat stage with this effect on one of the user's opponents. The heuristic for this scoring varies based
+   * on the stat changed:
+   * - `ATK` / `SPATK`: If the target has a move of matching {@linkcode MoveCategory}, grant (-0.5) per stat stage.
+   * - `DEF` / `SPDEF`: Check the offensive stat affinities (i.e. which is higher between
+   * `ATK` and `SPATK`) of each of the target's opponents (i.e. the user and its ally, if active).
+   * This grants (-0.5) per stat stage, per opponent with a matching affinity.
+   * - `SPD`: Grants (+1) for each of the target's opponents that would outspeed the target as a result of this effect.
+   * - `ACC`: Grants (-0.5) per stat stage.
+   * - `EVA`: If any of the target's opponents has at least one move whose accuracy falls below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
+   * grant (+0.5) per stat stage.
+   * @param user - The {@linkcode Pokemon} evaluating this effect
+   * @param target - The {@linkcode Pokemon} this effect is evaluated against. This can be assumed to be one of
+   * the user's opponents.
+   * @param stat - The {@linkcode BattleStat} being evaluated
+   * @returns The "raw" Effect Score bonus (or penalty) for the given stat. This score is combined with other
+   * stats and {@link getTieredScore | tiered} to yield the final Effect Score.
+   */
   private getOpposingTargetScoreByStat(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
     const effectiveStatOptions = {
       abilityApplyMode: AbilityApplyMode.REVEALED,
       simulated: true,
     };
     const oppEffectiveStatOptions = { simulated: true };
+
+    const levels = this.getAdjustedLevels(user, target, stat);
+    if (levels === 0) {
+      return 0;
+    }
 
     switch (stat) {
       case Stat.ATK:
@@ -191,7 +258,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         const moveset = target.estimateAttackMoves();
 
         if (moveset.some((mv) => mv.category === category)) {
-          return -0.5 * this.getLevels(user);
+          return -0.5 * levels;
         }
         return 0;
       }
@@ -208,10 +275,10 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
               > opp.getEffectiveStat(otherStat, oppEffectiveStatOptions),
           ).length;
 
-        return -0.5 * numOppsWithMatchingAffinity * this.getLevels(user);
+        return -0.5 * numOppsWithMatchingAffinity * levels;
       }
       case Stat.SPD: {
-        if (this.getLevels(user) > 0) {
+        if (levels > 0) {
           return MINOR_EFFECT_SCORE_PENALTY;
         }
 
@@ -219,7 +286,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         const startingSpdStage = target.getStatStage(stat);
         const startingSpdMultiplier = Math.max(2, 2 + startingSpdStage) / Math.max(2, 2 - startingSpdStage);
 
-        const finalSpdStage = startingSpdStage + this.getLevels(user);
+        const finalSpdStage = startingSpdStage + levels;
         const finalSpdMultiplier = Math.max(2, 2 + finalSpdStage) / Math.max(2, 2 - finalSpdStage);
 
         const relativeSpdMultiplier = finalSpdMultiplier / startingSpdMultiplier;
@@ -232,9 +299,9 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
       }
       case Stat.ACC:
-        return -0.5 * this.getLevels(user);
+        return -0.5 * levels;
       case Stat.EVA: {
-        if (this.getLevels(user) > 0) {
+        if (levels > 0) {
           return MINOR_EFFECT_SCORE_PENALTY;
         }
 
@@ -244,8 +311,42 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
             opp.getMoveset().some((pkmMove) => pkmMove.getMove().accuracy < LOW_ACCURACY_PENALTY_THRESHOLD),
           );
 
-        return (oppHasInaccurateMove ? -0.5 : 0) * this.getLevels(user);
+        return (oppHasInaccurateMove ? -0.5 : 0) * levels;
       }
     }
+  }
+
+  /**
+   * Computes the final amount of stat stages changed for the given stat based on
+   * the target's known abilities. This accounts for cancelling effects such as
+   * Mist and Clear Body and multipliers such as Simple and Contrary.
+   * @param user - The {@linkcode EnemyPokemon} evaluating a move with this effect
+   * @param target - The {@linkcode Pokemon} the effect is evaluated against
+   * @param stat - The {@linkcode Stat} for which the stages are evaluated
+   * @returns The final stat stage change after external effects are accounted for
+   *
+   * @privateRemarks This is only to be used in Enemy AI Effect Score calculations.
+   * @todo Much of this is replicated from {@linkcode StatStageChangePhase}, which
+   * should be refactored to make this logic more easily accessible outside of the Phase itself
+   */
+  private getAdjustedLevels(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
+    const abApplyFunc = getAbApplyFunc(target.isOpponent(user) ? AbilityApplyMode.REVEALED : AbilityApplyMode.DEFAULT);
+    const stages = new NumberHolder(this.getLevels(user));
+
+    if (!this.selfTarget && stages.value < 0) {
+      const cancelled = new BooleanHolder(false);
+      globalScene.arena.applyTags<MistTag>(ArenaTagType.MIST, target.getArenaTagSide(), true, user, cancelled);
+
+      if (!cancelled.value) {
+        abApplyFunc<ProtectStatAbAttr>(AbAttrFlag.PROTECT_STAT, target, true, stat, cancelled);
+      }
+
+      if (cancelled.value) {
+        return 0;
+      }
+    }
+
+    abApplyFunc<StatStageChangeMultiplierAbAttr>(AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER, target, true, stages);
+    return stages.value;
   }
 }

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -9,7 +9,10 @@ import { globalScene } from "#app/global-scene";
 import type { MistTag } from "#arena-tags/mist-tag";
 import { POST_STAT_STAGE_REDUCTION_ABILITIES } from "#constants/ability-constants";
 import {
+  ACCURACY_REDUCTION_STAGE_LIMIT,
   BAD_MOVE_PENALTY,
+  DEFENSE_LOW_INCENTIVE_THRESHOLD,
+  EVASION_BOOST_STAGE_LIMIT,
   LOW_ACCURACY_PENALTY_THRESHOLD,
   MAJOR_EFFECT_SCORE_PENALTY,
   MINOR_EFFECT_SCORE_BONUS,
@@ -144,12 +147,14 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * on the stat changed:
    * - `ATK` / `SPATK`: If the target has a move of matching {@linkcode MoveCategory}, grant (+0.5) per stat stage.
    * - `DEF` / `SPDEF`: Check the offensive stat affinities of each opponent (i.e. which is higher between
-   * `ATK` and `SPATK`). This grants (+0.5) per stat stage, per opponent with a matching affinity. For `DEF`
-   * boosts, if the target has Body Press, this grants an additional (+1).
+   * `ATK` and `SPATK`). This grants (+0.5) per stat stage, per opponent with a matching affinity. If the
+   * target's stage for the affected stat is at or above the {@linkcode DEFENSE_LOW_INCENTIVE_THRESHOLD},
+   * this bonus is halved. For `DEF` boosts, if the target has Body Press, this grants an additional (+1).
    * - `SPD`: Grants (+1) per opponent that the target would outspeed as a result of this effect.
    * - `ACC`: If the target has at least one move whose accuracy falls below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
    * grant, (+0.5) per stat stage.
-   * - `EVA`: Grants (+0.5) per stat stage.
+   * - `EVA`: Grants (+0.5) per stat stage unless the target's `EVA` stat stage is at or above the
+   * {@linkcode EVASION_BOOST_STAGE_LIMIT}.
    * @param user - The {@linkcode Pokemon} evaluating this effect
    * @param target - The {@linkcode Pokemon} this effect is evaluated against. This can be assumed to be either the
    * user or its ally.
@@ -186,6 +191,8 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
         const [relevantStat, otherStat]: BattleStat[] =
           stat === Stat.DEF ? [Stat.ATK, Stat.SPATK] : [Stat.SPATK, Stat.ATK];
 
+        const scoreMultiplier = target.getStatStage(stat) < DEFENSE_LOW_INCENTIVE_THRESHOLD ? 0.5 : 0.25;
+
         const numOppsWithMatchingAffinity = target
           .getOpponents()
           .filter(
@@ -196,7 +203,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
         const bodyPressBonus = levels > 0 && target.hasMove(MoveId.BODY_PRESS) ? MINOR_EFFECT_SCORE_BONUS : 0;
 
-        return 0.5 * numOppsWithMatchingAffinity * levels + bodyPressBonus;
+        return scoreMultiplier * numOppsWithMatchingAffinity * levels + bodyPressBonus;
       }
       case Stat.SPD: {
         if (levels < 0) {
@@ -230,8 +237,12 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
         return (targetHasInaccurateMove ? 0.5 : 0) * levels;
       }
-      case Stat.EVA:
-        return 0.5 * levels;
+      case Stat.EVA: {
+        if (target.getStatStage(stat) < EVASION_BOOST_STAGE_LIMIT) {
+          return 0.5 * levels;
+        }
+        return 0;
+      }
     }
   }
 
@@ -244,7 +255,7 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
    * `ATK` and `SPATK`) of each of the target's opponents (i.e. the user and its ally, if active).
    * This grants (-0.5) per stat stage, per opponent with a matching affinity.
    * - `SPD`: Grants (+1) for each of the target's opponents that would outspeed the target as a result of this effect.
-   * - `ACC`: Grants (-0.5) per stat stage.
+   * - `ACC`: Grants (-0.5) per stat stage unless the target's `ACC` stat stage is at or below the {@linkcode ACCURACY_REDUCTION_STAGE_LIMIT}.
    * - `EVA`: If any of the target's opponents has at least one move whose accuracy falls below the {@linkcode LOW_ACCURACY_PENALTY_THRESHOLD},
    * grant (+0.5) per stat stage.
    * @param user - The {@linkcode Pokemon} evaluating this effect
@@ -323,8 +334,12 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
 
         return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
       }
-      case Stat.ACC:
-        return -0.5 * levels;
+      case Stat.ACC: {
+        if (target.getStatStage(stat) > ACCURACY_REDUCTION_STAGE_LIMIT) {
+          return -0.5 * levels;
+        }
+        return 0;
+      }
       case Stat.EVA: {
         if (levels > 0) {
           return MINOR_EFFECT_SCORE_PENALTY;

--- a/src/data/moves/move-attrs/stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/stat-stage-change-attr.ts
@@ -27,7 +27,7 @@ import type { Pokemon } from "#field/pokemon";
 import { ChanceBasedMoveEffectAttr, type ChanceBasedMoveEffectAttrOptions } from "#moves/chance-based-move-effect-attr";
 import type { Move } from "#moves/move";
 import type { MoveConditionFunc } from "#types/move-types";
-import { BooleanHolder, isBetween, NumberHolder } from "#utils/common-utils";
+import { BooleanHolder, clamp, isBetween, NumberHolder } from "#utils/common-utils";
 
 /**
  * Set of optional parameters that may be applied to stat stage changing effects
@@ -363,6 +363,9 @@ export class StatStageChangeAttr extends ChanceBasedMoveEffectAttr {
     }
 
     abApplyFunc<StatStageChangeMultiplierAbAttr>(AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER, target, true, stages);
+
+    const currentStages = target.getStatStage(stat);
+    stages.value = clamp(stages.value, -6 - currentStages, 6 - currentStages);
     return stages.value;
   }
 }

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -102,18 +102,18 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
    * @see {@linkcode BURN_SYNERGY_ABILITIES}
    * @see {@linkcode POISON_SYNERGY_ABILITIES}
    */
-  public override getAllyTargetScore(user: EnemyPokemon, ally: Pokemon, _move: Move): number | null {
-    if (!ally.canSetStatus(this.effect, true, this.overrideStatus, user)) {
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, _move: Move): number | null {
+    if (!target.canSetStatus(this.effect, true, this.overrideStatus, user)) {
       return null;
     }
 
-    if (this.effect === StatusEffect.BURN && BURN_SYNERGY_ABILITIES.some((abId) => ally.hasAbility(abId))) {
+    if (this.effect === StatusEffect.BURN && BURN_SYNERGY_ABILITIES.some((abId) => target.hasAbility(abId))) {
       return this.getRandomScore(user, 80, MAJOR_EFFECT_SCORE_BONUS);
     }
 
     if (
       [StatusEffect.POISON, StatusEffect.TOXIC].includes(this.effect)
-      && POISON_SYNERGY_ABILITIES.some((abId) => ally.hasAbility(abId))
+      && POISON_SYNERGY_ABILITIES.some((abId) => target.hasAbility(abId))
     ) {
       /**
        * The chance to grant a bonus for poisoning the user's ally (with a status move).

--- a/src/data/moves/move-attrs/status-effect-attr.ts
+++ b/src/data/moves/move-attrs/status-effect-attr.ts
@@ -11,9 +11,8 @@ import {
   POISON_SYNERGY_ABILITIES,
   POISONING_SYNERGY_ABILITIES,
 } from "#constants/ability-constants";
-import { BAD_MOVE_PENALTY, MAJOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
+import { BAD_MOVE_PENALTY, MAJOR_EFFECT_SCORE_BONUS, OPP_EFFECTIVE_STAT_OPTIONS } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
-import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { MoveCategory } from "#enums/move-category";
 import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
@@ -162,12 +161,8 @@ export class StatusEffectAttr extends ChanceBasedMoveEffectAttr {
       case StatusEffect.FREEZE:
         return 2.5;
       case StatusEffect.BURN: {
-        const effectiveStatOptions = {
-          abilityApplyMode: AbilityApplyMode.REVEALED,
-          simulated: true,
-        };
-        return target.getEffectiveStat(Stat.ATK, effectiveStatOptions)
-          > target.getEffectiveStat(Stat.SPATK, effectiveStatOptions)
+        return target.getEffectiveStat(Stat.ATK, OPP_EFFECTIVE_STAT_OPTIONS)
+          > target.getEffectiveStat(Stat.SPATK, OPP_EFFECTIVE_STAT_OPTIONS)
           ? 2
           : 1;
       }

--- a/src/data/moves/move-attrs/telekinesis-attr.ts
+++ b/src/data/moves/move-attrs/telekinesis-attr.ts
@@ -1,3 +1,4 @@
+import { LOW_ACCURACY_PENALTY_THRESHOLD } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -22,7 +23,11 @@ export class TelekinesisAttr extends AddBattlerTagAttr {
     if (
       user
         .getField()
-        .some((p) => p.getMoveset().some((mv) => mv.getMove().calculateBattleAccuracy(p, target, true) < 80))
+        .some((p) =>
+          p
+            .getMoveset()
+            .some((mv) => mv.getMove().calculateBattleAccuracy(p, target, true) < LOW_ACCURACY_PENALTY_THRESHOLD),
+        )
     ) {
       return this.getRandomScore(user, 40);
     }

--- a/src/data/moves/move-conditions/shell-trap-condition.ts
+++ b/src/data/moves/move-conditions/shell-trap-condition.ts
@@ -1,6 +1,5 @@
 import type { ShellTrapTag } from "#battler-tags/shell-trap-tag";
-import { MAJOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
-import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import { MAJOR_EFFECT_SCORE_PENALTY, OPP_EFFECTIVE_STAT_OPTIONS } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { Stat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
@@ -30,7 +29,7 @@ export class ShellTrapCondition extends MoveCondition {
     const effectiveStatOptions = {
       opponent: user,
       move,
-      abilityApplyMode: AbilityApplyMode.REVEALED,
+      ...OPP_EFFECTIVE_STAT_OPTIONS,
     };
 
     return opponents

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -822,7 +822,7 @@ export abstract class Move {
     isKnockOut: boolean,
     isFail: boolean,
   ): number {
-    if (target === user.getAlly()) {
+    if (target.isAlly(user)) {
       /*
        * Attacks (other than Pollen Puff) are always penalized against allies
        * TODO:

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3045,12 +3045,24 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Compares if `this` and {@linkcode target} are on the same team.
+   * Compares if `this` and {@linkcode target} are opponents to each other.
    * @param target the {@linkcode Pokemon} to compare against.
-   * @returns `true` if the two pokemon are allies, `false` otherwise
+   * @returns `true` if the two pokemon are opponents, `false` otherwise
    */
   public isOpponent(target: Pokemon): boolean {
     return this.isPlayer() !== target.isPlayer();
+  }
+
+  /**
+   * Checks if `this` and a given active {@linkcode target} are allies. This can
+   * also be used to assert if `this` is of the same class as the target.
+   * @param target - The active {@linkcode Pokemon} to check
+   * @returns `true` if the two pokemon are allies
+   */
+  public isAlly(target: PlayerPokemon): this is PlayerPokemon;
+  public isAlly(target: EnemyPokemon): this is EnemyPokemon;
+  public isAlly(target: PlayerPokemon | EnemyPokemon): this is typeof target {
+    return this === target.getAlly();
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -219,7 +219,7 @@ interface DamageFunctionOptions {
   source?: Pokemon;
 }
 
-interface EffectiveStatOptions {
+export interface EffectiveStatOptions {
   /** The opposing {@linkcode Pokemon}, usually involved in an incoming or outgoing attack */
   opponent?: Pokemon;
   /** The {@linkcode Move} being used */

--- a/test/ai/move-effect-scores/agility.test.ts
+++ b/test/ai/move-effect-scores/agility.test.ts
@@ -1,0 +1,68 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Agility", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.AGILITY, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when using the move would improve the user's turn order", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStat(Stat.SPD, 75);
+    enemy.setStat(Stat.SPD, 50);
+
+    expect(enemy).toPreferSelectingMove(MoveId.AGILITY);
+  });
+
+  it("should not be preferred when using the move would not improve the user's turn order", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStat(Stat.SPD, 75);
+    enemy.setStat(Stat.SPD, 100);
+
+    expect(enemy).not.toPreferSelectingMove(MoveId.AGILITY);
+  });
+
+  it("should be avoided when the user has Contrary", async () => {
+    game.override.enemyAbility(AbilityId.CONTRARY);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStat(Stat.SPD, 75);
+    enemy.setStat(Stat.SPD, 50);
+
+    expect(enemy).toNeverSelectMove(MoveId.AGILITY);
+  });
+});

--- a/test/ai/move-effect-scores/belly-drum.test.ts
+++ b/test/ai/move-effect-scores/belly-drum.test.ts
@@ -1,0 +1,58 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Belly Drum", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.BELLY_DRUM, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be strongly preferred when the user isn't defensively threatened by the opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.BELLY_DRUM);
+  });
+
+  it("should be avoided when the user is defensively threatened by the opponent", async () => {
+    game.override.moveset(MoveId.THUNDERBOLT);
+    await game.classicMode.startBattle(SpeciesId.REGIELEKI);
+
+    revealAllMoves(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.BELLY_DRUM);
+  });
+
+  it("should be avoided when the user has Contrary", async () => {
+    game.override.enemyAbility(AbilityId.CONTRARY);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.BELLY_DRUM);
+  });
+});

--- a/test/ai/move-effect-scores/charm.test.ts
+++ b/test/ai/move-effect-scores/charm.test.ts
@@ -1,0 +1,72 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Charm", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.CHARM, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the opponent is a physical attacker", async () => {
+    await game.classicMode.startBattle(SpeciesId.DRILBUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.CHARM);
+  });
+
+  it("should not be preferred when the opponent is a special attacker", async () => {
+    await game.classicMode.startBattle(SpeciesId.SOBBLE);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.CHARM);
+  });
+
+  it("should be strongly preferred when the opponent is known to have Simple", async () => {
+    game.override.ability(AbilityId.SIMPLE);
+
+    await game.classicMode.startBattle(SpeciesId.DRILBUR);
+
+    revealAllAbilities(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.CHARM);
+  });
+
+  it.each([
+    { abilityName: "Contrary", abilityId: AbilityId.CONTRARY },
+    { abilityName: "Clear Body", abilityId: AbilityId.CLEAR_BODY },
+    { abilityName: "White Smoke", abilityId: AbilityId.WHITE_SMOKE },
+    { abilityName: "Hyper Cutter", abilityId: AbilityId.HYPER_CUTTER },
+  ])("should be avoided when the opponent is known to have $abilityName", async ({ abilityId }) => {
+    game.override.ability(abilityId);
+
+    await game.classicMode.startBattle(SpeciesId.DRILBUR);
+
+    revealAllAbilities(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.CHARM);
+  });
+});

--- a/test/ai/move-effect-scores/defog.test.ts
+++ b/test/ai/move-effect-scores/defog.test.ts
@@ -68,7 +68,9 @@ describe("Move Effect Scores - Defog", () => {
     { tagName: "Reflect", tagType: ArenaTagType.REFLECT },
     { tagName: "Aurora Veil", tagType: ArenaTagType.AURORA_VEIL },
     { tagName: "Safeguard", tagType: ArenaTagType.SAFEGUARD },
-    { tagName: "Mist", tagType: ArenaTagType.MIST },
+    // TODO: Because Mist blocks the evasiveness drop, Defog is
+    // harshly penalized into it.
+    // { tagName: "Mist", tagType: ArenaTagType.MIST },
   ])("Screen Removal", ({ tagName, tagType }) => {
     it(`should be preferred when ${tagName} is on the opponent's side of the field`, async () => {
       await game.classicMode.startBattle(SpeciesId.MAGIKARP);

--- a/test/ai/move-effect-scores/iron-defense.test.ts
+++ b/test/ai/move-effect-scores/iron-defense.test.ts
@@ -1,0 +1,73 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Iron Defense", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.IRON_DEFENSE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the opponent is a physical attacker", async () => {
+    await game.classicMode.startBattle(SpeciesId.DRILBUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.IRON_DEFENSE);
+  });
+
+  it("should not be preferred when the opponent is a special attacker", async () => {
+    await game.classicMode.startBattle(SpeciesId.SOBBLE);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.IRON_DEFENSE);
+  });
+
+  it("should be strongly preferred when the user has Simple", async () => {
+    game.override.enemyAbility(AbilityId.SIMPLE);
+
+    await game.classicMode.startBattle(SpeciesId.DRILBUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.IRON_DEFENSE);
+  });
+
+  it("should be avoided when the user has Contrary", async () => {
+    game.override.enemyAbility(AbilityId.CONTRARY);
+
+    await game.classicMode.startBattle(SpeciesId.DRILBUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.IRON_DEFENSE);
+  });
+
+  it("should be preferred when the user knows Body Press", async () => {
+    game.override.enemyMoveset([MoveId.IRON_DEFENSE, MoveId.BODY_PRESS, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGCARGO);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.IRON_DEFENSE);
+  });
+});

--- a/test/ai/move-effect-scores/scary-face.test.ts
+++ b/test/ai/move-effect-scores/scary-face.test.ts
@@ -1,0 +1,77 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Scary Face", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SCARY_FACE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when using the move would improve the user's turn order", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    player.setStat(Stat.SPD, 75);
+    enemy.setStat(Stat.SPD, 50);
+
+    expect(enemy).toPreferSelectingMove(MoveId.SCARY_FACE);
+  });
+
+  it("should not be preferred when using the move would not improve the user's turn order", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    player.setStat(Stat.SPD, 50);
+    enemy.setStat(Stat.SPD, 75);
+
+    expect(enemy).not.toPreferSelectingMove(MoveId.SCARY_FACE);
+  });
+
+  it.each([
+    { abilityName: "Contrary", abilityId: AbilityId.CONTRARY },
+    { abilityName: "Clear Body", abilityId: AbilityId.CLEAR_BODY },
+    { abilityName: "White Smoke", abilityId: AbilityId.WHITE_SMOKE },
+  ])("should be avoided when the opponent is known to have $abilityName", async ({ abilityId }) => {
+    game.override.ability(abilityId);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    revealAllAbilities(game.scene);
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    player.setStat(Stat.SPD, 75);
+    enemy.setStat(Stat.SPD, 50);
+
+    expect(enemy).toNeverSelectMove(MoveId.SCARY_FACE);
+  });
+});

--- a/test/ai/move-effect-scores/screech.test.ts
+++ b/test/ai/move-effect-scores/screech.test.ts
@@ -1,0 +1,74 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Screech", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SCREECH, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user is a physical attacker", async () => {
+    game.override.enemySpecies(SpeciesId.DRILBUR);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SCREECH);
+  });
+
+  it("should not be preferred when the user is a special attacker", async () => {
+    game.override.enemySpecies(SpeciesId.SOBBLE);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.SCREECH);
+  });
+
+  it("should be strongly preferred when the opponent is known to have Simple", async () => {
+    game.override.enemySpecies(SpeciesId.DRILBUR).ability(AbilityId.SIMPLE);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    revealAllAbilities(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SCREECH);
+  });
+
+  it.each([
+    { abilityName: "Contrary", abilityId: AbilityId.CONTRARY },
+    { abilityName: "Clear Body", abilityId: AbilityId.CLEAR_BODY },
+    { abilityName: "White Smoke", abilityId: AbilityId.WHITE_SMOKE },
+  ])("should be avoided when the opponent is known to have $abilityName", async ({ abilityId }) => {
+    game.override.enemySpecies(SpeciesId.DRILBUR).ability(abilityId);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    revealAllAbilities(game.scene);
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SCREECH);
+  });
+});

--- a/test/ai/move-effect-scores/strength-sap.test.ts
+++ b/test/ai/move-effect-scores/strength-sap.test.ts
@@ -52,8 +52,7 @@ describe("Move Effect Scores - Strength Sap", () => {
     expect(enemy).toNeverSelectMove(MoveId.STRENGTH_SAP);
   });
 
-  // TODO: the AI should be aware of Clear Body once stat stage changes are scored
-  it.todo("should be avoided when the opponent has Clear Body", async () => {
+  it("should be avoided when the opponent has Clear Body", async () => {
     game.override.ability(AbilityId.CLEAR_BODY);
 
     await game.classicMode.startBattle(SpeciesId.EXCADRILL);

--- a/test/ai/move-effect-scores/swords-dance.test.ts
+++ b/test/ai/move-effect-scores/swords-dance.test.ts
@@ -1,0 +1,66 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Swords Dance", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SWORDS_DANCE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user has a physical attack", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SWORDS_DANCE);
+  });
+
+  it("should not be preferred when the user does not have a physical attack", async () => {
+    game.override.enemyMoveset([MoveId.SWORDS_DANCE, MoveId.SPLASH, MoveId.WATER_GUN]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.SWORDS_DANCE);
+  });
+
+  it("should be strongly preferred when the user has Simple", async () => {
+    game.override.enemyAbility(AbilityId.SIMPLE);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SWORDS_DANCE);
+  });
+
+  it("should be avoided when the user has Contrary", async () => {
+    game.override.enemyAbility(AbilityId.CONTRARY);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SWORDS_DANCE);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

The AI should now properly evaluate moves that increase or decrease one or more Pokemon's stat stages.

## Why am I making these changes?

Part of the AI Rework.

## What are the changes from a developer perspective?

- Added scoring logic for `StatStageChangeAttr` and subclass `CutHpStatStageBoostAttr`.
- Added some helper methods for scoring to `ChanceBasedMoveEffectAttr` so that ally target scores can apply chance-based tiering on a per-attribute basis

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`

New unit tests (can be run with `pnpm test[:silent] move-effect-scores/testName`):
- `swords-dance`
- `iron-defense`
- `agility`
- `charm`
- `screech`
- `scary-face`
- `strength-sap` (1 newly enabled test)
- `belly-drum`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
