### PR TITLE
ai-rework: Add Effect Scores for misc. stat-modifying attributes

### DIFF
--- a/src/data/moves/move-attrs/acupressure-stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/acupressure-stat-stage-change-attr.ts
@@ -1,15 +1,21 @@
+import { applyAbAttrs } from "#abilities/apply-ab-attrs";
+import type { StatStageChangeMultiplierAbAttr } from "#abilities/stat-stage-change-multiplier-ab-attr";
 import { globalScene } from "#app/global-scene";
+import { BAD_MOVE_PENALTY, MINOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
+import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BATTLE_STATS } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
+import { ValueHolder } from "#utils/common-utils";
 
 /**
  * Attribute to increase a random stat on the user by 2 stages.
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Acupressure_(move) | Acupressure}.
  */
 export class AcupressureStatStageChangeAttr extends MoveEffectAttr {
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
     const randStats = BATTLE_STATS.filter((s) => target.getStatStage(s) < 6);
     if (randStats.length > 0) {
       const boostStat = [randStats[user.randSeedInt(randStats.length)]];
@@ -23,5 +29,35 @@ export class AcupressureStatStageChangeAttr extends MoveEffectAttr {
       return true;
     }
     return false;
+  }
+
+  /**
+   * @returns 75%(+1) if the target is projected to gain stats from this effect (i.e. the
+   * target doesn't have Contrary). Otherwise, this grants a {@linkcode BAD_MOVE_PENALTY}
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const statGain = this.getProjectedStatGain(target);
+    if (statGain <= 0) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    return this.getRandomScore(user, 75);
+  }
+
+  /** @returns The output of {@linkcode getEffectScore} with an additional {@linkcode MINOR_EFFECT_SCORE_BONUS} */
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, move: Move): number {
+    return this.getEffectScore(user, target, move) + MINOR_EFFECT_SCORE_BONUS;
+  }
+
+  /**
+   * @param target - The {@linkcode Pokemon} to be targeted by this effect
+   * @returns The projected number of stat stages the target will gain from this effect, accounting for
+   * multipliers such as Simple and Contrary.
+   */
+  private getProjectedStatGain(target: Pokemon): number {
+    const statGain = new ValueHolder(2);
+    applyAbAttrs<StatStageChangeMultiplierAbAttr>(AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER, target, true, statGain);
+
+    return statGain.value;
   }
 }

--- a/src/data/moves/move-attrs/average-stats-attr.ts
+++ b/src/data/moves/move-attrs/average-stats-attr.ts
@@ -1,6 +1,10 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { ALLY_EFFECTIVE_STAT_OPTIONS, OPP_EFFECTIVE_STAT_OPTIONS } from "#constants/ai-constants";
+import {
+  ALLY_EFFECTIVE_STAT_OPTIONS,
+  MAJOR_EFFECT_SCORE_PENALTY,
+  OPP_EFFECTIVE_STAT_OPTIONS,
+} from "#constants/ai-constants";
 import type { EffectiveStat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -51,11 +55,20 @@ export class AverageStatsAttr extends MoveEffectAttr {
    * so the score from this attribute cannot exceed (+2).
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    /**
+     * For this effect to be considered beneficial to the user for a specific stat,
+     * the target's stat must be greater than the user's by at least this factor.
+     */
+    const minStatFactor = 2;
     const benefitStats = this.stats.filter(
       (stat) =>
-        user.getEffectiveStat(stat, ALLY_EFFECTIVE_STAT_OPTIONS)
+        user.getEffectiveStat(stat, ALLY_EFFECTIVE_STAT_OPTIONS) * minStatFactor
         < target.getEffectiveStat(stat, OPP_EFFECTIVE_STAT_OPTIONS),
     ).length;
+
+    if (benefitStats === 0) {
+      return MAJOR_EFFECT_SCORE_PENALTY;
+    }
 
     return this.getRandomScore(user, 55, benefitStats, benefitStats - 1);
   }

--- a/src/data/moves/move-attrs/average-stats-attr.ts
+++ b/src/data/moves/move-attrs/average-stats-attr.ts
@@ -1,6 +1,8 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { ALLY_EFFECTIVE_STAT_OPTIONS, OPP_EFFECTIVE_STAT_OPTIONS } from "#constants/ai-constants";
 import type { EffectiveStat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -24,7 +26,7 @@ export class AverageStatsAttr extends MoveEffectAttr {
     this.msgKey = msgKey;
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
     for (const s of this.stats) {
       const avg = Math.floor((user.getStat(s, false) + target.getStat(s, false)) / 2);
 
@@ -38,5 +40,23 @@ export class AverageStatsAttr extends MoveEffectAttr {
     );
 
     return true;
+  }
+
+  /**
+   * @returns A bonus that scales with the number of {@linkcode stats} where the user is
+   * expected to benefit from this attribute's effect against the target.
+   *
+   * @privateRemarks
+   * All moves that use this attribute (namely Power/Guard Split) only affect two stats,
+   * so the score from this attribute cannot exceed (+2).
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const benefitStats = this.stats.filter(
+      (stat) =>
+        user.getEffectiveStat(stat, ALLY_EFFECTIVE_STAT_OPTIONS)
+        < target.getEffectiveStat(stat, OPP_EFFECTIVE_STAT_OPTIONS),
+    ).length;
+
+    return this.getRandomScore(user, 55, benefitStats, benefitStats - 1);
   }
 }

--- a/src/data/moves/move-attrs/copy-stats-attr.ts
+++ b/src/data/moves/move-attrs/copy-stats-attr.ts
@@ -1,7 +1,9 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { BAD_MOVE_PENALTY, SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
-import { BATTLE_STATS } from "#enums/stat";
+import { BATTLE_STATS, type BattleStat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -34,5 +36,38 @@ export class CopyStatsAttr extends MoveEffectAttr {
     );
 
     return true;
+  }
+
+  /**
+   * @returns (+0.5) for each stat stage the user would gain from this effect against the given
+   * target. If the projected gain is 0 or less, this grants a {@linkcode BAD_MOVE_PENALTY} instead.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const totalStatGain = BATTLE_STATS.reduce(
+      (total, stat) => total + this.getProjectedStatGain(user, target, stat),
+      0,
+    );
+
+    if (totalStatGain <= 0) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    return Math.min(Math.floor(totalStatGain * 0.5), SOFT_EFFECT_SCORE_LIMIT);
+  }
+
+  /** This effect treats allies in the same way as opponents */
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, move: Move): number {
+    return this.getEffectScore(user, target, move);
+  }
+
+  /**
+   * @param user - The {@linkcode EnemyPokemon} evaluating this effect
+   * @param target - The {@linkcode Pokemon} this effect is evaluated against
+   * @param stat - The {@linkcode BattleStat} for which the stat stage gain is calculated
+   * @returns The number of stat stages the given user gains in the given stat when this
+   * attribute's effect is applied to the target
+   */
+  private getProjectedStatGain(user: EnemyPokemon, target: Pokemon, stat: BattleStat) {
+    return target.getStatStage(stat) - user.getStatStage(stat);
   }
 }

--- a/src/data/moves/move-attrs/copy-stats-attr.ts
+++ b/src/data/moves/move-attrs/copy-stats-attr.ts
@@ -39,7 +39,7 @@ export class CopyStatsAttr extends MoveEffectAttr {
   }
 
   /**
-   * @returns (+0.5) for each stat stage the user would gain from this effect against the given
+   * @returns (+1) for every `2` stat stages the user would gain from this effect against the given
    * target. If the projected gain is 0 or less, this grants a {@linkcode BAD_MOVE_PENALTY} instead.
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {

--- a/src/data/moves/move-attrs/invert-stats-attr.ts
+++ b/src/data/moves/move-attrs/invert-stats-attr.ts
@@ -1,6 +1,8 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { MINOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_PENALTY, SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
 import { BATTLE_STATS } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -11,7 +13,7 @@ import i18next from "i18next";
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Topsy-Turvy_(move) | Topsy-Turvy}.
  */
 export class InvertStatsAttr extends MoveEffectAttr {
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
     for (const s of BATTLE_STATS) {
       target.setStatStage(s, -target.getStatStage(s));
     }
@@ -25,5 +27,30 @@ export class InvertStatsAttr extends MoveEffectAttr {
     );
 
     return true;
+  }
+
+  /**
+   * @returns an Effect Score modifier equal to the effective stat stages gained from this effect
+   * multiplied by {@linkcode MINOR_EFFECT_SCORE_PENALTY}. This modifier cannot exceed the {@linkcode SOFT_EFFECT_SCORE_LIMIT}.
+   */
+  public override getEffectScore(_user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    return Math.min(this.getProjectedStatChange(target) * MINOR_EFFECT_SCORE_PENALTY, SOFT_EFFECT_SCORE_LIMIT);
+  }
+
+  /**
+   * @returns an Effect Score modifier equal to the effective stat stages gained from this effect
+   * multiplied by {@linkcode MINOR_EFFECT_SCORE_BONUS}. This modifier cannot exceed the {@linkcode SOFT_EFFECT_SCORE_LIMIT}.
+   */
+  public override getAllyTargetScore(_user: EnemyPokemon, target: EnemyPokemon, _move: Move): number {
+    return Math.min(this.getProjectedStatChange(target) * MINOR_EFFECT_SCORE_BONUS, SOFT_EFFECT_SCORE_LIMIT);
+  }
+
+  /**
+   * @param target - The {@linkcode Pokemon} on which this effect is evaluated
+   * @returns The effective change (in number of stat stages) this attribute's effect is expected
+   * to apply to the given target
+   */
+  private getProjectedStatChange(target: Pokemon) {
+    return BATTLE_STATS.reduce((total, stat) => total + target.getStatStage(stat) * -2, 0);
   }
 }

--- a/src/data/moves/move-attrs/invert-stats-attr.ts
+++ b/src/data/moves/move-attrs/invert-stats-attr.ts
@@ -50,7 +50,7 @@ export class InvertStatsAttr extends MoveEffectAttr {
    * @returns The effective change (in number of stat stages) this attribute's effect is expected
    * to apply to the given target
    */
-  private getProjectedStatChange(target: Pokemon) {
+  private getProjectedStatChange(target: Pokemon): number {
     return BATTLE_STATS.reduce((total, stat) => total + target.getStatStage(stat) * -2, 0);
   }
 }

--- a/src/data/moves/move-attrs/order-up-stat-boost-attr.ts
+++ b/src/data/moves/move-attrs/order-up-stat-boost-attr.ts
@@ -1,7 +1,9 @@
 import { globalScene } from "#app/global-scene";
 import type { CommandedTag } from "#battler-tags/commanded-tag";
+import { MINOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { type EffectiveStat, Stat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -55,5 +57,10 @@ export class OrderUpStatBoostAttr extends MoveEffectAttr {
       1,
     );
     return true;
+  }
+
+  /** @returns A {@linkcode MINOR_EFFECT_SCORE_BONUS} if the user is Commanded by its ally */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    return user.hasTag(BattlerTagType.COMMANDED) ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/post-victory-stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/post-victory-stat-stage-change-attr.ts
@@ -1,4 +1,7 @@
+import { BAD_MOVE_PENALTY, KO_ATTACK_SCORE } from "#constants/ai-constants";
+import { AbilityId } from "#enums/ability-id";
 import type { BattleStat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveAttr } from "#moves/move-attr";
@@ -30,11 +33,27 @@ export class PostVictoryStatStageChangeAttr extends MoveAttr {
     this.showMessage = showMessage;
   }
 
-  applyPostVictory(user: Pokemon, target: Pokemon, move: Move): void {
+  /** @todo Override {@linkcode apply} instead */
+  public applyPostVictory(user: Pokemon, target: Pokemon, move: Move): void {
     if (this.condition && !this.condition(user, target, move)) {
       return;
     }
     const statChangeAttr = new StatStageChangeAttr(this.stats, this.stages, this.showMessage);
     statChangeAttr.applyEffect(user, target, move);
+  }
+
+  /**
+   * @returns (+3) if the user is expected to KO the target with the given move. Combined with Attack Score, this
+   * means a KO will yield a (+7) score, meaning the AI will prioritize moves with this effect over moves with
+   * high priority. Under the same conditions, if the user has Contrary, this grants a {@linkcode BAD_MOVE_PENALTY}.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (
+      user.getExpectedAttackScore(target, move) >= KO_ATTACK_SCORE
+      && this.stats.some((stat) => user.getStatStage(stat) < 6)
+    ) {
+      return user.hasAbility(AbilityId.CONTRARY) ? BAD_MOVE_PENALTY : 3;
+    }
+    return 0;
   }
 }

--- a/src/data/moves/move-attrs/post-victory-stat-stage-change-attr.ts
+++ b/src/data/moves/move-attrs/post-victory-stat-stage-change-attr.ts
@@ -26,7 +26,7 @@ export class PostVictoryStatStageChangeAttr extends MoveAttr {
     showMessage: boolean = true,
     _firstHitOnly: boolean = false,
   ) {
-    super();
+    super(true);
     this.stats = stats;
     this.stages = stages;
     this.condition = condition;

--- a/src/data/moves/move-attrs/reset-stats-attr.ts
+++ b/src/data/moves/move-attrs/reset-stats-attr.ts
@@ -53,11 +53,11 @@ export class ResetStatsAttr extends MoveEffectAttr {
    * This also grants a {@linkcode BAD_MOVE_PENALTY} when the net stat stage change does not
    * favor the user's side of the field.
    */
-  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
     const affectedPokemon = this.targetAllPokemon ? globalScene.getField(true) : [target];
 
     const uncappedScore = affectedPokemon.reduce((total, p) => total + this.getIndividualEffectScore(user, p), 0);
-    if (uncappedScore <= 0) {
+    if (uncappedScore <= 0 && move.isStatusMove()) {
       return BAD_MOVE_PENALTY;
     }
     return Math.min(uncappedScore, SOFT_EFFECT_SCORE_LIMIT);

--- a/src/data/moves/move-attrs/reset-stats-attr.ts
+++ b/src/data/moves/move-attrs/reset-stats-attr.ts
@@ -1,6 +1,8 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { BAD_MOVE_PENALTY, SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
 import { BATTLE_STATS } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -42,5 +44,36 @@ export class ResetStatsAttr extends MoveEffectAttr {
       pokemon.setStatStage(s, 0);
     }
     pokemon.updateInfo();
+  }
+
+  /**
+   * @returns An Effect Score modifier based on the effective stat stage changes for all
+   * affected allies and opponents as a result of this move action. This effect is rewarded
+   * when affected opponents have positive stat stages and/or allies have negative stat stages.
+   * This also grants a {@linkcode BAD_MOVE_PENALTY} when the net stat stage change does not
+   * favor the user's side of the field.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const affectedPokemon = this.targetAllPokemon ? globalScene.getField(true) : [target];
+
+    const uncappedScore = affectedPokemon.reduce((total, p) => total + this.getIndividualEffectScore(user, p), 0);
+    if (uncappedScore <= 0) {
+      return BAD_MOVE_PENALTY;
+    }
+    return Math.min(uncappedScore, SOFT_EFFECT_SCORE_LIMIT);
+  }
+
+  /**
+   * @param user - The {@linkcode EnemyPokemon} evaluating this attribute's effect
+   * @param target - The {@linkcode Pokemon} this effect is evaluated against
+   * @returns The Effect Score bonus or penalty for resetting the given target's current stat stages. This
+   * score scales with the target's current stat stage for each stat. If the target is an opponent to the user,
+   * this grants (+0.5) times the combined number of stat stages across all {@linkcode BATTLE_STATS}. This scoring
+   * logic is inverted for ally targets (including the user itself).
+   */
+  private getIndividualEffectScore(user: EnemyPokemon, target: Pokemon): number {
+    const scoreMultiplier = target.isOpponent(user) ? 0.5 : -0.5;
+
+    return Math.floor(BATTLE_STATS.reduce((total, stat) => total + target.getStatStage(stat) * scoreMultiplier, 0));
   }
 }

--- a/src/data/moves/move-attrs/shift-stat-attr.ts
+++ b/src/data/moves/move-attrs/shift-stat-attr.ts
@@ -40,15 +40,4 @@ export class ShiftStatAttr extends MoveEffectAttr {
 
     return true;
   }
-
-  /**
-   * Encourages the user to use the move if the stat to switch with is greater than the stat to switch.
-   * @param user the {@linkcode Pokemon} that used the move
-   * @param _target n/a
-   * @param _move n/a
-   * @returns number of points to add to the user's benefit score
-   */
-  override getUserBenefitScore(user: Pokemon, _target: Pokemon, _move: Move): number {
-    return user.getStat(this.statToSwitchWith, false) > user.getStat(this.statToSwitch, false) ? 10 : 0;
-  }
 }

--- a/src/data/moves/move-attrs/shift-stat-attr.ts
+++ b/src/data/moves/move-attrs/shift-stat-attr.ts
@@ -1,7 +1,10 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { MINOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
+import { MoveCategory } from "#enums/move-category";
 import type { EffectiveStat } from "#enums/stat";
-import { getStatKey } from "#enums/stat";
+import { getStatKey, Stat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -12,32 +15,56 @@ import i18next from "i18next";
  * Used by Power Shift.
  */
 export class ShiftStatAttr extends MoveEffectAttr {
-  private statToSwitch: EffectiveStat;
-  private statToSwitchWith: EffectiveStat;
+  private statsToSwitch: [EffectiveStat, EffectiveStat];
 
-  constructor(statToSwitch: EffectiveStat, statToSwitchWith: EffectiveStat) {
-    super();
+  constructor(...statsToSwitch: [EffectiveStat, EffectiveStat]) {
+    super(true);
 
-    this.statToSwitch = statToSwitch;
-    this.statToSwitchWith = statToSwitchWith;
+    this.statsToSwitch = statsToSwitch;
   }
 
   override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
-    const firstStat = user.getStat(this.statToSwitch, false);
-    const secondStat = user.getStat(this.statToSwitchWith, false);
-
-    user.setStat(this.statToSwitch, secondStat, false);
-    user.setStat(this.statToSwitchWith, firstStat, false);
+    const postShiftStatValues = this.statsToSwitch.map((stat) => user.getStat(stat, false)).reverse();
+    this.statsToSwitch.forEach((stat, i) => user.setStat(stat, postShiftStatValues[i], false));
 
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t("moveTriggers:shiftedStats", {
         pokemonName: getPokemonNameWithAffix(user),
-        statToSwitch: i18next.t(getStatKey(this.statToSwitch)),
-        statToSwitchWith: i18next.t(getStatKey(this.statToSwitchWith)),
+        statToSwitch: i18next.t(getStatKey(this.statsToSwitch[0])),
+        statToSwitchWith: i18next.t(getStatKey(this.statsToSwitch[1])),
       }),
     );
 
     return true;
+  }
+
+  /**
+   * @returns A {@linkcode MINOR_EFFECT_SCORE_BONUS} if all of the below conditions apply:
+   * - At least one of the shifted stats is an offensive stat (Attack or Sp. Atk)
+   * - The user does not have a move whose category matches the shifted offensive stat
+   * - The offensive stat is greater than the other shifted stat on the user
+   *
+   * If no offensive stats are shifted, this grants (+0). If any of the other conditions
+   * do not apply, this grants a {@linkcode MINOR_EFFECT_SCORE_PENALTY}.
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    const offensiveStatToShiftIndex = this.statsToSwitch.findIndex((stat) => [Stat.ATK, Stat.SPATK].includes(stat));
+    if (offensiveStatToShiftIndex === -1) {
+      return 0;
+    }
+    const offensiveStat = this.statsToSwitch[offensiveStatToShiftIndex];
+    const otherStat = this.statsToSwitch[offensiveStatToShiftIndex ? 0 : 1];
+    const matchingCategory = offensiveStat === Stat.ATK ? MoveCategory.PHYSICAL : MoveCategory.SPECIAL;
+
+    const userHasMatchingMove = user
+      .getMoveset()
+      .some((mv) => user.getMoveCategory(user.getOpponents()[0], mv.getMove()) === matchingCategory);
+
+    if (offensiveStat > otherStat && !userHasMatchingMove) {
+      return MINOR_EFFECT_SCORE_BONUS;
+    }
+
+    return MINOR_EFFECT_SCORE_PENALTY;
   }
 }

--- a/src/data/moves/move-attrs/steal-positive-stats-attr.ts
+++ b/src/data/moves/move-attrs/steal-positive-stats-attr.ts
@@ -2,13 +2,15 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { StatStageChangeMultiplierAbAttr } from "#abilities/stat-stage-change-multiplier-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { MINOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { MoveEffectTrigger } from "#enums/move-effect-trigger";
-import { BATTLE_STATS } from "#enums/stat";
+import { BATTLE_STATS, type BattleStat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
-import { NumberHolder } from "#utils/common-utils";
+import { clamp, NumberHolder, ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -49,5 +51,38 @@ export class StealPositiveStatsAttr extends MoveEffectAttr {
     }
 
     return statsStolen;
+  }
+
+  /**
+   * @returns A {@link MINOR_EFFECT_SCORE_BONUS | minor bonus} for each stat stage the user would gain
+   * from this effect against the given target. The projected stat stage gain accounts for
+   * stat stage multipliers such as Simple and Contrary.
+   *
+   * @remarks
+   * Unlike other large Effect Score modifiers, this effect's score is uncapped, so the AI
+   * should prefer moves with this effect over KO moves in extreme cases.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const totalStatGain = BATTLE_STATS.reduce((total, stat) => total + this.getAdjustedStatGain(user, target, stat), 0);
+
+    return totalStatGain * MINOR_EFFECT_SCORE_BONUS;
+  }
+
+  /**
+   * Calculates how many stages of a single stat the user would gain from applying this attribute's
+   * effect to the target. This accounts for the user's stat stage limits as well as stat stage change
+   * multipliers from the user's Simple or Contrary.
+   * @param user - The {@linkcode EnemyPokemon} evaluating the effect
+   * @param target - The {@linkcode Pokemon} the effect is evaluated against
+   * @param stat - The {@linkcode BattleStat} whose gain is evaluated
+   * @returns The number of stages the user would gain in the given stat when applying this effect
+   * against the given target.
+   */
+  private getAdjustedStatGain(user: EnemyPokemon, target: Pokemon, stat: BattleStat): number {
+    const statGain = new ValueHolder(Math.max(target.getStatStage(stat), 0));
+    applyAbAttrs<StatStageChangeMultiplierAbAttr>(AbAttrFlag.STAT_STAGE_CHANGE_MULTIPLIER, user, true, statGain);
+
+    const currentStage = user.getStatStage(stat);
+    return clamp(statGain.value, -6 - currentStage, 6 - currentStage);
   }
 }

--- a/src/data/moves/move-attrs/swap-stat-attr.ts
+++ b/src/data/moves/move-attrs/swap-stat-attr.ts
@@ -1,9 +1,13 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { type EffectiveStat, getStatKey } from "#enums/stat";
-import type { Pokemon } from "#field/pokemon";
+import { BAD_MOVE_PENALTY, MINOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
+import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import { type EffectiveStat, getStatKey, Stat } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
+import type { EffectiveStatOptions, Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
+import { isBetween } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -34,5 +38,32 @@ export class SwapStatAttr extends MoveEffectAttr {
     );
 
     return true;
+  }
+
+  /**
+   * @returns A {@link MINOR_EFFECT_SCORE_BONUS | minor bonus} for each opponent the user
+   * would outspeed as a result of applying this attribute's effect on the target. All
+   * abilities (including revealed abilities) are ignored for the stat calculations in this scoring.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const effectiveStatOptions: EffectiveStatOptions = {
+      abilityApplyMode: AbilityApplyMode.IGNORE,
+      simulated: true,
+    };
+
+    const startingSpeed = user.getEffectiveStat(Stat.SPD, effectiveStatOptions);
+    const projectedSpeed = target.getEffectiveStat(Stat.SPD, effectiveStatOptions);
+
+    if (projectedSpeed <= startingSpeed) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    const numOpponentsToOutspeed = user
+      .getOpponents()
+      .filter((opp) =>
+        isBetween(opp.getEffectiveStat(Stat.SPD, effectiveStatOptions), startingSpeed, projectedSpeed),
+      ).length;
+
+    return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
   }
 }

--- a/src/data/moves/move-attrs/swap-stat-attr.ts
+++ b/src/data/moves/move-attrs/swap-stat-attr.ts
@@ -1,10 +1,16 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { BAD_MOVE_PENALTY, MINOR_EFFECT_SCORE_BONUS } from "#constants/ai-constants";
-import { AbilityApplyMode } from "#enums/ability-apply-mode";
+import {
+  ALLY_EFFECTIVE_STAT_OPTIONS,
+  BAD_MOVE_PENALTY,
+  MAJOR_EFFECT_SCORE_BONUS,
+  MINOR_EFFECT_SCORE_BONUS,
+  OPP_EFFECTIVE_STAT_OPTIONS,
+} from "#constants/ai-constants";
 import { type EffectiveStat, getStatKey, Stat } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
-import type { EffectiveStatOptions, Pokemon } from "#field/pokemon";
+import type { PlayerPokemon } from "#field/player-pokemon";
+import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
 import { isBetween } from "#utils/common-utils";
@@ -42,32 +48,50 @@ export class SwapStatAttr extends MoveEffectAttr {
 
   /**
    * @returns A {@link MINOR_EFFECT_SCORE_BONUS | minor bonus} for each opponent the user
-   * would outspeed as a result of applying this attribute's effect on the target. All
-   * abilities (including revealed abilities) are ignored for the stat calculations in this scoring.
+   * would outspeed as a result of applying this attribute's effect on the target.
    *
    * @privateRemarks
    * This scoring is specific to Speed Swap. It may need to be generalized if other moves with
    * this attribute are implemented.
    */
-  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
-    const effectiveStatOptions: EffectiveStatOptions = {
-      abilityApplyMode: AbilityApplyMode.IGNORE,
-      simulated: true,
-    };
+  public override getEffectScore(user: EnemyPokemon, target: PlayerPokemon, _move: Move): number {
+    const [userProjSpeed, targetProjSpeed] = this.getProjectedSpeeds(user, target);
 
-    const startingSpeed = user.getEffectiveStat(Stat.SPD, effectiveStatOptions);
-    const projectedSpeed = target.getEffectiveStat(Stat.SPD, effectiveStatOptions);
-
-    if (projectedSpeed <= startingSpeed) {
+    if (userProjSpeed <= targetProjSpeed) {
       return BAD_MOVE_PENALTY;
     }
 
-    const numOpponentsToOutspeed = user
-      .getOpponents()
-      .filter((opp) =>
-        isBetween(opp.getEffectiveStat(Stat.SPD, effectiveStatOptions), startingSpeed, projectedSpeed),
-      ).length;
+    const targetAlly = target.getAlly();
+    if (
+      targetAlly?.isActive(true)
+      && isBetween(
+        targetAlly.getEffectiveStat(Stat.SPD, OPP_EFFECTIVE_STAT_OPTIONS),
+        user.getEffectiveStat(Stat.SPD),
+        userProjSpeed,
+      )
+    ) {
+      return MAJOR_EFFECT_SCORE_BONUS;
+    }
+    return MINOR_EFFECT_SCORE_BONUS;
+  }
 
-    return numOpponentsToOutspeed * MINOR_EFFECT_SCORE_BONUS;
+  /**
+   * Calculates the projected speeds of the given user and target after applying
+   * this attribute's effect.
+   * @param user - The {@linkcode EnemyPokemon} evaluating the effect
+   * @param target - The {@linkcode Pokemon} the effect is evaluated against
+   * @returns A tuple in the format `[userProjSpeed, targetProjSpeed]` of each Pokemon's
+   * predicted Speed after applying this effect
+   * @todo Abilities' effects are applied to the wrong Pokemon in these stat calculations
+   */
+  private getProjectedSpeeds(user: EnemyPokemon, target: PlayerPokemon): [number, number] {
+    const userProjSpeed =
+      (target.getEffectiveStat(Stat.SPD, OPP_EFFECTIVE_STAT_OPTIONS) * user.getStatStageMultiplier(Stat.SPD))
+      / target.getStatStageMultiplier(Stat.SPD);
+    const targetProjSpeed =
+      (user.getEffectiveStat(Stat.SPD, ALLY_EFFECTIVE_STAT_OPTIONS) * target.getStatStageMultiplier(Stat.SPD))
+      / user.getStatStageMultiplier(Stat.SPD);
+
+    return [userProjSpeed, targetProjSpeed];
   }
 }

--- a/src/data/moves/move-attrs/swap-stat-attr.ts
+++ b/src/data/moves/move-attrs/swap-stat-attr.ts
@@ -44,6 +44,10 @@ export class SwapStatAttr extends MoveEffectAttr {
    * @returns A {@link MINOR_EFFECT_SCORE_BONUS | minor bonus} for each opponent the user
    * would outspeed as a result of applying this attribute's effect on the target. All
    * abilities (including revealed abilities) are ignored for the stat calculations in this scoring.
+   *
+   * @privateRemarks
+   * This scoring is specific to Speed Swap. It may need to be generalized if other moves with
+   * this attribute are implemented.
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
     const effectiveStatOptions: EffectiveStatOptions = {

--- a/src/data/moves/move-attrs/swap-stat-stages-attr.ts
+++ b/src/data/moves/move-attrs/swap-stat-stages-attr.ts
@@ -1,7 +1,9 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
 import type { BattleStat } from "#enums/stat";
 import { getStatKey } from "#enums/stat";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -22,7 +24,7 @@ export class SwapStatStagesAttr extends MoveEffectAttr {
     this.stats = stats;
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
     for (const s of this.stats) {
       const temp = user.getStatStage(s);
       user.setStatStage(s, target.getStatStage(s));
@@ -48,5 +50,24 @@ export class SwapStatStagesAttr extends MoveEffectAttr {
       );
     }
     return true;
+  }
+
+  /**
+   * @returns (+0.5) per stat stage the user would gain from this effect, rounded down. The
+   * total bonus cannot exceed the {@linkcode SOFT_EFFECT_SCORE_LIMIT}.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const uncappedScore = Math.floor(this.getProjectedStatGain(user, target) * 0.5);
+    return Math.min(uncappedScore, SOFT_EFFECT_SCORE_LIMIT);
+  }
+
+  /**
+   * @param user - The {@linkcode EnemyPokemon} evaluating this effect
+   * @param target - The {@linkcode Pokemon} this effect is evaluated against
+   * @returns The projected number of stat stages the user would gain from
+   * applying this attribute's effect on the target
+   */
+  private getProjectedStatGain(user: EnemyPokemon, target: Pokemon): number {
+    return this.stats.reduce((total, stat) => total + target.getStatStage(stat) - user.getStatStage(stat), 0);
   }
 }

--- a/src/data/moves/move-attrs/swap-stat-stages-attr.ts
+++ b/src/data/moves/move-attrs/swap-stat-stages-attr.ts
@@ -1,6 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
+import { BAD_MOVE_PENALTY, SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
 import type { BattleStat } from "#enums/stat";
 import { getStatKey } from "#enums/stat";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
@@ -54,10 +54,14 @@ export class SwapStatStagesAttr extends MoveEffectAttr {
 
   /**
    * @returns (+0.5) per stat stage the user would gain from this effect, rounded down. The
-   * total bonus cannot exceed the {@linkcode SOFT_EFFECT_SCORE_LIMIT}.
+   * total bonus cannot exceed the {@linkcode SOFT_EFFECT_SCORE_LIMIT}. If the user would not gain stat stages
+   * from this effect, this grants a {@linkcode BAD_MOVE_PENALTY} instead.
    */
   public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
     const uncappedScore = Math.floor(this.getProjectedStatGain(user, target) * 0.5);
+    if (uncappedScore <= 0) {
+      return BAD_MOVE_PENALTY;
+    }
     return Math.min(uncappedScore, SOFT_EFFECT_SCORE_LIMIT);
   }
 

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -27,6 +27,7 @@ import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveCategory } from "#enums/move-category";
+import { MoveEffectTrigger } from "#enums/move-effect-trigger";
 import { MoveFlags } from "#enums/move-flags";
 import { MoveId } from "#enums/move-id";
 import { MoveTarget } from "#enums/move-target";
@@ -43,6 +44,7 @@ import { GMaxPowerAttr } from "#moves/gmax-power-attr";
 import { IncrementMovePriorityAttr } from "#moves/increment-move-priority-attr";
 import type { MoveAttr } from "#moves/move-attr";
 import { MoveCondition } from "#moves/move-condition";
+import { MoveEffectAttr } from "#moves/move-effect-attr";
 import { MultiHitAttr } from "#moves/multi-hit-attr";
 import { MultiHitPowerIncrementAttr } from "#moves/multi-hit-power-increment-attr";
 import { OneHitKOAccuracyAttr } from "#moves/one-hit-ko-accuracy-attr";
@@ -861,7 +863,9 @@ export abstract class Move {
 
     let attrs: MoveAttr[] = this.attrs;
     if (isKnockOut) {
-      attrs = attrs.filter((attr) => attr.selfTarget);
+      attrs = attrs.filter(
+        (attr) => attr.selfTarget || (attr instanceof MoveEffectAttr && attr.trigger !== MoveEffectTrigger.POST_APPLY),
+      );
     }
 
     if (isFail) {

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -863,6 +863,11 @@ export abstract class Move {
 
     let attrs: MoveAttr[] = this.attrs;
     if (isKnockOut) {
+      /*
+       * If the move KOs the target, only the following attributes contribute to score:
+       * - Self-targeted attributes
+       * - Effects that apply to the target before the target is hit
+       */
       attrs = attrs.filter(
         (attr) => attr.selfTarget || (attr instanceof MoveEffectAttr && attr.trigger !== MoveEffectTrigger.POST_APPLY),
       );

--- a/test/ai/move-effect-scores/acupressure.test.ts
+++ b/test/ai/move-effect-scores/acupressure.test.ts
@@ -1,0 +1,68 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Acupressure", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  const baseMoveset: MoveId[] = [MoveId.ACUPRESSURE, MoveId.SPLASH, MoveId.TACKLE];
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset(baseMoveset)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred over moves with low impact", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.ACUPRESSURE);
+  });
+
+  it("should not be preferred over Swords Dance when Attack is relevant", async () => {
+    game.override.enemyMoveset([...baseMoveset, MoveId.SWORDS_DANCE]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SWORDS_DANCE);
+  });
+
+  it("should be avoided when the user has Contrary", async () => {
+    game.override.enemyAbility(AbilityId.CONTRARY);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.ACUPRESSURE);
+  });
+
+  it("should be preferred over Swords Dance when targeting the user's ally", async () => {
+    game.override.battleType("double").enemyMoveset([...baseMoveset, MoveId.SWORDS_DANCE]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).toPreferSelectingMove(MoveId.ACUPRESSURE);
+  });
+});

--- a/test/ai/move-effect-scores/average-stats.test.ts
+++ b/test/ai/move-effect-scores/average-stats.test.ts
@@ -1,0 +1,106 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { type PermanentStat, Stat } from "#enums/stat";
+import type { Pokemon } from "#field/pokemon";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Average Stats", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  type TestCase = {
+    moveName: string;
+    moveId: MoveId;
+    stats: {
+      statName: string;
+      stat: PermanentStat;
+    }[];
+  };
+  const testCases: TestCase[] = [
+    {
+      moveName: "Guard Split",
+      moveId: MoveId.GUARD_SPLIT,
+      stats: [
+        { statName: "Defense", stat: Stat.DEF },
+        { statName: "Sp. Def", stat: Stat.SPDEF },
+      ],
+    },
+    {
+      moveName: "Power Split",
+      moveId: MoveId.POWER_SPLIT,
+      stats: [
+        { statName: "Attack", stat: Stat.ATK },
+        { statName: "Sp. Atk", stat: Stat.SPATK },
+      ],
+    },
+  ];
+
+  describe.each(testCases)("$moveName", ({ moveId, stats }) => {
+    beforeEach(async () => {
+      game.override.enemyMoveset([moveId, MoveId.SPLASH]);
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+    });
+
+    const initStats = (pokemon: Pokemon[]) => {
+      pokemon.forEach((p) => stats.forEach(({ stat }) => p.setStat(stat, 50)));
+    };
+
+    it("should be avoided when the user and target have equal stats", async () => {
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      initStats([player, enemy]);
+
+      expect(enemy).toNeverSelectMove(moveId);
+    });
+
+    it.each(stats)(
+      "should be preferred when the target has significantly higher $statName than the user",
+      async ({ stat }) => {
+        const player = game.field.getPlayerPokemon();
+        const enemy = game.field.getEnemyPokemon();
+        initStats([player, enemy]);
+        player.setStat(stat, 150);
+
+        expect(enemy).toPreferSelectingMove(moveId);
+      },
+    );
+
+    it.each(stats)(
+      "should be avoided when the target has slightly higher $statName than the user",
+      async ({ stat }) => {
+        const player = game.field.getPlayerPokemon();
+        const enemy = game.field.getEnemyPokemon();
+        initStats([player, enemy]);
+        player.setStat(stat, 75);
+
+        expect(enemy).toNeverSelectMove(moveId);
+      },
+    );
+  });
+});

--- a/test/ai/move-effect-scores/clear-smog.test.ts
+++ b/test/ai/move-effect-scores/clear-smog.test.ts
@@ -1,0 +1,62 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Clear Smog", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.CLEAR_SMOG, MoveId.SWORDS_DANCE, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no stat stage changes are on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.CLEAR_SMOG);
+  });
+
+  it("should be preferred when the target has increased stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, 2);
+
+    expect(enemy).toPreferSelectingMove(MoveId.CLEAR_SMOG);
+  });
+
+  it("should be avoided when the target has decreased stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, -2);
+
+    expect(enemy).toNeverSelectMove(MoveId.CLEAR_SMOG);
+  });
+});

--- a/test/ai/move-effect-scores/fell-stinger.test.ts
+++ b/test/ai/move-effect-scores/fell-stinger.test.ts
@@ -1,0 +1,87 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Fell Stinger", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.DRILBUR)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.FELL_STINGER, MoveId.AERIAL_ACE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when the user cannot KO the target", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.FELL_STINGER);
+  });
+
+  it("should be strongly preferred when the user can KO the target", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.hp = 1;
+
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.FELL_STINGER);
+  });
+
+  it("should be strongly preferred over priority moves when the user can KO the target", async () => {
+    game.override.enemyMoveset([MoveId.FELL_STINGER, MoveId.QUICK_ATTACK]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.hp = 1;
+
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.FELL_STINGER);
+  });
+
+  it("should not be preferred when the user already has max Attack stages", async () => {
+    game.override.enemyMoveset([MoveId.FELL_STINGER, MoveId.QUICK_ATTACK]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.hp = 1;
+    enemy.setStatStage(Stat.ATK, 6);
+
+    expect(enemy).toNeverSelectMove(MoveId.FELL_STINGER);
+  });
+
+  it("should be avoided when the user has Contrary", async () => {
+    game.override.enemyAbility(AbilityId.CONTRARY);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.hp = 1;
+
+    expect(enemy).toNeverSelectMove(MoveId.FELL_STINGER);
+  });
+});

--- a/test/ai/move-effect-scores/haze.test.ts
+++ b/test/ai/move-effect-scores/haze.test.ts
@@ -1,0 +1,80 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Haze", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.HAZE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be avoided when no stat stage changes are on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.HAZE);
+  });
+
+  it("should be preferred when an opponent has increased stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, 2);
+
+    expect(enemy).toPreferSelectingMove(MoveId.HAZE);
+  });
+
+  it("should be avoided when an opponent has decreased stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, -2);
+
+    expect(enemy).toNeverSelectMove(MoveId.HAZE);
+  });
+
+  it("should be preferred when an ally has decreased stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.setStatStage(Stat.ATK, -2);
+
+    expect(enemy).toPreferSelectingMove(MoveId.HAZE);
+  });
+
+  it("should be avoided when an ally has increased stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.setStatStage(Stat.ATK, 2);
+
+    expect(enemy).toNeverSelectMove(MoveId.HAZE);
+  });
+});

--- a/test/ai/move-effect-scores/psych-up.test.ts
+++ b/test/ai/move-effect-scores/psych-up.test.ts
@@ -1,0 +1,82 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Psych Up", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.PSYCH_UP, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  const initTest = async ({ playerStatStage = 0, enemyStatStage = 0 } = {}) => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+
+    player.setStatStage(Stat.ATK, playerStatStage);
+    enemy.setStatStage(Stat.ATK, enemyStatStage);
+  };
+
+  it("should be avoided when the target has no positive stat stages", async () => {
+    await initTest();
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PSYCH_UP);
+  });
+
+  it("should not be preferred when the target has one positive stat stage", async () => {
+    await initTest({ playerStatStage: 1 });
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.PSYCH_UP);
+  });
+
+  it("should be preferred when the target has two more stat stages than the user", async () => {
+    await initTest({ playerStatStage: 4, enemyStatStage: 2 });
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.PSYCH_UP);
+  });
+
+  it("should be avoided when the user has more stat stages than the target", async () => {
+    await initTest({ playerStatStage: 2, enemyStatStage: 4 });
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PSYCH_UP);
+  });
+
+  it("should be preferred when the user's ally has boosted stats", async () => {
+    game.override.battleType("double");
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.setStatStage(Stat.ATK, 2);
+
+    expect(enemy1).toPreferSelectingMove(MoveId.PSYCH_UP);
+  });
+});

--- a/test/ai/move-effect-scores/spectral-thief.test.ts
+++ b/test/ai/move-effect-scores/spectral-thief.test.ts
@@ -1,0 +1,85 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move Effect Scores - Spectral Thief", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .battleType("single")
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .ability(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SPECTRAL_THIEF, MoveId.EARTHQUAKE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when the target has no positive stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.SPECTRAL_THIEF);
+  });
+
+  it("should be preferred when the target has at least one positive stat stage", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, 1);
+
+    expect(enemy).toPreferSelectingMove(MoveId.SPECTRAL_THIEF);
+  });
+
+  it("should be strongly preferred when the target has several positive stat stages", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, 6);
+
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SPECTRAL_THIEF);
+  });
+
+  it("should be avoided when the user has Contrary and would steal stat stages", async () => {
+    game.override.enemyAbility(AbilityId.CONTRARY);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, 6);
+
+    expect(enemy).toNeverSelectMove(MoveId.SPECTRAL_THIEF);
+  });
+
+  it("should be preferred over priority moves that KO when the target is boosted", async () => {
+    game.override.enemyMoveset([MoveId.SPECTRAL_THIEF, MoveId.QUICK_ATTACK]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, 6);
+    player.hp = 1;
+
+    expect(enemy).toPreferSelectingMove(MoveId.SPECTRAL_THIEF);
+  });
+});

--- a/test/ai/move-effect-scores/speed-swap.test.ts
+++ b/test/ai/move-effect-scores/speed-swap.test.ts
@@ -1,0 +1,57 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Speed Swap", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SPEED_SWAP, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user is slower than the target", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStat(Stat.SPD, 100);
+    enemy.setStat(Stat.SPD, 50);
+
+    expect(enemy).toPreferSelectingMove(MoveId.SPEED_SWAP);
+  });
+
+  it("should be avoided when the user is faster than the target", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStat(Stat.SPD, 50);
+    enemy.setStat(Stat.SPD, 100);
+
+    expect(enemy).toNeverSelectMove(MoveId.SPEED_SWAP);
+  });
+});

--- a/test/ai/move-effect-scores/swap-stat-stages.test.ts
+++ b/test/ai/move-effect-scores/swap-stat-stages.test.ts
@@ -1,0 +1,103 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { BATTLE_STATS, type BattleStat, Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Swap Stat Stages", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  type StatStub = {
+    statName: string;
+    stat: BattleStat;
+  };
+  const statStubs: StatStub[] = [
+    { statName: "Attack", stat: Stat.ATK },
+    { statName: "Defense", stat: Stat.DEF },
+    { statName: "Sp. Atk", stat: Stat.SPATK },
+    { statName: "Sp. Def", stat: Stat.SPDEF },
+    { statName: "Speed", stat: Stat.SPD },
+    { statName: "Accuracy", stat: Stat.ACC },
+    { statName: "Evasiveness", stat: Stat.EVA },
+  ];
+
+  type TestCase = {
+    moveName: string;
+    moveId: MoveId;
+    positives: BattleStat[];
+  };
+  const testCases: TestCase[] = [
+    { moveName: "Guard Swap", moveId: MoveId.GUARD_SWAP, positives: [Stat.DEF, Stat.SPDEF] },
+    { moveName: "Power Swap", moveId: MoveId.POWER_SWAP, positives: [Stat.ATK, Stat.SPATK] },
+    { moveName: "Heart Swap", moveId: MoveId.HEART_SWAP, positives: [...BATTLE_STATS] },
+  ];
+
+  describe.each(testCases)("$moveName", ({ moveId, positives }) => {
+    const relevantStats = statStubs.filter(({ stat }) => positives.includes(stat));
+    const irrelevantStats = statStubs.filter(({ stat }) => !positives.includes(stat));
+
+    beforeEach(async () => {
+      game.override.enemyMoveset([moveId, MoveId.SPLASH, MoveId.TACKLE]);
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+    });
+
+    it("should be avoided when no stat stage changes are present on the field", async () => {
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(moveId);
+    });
+
+    it.each(irrelevantStats)("should be avoided when the opponent has increased $statName", async ({ stat }) => {
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      player.setStatStage(stat, 2);
+
+      expect(enemy).toNeverSelectMove(moveId);
+    });
+
+    it.each(relevantStats)("should be preferred when the opponent has increased $statName", async ({ stat }) => {
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      player.setStatStage(stat, 2);
+
+      expect(enemy).toPreferSelectingMove(moveId);
+    });
+
+    it.each(relevantStats)(
+      "should be avoided when the user has more $statName stages than the opponent",
+      async ({ stat }) => {
+        const player = game.field.getPlayerPokemon();
+        const enemy = game.field.getEnemyPokemon();
+        player.setStatStage(stat, 2);
+        enemy.setStatStage(stat, 3);
+
+        expect(enemy).toNeverSelectMove(moveId);
+      },
+    );
+  });
+});

--- a/test/ai/move-effect-scores/topsy-turvy.test.ts
+++ b/test/ai/move-effect-scores/topsy-turvy.test.ts
@@ -1,0 +1,74 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Topsy Turvy", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.TOPSY_TURVY, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when the target has no stat changes", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.TOPSY_TURVY);
+  });
+
+  it("should be preferred when the target has an increased stat stage", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, 1);
+
+    expect(enemy).toPreferSelectingMove(MoveId.TOPSY_TURVY);
+  });
+
+  it("should not be prioritized over KO moves", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.hp = 1;
+    player.setStatStage(Stat.ATK, 6);
+
+    expect(enemy).toNeverSelectMove(MoveId.TOPSY_TURVY);
+  });
+
+  it("should be preferred when an ally has a decreased stat stage", async () => {
+    game.override.battleType("double");
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.setStatStage(Stat.ATK, -1);
+
+    expect(enemy1).toPreferSelectingMove(MoveId.TOPSY_TURVY);
+  });
+});

--- a/test/ai/move-effect-scores/topsy-turvy.test.ts
+++ b/test/ai/move-effect-scores/topsy-turvy.test.ts
@@ -50,6 +50,16 @@ describe("AI (Move Effect Scores) - Topsy Turvy", () => {
     expect(enemy).toPreferSelectingMove(MoveId.TOPSY_TURVY);
   });
 
+  it("should be avoided when the target has a decreased stat stage", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStatStage(Stat.ATK, -1);
+
+    expect(enemy).toNeverSelectMove(MoveId.TOPSY_TURVY);
+  });
+
   it("should not be prioritized over KO moves", async () => {
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
@@ -70,5 +80,18 @@ describe("AI (Move Effect Scores) - Topsy Turvy", () => {
     enemy2.setStatStage(Stat.ATK, -1);
 
     expect(enemy1).toPreferSelectingMove(MoveId.TOPSY_TURVY);
+  });
+
+  it("should be avoided when an ally has an increased stat stage", async () => {
+    game.override.battleType("double");
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    // Set opponents to -1 ATK to make them unfavorable targets
+    game.scene.getPlayerField().forEach((p) => p.setStatStage(Stat.ATK, -1));
+    enemy2.setStatStage(Stat.ATK, 1);
+
+    expect(enemy1).toNeverSelectMove(MoveId.TOPSY_TURVY);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

The AI should now properly evaluate the following moves:
- Spectral Thief
- Psych Up
- Order Up
- Acupressure
- Fell Stinger
- Topsy-Turvy
- Haze, Freezy Frost, and Clear Smog
- Guard Swap, Power Swap, and Heart Swap
- Speed Swap
- Power Split and Guard Split

## Why am I making these changes?

Part of the AI Rework

## What are the changes from a developer perspective?

Added Effect Score overrides for the following move attributes:
- `StealPositiveStatsAttr`
- `CopyStatsAttr`
- `OrderUpStatBoostAttr`
- `AcupressureStatStageChangeAttr`
- `PostVictoryStatStageChangeAttr`
- `InvertStatsAttr`
- `ResetStatsAttr`
- `SwapStatStagesAttr`
- `SwapStatAttr`
- `AverageStatsAttr`

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`

New unit tests (can be run with `pnpm test move-effect-scores/testName`):
- `spectral-thief`
- `psych-up`
- `acupressure`
- `fell-stinger`
- `topsy-turvy`
- `haze`
- `clear-smog`
- `swap-stat-stages`
- `speed-swap`
- `average-stats`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?