### PR TITLE
ai-rework: Add Effect Scores for self-damaging move effects

### DIFF
--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -76,3 +76,9 @@ export const POST_STAT_STAGE_REDUCTION_ABILITIES = Object.freeze<AbilityId[]>([
   AbilityId.DEFIANT,
   AbilityId.COMPETITIVE,
 ]);
+
+/** Abilities that grant the source immunity to recoil damage from its attacks */
+export const RECOIL_DAMAGE_PREVENTION_ABILITIES = Object.freeze<AbilityId[]>([
+  AbilityId.ROCK_HEAD,
+  AbilityId.MAGIC_GUARD,
+]);

--- a/src/constants/ai-constants.ts
+++ b/src/constants/ai-constants.ts
@@ -23,6 +23,13 @@ export const KO_ATTACK_SCORE = 4;
 export const ATTACK_SCORE_HP_THRESHOLD = 40;
 
 /**
+ * A relatively minor bonus to a move attribute's {@link MoveAttr.getEffectScore | Effect Score}.
+ * Used when a move with the attribute gains a slight advantage in
+ * a given battle state.
+ */
+export const MINOR_EFFECT_SCORE_BONUS = 1;
+
+/**
  * A relatively major bonus to a move attribute's {@link MoveAttr.getEffectScore | Effect Score}.
  * Used when a move with the attribute gains a decisive advantage in
  * a given battle state.
@@ -30,11 +37,19 @@ export const ATTACK_SCORE_HP_THRESHOLD = 40;
 export const MAJOR_EFFECT_SCORE_BONUS = 2;
 
 /**
- * A relatively minor bonus to a move attribute's {@link MoveAttr.getEffectScore | Effect Score}.
- * Used when a move with the attribute gains a slight advantage in
- * a given battle state.
+ * A drastic bonus to a move attribute's {@link MoveAttr.getEffectScore | Effect Score}.
+ * This should be used very sparingly; it tows the line of Effect Scores'
+ * {@link SOFT_EFFECT_SCORE_LIMIT | soft limit} and may cause some moves
+ * to surpass the scores of moves that can KO if not used carefully.
  */
-export const MINOR_EFFECT_SCORE_BONUS = 1;
+export const DRASTIC_EFFECT_SCORE_BONUS = 3;
+
+/**
+ * A relatively minor penalty to a move's score. Used when a move has
+ * a potential drawback or has a chance of failing from an unresolvable condition
+ * in a given battle state.
+ */
+export const MINOR_EFFECT_SCORE_PENALTY = -MINOR_EFFECT_SCORE_BONUS;
 
 /**
  * A relatively major penalty to a move's score. Used when a move has
@@ -44,11 +59,10 @@ export const MINOR_EFFECT_SCORE_BONUS = 1;
 export const MAJOR_EFFECT_SCORE_PENALTY = -MAJOR_EFFECT_SCORE_BONUS;
 
 /**
- * A relatively minor penalty to a move's score. Used when a move has
- * a potential drawback or has a chance of failing from an unresolvable condition
- * in a given battle state.
+ * A drastic penalty to a move attribute's {@link MoveAttr.getEffectScore | Effect Score}.
+ * The AI should avoid moves with this penalty outside of extreme circumstances.
  */
-export const MINOR_EFFECT_SCORE_PENALTY = -MINOR_EFFECT_SCORE_BONUS;
+export const DRASTIC_EFFECT_SCORE_PENALTY = -DRASTIC_EFFECT_SCORE_BONUS;
 
 /**
  * A weakly enforced upper limit for move attributes' {@link MoveAttr.getEffectScore | Effect Scores}.

--- a/src/data/moves/move-attrs/add-substitute-attr.ts
+++ b/src/data/moves/move-attrs/add-substitute-attr.ts
@@ -1,6 +1,12 @@
 import { getPokemonNameWithAffix } from "#app/messages";
+import {
+  MAJOR_EFFECT_SCORE_BONUS,
+  MINOR_EFFECT_SCORE_BONUS,
+  STRONG_MATCHUP_SCORE_THRESHOLD,
+} from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { HitResult } from "#enums/hit-result";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -26,14 +32,7 @@ export class AddSubstituteAttr extends MoveEffectAttr {
     this.isShedTail = isShedTail;
   }
 
-  private getHpCost(user: Pokemon): number {
-    if (this.isShedTail) {
-      return Math.ceil(user.getMaxHp() * 0.5);
-    }
-    return Math.floor(user.getMaxHp() * 0.25);
-  }
-
-  override applyEffect(user: Pokemon, _target: Pokemon, move: Move): boolean {
+  public override applyEffect(user: Pokemon, _target: Pokemon, move: Move): boolean {
     const hpCost = this.getHpCost(user);
     user.damageAndUpdate(hpCost, {
       result: HitResult.OTHER,
@@ -44,14 +43,14 @@ export class AddSubstituteAttr extends MoveEffectAttr {
     return true;
   }
 
-  override getUserBenefitScore(user: Pokemon, _target: Pokemon, _move: Move): number {
-    if (user.isBoss()) {
-      return -10;
+  private getHpCost(user: Pokemon): number {
+    if (this.isShedTail) {
+      return Math.ceil(user.getMaxHp() * 0.5);
     }
-    return 5;
+    return Math.floor(user.getMaxHp() * 0.25);
   }
 
-  override getCondition(): MoveConditionFunc {
+  public override getCondition(): MoveConditionFunc {
     /**
      * Only works if
      * - The user does not have a substitute out already
@@ -62,7 +61,12 @@ export class AddSubstituteAttr extends MoveEffectAttr {
       !user.hasTag(BattlerTagType.SUBSTITUTE) && user.hp > this.getHpCost(user) && user.getMaxHp() > 1;
   }
 
-  override getFailedText(user: Pokemon, _target: Pokemon, _move: Move, _cancelled: BooleanHolder): string | null {
+  public override getFailedText(
+    user: Pokemon,
+    _target: Pokemon,
+    _move: Move,
+    _cancelled: BooleanHolder,
+  ): string | null {
     if (user.hasTag(BattlerTagType.SUBSTITUTE)) {
       return i18next.t("moveTriggers:substituteOnOverlap", { pokemonName: getPokemonNameWithAffix(user) });
     }
@@ -70,5 +74,25 @@ export class AddSubstituteAttr extends MoveEffectAttr {
       return i18next.t("moveTriggers:substituteNotEnoughHp");
     }
     return i18next.t("battle:attackFailed");
+  }
+
+  /**
+   * @returns
+   * - (-10) if the user is a Boss Pokemon
+   * - A {@linkcode MINOR_EFFECT_SCORE_BONUS} if this attribute is for Shed Tail's substitute effect
+   * - A {@linkcode MAJOR_EFFECT_SCORE_BONUS} if this attribute is for Substitute and the
+   *   user has a {@link STRONG_MATCHUP_SCORE_THRESHOLD | strong matchup} against its opponents
+   * - (+0) if none of the above conditions apply
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    if (user.isBoss()) {
+      return -10;
+    }
+
+    if (this.isShedTail) {
+      return MINOR_EFFECT_SCORE_BONUS;
+    }
+
+    return user.getAverageMatchupScore() >= STRONG_MATCHUP_SCORE_THRESHOLD ? MAJOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/add-substitute-attr.ts
+++ b/src/data/moves/move-attrs/add-substitute-attr.ts
@@ -1,8 +1,8 @@
 import { getPokemonNameWithAffix } from "#app/messages";
 import {
+  FAVORABLE_MATCHUP_SCORE_THRESHOLD,
   MAJOR_EFFECT_SCORE_BONUS,
   MINOR_EFFECT_SCORE_BONUS,
-  STRONG_MATCHUP_SCORE_THRESHOLD,
 } from "#constants/ai-constants";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { HitResult } from "#enums/hit-result";
@@ -81,7 +81,7 @@ export class AddSubstituteAttr extends MoveEffectAttr {
    * - (-10) if the user is a Boss Pokemon
    * - A {@linkcode MINOR_EFFECT_SCORE_BONUS} if this attribute is for Shed Tail's substitute effect
    * - A {@linkcode MAJOR_EFFECT_SCORE_BONUS} if this attribute is for Substitute and the
-   *   user has a {@link STRONG_MATCHUP_SCORE_THRESHOLD | strong matchup} against its opponents
+   *   user has a {@link FAVORABLE_MATCHUP_SCORE_THRESHOLD | favorable matchup} against its opponents
    * - (+0) if none of the above conditions apply
    */
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
@@ -93,6 +93,6 @@ export class AddSubstituteAttr extends MoveEffectAttr {
       return MINOR_EFFECT_SCORE_BONUS;
     }
 
-    return user.getAverageMatchupScore() >= STRONG_MATCHUP_SCORE_THRESHOLD ? MAJOR_EFFECT_SCORE_BONUS : 0;
+    return user.getAverageMatchupScore() >= FAVORABLE_MATCHUP_SCORE_THRESHOLD ? MAJOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
+++ b/src/data/moves/move-attrs/cut-hp-stat-stage-boost-attr.ts
@@ -57,6 +57,10 @@ export class CutHpStatStageBoostAttr extends StatStageChangeAttr {
    * grants a {@linkcode BAD_MOVE_PENALTY}.
    */
   public override getRawEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (user.isBoss()) {
+      return -10;
+    }
+
     const oppMaxEas = user.getOpponents().map((opp) =>
       opp.estimateAttackMoves().reduce((maxEas, mv) => {
         const eas = opp.getExpectedAttackScore(user, mv);

--- a/src/data/moves/move-attrs/half-sacrificial-attr.ts
+++ b/src/data/moves/move-attrs/half-sacrificial-attr.ts
@@ -2,7 +2,7 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { BlockNonDirectDamageAbAttr } from "#abilities/block-non-direct-damage-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import { ATTACK_SCORE_HP_THRESHOLD, BAD_MOVE_PENALTY } from "#constants/ai-constants";
+import { ATTACK_SCORE_HP_THRESHOLD, BAD_MOVE_PENALTY, MINOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { HitResult } from "#enums/hit-result";
 import { MoveEffectTrigger } from "#enums/move-effect-trigger";
@@ -51,6 +51,10 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
    * penalty from this effect and therefore should virtually never use moves with it.
    */
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    if (user.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
+      return 0;
+    }
+
     if (user.isBoss()) {
       return -10;
     }
@@ -66,7 +70,7 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
     const meetsHpCutThreshold = oppMaxEas.every(
       (eas) => eas < ((user.getHpRatio() - 0.5) * 100) / ATTACK_SCORE_HP_THRESHOLD,
     );
-    const hpCutPenalty = meetsHpCutThreshold ? 0 : BAD_MOVE_PENALTY;
+    const hpCutPenalty = meetsHpCutThreshold ? MINOR_EFFECT_SCORE_PENALTY : BAD_MOVE_PENALTY;
 
     return hpCutPenalty;
   }

--- a/src/data/moves/move-attrs/half-sacrificial-attr.ts
+++ b/src/data/moves/move-attrs/half-sacrificial-attr.ts
@@ -2,9 +2,11 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { BlockNonDirectDamageAbAttr } from "#abilities/block-non-direct-damage-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { ATTACK_SCORE_HP_THRESHOLD, BAD_MOVE_PENALTY } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { HitResult } from "#enums/hit-result";
 import { MoveEffectTrigger } from "#enums/move-effect-trigger";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -21,7 +23,7 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
     super(true, { trigger: MoveEffectTrigger.POST_TARGET });
   }
 
-  override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     const cancelled = new BooleanHolder(false);
     // Check to see if the Pokemon has an ability that blocks non-direct damage
     applyAbAttrs<BlockNonDirectDamageAbAttr>(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE, user, false, cancelled);
@@ -39,12 +41,33 @@ export class HalfSacrificialAttr extends MoveEffectAttr {
     return true;
   }
 
-  override getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
+  /**
+   * @returns An additional penalty for reducing the user's HP to go with the score
+   * for this effect's stat stage changes. This checks each of the user's opponents'
+   * max {@link Pokemon.getExpectedAttackScore | EAS} among their estimated attacks
+   * to predict how much damage the user will receive this turn. If the user is
+   * projected to receive enough damage to faint after applying this effect, this
+   * grants a {@linkcode BAD_MOVE_PENALTY}. Boss Pokemon are always granted a (-10)
+   * penalty from this effect and therefore should virtually never use moves with it.
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
     if (user.isBoss()) {
       return -10;
     }
-    return Math.ceil(
-      ((1 - user.getHpRatio() / 2) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, user) - 0.5),
+
+    const oppMaxEas = user.getOpponents().map((opp) =>
+      opp.estimateAttackMoves().reduce((maxEas, mv) => {
+        const eas = opp.getExpectedAttackScore(user, mv);
+
+        return Math.max(maxEas, eas);
+      }, 0),
     );
+
+    const meetsHpCutThreshold = oppMaxEas.every(
+      (eas) => eas < ((user.getHpRatio() - 0.5) * 100) / ATTACK_SCORE_HP_THRESHOLD,
+    );
+    const hpCutPenalty = meetsHpCutThreshold ? 0 : BAD_MOVE_PENALTY;
+
+    return hpCutPenalty;
   }
 }

--- a/src/data/moves/move-attrs/recoil-attr.ts
+++ b/src/data/moves/move-attrs/recoil-attr.ts
@@ -3,8 +3,11 @@ import type { BlockNonDirectDamageAbAttr } from "#abilities/block-non-direct-dam
 import type { BlockRecoilDamageAbAttr } from "#abilities/block-recoil-damage-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { RECOIL_DAMAGE_PREVENTION_ABILITIES } from "#constants/ability-constants";
+import { ATTACK_SCORE_HP_THRESHOLD, BAD_MOVE_PENALTY } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { HitResult } from "#enums/hit-result";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -27,7 +30,7 @@ export class RecoilAttr extends MoveEffectAttr {
     this.unblockable = unblockable;
   }
 
-  override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     const cancelled = new BooleanHolder(false);
     if (!this.unblockable) {
       applyAbAttrs<BlockRecoilDamageAbAttr>(AbAttrFlag.BLOCK_RECOIL_DAMAGE, user, false, cancelled);
@@ -62,7 +65,34 @@ export class RecoilAttr extends MoveEffectAttr {
     return true;
   }
 
-  override getUserBenefitScore(_user: Pokemon, _target: Pokemon, move: Move): number {
-    return Math.floor(move.power / 5 / -4);
+  /**
+   * @returns An Effect Score penalty that reflects the Attack Score given for
+   * dealing the estimated recoil damage to the user.
+   * - If the user has an ability that prevents recoil damage, this grants (+0).
+   * - Otherwise, estimate the damage dealt to the user from this effect
+   *   - If the user is expected to faint from this effect,
+   *   grant a {@linkcode BAD_MOVE_PENALTY}
+   *   - Otherwise, the penalty from this effect is roughly equal to the EAS
+   *   for the estimated damage dealt to the user, inverted and rounded to the
+   *   nearest integer. If the user is a Boss Pokemon, this penalty is doubled.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, move: Move): number {
+    if (RECOIL_DAMAGE_PREVENTION_ABILITIES.some((abId) => user.hasAbility(abId))) {
+      return 0;
+    }
+
+    const approxSelfDamage = toDmgValue(
+      user.getExpectedAttackScore(target, move)
+        * (ATTACK_SCORE_HP_THRESHOLD / 100)
+        * target.getMaxHp()
+        * this.damageRatio,
+    );
+
+    if (approxSelfDamage > user.hp) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    const selfDamagePenalty = ((-approxSelfDamage / user.getMaxHp()) * 100) / ATTACK_SCORE_HP_THRESHOLD;
+    return Math.round(selfDamagePenalty) * (user.isBoss() ? 2 : 1);
   }
 }

--- a/src/data/moves/move-attrs/remove-type-attr.ts
+++ b/src/data/moves/move-attrs/remove-type-attr.ts
@@ -1,5 +1,7 @@
+import { MINOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveEffectTrigger } from "#enums/move-effect-trigger";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -23,7 +25,7 @@ export class RemoveTypeAttr extends MoveEffectAttr {
     this.messageCallback = messageCallback;
   }
 
-  override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     if (user.isTerastallized && user.teraType === this.removedType) {
       // active tera types cannot be removed
       return false;
@@ -42,5 +44,10 @@ export class RemoveTypeAttr extends MoveEffectAttr {
     }
 
     return true;
+  }
+
+  /** @returns a {@linkcode MINOR_EFFECT_SCORE_PENALTY} if the user isn't Terastallized */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    return user.isTerastallized ? 0 : MINOR_EFFECT_SCORE_PENALTY;
   }
 }

--- a/src/data/moves/move-attrs/remove-type-attr.ts
+++ b/src/data/moves/move-attrs/remove-type-attr.ts
@@ -48,6 +48,13 @@ export class RemoveTypeAttr extends MoveEffectAttr {
 
   /** @returns a {@linkcode MINOR_EFFECT_SCORE_PENALTY} if the user isn't Terastallized */
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
-    return user.isTerastallized ? 0 : MINOR_EFFECT_SCORE_PENALTY;
+    /**
+     * Whether or not the user is set to Terastallize into the type matching this effect
+     * @todo {@linkcode EnemyPokemon.shouldTera}'s output may need to be cached in the future to
+     * make this and the user's final decision to Tera consistent
+     */
+    const willTera = user.shouldTera() && user.teraType === this.removedType;
+
+    return user.isTerastallized || willTera ? 0 : MINOR_EFFECT_SCORE_PENALTY;
   }
 }

--- a/src/data/moves/move-attrs/sacrificial-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-attr.ts
@@ -1,5 +1,11 @@
+import {
+  DRASTIC_EFFECT_SCORE_PENALTY,
+  FAVORABLE_MATCHUP_SCORE_THRESHOLD,
+  MINOR_EFFECT_SCORE_PENALTY,
+} from "#constants/ai-constants";
 import { HitResult } from "#enums/hit-result";
 import { MoveEffectTrigger } from "#enums/move-effect-trigger";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -12,7 +18,7 @@ export class SacrificialAttr extends MoveEffectAttr {
     super(true, { trigger: onHit ? MoveEffectTrigger.POST_APPLY : MoveEffectTrigger.POST_TARGET });
   }
 
-  override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  public override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
     user.damageAndUpdate(user.hp, {
       result: HitResult.SELF_KO,
       ignoreSegments: true,
@@ -22,10 +28,20 @@ export class SacrificialAttr extends MoveEffectAttr {
     return true;
   }
 
-  override getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
+  /**
+   * @returns A penalty corresponding to the user's perceived matchup against its opponents.
+   * If the user's average MUS is below the {@linkcode FAVORABLE_MATCHUP_SCORE_THRESHOLD},
+   * this grants a {@linkcode MINOR_EFFECT_SCORE_PENALTY}. Otherwise, this grants a
+   * {@linkcode DRASTIC_EFFECT_SCORE_PENALTY}. Boss Pokemon are always granted
+   * a (-20) penalty from this effect and therefore should virtually never use moves with it.
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
     if (user.isBoss()) {
       return -20;
     }
-    return Math.ceil(((1 - user.getHpRatio()) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, user) - 0.5));
+
+    return user.getAverageMatchupScore() <= FAVORABLE_MATCHUP_SCORE_THRESHOLD
+      ? MINOR_EFFECT_SCORE_PENALTY
+      : DRASTIC_EFFECT_SCORE_PENALTY;
   }
 }

--- a/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
@@ -4,7 +4,6 @@ import {
   ATTACK_SCORE_HP_THRESHOLD,
   BAD_MOVE_PENALTY,
   FAVORABLE_MATCHUP_SCORE_THRESHOLD,
-  MINOR_EFFECT_SCORE_BONUS,
 } from "#constants/ai-constants";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
@@ -63,6 +62,10 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
    * against its opponents, this grants a {@linkcode BAD_MOVE_PENALTY}.
    * - Otherwise, this attribute's Effect Score scales with the damage taken by the
    * most damaged non-fainted Pokemon in the user's party (in terms of % max HP).
+   *
+   * Note that Lunar Dance's PP-restoring effect does not contribute to Effect Score.
+   * Because enemies only appear for a single battle, an individual Pokemon's PP isn't
+   * expected to have a significant impact in battle.
    */
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
     if (user.isBoss()) {
@@ -83,6 +86,6 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
       return BAD_MOVE_PENALTY;
     }
 
-    return healScore + (this.restorePP ? MINOR_EFFECT_SCORE_BONUS : 0);
+    return healScore;
   }
 }

--- a/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
@@ -77,10 +77,12 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
 
     const maxHealPercentage = Math.max(...possibleHealTargets.map((p) => p.getInverseHp() / p.getMaxHp()), 0);
 
-    const healScore =
-      Math.floor((maxHealPercentage * 100) / ATTACK_SCORE_HP_THRESHOLD)
-      + (this.restorePP ? MINOR_EFFECT_SCORE_BONUS : 0);
+    const healScore = Math.floor((maxHealPercentage * 100) / ATTACK_SCORE_HP_THRESHOLD);
 
-    return healScore === 0 ? BAD_MOVE_PENALTY : healScore;
+    if (healScore === 0) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    return healScore + (this.restorePP ? MINOR_EFFECT_SCORE_BONUS : 0);
   }
 }

--- a/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-full-restore-attr.ts
@@ -1,6 +1,13 @@
 import { globalScene } from "#app/global-scene";
 import type { PendingHealTag } from "#arena-tags/pending-heal-tag";
+import {
+  ATTACK_SCORE_HP_THRESHOLD,
+  BAD_MOVE_PENALTY,
+  FAVORABLE_MATCHUP_SCORE_THRESHOLD,
+  MINOR_EFFECT_SCORE_BONUS,
+} from "#constants/ai-constants";
 import { ArenaTagType } from "#enums/arena-tag-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { SacrificialAttr } from "#moves/sacrificial-attr";
@@ -25,7 +32,7 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
     this.moveTriggerMessage = moveTriggerMessage;
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
     globalScene.arena.addTag(ArenaTagType.PENDING_HEAL, 0);
 
     const tag = globalScene.arena.findTag<PendingHealTag>(ArenaTagType.PENDING_HEAL);
@@ -39,16 +46,41 @@ export class SacrificialFullRestoreAttr extends SacrificialAttr {
     return super.applyEffect(user, target, move);
   }
 
-  override getUserBenefitScore(_user: Pokemon, _target: Pokemon, _move: Move): number {
-    return -20;
-  }
-
   /**
    * Only works if there is at least 1 unfainted allowed Pokemon in the party and not already in battle
    * @returns the condition function to add to Move objects with this attribute
    */
-  override getCondition(): MoveConditionFunc {
+  public override getCondition(): MoveConditionFunc {
     return (user, _target, _move) =>
       user.getParty().filter((p) => p.isActive()).length > globalScene.currentBattle.getBattlerCount();
+  }
+
+  /**
+   * @returns An Effect Score modifier as follows:
+   * - If the user is a Boss, this grants (-20). Bosses should virtually never
+   * use moves with this effect.
+   * - If the user has a {@link FAVORABLE_MATCHUP_SCORE_THRESHOLD | favorable matchup}
+   * against its opponents, this grants a {@linkcode BAD_MOVE_PENALTY}.
+   * - Otherwise, this attribute's Effect Score scales with the damage taken by the
+   * most damaged non-fainted Pokemon in the user's party (in terms of % max HP).
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    if (user.isBoss()) {
+      return -20;
+    }
+
+    if (user.getAverageMatchupScore() >= FAVORABLE_MATCHUP_SCORE_THRESHOLD) {
+      return BAD_MOVE_PENALTY;
+    }
+
+    const possibleHealTargets = user.getParty().filter((p) => !p.isActive(true) && p.isAllowedInBattle());
+
+    const maxHealPercentage = Math.max(...possibleHealTargets.map((p) => p.getInverseHp() / p.getMaxHp()), 0);
+
+    const healScore =
+      Math.floor((maxHealPercentage * 100) / ATTACK_SCORE_HP_THRESHOLD)
+      + (this.restorePP ? MINOR_EFFECT_SCORE_BONUS : 0);
+
+    return healScore === 0 ? BAD_MOVE_PENALTY : healScore;
   }
 }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -831,6 +831,10 @@ export abstract class Move {
     isFail: boolean,
     isMultiTarget: boolean,
   ): number {
+    let attrs = this.attrs.filter(
+      (attr) => !(attr instanceof MoveEffectAttr && attr.trigger === MoveEffectTrigger.POST_TARGET),
+    );
+
     if (target.isAlly(user)) {
       /*
        * Single-target attacks (other than Pollen Puff) are always penalized against allies
@@ -859,7 +863,6 @@ export abstract class Move {
       return allyTargetScores.reduce((total, score) => total + score, 0);
     }
 
-    let attrs: MoveAttr[] = this.attrs;
     if (isKnockOut) {
       /*
        * If the move KOs the target, only the following attributes contribute to score:
@@ -875,7 +878,27 @@ export abstract class Move {
       attrs = attrs.filter((attr) => attr.appliesScoreOnFail);
     }
 
-    return attrs.map((attr) => attr.getEffectScore(user, target, this)).reduce((total, score) => total + score, 0);
+    return attrs.reduce((score, attr) => score + attr.getEffectScore(user, target, this), 0);
+  }
+
+  /**
+   * Calculates the Effect Score gained (or lost) from all move effects
+   * with a {@linkcode MoveEffectTrigger.POST_TARGET | POST_TARGET} effect trigger.
+   * These effects trigger exactly once instead of once per target.
+   * @param user - The {@linkcode EnemyPokemon} evaluating this move
+   * @param isFail - `true` if the move is expected to fail.
+   * @returns - The integer "post-target" Effect Score component
+   */
+  public getPostTargetEffectScore(user: EnemyPokemon, isFail: boolean): number {
+    let attrs: MoveAttr[] = this.attrs.filter(
+      (attr) => attr instanceof MoveEffectAttr && attr.trigger === MoveEffectTrigger.POST_TARGET,
+    );
+
+    if (isFail) {
+      attrs = attrs.filter((attr) => attr.appliesScoreOnFail);
+    }
+
+    return attrs.reduce((score, attr) => score + attr.getEffectScore(user, user, this), 0);
   }
 
   /**

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -226,6 +226,7 @@ export class EnemyPokemon extends Pokemon {
     return (
       (isFail ? BAD_MOVE_PENALTY : conditionScore + attackScore + this.getCriticalHitBonus(target, move, attackScore))
       + move.getEffectScore(this, target, isKnockOut, isFail)
+      + move.getPostTargetEffectScore(this, isFail)
     );
   }
 
@@ -289,6 +290,7 @@ export class EnemyPokemon extends Pokemon {
     return (
       (isBadMove ? BAD_MOVE_PENALTY : conditionScore + totalAttackScore + critBonus)
       + targets.reduce((score, target, i) => score + move.getEffectScore(this, target, isKnockOut[i], isFail, true), 0)
+      + move.getPostTargetEffectScore(this, isFail)
     );
   }
 

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -601,7 +601,7 @@ export class EnemyPokemon extends Pokemon {
   }
 
   /** @returns `true` if this Pokemon should Terastallize on its next action */
-  private shouldTera(): boolean {
+  public shouldTera(): boolean {
     if (this.isTerastallized) {
       return false;
     }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2365,8 +2365,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     let score: number = 0;
     if (damage >= opponent.hp) {
       score = this.getAttackScoreOnKnockOut(move);
-    } else if (damage <= 0) {
-      score = -1;
     } else {
       const damagePct = Math.floor((damage / opponent.getMaxHp()) * 100);
       score = damagePct / ATTACK_SCORE_HP_THRESHOLD;

--- a/test/ai/move-effect-scores/brave-bird.test.ts
+++ b/test/ai/move-effect-scores/brave-bird.test.ts
@@ -1,0 +1,50 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Brave Bird", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.BRAVE_BIRD, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred in normal conditions", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.BRAVE_BIRD);
+  });
+
+  it("should be avoided when the user is critically damaged", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = 1;
+
+    expect(enemy).toNeverSelectMove(MoveId.BRAVE_BIRD);
+  });
+});

--- a/test/ai/move-effect-scores/burn-up.test.ts
+++ b/test/ai/move-effect-scores/burn-up.test.ts
@@ -1,0 +1,65 @@
+import { AbilityId } from "#enums/ability-id";
+import { ElementalType } from "#enums/elemental-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Burn Up", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.CYNDAQUIL)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.BURN_UP, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred in normal conditions", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.BURN_UP);
+  });
+
+  it("should be preferred when the user is Terastallized", async () => {
+    game.override.forceEnemyTera().enemyTeraType(ElementalType.FIRE);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    // Wait a turn for the enemy to Terastallize
+    game.move.use(MoveId.SPLASH);
+    await game.move.selectEnemyMove(MoveId.SPLASH);
+    await game.toNextTurn();
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.BURN_UP);
+  });
+
+  it("should be preferred when the user is set to Terastallize on the same turn", async () => {
+    game.override.forceEnemyTera().enemyTeraType(ElementalType.FIRE);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.BURN_UP);
+  });
+});

--- a/test/ai/move-effect-scores/explosion.test.ts
+++ b/test/ai/move-effect-scores/explosion.test.ts
@@ -1,0 +1,85 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Explosion", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("double")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.EXPLOSION, MoveId.TACKLE, MoveId.SPLASH])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when the user cannot KO any opponents", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).not.toPreferSelectingMove(MoveId.EXPLOSION);
+  });
+
+  it("should be preferred when the user can KO both opponents", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    for (const player of game.scene.getPlayerField()) {
+      player.hp = 1;
+    }
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).toPreferSelectingMove(MoveId.EXPLOSION);
+  });
+
+  it("should be preferred when the user is critically damaged", async () => {
+    game.override.enemySpecies(SpeciesId.DUSKULL);
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    const [enemy] = game.scene.getEnemyField();
+    enemy.hp = 1;
+
+    expect(enemy).toPreferSelectingMove(MoveId.EXPLOSION);
+  });
+
+  it("should be avoided compared to other attacks with no effect", async () => {
+    game.override.enemySpecies(SpeciesId.DUSKULL).enemyMoveset([MoveId.EXPLOSION, MoveId.BOOMBURST]);
+
+    await game.classicMode.startBattle(SpeciesId.DUSKULL, SpeciesId.SHUPPET);
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).toNeverSelectMove(MoveId.EXPLOSION);
+  });
+
+  it("should be avoided when opposing Pokemon have Damp", async () => {
+    game.override.ability(AbilityId.DAMP);
+
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+    game.field.revealAllAbilities();
+    for (const player of game.scene.getPlayerField()) {
+      player.hp = 1;
+    }
+
+    const [enemy] = game.scene.getEnemyField();
+    expect(enemy).toNeverSelectMove(MoveId.EXPLOSION);
+  });
+});

--- a/test/ai/move-effect-scores/mind-blown.test.ts
+++ b/test/ai/move-effect-scores/mind-blown.test.ts
@@ -1,0 +1,71 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Mind Blown", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.CYNDAQUIL)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.MIND_BLOWN, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user is at full HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.TANGROWTH);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.MIND_BLOWN);
+  });
+
+  it("should be avoided when the user is at half HP", async () => {
+    await game.classicMode.startBattle(SpeciesId.TANGROWTH);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp / 2);
+
+    expect(enemy).toNeverSelectMove(MoveId.MIND_BLOWN);
+  });
+
+  it("should be preferred when the user has Magic Guard", async () => {
+    game.override.enemyAbility(AbilityId.MAGIC_GUARD);
+
+    await game.classicMode.startBattle(SpeciesId.TANGROWTH);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = Math.floor(enemy.hp / 2);
+
+    expect(enemy).toPreferSelectingMove(MoveId.MIND_BLOWN);
+  });
+
+  it("should be avoided compared to other attacks with no effect", async () => {
+    game.override.enemyMoveset([MoveId.MIND_BLOWN, MoveId.EMBER]).ability(AbilityId.FLASH_FIRE);
+
+    await game.classicMode.startBattle(SpeciesId.TANGROWTH);
+
+    game.field.revealAllAbilities();
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.MIND_BLOWN);
+  });
+});

--- a/test/ai/move-effect-scores/sacrificial-full-restore.test.ts
+++ b/test/ai/move-effect-scores/sacrificial-full-restore.test.ts
@@ -1,0 +1,76 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Sacrificial Full Restore", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .startingWave(8); // Forces a Trainer battle with an inactive Pokemon
+  });
+
+  const testCases = [
+    { moveName: "Healing Wish", moveId: MoveId.HEALING_WISH },
+    { moveName: "Lunar Dance", moveId: MoveId.LUNAR_DANCE },
+  ];
+
+  describe.each(testCases)("$moveName", ({ moveId }) => {
+    beforeEach(async () => {
+      game.override.enemyMoveset([moveId, MoveId.SPLASH, MoveId.TACKLE]);
+    });
+
+    it("should be avoided when all party pokemon are healthy", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(moveId);
+    });
+
+    it("should be preferred when all party pokemon are critically damaged", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+      for (const p of game.scene.getEnemyParty()) {
+        p.hp = 1;
+      }
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toPreferSelectingMove(moveId);
+    });
+
+    it("should be avoided when the user is a Boss Pokemon", async () => {
+      game.override.enemyHealthSegments(2);
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+      for (const p of game.scene.getEnemyParty()) {
+        p.hp = 1;
+      }
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(moveId);
+    });
+  });
+});

--- a/test/ai/move-effect-scores/substitute.test.ts
+++ b/test/ai/move-effect-scores/substitute.test.ts
@@ -1,0 +1,80 @@
+import { AbilityId } from "#enums/ability-id";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Substitute", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.EXCADRILL)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SUBSTITUTE, MoveId.SPLASH, MoveId.BULLDOZE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user has a strong matchup against the opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.BELLIBOLT);
+
+    const enemy = game.field.getEnemyPokemon();
+    // console.log(enemy.getAverageMatchupScore());
+    expect(enemy).toPreferSelectingMove(MoveId.SUBSTITUTE);
+  });
+
+  it("should not be preferred when the user has a weak matchup against the opponent", async () => {
+    game.override.enemyMoveset([MoveId.SUBSTITUTE, MoveId.EXTREME_SPEED, MoveId.SPLASH]);
+
+    await game.classicMode.startBattle(SpeciesId.GYARADOS);
+
+    const enemy = game.field.getEnemyPokemon();
+    // console.log(enemy.getAverageMatchupScore());
+    expect(enemy).not.toPreferSelectingMove(MoveId.SUBSTITUTE);
+  });
+
+  it("should be avoided when the user is a Boss Pokemon", async () => {
+    game.override.enemyHealthSegments(2);
+
+    await game.classicMode.startBattle(SpeciesId.BELLIBOLT);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SUBSTITUTE);
+  });
+
+  it("should be avoided when the user is critically damaged", async () => {
+    await game.classicMode.startBattle(SpeciesId.BELLIBOLT);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.hp = 1;
+
+    expect(enemy).toNeverSelectMove(MoveId.SUBSTITUTE);
+  });
+
+  it("should be avoided when the user already has an active substitute", async () => {
+    await game.classicMode.startBattle(SpeciesId.BELLIBOLT);
+
+    const enemy = game.field.getEnemyPokemon();
+    enemy.addTag(BattlerTagType.SUBSTITUTE, 0, MoveId.NONE, enemy.id);
+
+    expect(enemy).toNeverSelectMove(MoveId.SUBSTITUTE);
+  });
+});

--- a/test/ai/move-effect-scores/substitute.test.ts
+++ b/test/ai/move-effect-scores/substitute.test.ts
@@ -37,7 +37,7 @@ describe("AI (Move Effect Scores) - Substitute", () => {
     await game.classicMode.startBattle(SpeciesId.BELLIBOLT);
 
     const enemy = game.field.getEnemyPokemon();
-    // console.log(enemy.getAverageMatchupScore());
+
     expect(enemy).toPreferSelectingMove(MoveId.SUBSTITUTE);
   });
 
@@ -47,7 +47,7 @@ describe("AI (Move Effect Scores) - Substitute", () => {
     await game.classicMode.startBattle(SpeciesId.GYARADOS);
 
     const enemy = game.field.getEnemyPokemon();
-    // console.log(enemy.getAverageMatchupScore());
+
     expect(enemy).not.toPreferSelectingMove(MoveId.SUBSTITUTE);
   });
 


### PR DESCRIPTION
## What are the changes the user will see?

The AI should now properly evaluate moves that may damage, KO, or apply other negative effects to the user. More specifically, this batch includes

- Sacrificial moves (e.g. Explosion)
- Mind Blown and Chloroblast
- Healing Wish and Lunar Dance
- Recoil moves (e.g. Flare Blitz)
- Burn Up and Double Shock
- Substitute and Shed Tail (partially)

Also, Belly Drum et. al have had their scoring updated to further discourage Boss Pokemon from using them.

## Why am I making these changes?

Part of the AI Rework

## What are the changes from a developer perspective?

- Move scoring functions have been updated to compute Effect Scores from post-target move effect attributes separately from other attributes. Post-target effects should now only contribute their scores once to the total Effect Score even if the move hits multiple targets.
- Added Effect Score overrides for the following attributes:
  - `AddSubstituteAttr`
  - `HalfSacrificialAttr`
  - `RecoilAttr`
  - `RemoveTypeAttr`
  - `SacrificialAttr`
  - `SacrificialFullRestoreAttr`
- `CutHpStatBoostAttr`'s scoring has been updated so that it falls more in line with `HalfSacrificialAttr`'s new scoring logic.

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`

New unit tests (can be run with `pnpm test[:silent] move-effect-scores/testName`):
- `explosion`
- `mind-blown`
- `brave-bird`
- `burn-up`
- `sacrificial-full-restore`
- `substitute`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
