### PR TITLE
ai-rework: Move ability- and move-revealing test utils to `FieldHelper`

### DIFF
--- a/test/ai/move-condition-scores/counter.test.ts
+++ b/test/ai/move-condition-scores/counter.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -36,7 +35,7 @@ describe("Move Condition Scores - Counter", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).not.toNeverSelectMove(MoveId.COUNTER);
@@ -47,7 +46,7 @@ describe("Move Condition Scores - Counter", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.COUNTER);
@@ -58,7 +57,7 @@ describe("Move Condition Scores - Counter", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.COUNTER);

--- a/test/ai/move-condition-scores/upper-hand.test.ts
+++ b/test/ai/move-condition-scores/upper-hand.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -36,7 +35,7 @@ describe("Move Condition Scores - Upper Hand", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.UPPER_HAND);
@@ -47,7 +46,7 @@ describe("Move Condition Scores - Upper Hand", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
     // Set Enemy to 1 HP to allow all of the Player's attacks to KO.
     // High-priority moves gain a major bonus to AS when they can KO opponents

--- a/test/ai/move-effect-scores/ability-change.test.ts
+++ b/test/ai/move-effect-scores/ability-change.test.ts
@@ -2,7 +2,6 @@ import { HIGH_VALUE_ABILITIES } from "#constants/ability-constants";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -39,7 +38,7 @@ describe("Move Effect Scores - Ability Change", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemyPokemon = game.field.getEnemyPokemon();
 
     expect(enemyPokemon).toPreferSelectingMove(MoveId.WORRY_SEED);
@@ -50,7 +49,7 @@ describe("Move Effect Scores - Ability Change", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemyPokemon = game.field.getEnemyPokemon();
 
     expect(enemyPokemon).not.toPreferSelectingMove(MoveId.WORRY_SEED);
@@ -71,7 +70,7 @@ describe("Move Effect Scores - Ability Change", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemyPokemon = game.field.getEnemyPokemon();
 
     expect(enemyPokemon).toNeverSelectMove(MoveId.WORRY_SEED);
@@ -82,7 +81,7 @@ describe("Move Effect Scores - Ability Change", () => {
 
     await game.classicMode.startBattle(SpeciesId.WISHIWASHI);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemyPokemon = game.field.getEnemyPokemon();
 
     expect(enemyPokemon).toNeverSelectMove(MoveId.WORRY_SEED);

--- a/test/ai/move-effect-scores/ability-copy.test.ts
+++ b/test/ai/move-effect-scores/ability-copy.test.ts
@@ -2,7 +2,6 @@ import { DETRIMENTAL_ABILITIES } from "#constants/ability-constants";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -50,7 +49,7 @@ describe("Move Effect Scores - Ability Copy", () => {
 
         await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-        revealAllAbilities(game.scene);
+        game.field.revealAllAbilities();
         const enemy = game.field.getEnemyPokemon();
 
         expect(enemy).toPreferSelectingMove(moveId);
@@ -64,7 +63,7 @@ describe("Move Effect Scores - Ability Copy", () => {
 
         await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-        revealAllAbilities(game.scene);
+        game.field.revealAllAbilities();
         const enemy = game.field.getEnemyPokemon();
 
         expect(enemy).toNeverSelectMove(moveId);
@@ -81,7 +80,7 @@ describe("Move Effect Scores - Ability Copy", () => {
 
       const [enemy1, enemy2] = game.scene.getEnemyField();
       game.field.mockAbility(enemy2, abilityId);
-      revealAllAbilities(game.scene);
+      game.field.revealAllAbilities();
 
       expect(enemy1).toPreferSelectingMove(MoveId.DOODLE);
     },

--- a/test/ai/move-effect-scores/ability-give.test.ts
+++ b/test/ai/move-effect-scores/ability-give.test.ts
@@ -2,7 +2,6 @@ import { DETRIMENTAL_ABILITIES, HIGH_VALUE_ABILITIES } from "#constants/ability-
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -41,7 +40,7 @@ describe("Move Effect Scores - Ability Give", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toPreferSelectingMove(MoveId.ENTRAINMENT);
@@ -56,7 +55,7 @@ describe("Move Effect Scores - Ability Give", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toPreferSelectingMove(MoveId.ENTRAINMENT);
@@ -77,7 +76,7 @@ describe("Move Effect Scores - Ability Give", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.ENTRAINMENT);
@@ -88,7 +87,7 @@ describe("Move Effect Scores - Ability Give", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.ENTRAINMENT);
@@ -99,7 +98,7 @@ describe("Move Effect Scores - Ability Give", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.ENTRAINMENT);

--- a/test/ai/move-effect-scores/belly-drum.test.ts
+++ b/test/ai/move-effect-scores/belly-drum.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -42,7 +41,7 @@ describe("Move Effect Scores - Belly Drum", () => {
     game.override.moveset(MoveId.THUNDERBOLT);
     await game.classicMode.startBattle(SpeciesId.REGIELEKI);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.BELLY_DRUM);
   });

--- a/test/ai/move-effect-scores/charm.test.ts
+++ b/test/ai/move-effect-scores/charm.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -50,7 +49,7 @@ describe("Move Effect Scores - Charm", () => {
 
     await game.classicMode.startBattle(SpeciesId.DRILBUR);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.CHARM);
   });
@@ -65,7 +64,7 @@ describe("Move Effect Scores - Charm", () => {
 
     await game.classicMode.startBattle(SpeciesId.DRILBUR);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.CHARM);
   });

--- a/test/ai/move-effect-scores/conditional-protect.test.ts
+++ b/test/ai/move-effect-scores/conditional-protect.test.ts
@@ -2,7 +2,6 @@ import { allMoves } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -46,7 +45,7 @@ describe("Move Effect Scores - Conditional Protection", () => {
 
       await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-      revealAllMoves(game.scene);
+      game.field.revealAllMoves();
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).not.toPreferSelectingMove(moveId);
     });
@@ -56,7 +55,7 @@ describe("Move Effect Scores - Conditional Protection", () => {
 
       await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
 
-      revealAllMoves(game.scene);
+      game.field.revealAllMoves();
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).toPreferSelectingMove(moveId);
     });
@@ -66,7 +65,7 @@ describe("Move Effect Scores - Conditional Protection", () => {
 
       await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
 
-      revealAllMoves(game.scene);
+      game.field.revealAllMoves();
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).not.toPreferSelectingMove(moveId);
     });

--- a/test/ai/move-effect-scores/drain-punch.test.ts
+++ b/test/ai/move-effect-scores/drain-punch.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -67,7 +66,7 @@ describe("Move Effect Scores - Drain Punch", () => {
 
     await game.classicMode.startBattle(SpeciesId.SNORLAX);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
     enemy.hp = 1;
     expect(enemy).toNeverSelectMove(MoveId.DRAIN_PUNCH);

--- a/test/ai/move-effect-scores/heal-block.test.ts
+++ b/test/ai/move-effect-scores/heal-block.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -47,7 +46,7 @@ describe("Move Effect Scores - Heal Block", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toPreferSelectingMove(MoveId.HEAL_BLOCK);
   });

--- a/test/ai/move-effect-scores/magnet-rise.test.ts
+++ b/test/ai/move-effect-scores/magnet-rise.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -44,7 +43,7 @@ describe("Move Effect Scores - Magnet Rise", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toPreferSelectingMove(MoveId.MAGNET_RISE);

--- a/test/ai/move-effect-scores/powder.test.ts
+++ b/test/ai/move-effect-scores/powder.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllMoves } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -39,7 +38,7 @@ describe("Move Effect Scores - Powder", () => {
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).not.toPreferSelectingMove(MoveId.POWDER);
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     expect(enemy).toPreferSelectingMove(MoveId.POWDER);
   });
 
@@ -57,7 +56,7 @@ describe("Move Effect Scores - Powder", () => {
 
     const enemy = game.field.getEnemyPokemon();
 
-    revealAllMoves(game.scene);
+    game.field.revealAllMoves();
     expect(enemy).not.toPreferSelectingMove(MoveId.POWDER);
   });
 });

--- a/test/ai/move-effect-scores/psycho-shift.test.ts
+++ b/test/ai/move-effect-scores/psycho-shift.test.ts
@@ -4,7 +4,6 @@ import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -106,7 +105,7 @@ describe("Move Effect Scores - Psycho Shift", () => {
         game.override.ability(immuneAbilityId);
 
         await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-        revealAllAbilities(game.scene);
+        game.field.revealAllAbilities();
 
         const enemy = game.field.getEnemyPokemon();
         expect(enemy).toNeverSelectMove(MoveId.PSYCHO_SHIFT);

--- a/test/ai/move-effect-scores/scary-face.test.ts
+++ b/test/ai/move-effect-scores/scary-face.test.ts
@@ -2,7 +2,6 @@ import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -65,7 +64,7 @@ describe("Move Effect Scores - Scary Face", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const player = game.field.getPlayerPokemon();
     const enemy = game.field.getEnemyPokemon();
 

--- a/test/ai/move-effect-scores/screech.test.ts
+++ b/test/ai/move-effect-scores/screech.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -53,7 +52,7 @@ describe("Move Effect Scores - Screech", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SCREECH);
   });
@@ -67,7 +66,7 @@ describe("Move Effect Scores - Screech", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.SCREECH);
   });

--- a/test/ai/move-effect-scores/strength-sap.test.ts
+++ b/test/ai/move-effect-scores/strength-sap.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -45,7 +44,7 @@ describe("Move Effect Scores - Strength Sap", () => {
 
     await game.classicMode.startBattle(SpeciesId.EXCADRILL);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
     enemy.hp = Math.floor(enemy.hp / 2);
 
@@ -57,7 +56,7 @@ describe("Move Effect Scores - Strength Sap", () => {
 
     await game.classicMode.startBattle(SpeciesId.EXCADRILL);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.STRENGTH_SAP);
   });

--- a/test/ai/move-effect-scores/suppress-abilities.test.ts
+++ b/test/ai/move-effect-scores/suppress-abilities.test.ts
@@ -2,7 +2,6 @@ import { HIGH_VALUE_ABILITIES } from "#constants/ability-constants";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -41,7 +40,7 @@ describe("Move Effect Scores - Ability Suppression", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toPreferSelectingMove(MoveId.GASTRO_ACID);
@@ -50,7 +49,7 @@ describe("Move Effect Scores - Ability Suppression", () => {
   it("Enemy should not prefer selecting Gastro Acid if the opponent has Torrent", async () => {
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).not.toPreferSelectingMove(MoveId.GASTRO_ACID);
@@ -71,7 +70,7 @@ describe("Move Effect Scores - Ability Suppression", () => {
 
     await game.classicMode.startBattle(SpeciesId.WISHIWASHI);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.GASTRO_ACID);

--- a/test/ai/move-effect-scores/switch-abilities.test.ts
+++ b/test/ai/move-effect-scores/switch-abilities.test.ts
@@ -2,7 +2,6 @@ import { DETRIMENTAL_ABILITIES } from "#constants/ability-constants";
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { revealAllAbilities } from "#test/test-utils/enemy-command-utils";
 import { GameManager } from "#test/test-utils/game-manager";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -41,7 +40,7 @@ describe("Move Effect Scores - Ability Switching", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toPreferSelectingMove(MoveId.SKILL_SWAP);
@@ -59,7 +58,7 @@ describe("Move Effect Scores - Ability Switching", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).not.toPreferSelectingMove(MoveId.SKILL_SWAP);
@@ -74,7 +73,7 @@ describe("Move Effect Scores - Ability Switching", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toPreferSelectingMove(MoveId.SKILL_SWAP);
@@ -85,7 +84,7 @@ describe("Move Effect Scores - Ability Switching", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.SKILL_SWAP);
@@ -96,7 +95,7 @@ describe("Move Effect Scores - Ability Switching", () => {
 
     await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    revealAllAbilities(game.scene);
+    game.field.revealAllAbilities();
     const enemy = game.field.getEnemyPokemon();
 
     expect(enemy).toNeverSelectMove(MoveId.SKILL_SWAP);

--- a/test/test-utils/enemy-command-utils.ts
+++ b/test/test-utils/enemy-command-utils.ts
@@ -53,16 +53,3 @@ export function getEnemyMoveChoices(pokemon: EnemyPokemon): MoveChoiceSet {
 
   return moveChoices;
 }
-
-/** Reveals the abilities of all Pokemon on the field */
-export function revealAllAbilities(scene: BattleScene): void {
-  scene.getField(true).forEach((p) => {
-    const abilityIds = p.getAbilities().map((ab) => ab.ability.id);
-    p.waveData.abilitiesRevealed.push(...abilityIds);
-  });
-}
-
-/** Reveals the moves of all Pokemon on the field */
-export function revealAllMoves(scene: BattleScene): void {
-  scene.getField(true).forEach((p) => p.getMoveset().forEach((mv) => p.waveData.revealedMoves.add(mv.moveId)));
-}

--- a/test/test-utils/helpers/field-helper.ts
+++ b/test/test-utils/helpers/field-helper.ts
@@ -90,4 +90,19 @@ export class FieldHelper extends GameManagerHelper {
     teraType ??= pokemon.getSpeciesForm(true).type1;
     vi.spyOn(pokemon, "teraType", "get").mockReturnValue(teraType);
   }
+
+  /** Reveals the abilities of all Pokemon on the field to the Enemy AI */
+  public revealAllAbilities(): void {
+    this.game.scene.getField(true).forEach((p) => {
+      const abilityIds = p.getAbilities().map((ab) => ab.ability.id);
+      p.waveData.abilitiesRevealed.push(...abilityIds);
+    });
+  }
+
+  /** Reveals the moves of all Pokemon on the field to the Enemy AI */
+  public revealAllMoves(): void {
+    this.game.scene
+      .getField(true)
+      .forEach((p) => p.getMoveset().forEach((mv) => p.waveData.revealedMoves.add(mv.moveId)));
+  }
 }


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

Some code cleanup for the AI Rework...

## What are the changes from a developer perspective?

The `revealAllAbiltiies` and `revealAllMoves` test utils are now methods within `FieldHelper` instead of standalone exported functions.

## How to test the changes?

`pnpm test:silent`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
