### PR TITLE
ai-rework: Rework multi-target move scoring logic

### DIFF
--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -787,6 +787,7 @@ export abstract class Move {
    * @param target - The {@linkcode Pokemon} targeted by the move
    * @param isKnockOut - `true` if the move is already known to KO the target (default `false`)
    * @param isFail - `true` if the move is already known to fail or have no effect (default `false`)
+   * @param isMultiTarget - `true` if the move is expected to apply to multiple Pokemon (default `false`)
    * @returns a score value accumulated from effect score modifiers.
    */
   public getEffectScore(
@@ -794,14 +795,15 @@ export abstract class Move {
     target: Pokemon,
     isKnockOut: boolean = false,
     isFail: boolean = false,
+    isMultiTarget: boolean = false,
   ): number {
     // penalize targeting Pokemon that are hidden by Commander
-    if (target && target.getAlly()?.getTag(BattlerTagType.COMMANDED)?.getSourcePokemon() === target) {
+    if (target && !isMultiTarget && target.getAlly()?.getTag(BattlerTagType.COMMANDED)?.getSourcePokemon() === target) {
       return COMMANDING_TARGET_PENALTY;
     }
 
     /** The combined score from all attributes of the move */
-    const attrScore = this.getCombinedAttributeScore(user, target, isKnockOut, isFail);
+    const attrScore = this.getCombinedAttributeScore(user, target, isKnockOut, isFail, isMultiTarget);
 
     /** The penalty given if the move is inaccurate */
     const accuracyPenalty = this.getBattleAccuracyPenalty(user, target);
@@ -817,6 +819,7 @@ export abstract class Move {
    * {@linkcode Pokemon.getAttackScore | Attack Score})
    * @param isFail - `true` if this move would fail or have no effect against the target
    * (as determined by {@linkcode getConditionScore | Condition Score})
+   * @param isMultiTarget - `true` if this move is expected to apply to multiple targets
    * @returns the cumulative integer score from this move's attributes
    * @see {@linkcode getEffectScore}
    * @see {@linkcode MoveAttr.getEffectScore}
@@ -826,15 +829,14 @@ export abstract class Move {
     target: Pokemon,
     isKnockOut: boolean,
     isFail: boolean,
+    isMultiTarget: boolean,
   ): number {
     if (target.isAlly(user)) {
       /*
-       * Attacks (other than Pollen Puff) are always penalized against allies
-       * TODO:
-       * - Reduce this penalty for multi-target moves
-       * - Use attribute flags instead of specific move IDs for more flexibility
+       * Single-target attacks (other than Pollen Puff) are always penalized against allies
+       * TODO: Use attribute flags instead of specific move IDs for more flexibility
        */
-      if (this.id !== MoveId.POLLEN_PUFF && !this.isStatusMove()) {
+      if (!isMultiTarget && this.id !== MoveId.POLLEN_PUFF && !this.isStatusMove()) {
         return ALLY_TARGET_PENALTY;
       }
 
@@ -842,20 +844,16 @@ export abstract class Move {
        * ALLY TARGET PENALTY:
        *
        * If the user is the target's ally, a {@link ALLY_TARGET_PENALTY | massive score penalty} is applied
-       * unless the move has at least one attribute that overrides the penalty.
+       * unless the move is multi-target or has at least one attribute that overrides the penalty.
        * In that case, the total score is the sum of {@link MoveAttr.getAllyTargetScore | ally target scores} from those
        * overriding attributes.
-       *
-       * **NOTE:** if at least one attribute overrides the Ally Target Penalty, ONLY
-       * the overriding attributes are accounted for in scoring. Score contributions
-       * from other non-overriding attributes are ignored.
        */
       const allyTargetScores = this.attrs
         .map((attr) => attr.getAllyTargetScore(user, target, this))
         .filter((score) => !isNil(score));
 
       if (allyTargetScores.length === 0) {
-        return ALLY_TARGET_PENALTY;
+        return isMultiTarget ? 0 : ALLY_TARGET_PENALTY;
       }
 
       return allyTargetScores.reduce((total, score) => total + score, 0);

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -1,9 +1,14 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { ALLY_TARGET_PENALTY } from "#constants/ai-constants";
+import type { MovePhase } from "#phases/move-phase";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { ConditionalCritAbAttr } from "#abilities/conditional-crit-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { activeOverrides } from "#app/overrides";
 import type { TurnCommand } from "#app/turn-command-manager";
-import { BAD_MOVE_PENALTY } from "#constants/ai-constants";
+import { BAD_MOVE_PENALTY, KO_ATTACK_SCORE } from "#constants/ai-constants";
 import { DYNAMAX_DAMAGE_TAKEN_FACTOR, PLAYER_PARTY_MAX_SIZE } from "#constants/game-constants";
 import { allMoves } from "#data/data-lists";
 import { pokemonPreEvolutions } from "#data/pokemon-pre-evolutions";
@@ -216,11 +221,74 @@ export class EnemyPokemon extends Pokemon {
     const attackScore = this.getAttackScore(target, move);
 
     const isFail = conditionScore <= BAD_MOVE_PENALTY || attackScore === -1;
-    const isKnockOut = !isFail && attackScore >= 4;
+    const isKnockOut = !isFail && attackScore >= KO_ATTACK_SCORE;
 
     return (
       (isFail ? BAD_MOVE_PENALTY : conditionScore + attackScore + this.getCriticalHitBonus(target, move, attackScore))
       + move.getEffectScore(this, target, isKnockOut, isFail)
+    );
+  }
+
+  /**
+   * Obtains the total score for the given multi-target move across
+   * all given targets when used by this Pokemon. The components of this score
+   * are much like that of {@link getMoveScore | single-target move scoring},
+   * but there are a few key differences:
+   * - Attack Score (AS) is based on the combined individual AS of each target.
+   * targeted allies to the user have their AS inverted when added to the combined score.
+   * - The {@linkcode BAD_MOVE_PENALTY} applies if the move is expected to fail
+   * OR the move is expected to deal more damage to allies than opponents (approximated by AS).
+   * - The {@linkcode ALLY_TARGET_PENALTY} does not apply to Effect Score (ES) calculations.
+   * @param targets - An array of all {@linkcode Pokemon} targeted by the move
+   * @param move - The {@linkcode Move} to evaluate
+   * @returns The sum of this move's score components across all targets
+   */
+  private getMultiTargetMoveScore(targets: Pokemon[], move: Move): number {
+    /**
+     * CS is equal to the highest individual CS across all targets,
+     * i.e. if the move is expected to succeed against at least one Pokemon,
+     * the move won't be penalized.
+     */
+    const conditionScore = Math.max(...targets.map((target) => move.getConditionScore(this, target)));
+    /**
+     * AS for multi-targeted moves is accumulated from all active Pokemon
+     * targeted by the move. Allied targets' AS is inverted before it is
+     * added to the total AS. Since {@linkcode getAttackScore} codifies
+     * 0-damage attacks with an AS of (-1), targeted allies that are immune
+     * effectively grant a {@linkcode MINOR_EFFECT_SCORE_BONUS} to the move action.
+     *
+     * Assuming the attack doesn't have high priority, this score has a maximum
+     * value of (+9) (2 opponent KOs + 1 immune ally in a double battle). Status
+     * moves still receive an AS of (+0) in all cases.
+     */
+    const attackScores = targets.map(
+      (target) => (target.isOpponent(this) ? 1 : -1) * this.getAttackScore(target, move),
+    );
+
+    const isFail = conditionScore <= BAD_MOVE_PENALTY;
+    const isKnockOut = attackScores.map((score) => !isFail && score >= KO_ATTACK_SCORE);
+    const totalAttackScore = attackScores.reduce((total, score) => total + score);
+
+    /**
+     * A multi-target move action is considered "bad" if the move is expected
+     * to fail or deal more damage to allies than opponents.
+     */
+    const isBadMove = isFail || totalAttackScore < 0;
+
+    /**
+     * The critical hit bonus for this move action is the sum of
+     * single-target critical hit bonuses against all opponent targets.
+     */
+    const critBonus = targets.reduce((score, target, i) => {
+      if (!target.isOpponent(this)) {
+        return score;
+      }
+      return score + this.getCriticalHitBonus(target, move, attackScores[i]);
+    }, 0);
+
+    return (
+      (isBadMove ? BAD_MOVE_PENALTY : conditionScore + totalAttackScore + critBonus)
+      + targets.reduce((score, target, i) => score + move.getEffectScore(this, target, isKnockOut[i], isFail, true), 0)
     );
   }
 
@@ -449,11 +517,10 @@ export class EnemyPokemon extends Pokemon {
         score,
       };
     }
+
     if (move.isFieldTarget()) {
-      /**
-       * Field-targeting effects are internally self-targeted during
-       * score evaluation.
-       */
+      // Field-targeting effects are internally self-targeted during
+      // score evaluation.
       const score = this.getMoveScore(this, move);
 
       return {
@@ -471,11 +538,23 @@ export class EnemyPokemon extends Pokemon {
      */
     const activeTargets = targets.filter((bi) => !isNil(globalScene.getPokemonByBattlerIndex(bi)));
     if (activeTargets.length === 0) {
-      /** Moves with no valid targets are given a "fail penalty" of (-5). */
+      // Moves with no valid targets are given a "fail penalty" of (-5).
       return {
         moveId: move.id,
         targets: [],
         score: BAD_MOVE_PENALTY,
+      };
+    }
+
+    if (multiple) {
+      // Multi-target moves are evaluated by their cumulative score across all valid targets
+      return {
+        moveId: move.id,
+        targets,
+        score: this.getMultiTargetMoveScore(
+          targets.map((bi) => globalScene.getPokemonByBattlerIndex(bi)).filter((p) => !isNil(p)),
+          move,
+        ),
       };
     }
 
@@ -487,17 +566,6 @@ export class EnemyPokemon extends Pokemon {
       (bi) => [bi, this.getMoveScore(globalScene.getPokemonByBattlerIndex(bi)!, move)], // TODO: find a way to get rid of this bang
     );
 
-    if (multiple) {
-      /**
-       * Multi-targeted moves use the full target set and the sum of move scores
-       * for each target.
-       */
-      return {
-        moveId: move.id,
-        targets,
-        score: targetScores.map((ts) => ts[1]).reduce((total, score) => total + score),
-      };
-    }
     if (move.moveTarget === MoveTarget.RANDOM_NEAR_ENEMY) {
       /**
        * Moves with random targeting resolve their final target within {@linkcode getMoveTargets},
@@ -514,6 +582,7 @@ export class EnemyPokemon extends Pokemon {
         score: averageScore,
       };
     }
+
     /**
      * Single-target moves form an optimal move action with the highest-scoring
      * {@linkcode BattlerIndex}. {@linkcode targetScores} is shuffled here so

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -550,9 +550,9 @@ export class EnemyPokemon extends Pokemon {
       // Multi-target moves are evaluated by their cumulative score across all valid targets
       return {
         moveId: move.id,
-        targets,
+        targets: activeTargets,
         score: this.getMultiTargetMoveScore(
-          targets.map((bi) => globalScene.getPokemonByBattlerIndex(bi)).filter((p) => !isNil(p)),
+          activeTargets.map((bi) => globalScene.getPokemonByBattlerIndex(bi)!),
           move,
         ),
       };

--- a/test/ai/move-effect-scores/earthquake.test.ts
+++ b/test/ai/move-effect-scores/earthquake.test.ts
@@ -1,0 +1,84 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Earthquake", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("double")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.EARTHQUAKE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when all targets can be hit", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).toPreferSelectingMove(MoveId.EARTHQUAKE);
+  });
+
+  it("should be preferred when all targets can be knocked out", async () => {
+    // Remove Tackle since it would have the same AS in this situation
+    game.override.enemyMoveset([MoveId.EARTHQUAKE, MoveId.SPLASH]);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    for (const p of game.scene.getField(true)) {
+      p.hp = 1;
+    }
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).toPreferSelectingMove(MoveId.EARTHQUAKE);
+  });
+
+  it("should be avoided when only the user's ally can be knocked out", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.hp = 1;
+
+    expect(enemy1).toNeverSelectMove(MoveId.EARTHQUAKE);
+  });
+
+  it("should be avoided when all targets are immune", async () => {
+    // Player Pokemon are both Flying-type
+    await game.classicMode.startBattle(SpeciesId.DUCKLETT, SpeciesId.WINGULL);
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).toNeverSelectMove(MoveId.EARTHQUAKE);
+  });
+
+  it("should be preferred when the user's ally is immune", async () => {
+    // Enemy Pokemon are both Flying-type
+    game.override.enemySpecies(SpeciesId.DUCKLETT);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.hp = 1;
+
+    expect(enemy1).toPreferSelectingMove(MoveId.EARTHQUAKE);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?

The AI should be more inclined to use multi-target moves in favorable situations in double battles.

## Why am I making these changes?

The AI has been using the Ally Target Penalty to dissuade it from attacking its allies with single-target attacks. However, this penalty also affected multi-target attacks, which basically prevented the AI from ever selecting spread moves like Earthquake in double battles as long as they had an active ally. This fixes that and other weak points in the scoring calculation.

## What are the changes from a developer perspective?

- Added `EnemyPokemon.getMultiTargetMoveScore`, which calculates Move Score for moves that can target multiple Pokemon (even if they only have 1 valid target).
- Added a `isMultiTarget` optional parameter to Effect Score calculating methods.

Move scoring for multi-target moves has several components similar to that of single-target moves (`getMoveScore`). However, there are a few key differences:
- Attack Score (AS) is calculated based on the combined individual AS-es against all valid targets. Allies' AS-es are inverted when added to the total AS.
- The critical hit bonus is calculated for each opposing target, then added together. Ally targets don't contribute to this bonus.
- In addition to the usual conditions, a multi-targeted move action is considered "bad" if the move is expected to deal more damage to the user's allies than to its opponents. Damage is approximated by AS calculations.
- The Ally Target Penalty does not apply to multi-targeted moves of any kind when calculating Effect Score.

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`
- [x] `pnpm test[:silent] move-effect-scores/earthquake` (**NEW**)

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
