### PR TITLE
ai-rework: Add Effect Scores for Terrain- and Weather-changing effects

### DIFF
--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -1,6 +1,7 @@
 /* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Ability } from "#abilities/ability";
 import type { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-effect-ab-attr";
+import type { WeatherType } from "#enums/weather-type";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 import { AbilityId } from "#enums/ability-id";
@@ -81,4 +82,52 @@ export const POST_STAT_STAGE_REDUCTION_ABILITIES = Object.freeze<AbilityId[]>([
 export const RECOIL_DAMAGE_PREVENTION_ABILITIES = Object.freeze<AbilityId[]>([
   AbilityId.ROCK_HEAD,
   AbilityId.MAGIC_GUARD,
+]);
+
+/**
+ * Abilities that grant a benefit when {@link WeatherType.SUNNY | harsh sunlight}
+ * or {@link WeatherType.HARSH_SUN | extremely harsh sunlight} is in effect
+ */
+export const SUN_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
+  AbilityId.CHLOROPHYLL,
+  AbilityId.SOLAR_POWER,
+  AbilityId.FLOWER_GIFT,
+  AbilityId.LEAF_GUARD,
+  AbilityId.PROTOSYNTHESIS,
+  AbilityId.FORECAST,
+]);
+
+/**
+ * Abilities that grant a benefit when {@link WeatherType.RAIN | rain}
+ * or {@link WeatherType.HEAVY_RAIN | heavy rain} is in effect
+ */
+export const RAIN_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
+  AbilityId.SWIFT_SWIM,
+  AbilityId.RAIN_DISH,
+  AbilityId.DRY_SKIN,
+  AbilityId.HYDRATION,
+  AbilityId.FORECAST,
+]);
+
+/**
+ * Abilities that grant a benefit when a {@link WeatherType.SANDSTORM | sandstorm}
+ * is in effect
+ */
+export const SAND_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
+  AbilityId.SAND_FORCE,
+  AbilityId.SAND_RUSH,
+  AbilityId.SAND_VEIL,
+  AbilityId.MAGIC_GUARD,
+  AbilityId.OVERCOAT,
+]);
+
+/**
+ * Abilities that grant a benefit when {@link WeatherType.HAIL | hail}
+ * or {@link WeatherType.SNOW | snow} is in effect
+ */
+export const SNOW_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
+  AbilityId.ICE_BODY,
+  AbilityId.SNOW_CLOAK,
+  AbilityId.SLUSH_RUSH,
+  AbilityId.ICE_FACE,
 ]);

--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -88,46 +88,37 @@ export const RECOIL_DAMAGE_PREVENTION_ABILITIES = Object.freeze<AbilityId[]>([
  * Abilities that grant a benefit when {@link WeatherType.SUNNY | harsh sunlight}
  * or {@link WeatherType.HARSH_SUN | extremely harsh sunlight} is in effect
  */
-export const SUN_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
-  AbilityId.CHLOROPHYLL,
-  AbilityId.SOLAR_POWER,
-  AbilityId.FLOWER_GIFT,
-  AbilityId.LEAF_GUARD,
-  AbilityId.PROTOSYNTHESIS,
-  AbilityId.FORECAST,
-]);
+export const SUN_SYNERGY_ABILITIES = Object.freeze<Set<AbilityId>>(
+  new Set([
+    AbilityId.CHLOROPHYLL,
+    AbilityId.SOLAR_POWER,
+    AbilityId.FLOWER_GIFT,
+    AbilityId.LEAF_GUARD,
+    AbilityId.PROTOSYNTHESIS,
+    AbilityId.FORECAST,
+  ]),
+);
 
 /**
  * Abilities that grant a benefit when {@link WeatherType.RAIN | rain}
  * or {@link WeatherType.HEAVY_RAIN | heavy rain} is in effect
  */
-export const RAIN_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
-  AbilityId.SWIFT_SWIM,
-  AbilityId.RAIN_DISH,
-  AbilityId.DRY_SKIN,
-  AbilityId.HYDRATION,
-  AbilityId.FORECAST,
-]);
+export const RAIN_SYNERGY_ABILITIES = Object.freeze<Set<AbilityId>>(
+  new Set([AbilityId.SWIFT_SWIM, AbilityId.RAIN_DISH, AbilityId.DRY_SKIN, AbilityId.HYDRATION, AbilityId.FORECAST]),
+);
 
 /**
  * Abilities that grant a benefit when a {@link WeatherType.SANDSTORM | sandstorm}
  * is in effect
  */
-export const SAND_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
-  AbilityId.SAND_FORCE,
-  AbilityId.SAND_RUSH,
-  AbilityId.SAND_VEIL,
-  AbilityId.MAGIC_GUARD,
-  AbilityId.OVERCOAT,
-]);
+export const SAND_SYNERGY_ABILITIES = Object.freeze<Set<AbilityId>>(
+  new Set([AbilityId.SAND_FORCE, AbilityId.SAND_RUSH, AbilityId.SAND_VEIL, AbilityId.MAGIC_GUARD, AbilityId.OVERCOAT]),
+);
 
 /**
  * Abilities that grant a benefit when {@link WeatherType.HAIL | hail}
  * or {@link WeatherType.SNOW | snow} is in effect
  */
-export const SNOW_SYNERGY_ABILITIES = Object.freeze<AbilityId[]>([
-  AbilityId.ICE_BODY,
-  AbilityId.SNOW_CLOAK,
-  AbilityId.SLUSH_RUSH,
-  AbilityId.ICE_FACE,
-]);
+export const SNOW_SYNERGY_ABILITIES = Object.freeze<Set<AbilityId>>(
+  new Set([AbilityId.ICE_BODY, AbilityId.SNOW_CLOAK, AbilityId.SLUSH_RUSH, AbilityId.ICE_FACE]),
+);

--- a/src/constants/move-constants.ts
+++ b/src/constants/move-constants.ts
@@ -1,4 +1,6 @@
 /* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { Terrain } from "#data/terrain";
+import type { TerrainType } from "#enums/terrain-type";
 import type { WeatherType } from "#enums/weather-type";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
@@ -82,3 +84,47 @@ export const SAND_SYNERGY_MOVES = Object.freeze<MoveId[]>([MoveId.WEATHER_BALL, 
  * {@link WeatherType.SNOW | snow} is in effect
  */
 export const SNOW_SYNERGY_MOVES = Object.freeze<MoveId[]>([MoveId.WEATHER_BALL, MoveId.BLIZZARD, MoveId.AURORA_VEIL]);
+
+/**
+ * Moves that gain a benefit when used while any {@linkcode Terrain}
+ * is in effect
+ */
+export const ALL_TERRAIN_SYNERGY_MOVES = Object.freeze<MoveId[]>([MoveId.TERRAIN_PULSE]);
+
+/**
+ * Moves that gain a benefit when used while
+ * {@link TerrainType.ELECTRIC | Electric Terrain} is in effect
+ */
+export const ELECTRIC_TERRAIN_SYNERGY_MOVES = Object.freeze<MoveId[]>([
+  ...ALL_TERRAIN_SYNERGY_MOVES,
+  MoveId.RISING_VOLTAGE,
+  MoveId.PSYBLADE,
+]);
+
+/**
+ * Moves that gain a benefit when used while
+ * {@link TerrainType.GRASSY | Grassy Terrain} is in effect
+ */
+export const GRASSY_TERRAIN_SYNERGY_MOVES = Object.freeze<MoveId[]>([
+  ...ALL_TERRAIN_SYNERGY_MOVES,
+  MoveId.GRASSY_GLIDE,
+  MoveId.FLORAL_HEALING,
+]);
+
+/**
+ * Moves that gain a benefit when used while
+ * {@link TerrainType.MISTY | Misty Terrain} is in effect
+ */
+export const MISTY_TERRAIN_SYNERGY_MOVES = Object.freeze<MoveId[]>([
+  ...ALL_TERRAIN_SYNERGY_MOVES,
+  MoveId.MISTY_EXPLOSION,
+]);
+
+/**
+ * Moves that gain a benefit when used while
+ * {@link TerrainType.PSYCHIC | Psychic Terrain} is in effect
+ */
+export const PSYCHIC_TERRAIN_SYNERGY_MOVES = Object.freeze<MoveId[]>([
+  ...ALL_TERRAIN_SYNERGY_MOVES,
+  MoveId.EXPANDING_FORCE,
+]);

--- a/src/constants/move-constants.ts
+++ b/src/constants/move-constants.ts
@@ -1,13 +1,17 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { WeatherType } from "#enums/weather-type";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { MoveId } from "#enums/move-id";
 
 /** An array of all tera {@linkcode MoveId | MoveIds}. */
-export const TERA_MOVES = Object.freeze([MoveId.TERA_BLAST, MoveId.TERA_STARSTORM]);
+export const TERA_MOVES = Object.freeze<MoveId[]>([MoveId.TERA_BLAST, MoveId.TERA_STARSTORM]);
 
 /** An array of all pledge {@linkcode MoveId | MoveIds}. */
-export const PLEDGE_MOVES = Object.freeze([MoveId.GRASS_PLEDGE, MoveId.FIRE_PLEDGE, MoveId.WATER_PLEDGE]);
+export const PLEDGE_MOVES = Object.freeze<MoveId[]>([MoveId.GRASS_PLEDGE, MoveId.FIRE_PLEDGE, MoveId.WATER_PLEDGE]);
 
 /** An array of all sacrificial {@linkcode MoveId | MoveIds}. */
-export const SACRIFICIAL_MOVES = Object.freeze([
+export const SACRIFICIAL_MOVES = Object.freeze<MoveId[]>([
   MoveId.SELF_DESTRUCT,
   MoveId.EXPLOSION,
   MoveId.MEMENTO,
@@ -18,7 +22,7 @@ export const SACRIFICIAL_MOVES = Object.freeze([
 ]);
 
 /** An array containing the {@linkcode MoveId | MoveIds} for all variations of the move Protect */
-export const PROTECT_MOVES = Object.freeze([
+export const PROTECT_MOVES = Object.freeze<MoveId[]>([
   MoveId.PROTECT,
   MoveId.DETECT,
   MoveId.ENDURE,
@@ -31,9 +35,50 @@ export const PROTECT_MOVES = Object.freeze([
 ]);
 
 /** An array containing the {@linkcode MoveId | MoveIds} for all Status moves that set hazards */
-export const HAZARD_STATUS_MOVES = Object.freeze([
+export const HAZARD_STATUS_MOVES = Object.freeze<MoveId[]>([
   MoveId.SPIKES,
   MoveId.TOXIC_SPIKES,
   MoveId.STEALTH_ROCK,
   MoveId.STICKY_WEB,
 ]);
+
+/**
+ * Moves that gain a benefit when used while {@link WeatherType.SUNNY | harsh sunlight} or
+ * {@link WeatherType.HARSH_SUN | extremely harsh sunlight} is in effect
+ */
+export const SUN_SYNERGY_MOVES = Object.freeze<MoveId[]>([
+  MoveId.WEATHER_BALL,
+  MoveId.GROWTH,
+  MoveId.SOLAR_BEAM,
+  MoveId.SOLAR_BLADE,
+  MoveId.MOONLIGHT,
+  MoveId.SYNTHESIS,
+  MoveId.MORNING_SUN,
+  MoveId.HYDRO_STEAM,
+]);
+
+/**
+ * Moves that gain a benefit when used while {@link WeatherType.RAIN | rain} or
+ * {@link WeatherType.HEAVY_RAIN | heavy rain} is in effect
+ */
+export const RAIN_SYNERGY_MOVES = Object.freeze<MoveId[]>([
+  MoveId.WEATHER_BALL,
+  MoveId.THUNDER,
+  MoveId.HURRICANE,
+  MoveId.BLEAKWIND_STORM,
+  MoveId.WILDBOLT_STORM,
+  MoveId.SANDSEAR_STORM,
+  MoveId.ELECTRO_SHOT,
+]);
+
+/**
+ * Moves that gain a benefit when used while a {@link WeatherType.SANDSTORM | sandstorm}
+ * is in effect
+ */
+export const SAND_SYNERGY_MOVES = Object.freeze<MoveId[]>([MoveId.WEATHER_BALL, MoveId.SHORE_UP]);
+
+/**
+ * Moves that gain a benefit when used while {@link WeatherType.HAIL | hail} or
+ * {@link WeatherType.SNOW | snow} is in effect
+ */
+export const SNOW_SYNERGY_MOVES = Object.freeze<MoveId[]>([MoveId.WEATHER_BALL, MoveId.BLIZZARD, MoveId.AURORA_VEIL]);

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -66,7 +66,9 @@ import { BypassRedirectAttr } from "#moves/bypass-redirect-attr";
 import { BypassSleepAttr } from "#moves/bypass-sleep-attr";
 import { CaptivateAttr } from "#moves/captivate-attr";
 import { CenterOfAttentionAttr } from "#moves/center-of-attention-attr";
+import { ChangeTerrainAttr } from "#moves/change-terrain-attr";
 import { ChangeTypeAttr } from "#moves/change-type-attr";
+import { ChangeWeatherAttr } from "#moves/change-weather-attr";
 import { ChargedAttr } from "#moves/charged-attr";
 import { ChargingAttackMove } from "#moves/charging-attack-move";
 import { ChargingSelfStatusMove } from "#moves/charging-self-status-move";
@@ -281,7 +283,6 @@ import { TeraBlastPowerAttr } from "#moves/tera-blast-power-attr";
 import { TeraBlastTypeAttr } from "#moves/tera-blast-type-attr";
 import { TeraMoveCategoryAttr } from "#moves/tera-move-category-attr";
 import { TeraStarstormTypeAttr } from "#moves/tera-starstorm-type-attr";
-import { TerrainChangeAttr } from "#moves/terrain-change-attr";
 import { TerrainPulseTypeAttr } from "#moves/terrain-pulse-type-attr";
 import { ThroatChopAttr } from "#moves/throat-chop-attr";
 import { ThunderAccuracyAttr } from "#moves/thunder-accuracy-attr";
@@ -304,7 +305,6 @@ import { WaterShurikenMultiHitTypeAttr } from "#moves/water-shuriken-multi-hit-t
 import { WaterShurikenPowerAttr } from "#moves/water-shuriken-power-attr";
 import { WeakenMoveTypeAttr } from "#moves/weaken-move-type-attr";
 import { WeatherBallTypeAttr } from "#moves/weather-ball-type-attr";
-import { WeatherChangeAttr } from "#moves/weather-change-attr";
 import { WeatherInstantChargeAttr } from "#moves/weather-instant-charge-attr";
 import { WeightPowerAttr } from "#moves/weight-power-attr";
 import { WishAttr } from "#moves/wish-attr";
@@ -956,7 +956,7 @@ export function initMoves() {
       .attr(FrenzyAttr)
       .target(MoveTarget.RANDOM_NEAR_ENEMY),
     new StatusMove(MoveId.SANDSTORM, ElementalType.ROCK, -1, 10, -1, 0, 2) //
-      .attr(WeatherChangeAttr, WeatherType.SANDSTORM)
+      .attr(ChangeWeatherAttr, WeatherType.SANDSTORM)
       .target(MoveTarget.BOTH_SIDES),
     new AttackMove(MoveId.GIGA_DRAIN, ElementalType.GRASS, MoveCategory.SPECIAL, 75, 100, 10, -1, 0, 2) //
       .attr(HitHealAttr)
@@ -1086,10 +1086,10 @@ export function initMoves() {
       .windMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(MoveId.RAIN_DANCE, ElementalType.WATER, -1, 5, -1, 0, 2) //
-      .attr(WeatherChangeAttr, WeatherType.RAIN)
+      .attr(ChangeWeatherAttr, WeatherType.RAIN)
       .target(MoveTarget.BOTH_SIDES),
     new StatusMove(MoveId.SUNNY_DAY, ElementalType.FIRE, -1, 5, -1, 0, 2) //
-      .attr(WeatherChangeAttr, WeatherType.SUNNY)
+      .attr(ChangeWeatherAttr, WeatherType.SUNNY)
       .target(MoveTarget.BOTH_SIDES),
     new AttackMove(MoveId.CRUNCH, ElementalType.DARK, MoveCategory.PHYSICAL, 80, 100, 15, 20, 0, 2) //
       .attr(StatStageChangeAttr, [Stat.DEF], -1)
@@ -1156,7 +1156,7 @@ export function initMoves() {
       .windMove()
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new StatusMove(MoveId.HAIL, ElementalType.ICE, -1, 10, -1, 0, 3) //
-      .attr(WeatherChangeAttr, WeatherType.HAIL)
+      .attr(ChangeWeatherAttr, WeatherType.HAIL)
       .target(MoveTarget.BOTH_SIDES),
     new StatusMove(MoveId.TORMENT, ElementalType.DARK, 100, 15, -1, 0, 3) //
       .attr(TormentAttr)
@@ -2280,10 +2280,10 @@ export function initMoves() {
           target.getTypes().includes(ElementalType.GRASS) && !target.hasTag(...SEMI_INVULNERABLE_BATTLER_TAG_TYPES),
       }),
     new StatusMove(MoveId.GRASSY_TERRAIN, ElementalType.GRASS, -1, 10, -1, 0, 6) //
-      .attr(TerrainChangeAttr, TerrainType.GRASSY)
+      .attr(ChangeTerrainAttr, TerrainType.GRASSY)
       .target(MoveTarget.BOTH_SIDES),
     new StatusMove(MoveId.MISTY_TERRAIN, ElementalType.FAIRY, -1, 10, -1, 0, 6) //
-      .attr(TerrainChangeAttr, TerrainType.MISTY)
+      .attr(ChangeTerrainAttr, TerrainType.MISTY)
       .target(MoveTarget.BOTH_SIDES),
     new StatusMove(MoveId.ELECTRIFY, ElementalType.ELECTRIC, -1, 20, -1, 0, 6) //
       .attr(ElectrifyAttr),
@@ -2370,7 +2370,7 @@ export function initMoves() {
       .attr(HappyHourAttr)
       .target(MoveTarget.USER_SIDE),
     new StatusMove(MoveId.ELECTRIC_TERRAIN, ElementalType.ELECTRIC, -1, 10, -1, 0, 6) //
-      .attr(TerrainChangeAttr, TerrainType.ELECTRIC)
+      .attr(ChangeTerrainAttr, TerrainType.ELECTRIC)
       .target(MoveTarget.BOTH_SIDES),
     new AttackMove(MoveId.DAZZLING_GLEAM, ElementalType.FAIRY, MoveCategory.SPECIAL, 80, 100, 10, -1, 0, 6) //
       .target(MoveTarget.ALL_NEAR_ENEMIES),
@@ -2587,7 +2587,7 @@ export function initMoves() {
     new AttackMove(MoveId.ANCHOR_SHOT, ElementalType.STEEL, MoveCategory.PHYSICAL, 80, 100, 20, 100, 0, 7) //
       .attr(TrapAttr, true),
     new StatusMove(MoveId.PSYCHIC_TERRAIN, ElementalType.PSYCHIC, -1, 10, -1, 0, 7) //
-      .attr(TerrainChangeAttr, TerrainType.PSYCHIC)
+      .attr(ChangeTerrainAttr, TerrainType.PSYCHIC)
       .target(MoveTarget.BOTH_SIDES),
     new AttackMove(MoveId.LUNGE, ElementalType.BUG, MoveCategory.PHYSICAL, 80, 100, 15, 100, 0, 7) //
       .attr(StatStageChangeAttr, [Stat.ATK], -1),
@@ -2679,7 +2679,7 @@ export function initMoves() {
       .unimplemented()
       .attr(StatStageChangeAttr, [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD], 2, true),
     new AttackMove(MoveId.GENESIS_SUPERNOVA, ElementalType.PSYCHIC, MoveCategory.SPECIAL, 185, -1, 1, 100, 0, 7) //
-      .attr(TerrainChangeAttr, TerrainType.PSYCHIC)
+      .attr(ChangeTerrainAttr, TerrainType.PSYCHIC)
       .unimplemented(),
     // #endregion
     new AttackMove(MoveId.SHELL_TRAP, ElementalType.FIRE, MoveCategory.SPECIAL, 150, 100, 5, -1, -3, 7) //
@@ -3418,7 +3418,7 @@ export function initMoves() {
       .attr(RemoveAllSubstitutesAttr)
       .snatchable(), // Custom
     new StatusMove(MoveId.SNOWSCAPE, ElementalType.ICE, -1, 10, -1, 0, 9) //
-      .attr(WeatherChangeAttr, WeatherType.SNOW)
+      .attr(ChangeWeatherAttr, WeatherType.SNOW)
       .target(MoveTarget.BOTH_SIDES),
     new AttackMove(MoveId.POUNCE, ElementalType.BUG, MoveCategory.PHYSICAL, 50, 100, 20, 100, 0, 9) //
       .attr(StatStageChangeAttr, [Stat.SPD], -1),

--- a/src/data/moves/move-attrs/change-terrain-attr.ts
+++ b/src/data/moves/move-attrs/change-terrain-attr.ts
@@ -50,10 +50,15 @@ export class ChangeTerrainAttr extends MoveEffectAttr {
       .getOpposingParty()
       .filter((p) => p.isAllowedInBattle())
       .reduce(
-        (score, p) => score + p.getTerrainBenefitScore(this.terrainType) - p.getTerrainBenefitScore(currentTerrain),
+        (score, p) =>
+          score + p.getTerrainBenefitScore(this.terrainType, true) - p.getTerrainBenefitScore(currentTerrain, true),
         0,
       );
 
-    return Math.min(Math.floor(userBenefit - oppBenefit), SOFT_EFFECT_SCORE_LIMIT);
+    const rawScore = userBenefit - oppBenefit;
+    const minScore = Math.floor(rawScore);
+    const tierUpChance = Math.floor((rawScore - minScore) * 100);
+
+    return Math.min(this.getRandomScore(user, tierUpChance, minScore + 1, minScore), SOFT_EFFECT_SCORE_LIMIT);
   }
 }

--- a/src/data/moves/move-attrs/change-terrain-attr.ts
+++ b/src/data/moves/move-attrs/change-terrain-attr.ts
@@ -11,7 +11,7 @@ import type { MoveConditionFunc } from "#types/move-types";
  * Attribute to add terrain of a set type to the field.
  * @see {@link https://bulbapedia.bulbagarden.net/wiki/Move_variations#Terrain_moves | Terrain moves}
  */
-export class TerrainChangeAttr extends MoveEffectAttr {
+export class ChangeTerrainAttr extends MoveEffectAttr {
   private terrainType: TerrainType;
 
   constructor(terrainType: TerrainType) {

--- a/src/data/moves/move-attrs/change-terrain-attr.ts
+++ b/src/data/moves/move-attrs/change-terrain-attr.ts
@@ -31,9 +31,6 @@ export class ChangeTerrainAttr extends MoveEffectAttr {
   /**
    * @returns An Effect Score based on how much the user's non-fainted party benefits
    * from the Terrain to set compared to the opponents' benefit.
-   *
-   * @todo Expand upon terrain benefit score calculation. It generally isn't aware of
-   * terrain-specific effects (aside from power multipliers).
    */
   public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
     const currentTerrain = globalScene.arena.terrain?.terrainType ?? TerrainType.NONE;

--- a/src/data/moves/move-attrs/change-weather-attr.ts
+++ b/src/data/moves/move-attrs/change-weather-attr.ts
@@ -10,7 +10,7 @@ import type { MoveConditionFunc } from "#types/move-types";
 /**
  * Attribute to set weather of a specified type on the field.
  */
-export class WeatherChangeAttr extends MoveEffectAttr {
+export class ChangeWeatherAttr extends MoveEffectAttr {
   private weatherType: WeatherType;
 
   constructor(weatherType: WeatherType) {

--- a/src/data/moves/move-attrs/change-weather-attr.ts
+++ b/src/data/moves/move-attrs/change-weather-attr.ts
@@ -51,6 +51,10 @@ export class ChangeWeatherAttr extends MoveEffectAttr {
         0,
       );
 
-    return Math.min(Math.floor(userBenefit - oppBenefit), SOFT_EFFECT_SCORE_LIMIT);
+    const rawScore = userBenefit - oppBenefit;
+    const minScore = Math.floor(rawScore);
+    const tierUpChance = Math.floor((rawScore - minScore) * 100);
+
+    return Math.min(this.getRandomScore(user, tierUpChance, minScore + 1, minScore), SOFT_EFFECT_SCORE_LIMIT);
   }
 }

--- a/src/data/moves/move-attrs/clear-terrain-attr.ts
+++ b/src/data/moves/move-attrs/clear-terrain-attr.ts
@@ -1,5 +1,5 @@
 import { TerrainType } from "#enums/terrain-type";
-import { TerrainChangeAttr } from "#moves/terrain-change-attr";
+import { ChangeTerrainAttr } from "#moves/change-terrain-attr";
 
 /**
  * Attribute to clear active terrain from the field.
@@ -7,12 +7,12 @@ import { TerrainChangeAttr } from "#moves/terrain-change-attr";
  * {@link https://bulbapedia.bulbagarden.net/wiki/Steel_Roller_(move) | Steel Roller},
  * and {@linkcode https://bulbapedia.bulbagarden.net/wiki/Ice_Spinner_(move) | Ice Spinner}.
  */
-export class ClearTerrainAttr extends TerrainChangeAttr {
+export class ClearTerrainAttr extends ChangeTerrainAttr {
   constructor() {
     super(TerrainType.NONE);
   }
 
-  /** Removes the condition from {@linkcode TerrainChangeAttr} */
+  /** Removes the condition from {@linkcode ChangeTerrainAttr} */
   public override getCondition(): null {
     return null;
   }

--- a/src/data/moves/move-attrs/clear-terrain-attr.ts
+++ b/src/data/moves/move-attrs/clear-terrain-attr.ts
@@ -1,8 +1,5 @@
-import { globalScene } from "#app/global-scene";
 import { TerrainType } from "#enums/terrain-type";
-import type { Pokemon } from "#field/pokemon";
-import type { Move } from "#moves/move";
-import { MoveEffectAttr } from "#moves/move-effect-attr";
+import { TerrainChangeAttr } from "#moves/terrain-change-attr";
 
 /**
  * Attribute to clear active terrain from the field.
@@ -10,8 +7,13 @@ import { MoveEffectAttr } from "#moves/move-effect-attr";
  * {@link https://bulbapedia.bulbagarden.net/wiki/Steel_Roller_(move) | Steel Roller},
  * and {@linkcode https://bulbapedia.bulbagarden.net/wiki/Ice_Spinner_(move) | Ice Spinner}.
  */
-export class ClearTerrainAttr extends MoveEffectAttr {
-  override applyEffect(_user: Pokemon, _target: Pokemon, _move: Move): boolean {
-    return globalScene.arena.trySetTerrain(TerrainType.NONE, true, true);
+export class ClearTerrainAttr extends TerrainChangeAttr {
+  constructor() {
+    super(TerrainType.NONE);
+  }
+
+  /** Removes the condition from {@linkcode TerrainChangeAttr} */
+  public override getCondition(): null {
+    return null;
   }
 }

--- a/src/data/moves/move-attrs/clear-weather-attr.ts
+++ b/src/data/moves/move-attrs/clear-weather-attr.ts
@@ -1,5 +1,6 @@
 import { globalScene } from "#app/global-scene";
 import { WeatherType } from "#enums/weather-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -23,5 +24,28 @@ export class ClearWeatherAttr extends MoveEffectAttr {
     }
 
     return false;
+  }
+
+  /**
+   * @returns The opposite of the perceived combined {@linkcode Pokemon.getWeatherBenefitScore | benefit}
+   * from the weather to remove. If this attribute's weather type isn't active, this
+   * grants (+0) instead.
+   *
+   * @privateRemarks
+   * This doesn't do anything for Defog since no benefit is assigned to Fog for any
+   * type, move, or ability. However, this allows for the attribute to be scored
+   * if it is ever reused to target different weather types.
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    if (!globalScene.arena.hasWeather(this.weatherType)) {
+      return 0;
+    }
+
+    return Math.floor(
+      user
+        .getParty()
+        .filter((p) => p.isAllowedInBattle())
+        .reduce((score, p) => score - p.getWeatherBenefitScore(this.weatherType), 0),
+    );
   }
 }

--- a/src/data/moves/move-attrs/terrain-change-attr.ts
+++ b/src/data/moves/move-attrs/terrain-change-attr.ts
@@ -1,5 +1,7 @@
 import { globalScene } from "#app/global-scene";
-import type { TerrainType } from "#enums/terrain-type";
+import { SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
+import { TerrainType } from "#enums/terrain-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -18,16 +20,40 @@ export class TerrainChangeAttr extends MoveEffectAttr {
     this.terrainType = terrainType;
   }
 
-  override applyEffect(_user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  public override applyEffect(_user: Pokemon, _target: Pokemon, _move: Move): boolean {
     return globalScene.arena.trySetTerrain(this.terrainType, true, true);
   }
 
-  override getCondition(): MoveConditionFunc {
+  public override getCondition(): MoveConditionFunc | null {
     return (_user, _target, _move) => !globalScene.arena.hasTerrain(this.terrainType);
   }
 
-  override getUserBenefitScore(_user: Pokemon, _target: Pokemon, _move: Move): number {
-    // TODO: Expand on this
-    return globalScene.arena.terrain ? 0 : 6;
+  /**
+   * @returns An Effect Score based on how much the user's non-fainted party benefits
+   * from the Terrain to set compared to the opponents' benefit.
+   *
+   * @todo Expand upon terrain benefit score calculation. It generally isn't aware of
+   * terrain-specific effects (aside from power multipliers).
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    const currentTerrain = globalScene.arena.terrain?.terrainType ?? TerrainType.NONE;
+
+    const userBenefit = user
+      .getParty()
+      .filter((p) => p.isAllowedInBattle())
+      .reduce(
+        (score, p) => score + p.getTerrainBenefitScore(this.terrainType) - p.getTerrainBenefitScore(currentTerrain),
+        0,
+      );
+
+    const oppBenefit = user
+      .getOpposingParty()
+      .filter((p) => p.isAllowedInBattle())
+      .reduce(
+        (score, p) => score + p.getTerrainBenefitScore(this.terrainType) - p.getTerrainBenefitScore(currentTerrain),
+        0,
+      );
+
+    return Math.min(Math.floor(userBenefit - oppBenefit), SOFT_EFFECT_SCORE_LIMIT);
   }
 }

--- a/src/data/moves/move-attrs/weather-change-attr.ts
+++ b/src/data/moves/move-attrs/weather-change-attr.ts
@@ -42,7 +42,7 @@ export class WeatherChangeAttr extends MoveEffectAttr {
         0,
       );
 
-    const enemyBenefit = user
+    const oppBenefit = user
       .getOpposingParty()
       .filter((p) => p.isAllowedInBattle())
       .reduce(
@@ -51,6 +51,6 @@ export class WeatherChangeAttr extends MoveEffectAttr {
         0,
       );
 
-    return Math.min(Math.floor(userBenefit - enemyBenefit), SOFT_EFFECT_SCORE_LIMIT);
+    return Math.min(Math.floor(userBenefit - oppBenefit), SOFT_EFFECT_SCORE_LIMIT);
   }
 }

--- a/src/data/moves/move-attrs/weather-change-attr.ts
+++ b/src/data/moves/move-attrs/weather-change-attr.ts
@@ -1,5 +1,7 @@
 import { globalScene } from "#app/global-scene";
-import type { WeatherType } from "#enums/weather-type";
+import { SOFT_EFFECT_SCORE_LIMIT } from "#constants/ai-constants";
+import { WeatherType } from "#enums/weather-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -17,11 +19,38 @@ export class WeatherChangeAttr extends MoveEffectAttr {
     this.weatherType = weatherType;
   }
 
-  override applyEffect(_user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  public override applyEffect(_user: Pokemon, _target: Pokemon, _move: Move): boolean {
     return globalScene.arena.trySetWeather(this.weatherType, true);
   }
 
-  override getCondition(): MoveConditionFunc {
+  public override getCondition(): MoveConditionFunc {
     return (_user, _target, _move) => globalScene.arena.canSetWeather(this.weatherType);
+  }
+
+  /**
+   * @returns An Effect Score based on how much the user's non-fainted party benefits
+   * from the Weather to set compared to the opponents' benefit.
+   */
+  public override getEffectScore(user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    const currentWeather = globalScene.arena.weather?.weatherType ?? WeatherType.NONE;
+
+    const userBenefit = user
+      .getParty()
+      .filter((p) => p.isAllowedInBattle())
+      .reduce(
+        (score, p) => score + p.getWeatherBenefitScore(this.weatherType) - p.getWeatherBenefitScore(currentWeather),
+        0,
+      );
+
+    const enemyBenefit = user
+      .getOpposingParty()
+      .filter((p) => p.isAllowedInBattle())
+      .reduce(
+        (score, p) =>
+          score + p.getWeatherBenefitScore(this.weatherType, true) - p.getWeatherBenefitScore(currentWeather, true),
+        0,
+      );
+
+    return Math.min(Math.floor(userBenefit - enemyBenefit), SOFT_EFFECT_SCORE_LIMIT);
   }
 }

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -232,10 +232,7 @@ export abstract class Move {
     return (this.flags & flag) > 0;
   }
 
-  /**
-   * Getter function that returns if the move hits multiple targets
-   * @returns boolean
-   */
+  /** @returns `true` if this move can hit multiple targets in a single attack */
   isMultiTarget(): boolean {
     switch (this.moveTarget) {
       case MoveTarget.ALL_OTHERS:
@@ -252,10 +249,7 @@ export abstract class Move {
     return false;
   }
 
-  /**
-   * Getter function that returns if the move targets the user or its ally
-   * @returns boolean
-   */
+  /** @returns `true` if this move targets the user and/or its ally */
   isAllyTarget(): boolean {
     switch (this.moveTarget) {
       case MoveTarget.USER:
@@ -269,6 +263,19 @@ export abstract class Move {
     return false;
   }
 
+  /** @returns `true` if this move targets a single enemy */
+  isSingleEnemyTarget(): boolean {
+    switch (this.moveTarget) {
+      case MoveTarget.OTHER:
+      case MoveTarget.NEAR_OTHER:
+      case MoveTarget.NEAR_ENEMY:
+      case MoveTarget.RANDOM_NEAR_ENEMY:
+        return true;
+    }
+    return false;
+  }
+
+  /** @returns `true` if this move targets one or both sides of the field */
   isFieldTarget(): boolean {
     switch (this.moveTarget) {
       case MoveTarget.BOTH_SIDES:

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -1,11 +1,9 @@
-import { getPokemonNameWithAffix } from "#app/messages";
 import type { BattlerIndex } from "#enums/battler-index";
 import { ElementalType } from "#enums/elemental-type";
 import { TerrainType } from "#enums/terrain-type";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { ProtectAttr } from "#moves/protect-attr";
-import i18next from "i18next";
 
 /** Class representing Terrain effects */
 export class Terrain {
@@ -83,103 +81,4 @@ export class Terrain {
 
     return false;
   }
-}
-
-/**
- * Get the name for a given terrain type
- * @param terrainType - The {@linkcode TerrainType}
- * @returns the associated name, or an empty string if there is none
- */
-export function getTerrainName(terrainType: TerrainType): string {
-  switch (terrainType) {
-    case TerrainType.MISTY:
-      return i18next.t("terrain:misty");
-    case TerrainType.ELECTRIC:
-      return i18next.t("terrain:electric");
-    case TerrainType.GRASSY:
-      return i18next.t("terrain:grassy");
-    case TerrainType.PSYCHIC:
-      return i18next.t("terrain:psychic");
-  }
-
-  return "";
-}
-
-/**
- * Function to get an RGB representation for a {@linkcode TerrainType}
- * TODO: we should either be using hex or RGB, not a mix
- * @param terrainType - The {@linkcode TerrainType}
- * @returns the associated RGB array of 3 numbers
- */
-export function getTerrainColor(terrainType: TerrainType): [number, number, number] {
-  switch (terrainType) {
-    case TerrainType.MISTY:
-      return [232, 136, 200]; // Pink
-    case TerrainType.ELECTRIC:
-      return [248, 248, 120]; // Yellow
-    case TerrainType.GRASSY:
-      return [120, 200, 80]; // Green
-    case TerrainType.PSYCHIC:
-      return [160, 64, 160]; // Purple
-  }
-
-  return [0, 0, 0];
-}
-
-/**
- * Function to get the starting message for a terrain
- * @param terrainType - the {@linkcode TerrainType} starting
- * @returns the associated string
- */
-export function getTerrainStartMessage(terrainType: TerrainType): string | null {
-  switch (terrainType) {
-    case TerrainType.MISTY:
-      return i18next.t("terrain:mistyStartMessage");
-    case TerrainType.ELECTRIC:
-      return i18next.t("terrain:electricStartMessage");
-    case TerrainType.GRASSY:
-      return i18next.t("terrain:grassyStartMessage");
-    case TerrainType.PSYCHIC:
-      return i18next.t("terrain:psychicStartMessage");
-    default:
-      console.warn("getTerrainStartMessage not defined. Using default null");
-      return null;
-  }
-}
-
-/**
- * Function to get the ending message for a terrain
- * @param terrainType - the {@linkcode TerrainType} ending
- * @returns the associated string
- */
-export function getTerrainClearMessage(terrainType: TerrainType): string | null {
-  switch (terrainType) {
-    case TerrainType.MISTY:
-      return i18next.t("terrain:mistyClearMessage");
-    case TerrainType.ELECTRIC:
-      return i18next.t("terrain:electricClearMessage");
-    case TerrainType.GRASSY:
-      return i18next.t("terrain:grassyClearMessage");
-    case TerrainType.PSYCHIC:
-      return i18next.t("terrain:psychicClearMessage");
-    default:
-      console.warn("getTerrainClearMessage not defined. Using default null");
-      return null;
-  }
-}
-
-/**
- * Function to get the message for when a terrain blocks a move
- * @param pokemon - The Pokemon being attacked
- * @param terrainType - the {@linkcode TerrainType} (misty terrain has a unique message)
- * @returns the associated string
- */
-export function getTerrainBlockMessage(pokemon: Pokemon, terrainType: TerrainType): string {
-  if (terrainType === TerrainType.MISTY) {
-    return i18next.t("terrain:mistyBlockMessage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) });
-  }
-  return i18next.t("terrain:defaultBlockMessage", {
-    pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
-    terrainName: getTerrainName(terrainType),
-  });
 }

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -1,13 +1,11 @@
 import type { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-effect-ab-attr";
 import { globalScene } from "#app/global-scene";
-import { getPokemonNameWithAffix } from "#app/messages";
 import { PRIMAL_WEATHER_TYPES } from "#constants/weather-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ElementalType } from "#enums/elemental-type";
 import { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
-import i18next from "i18next";
 
 /** Class representing Weather effects */
 export class Weather {
@@ -149,113 +147,4 @@ export class Weather {
 
     return false;
   }
-}
-
-// TODO: Should localization return null or "" as a default? Inconsistencies in the codebase
-
-/**
- * Function to get the starting message for weather
- * @param weatherType - the {@linkcode WeatherType} starting
- * @returns the associated string
- */
-export function getWeatherStartMessage(weatherType: WeatherType): string | null {
-  switch (weatherType) {
-    case WeatherType.SUNNY:
-      return i18next.t("weather:sunnyStartMessage");
-    case WeatherType.RAIN:
-      return i18next.t("weather:rainStartMessage");
-    case WeatherType.SANDSTORM:
-      return i18next.t("weather:sandstormStartMessage");
-    case WeatherType.HAIL:
-      return i18next.t("weather:hailStartMessage");
-    case WeatherType.SNOW:
-      return i18next.t("weather:snowStartMessage");
-    case WeatherType.FOG:
-      return i18next.t("weather:fogStartMessage");
-    case WeatherType.HEAVY_RAIN:
-      return i18next.t("weather:heavyRainStartMessage");
-    case WeatherType.HARSH_SUN:
-      return i18next.t("weather:harshSunStartMessage");
-    case WeatherType.STRONG_WINDS:
-      return i18next.t("weather:strongWindsStartMessage");
-  }
-
-  return null;
-}
-
-/**
- * Function to get the lapsing message for weather
- * @param weatherType - the {@linkcode WeatherType} lapsing
- * @returns the associated string
- */
-export function getWeatherLapseMessage(weatherType: WeatherType): string {
-  switch (weatherType) {
-    case WeatherType.SUNNY:
-      return i18next.t("weather:sunnyLapseMessage");
-    case WeatherType.RAIN:
-      return i18next.t("weather:rainLapseMessage");
-    case WeatherType.SANDSTORM:
-      return i18next.t("weather:sandstormLapseMessage");
-    case WeatherType.HAIL:
-      return i18next.t("weather:hailLapseMessage");
-    case WeatherType.SNOW:
-      return i18next.t("weather:snowLapseMessage");
-    case WeatherType.FOG:
-      return i18next.t("weather:fogLapseMessage");
-    case WeatherType.HEAVY_RAIN:
-      return i18next.t("weather:heavyRainLapseMessage");
-    case WeatherType.HARSH_SUN:
-      return i18next.t("weather:harshSunLapseMessage");
-    case WeatherType.STRONG_WINDS:
-      return i18next.t("weather:strongWindsLapseMessage");
-    case WeatherType.NONE:
-      return "";
-  }
-}
-
-/**
- * Function to get the associated message for when a Pokemon is damaged by weather (sandstorm or hail)
- * @param weatherType - The {@linkcode WeatherType}
- * @param pokemon - The {@linkcode Pokemon} being damaged
- * @returns the corresponding string
- */
-export function getWeatherDamageMessage(weatherType: WeatherType, pokemon: Pokemon): string | null {
-  switch (weatherType) {
-    case WeatherType.SANDSTORM:
-      return i18next.t("weather:sandstormDamageMessage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) });
-    case WeatherType.HAIL:
-      return i18next.t("weather:hailDamageMessage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) });
-  }
-
-  return null;
-}
-
-/**
- * Function to get the ending message for weather
- * @param weatherType - the {@linkcode WeatherType} ending
- * @returns the associated string
- */
-export function getWeatherClearMessage(weatherType: WeatherType): string | null {
-  switch (weatherType) {
-    case WeatherType.SUNNY:
-      return i18next.t("weather:sunnyClearMessage");
-    case WeatherType.RAIN:
-      return i18next.t("weather:rainClearMessage");
-    case WeatherType.SANDSTORM:
-      return i18next.t("weather:sandstormClearMessage");
-    case WeatherType.HAIL:
-      return i18next.t("weather:hailClearMessage");
-    case WeatherType.SNOW:
-      return i18next.t("weather:snowClearMessage");
-    case WeatherType.FOG:
-      return i18next.t("weather:fogClearMessage");
-    case WeatherType.HEAVY_RAIN:
-      return i18next.t("weather:heavyRainClearMessage");
-    case WeatherType.HARSH_SUN:
-      return i18next.t("weather:harshSunClearMessage");
-    case WeatherType.STRONG_WINDS:
-      return i18next.t("weather:strongWindsClearMessage");
-  }
-
-  return null;
 }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -14,7 +14,7 @@ import { type BiomeTierTrainerPools, getBiomeBgm, IndoorBiomes, type PokemonPool
 import { allBiomes } from "#data/data-lists";
 import { SpeciesFormChangeRevertWeatherFormTrigger, SpeciesFormChangeWeatherTrigger } from "#data/pokemon-forms";
 import type { PokemonSpecies } from "#data/pokemon-species";
-import { getTerrainClearMessage, getTerrainStartMessage, Terrain } from "#data/terrain";
+import { Terrain } from "#data/terrain";
 import { Weather } from "#data/weather";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
@@ -37,6 +37,7 @@ import type { Move } from "#moves/move";
 import { coerceArray, enumValueToKey, getTSEnumValues } from "#utils/common-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { randSeedInt, weightedPick } from "#utils/random-utils";
+import { getTerrainClearMessage, getTerrainStartMessage } from "#utils/terrain-utils";
 import { getWeatherClearMessage, getWeatherStartMessage } from "#utils/weather-utils";
 
 export class Arena {

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -15,7 +15,7 @@ import { allBiomes } from "#data/data-lists";
 import { SpeciesFormChangeRevertWeatherFormTrigger, SpeciesFormChangeWeatherTrigger } from "#data/pokemon-forms";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { getTerrainClearMessage, getTerrainStartMessage, Terrain } from "#data/terrain";
-import { getWeatherClearMessage, getWeatherStartMessage, Weather } from "#data/weather";
+import { Weather } from "#data/weather";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
 import { ArenaTagSide } from "#enums/arena-tag-side";
@@ -37,6 +37,7 @@ import type { Move } from "#moves/move";
 import { coerceArray, enumValueToKey, getTSEnumValues } from "#utils/common-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { randSeedInt, weightedPick } from "#utils/random-utils";
+import { getWeatherClearMessage, getWeatherStartMessage } from "#utils/weather-utils";
 
 export class Arena {
   public biomeId: BiomeId;

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -711,6 +711,10 @@ export class EnemyPokemon extends Pokemon {
     return true;
   }
 
+  public override isAllowedInBattle(): boolean {
+    return !this.isFainted();
+  }
+
   hasTrainer(): boolean {
     return this.trainerSlot !== TrainerSlot.NONE;
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2656,7 +2656,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return -1;
     }
 
-    return this.getOpponents().every((opp) => this.outspeeds(opp, opp.isPlayer())) ? 1 : 0;
+    return this.getOpponents().every((opp) => this.outspeeds(opp, opp.isPlayer())) ? 0.5 : 0;
   }
 
   getEvolution(): SpeciesFormEvolution | null {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -161,6 +161,7 @@ import { BypassBurnDamageReductionAttr } from "#moves/bypass-burn-damage-reducti
 import { CombinedPledgeStabBoostAttr } from "#moves/combined-pledge-stab-boost-attr";
 import { CritOnlyAttr } from "#moves/crit-only-attr";
 import { DoubleDamageToMaxAttr } from "#moves/double-damage-to-max-attr";
+import { DrowsyAttr } from "#moves/drowsy-attr";
 import { FixedDamageAttr } from "#moves/fixed-damage-attr";
 import { HighCritAttr } from "#moves/high-crit-attr";
 import { HitsTagAttr } from "#moves/hits-tag-attr";
@@ -168,12 +169,16 @@ import { IgnoreOpponentStatStagesAttr } from "#moves/ignore-opponent-stat-stages
 import { IgnoreWeatherTypeDebuffAttr } from "#moves/ignore-weather-type-debuff-attr";
 import { ModifiedDamageAttr } from "#moves/modified-damage-attr";
 import { AttackMove, getMoveTargets, type Move } from "#moves/move";
+import type { MoveAttr } from "#moves/move-attr";
+import { MultiStatusEffectAttr } from "#moves/multi-status-effect-attr";
 import { OneHitKOAccuracyAttr } from "#moves/one-hit-ko-accuracy-attr";
 import { OneHitKOAttr } from "#moves/one-hit-ko-attr";
+import { PsychoShiftEffectAttr } from "#moves/psycho-shift-effect-attr";
 import { RechargeAttr } from "#moves/recharge-attr";
 import { RespectAttackTypeImmunityAttr } from "#moves/respect-attack-type-immunity-attr";
 import { SacrificialAttr } from "#moves/sacrificial-attr";
 import { StatStageChangeAttr } from "#moves/stat-stage-change-attr";
+import { StatusEffectAttr } from "#moves/status-effect-attr";
 import { TypelessAttr } from "#moves/typeless-attr";
 import { VariableAtkAttr } from "#moves/variable-atk-attr";
 import { VariableDefAttr } from "#moves/variable-def-attr";
@@ -187,6 +192,7 @@ import type { AbilityFilterOptions } from "#types/ability-types";
 import type { DamageCalculationResult, DamageResult, TurnMove } from "#types/move-types";
 import type { PokemonScoreData } from "#types/pokemon-score-data";
 import type { PokemonSummonData, PokemonTurnData, PokemonWaveData, Status } from "#types/pokemon-types";
+import type { Constructor } from "#types/utility-types";
 import type { BattleInfo } from "#ui/battle-info";
 import { applyChallenges } from "#utils/challenge-utils";
 import {
@@ -1507,16 +1513,32 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /**
-   * Checks whether this Pokemon knows a specific move.
-   * @param moveId - The {@linkcode MoveId} to check.
+   * Checks whether this Pokemon knows a specific move
+   * @param moveId - The {@linkcode MoveId} to check
    * @param revealedOnly - (Default `false`) If `true`, limits the search to
-   * moves that the Pokemon has revealed in battle.
+   * moves that the Pokemon has revealed in battle
    * @returns `true` if the Pokemon knows the given move
    */
   public hasMove(moveId: MoveId, revealedOnly: boolean = false): boolean {
     return revealedOnly
       ? this.waveData.revealedMoves.has(moveId)
       : this.getMoveset().some((mv) => mv.moveId === moveId);
+  }
+
+  /**
+   * Checks whether this Pokemon knows a move with a specific {@linkcode MoveAttr}
+   * @param attr - The type of {@linkcode MoveAttr} to check
+   * @param revealedOnly - (Default `false`) If `true`, limits the search to
+   * moves that the Pokemon has revealed in battle
+   * @returns `true` if the Pokemon knows a move with the given attribute
+   * @todo Use enum flags for move attributes instead to reduce risk of dependency violations
+   */
+  public hasMoveWithAttr(attr: Constructor<MoveAttr>, revealedOnly: boolean = false): boolean {
+    const revealedMoves = revealedOnly
+      ? [...this.waveData.revealedMoves].map((moveId) => allMoves.get(moveId))
+      : this.getMoveset().map((pkMove) => pkMove.getMove());
+
+    return revealedMoves.some((move) => move.hasAttr(attr));
   }
 
   /**
@@ -2514,10 +2536,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Calculates a score to measure how much this Pokemon benefits from the
-   * given type of terrain. The final score consists of three components:
+   * given type of Terrain. The final score consists of three components:
    * - An assigned score for the Pokemon's type(s) according to {@linkcode getTerrainTypeSynergyScore}.
    * - (+1) for each Ability the Pokemon has (and can apply) that benefits from the terrain.
    * - (+0.5) for each Move the Pokemon knows that benefits from the terrain.
+   * - An assigned score for the Terrain's "secondary effect" according to
+   * {@linkcode getTerrainSecondaryEffectScore}.
    * @param weatherType - The {@link WeatherType | type} of weather to evaluate this Pokemon against
    * @param estimate - If `true`, limits checked abilities and moves to those revealed in battle
    * @returns A decimal score approximating the Pokemon's potential synergy with the given weather
@@ -2544,7 +2568,95 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       0,
     );
 
-    return typeScore + abilityScore + moveScore;
+    const secondaryEffectScore = this.getTerrainSecondaryEffectScore(terrainType, estimate);
+
+    return typeScore + abilityScore + moveScore + secondaryEffectScore;
+  }
+
+  /**
+   * Calculates the benefit score component for the given terrain's "secondary" effect. For the purpose
+   * of this score, each Terrain's secondary effect is as follows:
+   * - {@link TerrainType.MISTY | Misty Terrain}: grants immunity to status conditions to all grounded Pokemon
+   * - {@link TerrainType.ELECTRIC | Electric Terrain}: grants immunity to Sleep to all grounded Pokemon
+   * - {@link TerrainType.GRASSY | Grassy Terrain}: halves the power of Earthquake, Bulldoze, and Magnitude
+   * - {@link TerrainType.PSYCHIC | Psychic Terrain}: grants immunity to opponents' high-priority moves
+   * to all grounded Pokemon
+   * @param terrainType - The {@linkcode TerrainType} to check
+   * @param estimate - If `true`, the data used for scoring (i.e. moves, abilities) is limited
+   * to what has been "revealed" to the Enemy AI in the current battle
+   * @returns The decimal secondary effect benefit score component for the given Terrain
+   * @see {@linkcode getTerrainBenefitScore}
+   */
+  private getTerrainSecondaryEffectScore(terrainType: TerrainType, estimate: boolean): number {
+    switch (terrainType) {
+      case TerrainType.MISTY:
+        return this.getMistyTerrainSecondaryEffectScore(estimate);
+      case TerrainType.ELECTRIC:
+        return this.getElectricTerrainSecondaryEffectScore(estimate);
+      case TerrainType.GRASSY:
+        return this.getGrassyTerrainSecondaryEffectScore(estimate);
+      case TerrainType.PSYCHIC:
+        return this.getPsychicTerrainSecondaryEffectScore(estimate);
+      default: {
+        terrainType satisfies TerrainType.NONE;
+        return 0;
+      }
+    }
+  }
+
+  /**
+   * Misty Terrain penalizes Pokemon if they have any status-effect-inflicting moves
+   * @see {@linkcode getTerrainSecondaryEffectScore}
+   */
+  private getMistyTerrainSecondaryEffectScore(estimate: boolean): number {
+    const badMoveAttrs: Constructor<MoveAttr>[] = [StatusEffectAttr, MultiStatusEffectAttr, PsychoShiftEffectAttr];
+
+    return badMoveAttrs.some((attr) => this.hasMoveWithAttr(attr, estimate)) ? -1 : 0;
+  }
+
+  /**
+   * Electric Terrain penalizes Pokemon if they have any Sleep-inducing moves
+   * @see {@linkcode getTerrainSecondaryEffectScore}
+   */
+  private getElectricTerrainSecondaryEffectScore(estimate: boolean): number {
+    const moveset = estimate
+      ? this.getRevealedMoves().map((moveId) => allMoves.get(moveId))
+      : this.getMoveset().map((pkMove) => pkMove.getMove());
+
+    const hasSleepMove = moveset.some(
+      (move) => move.hasAttr(DrowsyAttr) || move.getAttrs(StatusEffectAttr)[0].effect === StatusEffect.SLEEP,
+    );
+
+    return hasSleepMove ? -1 : 0;
+  }
+
+  /**
+   * Grassy Terrain penalizes Pokemon if they know Earthquake, Bulldoze, or Magnitude
+   * @see {@linkcode getTerrainSecondaryEffectScore}
+   */
+  private getGrassyTerrainSecondaryEffectScore(estimate: boolean): number {
+    const badMoves: MoveId[] = [MoveId.EARTHQUAKE, MoveId.BULLDOZE, MoveId.MAGNITUDE];
+
+    return badMoves.some((moveId) => this.hasMove(moveId, estimate)) ? -1 : 0;
+  }
+
+  /**
+   * Psychic Terrain penalizes Pokemon if they know a single-target, high-priority move.
+   * If not, it may reward Pokemon that are faster than any of their active opponents.
+   * @see {@linkcode getTerrainSecondaryEffectScore}
+   */
+  private getPsychicTerrainSecondaryEffectScore(estimate: boolean): number {
+    const moveset = estimate
+      ? this.getRevealedMoves().map((moveId) => allMoves.get(moveId))
+      : this.getMoveset().map((pkMove) => pkMove.getMove());
+
+    const hasPriorityMove = moveset.some((move) => move.getPriority(this) > 0 && move.isSingleEnemyTarget());
+
+    if (hasPriorityMove) {
+      return -1;
+    }
+
+    return this.getOpponents().every((opp) => this.outspeeds(opp, opp.isPlayer())) ? 1 : 0;
   }
 
   getEvolution(): SpeciesFormEvolution | null {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2519,12 +2519,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       0,
     );
 
-    const abilityScore = getWeatherSynergyAbilities(weatherType).reduce((score, abilityId) => {
-      if (estimate) {
-        return score + (this.hasRevealedAbility(abilityId) ? 1 : 0);
-      }
-      return score + (this.hasAbility(abilityId) ? 1 : 0);
-    }, 0);
+    // TODO: This ability check doesn't account for ability suppression
+    const abilities = this.getAbilities({ revealedOnly: estimate });
+    const synergyAbilities = getWeatherSynergyAbilities(weatherType);
+    const abilityScore = abilities.reduce(
+      (total, { ability }) => total + (synergyAbilities.has(ability.id) ? 1 : 0),
+      0,
+    );
 
     const moveScore = getWeatherSynergyMoves(weatherType).reduce(
       (score, moveId) => score + (this.hasMove(moveId, estimate) ? 0.5 : 0),
@@ -2556,12 +2557,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       0,
     );
 
-    const abilityScore = getTerrainSynergyAbilities(terrainType).reduce((score, abilityId) => {
-      if (estimate) {
-        return score + (this.hasRevealedAbility(abilityId) ? 1 : 0);
-      }
-      return score + (this.hasAbility(abilityId) ? 1 : 0);
-    }, 0);
+    // TODO: This ability check doesn't account for ability suppression
+    const abilities = this.getAbilities({ revealedOnly: estimate });
+    const synergyAbilities = getTerrainSynergyAbilities(terrainType);
+    const abilityScore = abilities.reduce(
+      (total, { ability }) => total + (synergyAbilities.has(ability.id) ? 1 : 0),
+      0,
+    );
 
     const moveScore = getTerrainSynergyMoves(terrainType).reduce(
       (score, moveId) => score + (this.hasMove(moveId, estimate) ? 0.5 : 0),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2561,7 +2561,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         return score + (this.hasRevealedAbility(abilityId) ? 1 : 0);
       }
       return score + (this.hasAbility(abilityId) ? 1 : 0);
-    });
+    }, 0);
 
     const moveScore = getTerrainSynergyMoves(terrainType).reduce(
       (score, moveId) => score + (this.hasMove(moveId, estimate) ? 0.5 : 0),

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -205,6 +205,7 @@ import { loadMoveAnimAssets } from "#utils/move-anim-utils";
 import { applyMoveAttrs } from "#utils/move-utils";
 import { getPokemonSpecies, getPokemonSpeciesForm, summonDataToJSON } from "#utils/pokemon-utils";
 import { randSeedInt } from "#utils/random-utils";
+import { getTerrainSynergyAbilities, getTerrainSynergyMoves, getTerrainTypeSynergyScore } from "#utils/terrain-utils";
 import { getWeatherSynergyAbilities, getWeatherSynergyMoves, getWeatherTypeSynergyScore } from "#utils/weather-utils";
 import i18next from "i18next";
 
@@ -1270,7 +1271,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * @param target - The {@linkcode Pokemon} to compare Speed against
    * @param estimate - If `true`, estimates the target's Speed, not accounting for unrevealed Abilities
-   * @returns `true` if this Pokemon has higher Speed than
+   * @returns `true` if this Pokemon has higher Speed than the given target Pokemon
    */
   public outspeeds(target: Pokemon, estimate: boolean = false): boolean {
     const abilityApplyMode = estimate ? AbilityApplyMode.REVEALED : AbilityApplyMode.DEFAULT;
@@ -2504,6 +2505,41 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }, 0);
 
     const moveScore = getWeatherSynergyMoves(weatherType).reduce(
+      (score, moveId) => score + (this.hasMove(moveId, estimate) ? 0.5 : 0),
+      0,
+    );
+
+    return typeScore + abilityScore + moveScore;
+  }
+
+  /**
+   * Calculates a score to measure how much this Pokemon benefits from the
+   * given type of terrain. The final score consists of three components:
+   * - An assigned score for the Pokemon's type(s) according to {@linkcode getTerrainTypeSynergyScore}.
+   * - (+1) for each Ability the Pokemon has (and can apply) that benefits from the terrain.
+   * - (+0.5) for each Move the Pokemon knows that benefits from the terrain.
+   * @param weatherType - The {@link WeatherType | type} of weather to evaluate this Pokemon against
+   * @param estimate - If `true`, limits checked abilities and moves to those revealed in battle
+   * @returns A decimal score approximating the Pokemon's potential synergy with the given weather
+   */
+  public getTerrainBenefitScore(terrainType: TerrainType, estimate: boolean = false): number {
+    if (!this.isGrounded()) {
+      return 0;
+    }
+
+    const typeScore = this.getTypes(true, true).reduce(
+      (score, elemType) => score + getTerrainTypeSynergyScore(terrainType, elemType),
+      0,
+    );
+
+    const abilityScore = getTerrainSynergyAbilities(terrainType).reduce((score, abilityId) => {
+      if (estimate) {
+        return score + (this.hasRevealedAbility(abilityId) ? 1 : 0);
+      }
+      return score + (this.hasAbility(abilityId) ? 1 : 0);
+    });
+
+    const moveScore = getTerrainSynergyMoves(terrainType).reduce(
       (score, moveId) => score + (this.hasMove(moveId, estimate) ? 0.5 : 0),
       0,
     );

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -205,6 +205,7 @@ import { loadMoveAnimAssets } from "#utils/move-anim-utils";
 import { applyMoveAttrs } from "#utils/move-utils";
 import { getPokemonSpecies, getPokemonSpeciesForm, summonDataToJSON } from "#utils/pokemon-utils";
 import { randSeedInt } from "#utils/random-utils";
+import { getWeatherSynergyAbilities, getWeatherSynergyMoves, getWeatherTypeSynergyScore } from "#utils/weather-utils";
 import i18next from "i18next";
 
 interface AbilityData {
@@ -2477,6 +2478,37 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public getAverageMatchupScore(): number {
     const opponents = this.getOpponents();
     return opponents.map((opp) => this.getMatchupScore(opp)).reduce((total, mus) => total + mus) / opponents.length;
+  }
+
+  /**
+   * Calculates a score to measure how much this Pokemon benefits from the
+   * given type of weather. The final score consists of three components:
+   * - An assigned score for the Pokemon's type(s) according to {@linkcode getWeatherTypeSynergyScore}.
+   * - (+1) for each Ability the Pokemon has (and can apply) that benefits from the weather.
+   * - (+0.5) for each Move the Pokemon knows that benefits from the weather.
+   * @param weatherType - The {@link WeatherType | type} of weather to evaluate this Pokemon against
+   * @param estimate - If `true`, limits checked abilities and moves to those revealed in battle
+   * @returns A decimal score approximating the Pokemon's potential synergy with the given weather
+   */
+  public getWeatherBenefitScore(weatherType: WeatherType, estimate: boolean = false): number {
+    const typeScore = this.getTypes(true, true).reduce(
+      (score, elemType) => score + getWeatherTypeSynergyScore(weatherType, elemType),
+      0,
+    );
+
+    const abilityScore = getWeatherSynergyAbilities(weatherType).reduce((score, abilityId) => {
+      if (estimate) {
+        return score + (this.hasRevealedAbility(abilityId) ? 1 : 0);
+      }
+      return score + (this.hasAbility(abilityId) ? 1 : 0);
+    }, 0);
+
+    const moveScore = getWeatherSynergyMoves(weatherType).reduce(
+      (score, moveId) => score + (this.hasMove(moveId, estimate) ? 0.5 : 0),
+      0,
+    );
+
+    return typeScore + abilityScore + moveScore;
   }
 
   getEvolution(): SpeciesFormEvolution | null {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2624,7 +2624,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       : this.getMoveset().map((pkMove) => pkMove.getMove());
 
     const hasSleepMove = moveset.some(
-      (move) => move.hasAttr(DrowsyAttr) || move.getAttrs(StatusEffectAttr)[0].effect === StatusEffect.SLEEP,
+      (move) => move.hasAttr(DrowsyAttr) || move.getAttrs(StatusEffectAttr)[0]?.effect === StatusEffect.SLEEP,
     );
 
     return hasSleepMove ? -1 : 0;

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -13,7 +13,6 @@ import type { ImprisoningTag } from "#battler-tags/imprisoning-tag";
 import type { MagicCoatTag } from "#battler-tags/magic-coat-tag";
 import type { SnatchingTag } from "#battler-tags/snatch-tag";
 import { allMoves } from "#data/data-lists";
-import { getTerrainBlockMessage } from "#data/terrain";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
@@ -41,6 +40,7 @@ import { BattlePhase } from "#phases/base/battle-phase";
 import { BooleanHolder, isNil, NumberHolder } from "#utils/common-utils";
 import { applyMoveAttrs, isFieldTargeted } from "#utils/move-utils";
 import { getStatusEffectActivationText, getStatusEffectHealText } from "#utils/status-effect-utils";
+import { getTerrainBlockMessage } from "#utils/terrain-utils";
 import i18next from "i18next";
 
 interface MovePhaseOptions {

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -6,7 +6,7 @@ import type { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-ef
 import { CommonBattleAnim } from "#animations/common-battle-anim";
 import { globalScene } from "#app/global-scene";
 import { WEATHER_DAMAGE_RATIO } from "#constants/weather-constants";
-import { getWeatherDamageMessage, getWeatherLapseMessage, type Weather } from "#data/weather";
+import type { Weather } from "#data/weather";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { CommonAnim } from "#enums/common-anim";
@@ -15,6 +15,7 @@ import { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
 import { FieldPhase } from "#phases/base/field-phase";
 import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { getWeatherDamageMessage, getWeatherLapseMessage } from "#utils/weather-utils";
 
 /**
  * Applies the end-of-turn effects from active {@linkcode Weather}, including

--- a/src/pipelines/field-sprite.ts
+++ b/src/pipelines/field-sprite.ts
@@ -1,7 +1,7 @@
 import { globalScene } from "#app/global-scene";
-import { getTerrainColor } from "#data/terrain";
 import { TerrainType } from "#enums/terrain-type";
 import { getCurrentTime } from "#utils/common-utils";
+import { getTerrainColor } from "#utils/terrain-utils";
 
 const spriteFragShader = `
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/src/utils/terrain-utils.ts
+++ b/src/utils/terrain-utils.ts
@@ -111,6 +111,13 @@ export function getTerrainBlockMessage(pokemon: Pokemon, terrainType: TerrainTyp
   });
 }
 
+/**
+ * Determines the benefit score assigned to Pokemon of the given {@linkcode ElementalType}
+ * under the given {@linkcode TerrainType}. This score is used for the Enemy AI's
+ * command selection.
+ * @returns A decimal score for the given elemental type under the given terrain type
+ * @see {@linkcode Pokemon.getTerrainBenefitScore}
+ */
 export function getTerrainTypeSynergyScore(terrainType: TerrainType, elementalType: ElementalType): number {
   switch (terrainType) {
     case TerrainType.MISTY:

--- a/src/utils/terrain-utils.ts
+++ b/src/utils/terrain-utils.ts
@@ -1,0 +1,165 @@
+import { getPokemonNameWithAffix } from "#app/messages";
+import {
+  ELECTRIC_TERRAIN_SYNERGY_MOVES,
+  GRASSY_TERRAIN_SYNERGY_MOVES,
+  MISTY_TERRAIN_SYNERGY_MOVES,
+  PSYCHIC_TERRAIN_SYNERGY_MOVES,
+} from "#constants/move-constants";
+import { AbilityId } from "#enums/ability-id";
+import { ElementalType } from "#enums/elemental-type";
+import type { MoveId } from "#enums/move-id";
+import { TerrainType } from "#enums/terrain-type";
+import type { Pokemon } from "#field/pokemon";
+import i18next from "i18next";
+
+/**
+ * Get the name for a given terrain type
+ * @param terrainType - The {@linkcode TerrainType}
+ * @returns the associated name, or an empty string if there is none
+ */
+export function getTerrainName(terrainType: TerrainType): string {
+  switch (terrainType) {
+    case TerrainType.MISTY:
+      return i18next.t("terrain:misty");
+    case TerrainType.ELECTRIC:
+      return i18next.t("terrain:electric");
+    case TerrainType.GRASSY:
+      return i18next.t("terrain:grassy");
+    case TerrainType.PSYCHIC:
+      return i18next.t("terrain:psychic");
+  }
+
+  return "";
+}
+
+/**
+ * Function to get an RGB representation for a {@linkcode TerrainType}
+ * TODO: we should either be using hex or RGB, not a mix
+ * @param terrainType - The {@linkcode TerrainType}
+ * @returns the associated RGB array of 3 numbers
+ */
+export function getTerrainColor(terrainType: TerrainType): [number, number, number] {
+  switch (terrainType) {
+    case TerrainType.MISTY:
+      return [232, 136, 200]; // Pink
+    case TerrainType.ELECTRIC:
+      return [248, 248, 120]; // Yellow
+    case TerrainType.GRASSY:
+      return [120, 200, 80]; // Green
+    case TerrainType.PSYCHIC:
+      return [160, 64, 160]; // Purple
+  }
+
+  return [0, 0, 0];
+}
+
+/**
+ * Function to get the starting message for a terrain
+ * @param terrainType - the {@linkcode TerrainType} starting
+ * @returns the associated string
+ */
+export function getTerrainStartMessage(terrainType: TerrainType): string | null {
+  switch (terrainType) {
+    case TerrainType.MISTY:
+      return i18next.t("terrain:mistyStartMessage");
+    case TerrainType.ELECTRIC:
+      return i18next.t("terrain:electricStartMessage");
+    case TerrainType.GRASSY:
+      return i18next.t("terrain:grassyStartMessage");
+    case TerrainType.PSYCHIC:
+      return i18next.t("terrain:psychicStartMessage");
+    default:
+      console.warn("getTerrainStartMessage not defined. Using default null");
+      return null;
+  }
+}
+
+/**
+ * Function to get the ending message for a terrain
+ * @param terrainType - the {@linkcode TerrainType} ending
+ * @returns the associated string
+ */
+export function getTerrainClearMessage(terrainType: TerrainType): string | null {
+  switch (terrainType) {
+    case TerrainType.MISTY:
+      return i18next.t("terrain:mistyClearMessage");
+    case TerrainType.ELECTRIC:
+      return i18next.t("terrain:electricClearMessage");
+    case TerrainType.GRASSY:
+      return i18next.t("terrain:grassyClearMessage");
+    case TerrainType.PSYCHIC:
+      return i18next.t("terrain:psychicClearMessage");
+    default:
+      console.warn("getTerrainClearMessage not defined. Using default null");
+      return null;
+  }
+}
+
+/**
+ * Function to get the message for when a terrain blocks a move
+ * @param pokemon - The Pokemon being attacked
+ * @param terrainType - the {@linkcode TerrainType} (misty terrain has a unique message)
+ * @returns the associated string
+ */
+export function getTerrainBlockMessage(pokemon: Pokemon, terrainType: TerrainType): string {
+  if (terrainType === TerrainType.MISTY) {
+    return i18next.t("terrain:mistyBlockMessage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) });
+  }
+  return i18next.t("terrain:defaultBlockMessage", {
+    pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
+    terrainName: getTerrainName(terrainType),
+  });
+}
+
+export function getTerrainTypeSynergyScore(terrainType: TerrainType, elementalType: ElementalType): number {
+  switch (terrainType) {
+    case TerrainType.MISTY:
+      return elementalType === ElementalType.DRAGON ? -1 : 0;
+    case TerrainType.ELECTRIC:
+      return elementalType === ElementalType.ELECTRIC ? 1 : 0;
+    case TerrainType.GRASSY:
+      return elementalType === ElementalType.GRASS ? 1 : 0;
+    case TerrainType.PSYCHIC:
+      return elementalType === ElementalType.PSYCHIC ? 1 : 0;
+    default: {
+      terrainType satisfies TerrainType.NONE;
+      return 0;
+    }
+  }
+}
+
+/**
+ * @param terrainType - The {@linkcode TerrainType} to check
+ * @returns An array of {@link AbilityId | IDs} for abilities that benefit from
+ * the given terrain type
+ */
+export function getTerrainSynergyAbilities(terrainType: TerrainType): readonly AbilityId[] {
+  switch (terrainType) {
+    case TerrainType.ELECTRIC:
+      return [AbilityId.QUARK_DRIVE, AbilityId.SURGE_SURFER, AbilityId.HADRON_ENGINE];
+    case TerrainType.GRASSY:
+      return [AbilityId.GRASS_PELT];
+    default:
+      return [];
+  }
+}
+
+/**
+ * @param terrainType - The {@linkcode TerrainType} to check
+ * @returns An array of {@link MoveId | IDs} for moves that benefit from
+ * the given terrain type
+ */
+export function getTerrainSynergyMoves(terrainType: TerrainType): readonly MoveId[] {
+  switch (terrainType) {
+    case TerrainType.MISTY:
+      return MISTY_TERRAIN_SYNERGY_MOVES;
+    case TerrainType.ELECTRIC:
+      return ELECTRIC_TERRAIN_SYNERGY_MOVES;
+    case TerrainType.GRASSY:
+      return GRASSY_TERRAIN_SYNERGY_MOVES;
+    case TerrainType.PSYCHIC:
+      return PSYCHIC_TERRAIN_SYNERGY_MOVES;
+    default:
+      return [];
+  }
+}

--- a/src/utils/terrain-utils.ts
+++ b/src/utils/terrain-utils.ts
@@ -133,7 +133,7 @@ export function getTerrainTypeSynergyScore(terrainType: TerrainType, elementalTy
  * @returns A set of {@link AbilityId | IDs} for abilities that benefit from
  * the given terrain type
  */
-export function getTerrainSynergyAbilities(terrainType: TerrainType): Readonly<Set<AbilityId>> {
+export function getTerrainSynergyAbilities(terrainType: TerrainType): ReadonlySet<AbilityId> {
   switch (terrainType) {
     case TerrainType.ELECTRIC:
       return new Set([AbilityId.QUARK_DRIVE, AbilityId.SURGE_SURFER, AbilityId.HADRON_ENGINE]);

--- a/src/utils/terrain-utils.ts
+++ b/src/utils/terrain-utils.ts
@@ -130,17 +130,17 @@ export function getTerrainTypeSynergyScore(terrainType: TerrainType, elementalTy
 
 /**
  * @param terrainType - The {@linkcode TerrainType} to check
- * @returns An array of {@link AbilityId | IDs} for abilities that benefit from
+ * @returns A set of {@link AbilityId | IDs} for abilities that benefit from
  * the given terrain type
  */
-export function getTerrainSynergyAbilities(terrainType: TerrainType): readonly AbilityId[] {
+export function getTerrainSynergyAbilities(terrainType: TerrainType): Readonly<Set<AbilityId>> {
   switch (terrainType) {
     case TerrainType.ELECTRIC:
-      return [AbilityId.QUARK_DRIVE, AbilityId.SURGE_SURFER, AbilityId.HADRON_ENGINE];
+      return new Set([AbilityId.QUARK_DRIVE, AbilityId.SURGE_SURFER, AbilityId.HADRON_ENGINE]);
     case TerrainType.GRASSY:
-      return [AbilityId.GRASS_PELT];
+      return new Set([AbilityId.GRASS_PELT]);
     default:
-      return [];
+      return new Set([]);
   }
 }
 

--- a/src/utils/weather-utils.ts
+++ b/src/utils/weather-utils.ts
@@ -207,7 +207,7 @@ function getStrongWindsSynergyScore(elementalType: ElementalType): number {
  * @returns A set of {@link AbilityId | IDs} for abilities that benefit from
  * the given weather type.
  */
-export function getWeatherSynergyAbilities(weatherType: WeatherType): Readonly<Set<AbilityId>> {
+export function getWeatherSynergyAbilities(weatherType: WeatherType): ReadonlySet<AbilityId> {
   switch (weatherType) {
     case WeatherType.SUNNY:
     case WeatherType.HARSH_SUN:

--- a/src/utils/weather-utils.ts
+++ b/src/utils/weather-utils.ts
@@ -1,0 +1,249 @@
+import { getPokemonNameWithAffix } from "#app/messages";
+import {
+  RAIN_SYNERGY_ABILITIES,
+  SAND_SYNERGY_ABILITIES,
+  SNOW_SYNERGY_ABILITIES,
+  SUN_SYNERGY_ABILITIES,
+} from "#constants/ability-constants";
+import {
+  RAIN_SYNERGY_MOVES,
+  SAND_SYNERGY_MOVES,
+  SNOW_SYNERGY_MOVES,
+  SUN_SYNERGY_MOVES,
+} from "#constants/move-constants";
+import type { AbilityId } from "#enums/ability-id";
+import { ElementalType } from "#enums/elemental-type";
+import type { MoveId } from "#enums/move-id";
+import { WeatherType } from "#enums/weather-type";
+import type { Pokemon } from "#field/pokemon";
+import i18next from "i18next";
+
+// TODO: Should localization return null or "" as a default? Inconsistencies in the codebase
+
+/**
+ * Function to get the starting message for weather
+ * @param weatherType - the {@linkcode WeatherType} starting
+ * @returns the associated string
+ */
+export function getWeatherStartMessage(weatherType: WeatherType): string | null {
+  switch (weatherType) {
+    case WeatherType.SUNNY:
+      return i18next.t("weather:sunnyStartMessage");
+    case WeatherType.RAIN:
+      return i18next.t("weather:rainStartMessage");
+    case WeatherType.SANDSTORM:
+      return i18next.t("weather:sandstormStartMessage");
+    case WeatherType.HAIL:
+      return i18next.t("weather:hailStartMessage");
+    case WeatherType.SNOW:
+      return i18next.t("weather:snowStartMessage");
+    case WeatherType.FOG:
+      return i18next.t("weather:fogStartMessage");
+    case WeatherType.HEAVY_RAIN:
+      return i18next.t("weather:heavyRainStartMessage");
+    case WeatherType.HARSH_SUN:
+      return i18next.t("weather:harshSunStartMessage");
+    case WeatherType.STRONG_WINDS:
+      return i18next.t("weather:strongWindsStartMessage");
+  }
+
+  return null;
+}
+
+/**
+ * Function to get the lapsing message for weather
+ * @param weatherType - the {@linkcode WeatherType} lapsing
+ * @returns the associated string
+ */
+export function getWeatherLapseMessage(weatherType: WeatherType): string {
+  switch (weatherType) {
+    case WeatherType.SUNNY:
+      return i18next.t("weather:sunnyLapseMessage");
+    case WeatherType.RAIN:
+      return i18next.t("weather:rainLapseMessage");
+    case WeatherType.SANDSTORM:
+      return i18next.t("weather:sandstormLapseMessage");
+    case WeatherType.HAIL:
+      return i18next.t("weather:hailLapseMessage");
+    case WeatherType.SNOW:
+      return i18next.t("weather:snowLapseMessage");
+    case WeatherType.FOG:
+      return i18next.t("weather:fogLapseMessage");
+    case WeatherType.HEAVY_RAIN:
+      return i18next.t("weather:heavyRainLapseMessage");
+    case WeatherType.HARSH_SUN:
+      return i18next.t("weather:harshSunLapseMessage");
+    case WeatherType.STRONG_WINDS:
+      return i18next.t("weather:strongWindsLapseMessage");
+    case WeatherType.NONE:
+      return "";
+  }
+}
+
+/**
+ * Function to get the associated message for when a Pokemon is damaged by weather (sandstorm or hail)
+ * @param weatherType - The {@linkcode WeatherType}
+ * @param pokemon - The {@linkcode Pokemon} being damaged
+ * @returns the corresponding string
+ */
+export function getWeatherDamageMessage(weatherType: WeatherType, pokemon: Pokemon): string | null {
+  switch (weatherType) {
+    case WeatherType.SANDSTORM:
+      return i18next.t("weather:sandstormDamageMessage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) });
+    case WeatherType.HAIL:
+      return i18next.t("weather:hailDamageMessage", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) });
+  }
+
+  return null;
+}
+
+/**
+ * Function to get the ending message for weather
+ * @param weatherType - the {@linkcode WeatherType} ending
+ * @returns the associated string
+ */
+export function getWeatherClearMessage(weatherType: WeatherType): string | null {
+  switch (weatherType) {
+    case WeatherType.SUNNY:
+      return i18next.t("weather:sunnyClearMessage");
+    case WeatherType.RAIN:
+      return i18next.t("weather:rainClearMessage");
+    case WeatherType.SANDSTORM:
+      return i18next.t("weather:sandstormClearMessage");
+    case WeatherType.HAIL:
+      return i18next.t("weather:hailClearMessage");
+    case WeatherType.SNOW:
+      return i18next.t("weather:snowClearMessage");
+    case WeatherType.FOG:
+      return i18next.t("weather:fogClearMessage");
+    case WeatherType.HEAVY_RAIN:
+      return i18next.t("weather:heavyRainClearMessage");
+    case WeatherType.HARSH_SUN:
+      return i18next.t("weather:harshSunClearMessage");
+    case WeatherType.STRONG_WINDS:
+      return i18next.t("weather:strongWindsClearMessage");
+  }
+
+  return null;
+}
+
+/**
+ * Scores a weather-type pairing based on how well the type synergizes with the weather
+ * @returns A decimal score representing the given weather's synergy with the given type
+ *
+ * @privateRemarks
+ * The score from this function is intended for use in Enemy AI command selection only.
+ */
+export function getWeatherTypeSynergyScore(weatherType: WeatherType, elementalType: ElementalType): number {
+  switch (weatherType) {
+    case WeatherType.SUNNY:
+    case WeatherType.HARSH_SUN:
+      return getSunSynergyScore(elementalType);
+    case WeatherType.RAIN:
+    case WeatherType.HEAVY_RAIN:
+      return getRainSynergyScore(elementalType);
+    case WeatherType.SANDSTORM:
+      return getSandstormSynergyScore(elementalType);
+    case WeatherType.HAIL:
+    case WeatherType.SNOW:
+      return getSnowSynergyScore(elementalType);
+    case WeatherType.FOG:
+      return 0;
+    case WeatherType.STRONG_WINDS:
+      return getStrongWindsSynergyScore(elementalType);
+    default: {
+      weatherType satisfies WeatherType.NONE;
+      return 0;
+    }
+  }
+}
+
+/** Scores the given type's synergy with Sun and Harsh Sun */
+function getSunSynergyScore(elementalType: ElementalType): number {
+  if (elementalType === ElementalType.FIRE) {
+    return 1;
+  }
+  if (elementalType === ElementalType.WATER) {
+    return -1;
+  }
+  return 0;
+}
+
+/** Scores the given type's synergy with Rain and Heavy Rain */
+function getRainSynergyScore(elementalType: ElementalType): number {
+  if (elementalType === ElementalType.WATER) {
+    return 1;
+  }
+  if (elementalType === ElementalType.FIRE) {
+    return -1;
+  }
+  return 0;
+}
+
+/** Scores the given type's synergy with Sandstorm */
+function getSandstormSynergyScore(elementalType: ElementalType): number {
+  if (elementalType === ElementalType.ROCK) {
+    return 1;
+  }
+  const noDamageTypes: ElementalType[] = [ElementalType.GROUND, ElementalType.STEEL];
+  if (noDamageTypes.includes(elementalType)) {
+    return 0.5;
+  }
+  return 0;
+}
+
+/** Scores the given type's synergy with Hail and Snow */
+function getSnowSynergyScore(elementalType: ElementalType): number {
+  return elementalType === ElementalType.ICE ? 1 : 0;
+}
+
+/** Scores the given type's synergy with Strong Winds */
+function getStrongWindsSynergyScore(elementalType: ElementalType): number {
+  return elementalType === ElementalType.FLYING ? 1 : 0;
+}
+
+/**
+ * @param weatherType - The {@linkcode WeatherType} to check
+ * @returns An array of {@link AbilityId | IDs} for abilities that benefit from
+ * the given weather type.
+ */
+export function getWeatherSynergyAbilities(weatherType: WeatherType): readonly AbilityId[] {
+  switch (weatherType) {
+    case WeatherType.SUNNY:
+    case WeatherType.HARSH_SUN:
+      return SUN_SYNERGY_ABILITIES;
+    case WeatherType.RAIN:
+    case WeatherType.HEAVY_RAIN:
+      return RAIN_SYNERGY_ABILITIES;
+    case WeatherType.SANDSTORM:
+      return SAND_SYNERGY_ABILITIES;
+    case WeatherType.HAIL:
+    case WeatherType.SNOW:
+      return SNOW_SYNERGY_ABILITIES;
+    default:
+      return [];
+  }
+}
+
+/**
+ * @param weatherType - The {@linkcode WeatherType} to check
+ * @returns An array of {@link MoveId | IDs} for moves that benefit from
+ * the given weather type.
+ */
+export function getWeatherSynergyMoves(weatherType: WeatherType): readonly MoveId[] {
+  switch (weatherType) {
+    case WeatherType.SUNNY:
+    case WeatherType.HARSH_SUN:
+      return SUN_SYNERGY_MOVES;
+    case WeatherType.RAIN:
+    case WeatherType.HEAVY_RAIN:
+      return RAIN_SYNERGY_MOVES;
+    case WeatherType.SANDSTORM:
+      return SAND_SYNERGY_MOVES;
+    case WeatherType.HAIL:
+    case WeatherType.SNOW:
+      return SNOW_SYNERGY_MOVES;
+    default:
+      return [];
+  }
+}

--- a/src/utils/weather-utils.ts
+++ b/src/utils/weather-utils.ts
@@ -128,11 +128,11 @@ export function getWeatherClearMessage(weatherType: WeatherType): string | null 
 }
 
 /**
- * Scores a weather-type pairing based on how well the type synergizes with the weather
+ * Scores a weather-type pairing based on how well the given {@linkcode ElementalType}
+ * synergizes with the given {@linkcode WeatherType}.
+ * This score is used for the Enemy AI's command selection.
  * @returns A decimal score representing the given weather's synergy with the given type
- *
- * @privateRemarks
- * The score from this function is intended for use in Enemy AI command selection only.
+ * @see {@linkcode Pokemon.getWeatherBenefitScore}
  */
 export function getWeatherTypeSynergyScore(weatherType: WeatherType, elementalType: ElementalType): number {
   switch (weatherType) {

--- a/src/utils/weather-utils.ts
+++ b/src/utils/weather-utils.ts
@@ -204,10 +204,10 @@ function getStrongWindsSynergyScore(elementalType: ElementalType): number {
 
 /**
  * @param weatherType - The {@linkcode WeatherType} to check
- * @returns An array of {@link AbilityId | IDs} for abilities that benefit from
+ * @returns A set of {@link AbilityId | IDs} for abilities that benefit from
  * the given weather type.
  */
-export function getWeatherSynergyAbilities(weatherType: WeatherType): readonly AbilityId[] {
+export function getWeatherSynergyAbilities(weatherType: WeatherType): Readonly<Set<AbilityId>> {
   switch (weatherType) {
     case WeatherType.SUNNY:
     case WeatherType.HARSH_SUN:
@@ -221,7 +221,7 @@ export function getWeatherSynergyAbilities(weatherType: WeatherType): readonly A
     case WeatherType.SNOW:
       return SNOW_SYNERGY_ABILITIES;
     default:
-      return [];
+      return new Set();
   }
 }
 

--- a/test/ai/move-effect-scores/defog.test.ts
+++ b/test/ai/move-effect-scores/defog.test.ts
@@ -3,7 +3,10 @@ import { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { TerrainType } from "#enums/terrain-type";
 import { GameManager } from "#test/test-utils/game-manager";
+import { isNil } from "#utils/common-utils";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 describe("Move Effect Scores - Defog", () => {
@@ -20,6 +23,8 @@ describe("Move Effect Scores - Defog", () => {
     game.phaseInterceptor.restoreOg();
   });
 
+  const baseMoveset: MoveId[] = [MoveId.DEFOG, MoveId.SPLASH, MoveId.TACKLE];
+
   beforeEach(() => {
     game = new GameManager(phaserGame);
     game.override
@@ -29,7 +34,7 @@ describe("Move Effect Scores - Defog", () => {
       .ability(AbilityId.BALL_FETCH)
       .startingLevel(100)
       .enemyLevel(100)
-      .enemyMoveset([MoveId.SPLASH, MoveId.TACKLE, MoveId.DEFOG]);
+      .enemyMoveset(baseMoveset);
   });
 
   it("should not be preferred when no effects are on the field", async () => {
@@ -91,9 +96,106 @@ describe("Move Effect Scores - Defog", () => {
     });
   });
 
-  // TODO: Implement scoring for weather removal and add tests
-  describe.todo("Weather Removal");
+  type TerrainTestCase = {
+    terrainName: string;
+    terrainType: TerrainType;
+    testSpecies: SpeciesId;
+    testAbility?: { abilityName: string; abilityId: AbilityId };
+  };
+  const terrainTestCases: TerrainTestCase[] = [
+    {
+      terrainName: "Electric Terrain",
+      terrainType: TerrainType.ELECTRIC,
+      testSpecies: SpeciesId.CHINCHOU,
+      testAbility: { abilityName: "Surge Surfer", abilityId: AbilityId.SURGE_SURFER },
+    },
+    {
+      terrainName: "Grassy Terrain",
+      terrainType: TerrainType.GRASSY,
+      testSpecies: SpeciesId.LOTAD,
+      testAbility: { abilityName: "Grass Pelt", abilityId: AbilityId.GRASS_PELT },
+    },
+    {
+      terrainName: "Psychic Terrain",
+      terrainType: TerrainType.PSYCHIC,
+      testSpecies: SpeciesId.ESPURR,
+    },
+  ];
 
-  // TODO: Implement scoring for terrain removal and add tests
-  describe.todo("Terrain Removal");
+  describe.each(terrainTestCases)("$terrainName Removal", ({ terrainType, testSpecies, testAbility }) => {
+    const initField = () => {
+      game.scene.getField(true).forEach((p) => p.setStat(Stat.SPD, 50));
+      game.scene.arena.trySetTerrain(terrainType, false, true);
+    };
+
+    it("Defog should be avoided when the current terrain favors the user", async () => {
+      game.override.enemySpecies(testSpecies);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+      initField();
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(MoveId.DEFOG);
+    });
+
+    it("Defog should be favored when the current terrain favors the opponent", async () => {
+      await game.classicMode.startBattle(testSpecies);
+      initField();
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toPreferSelectingMove(MoveId.DEFOG);
+    });
+
+    it("Defog should be avoided when the user has Terrain Pulse", async () => {
+      game.override.enemyMoveset([MoveId.DEFOG, MoveId.TERRAIN_PULSE, MoveId.SPLASH, MoveId.TACKLE]);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+      initField();
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(MoveId.DEFOG);
+    });
+
+    it("Defog should be preferred when the enemy is known to have Terrain Pulse", async () => {
+      game.override.moveset(MoveId.TERRAIN_PULSE);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+      initField();
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).not.toPreferSelectingMove(MoveId.DEFOG);
+
+      game.field.revealAllMoves();
+      expect(enemy).toPreferSelectingMove(MoveId.DEFOG);
+    });
+
+    if (isNil(testAbility)) {
+      return;
+    }
+
+    const { abilityName, abilityId } = testAbility;
+
+    it(`Defog should be avoided when the user has ${abilityName}`, async () => {
+      game.override.enemyAbility(abilityId);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+      initField();
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(MoveId.DEFOG);
+    });
+
+    it(`Defog should be preferred when the opponent is known to have ${abilityName}`, async () => {
+      game.override.ability(abilityId);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+      initField();
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).not.toPreferSelectingMove(MoveId.DEFOG);
+
+      game.field.revealAllAbilities();
+      expect(enemy).toPreferSelectingMove(MoveId.DEFOG);
+    });
+  });
 });

--- a/test/ai/move-effect-scores/electric-terrain.test.ts
+++ b/test/ai/move-effect-scores/electric-terrain.test.ts
@@ -1,0 +1,133 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Electric Terrain", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.ELECTRIC_TERRAIN, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no synergies are on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.ELECTRIC_TERRAIN);
+  });
+
+  it("should be preferred when the user is Electric-type", async () => {
+    game.override.enemySpecies(SpeciesId.PAWMI);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.ELECTRIC_TERRAIN);
+  });
+
+  it("should be avoided when the opponent is Electric-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.PAWMI);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.ELECTRIC_TERRAIN);
+  });
+
+  const abilityTestCases = [
+    { abilityName: "Surge Surfer", abilityId: AbilityId.SURGE_SURFER },
+    { abilityName: "Quark Drive", abilityId: AbilityId.QUARK_DRIVE },
+    // Hadron Engine is excluded since it already sets Electric Terrain
+  ];
+
+  it.each(abilityTestCases)("should be preferred when the user has $abilityName", async ({ abilityId }) => {
+    game.override.enemyAbility(abilityId);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.ELECTRIC_TERRAIN);
+  });
+
+  it.each(abilityTestCases)(
+    "should be avoided when the opponent is known to have $abilityName",
+    async ({ abilityId }) => {
+      game.override.ability(abilityId);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).not.toNeverSelectMove(MoveId.ELECTRIC_TERRAIN);
+
+      game.field.revealAllAbilities();
+      expect(enemy).toNeverSelectMove(MoveId.ELECTRIC_TERRAIN);
+    },
+  );
+
+  const moveTestCases = [
+    { moveName: "Terrain Pulse", moveId: MoveId.TERRAIN_PULSE },
+    { moveName: "Rising Voltage", moveId: MoveId.RISING_VOLTAGE },
+  ];
+
+  it.each(moveTestCases)("should be preferred when the user has $moveName", async ({ moveId }) => {
+    game.override.enemyMoveset([MoveId.ELECTRIC_TERRAIN, moveId, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.CHIKORITA);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.ELECTRIC_TERRAIN);
+  });
+
+  it("should be preferred when the opponent is known to have a Sleep-inducing move", async () => {
+    game.override.moveset(MoveId.HYPNOSIS);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.ELECTRIC_TERRAIN);
+
+    game.field.revealAllMoves();
+    expect(enemy).toPreferSelectingMove(MoveId.ELECTRIC_TERRAIN);
+  });
+
+  it("should not be preferred when the opponent is known to have a Burn-inducing move", async () => {
+    game.override.moveset(MoveId.WILL_O_WISP);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    game.field.revealAllAbilities();
+
+    expect(enemy).not.toPreferSelectingMove(MoveId.ELECTRIC_TERRAIN);
+  });
+
+  it("should be avoided when the user has a Sleep-inducing move", async () => {
+    game.override.enemyMoveset([MoveId.ELECTRIC_TERRAIN, MoveId.HYPNOSIS, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.ELECTRIC_TERRAIN);
+  });
+});

--- a/test/ai/move-effect-scores/grassy-terrain.test.ts
+++ b/test/ai/move-effect-scores/grassy-terrain.test.ts
@@ -1,0 +1,117 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Grassy Terrain", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.GRASSY_TERRAIN, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no synergies are on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.GRASSY_TERRAIN);
+  });
+
+  it("should be preferred when the user is Grass-type", async () => {
+    game.override.enemySpecies(SpeciesId.CHIKORITA);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.GRASSY_TERRAIN);
+  });
+
+  it("should be avoided when the opponent is Grass-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.CHIKORITA);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.GRASSY_TERRAIN);
+  });
+
+  it("should be preferred when the user has Grass Pelt", async () => {
+    game.override.enemyAbility(AbilityId.GRASS_PELT);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.GRASSY_TERRAIN);
+  });
+
+  it("should be avoided when the opponent is known to have Grass Pelt", async () => {
+    game.override.ability(AbilityId.GRASS_PELT);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toNeverSelectMove(MoveId.GRASSY_TERRAIN);
+
+    game.field.revealAllAbilities();
+    expect(enemy).toNeverSelectMove(MoveId.GRASSY_TERRAIN);
+  });
+
+  it.each([
+    { moveName: "Terrain Pulse", moveId: MoveId.TERRAIN_PULSE },
+    { moveName: "Grassy Glide", moveId: MoveId.GRASSY_GLIDE },
+  ])("should be preferred when the user knows $moveName", async ({ moveId }) => {
+    game.override.enemyMoveset([MoveId.GRASSY_TERRAIN, moveId, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.MELTAN);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.GRASSY_TERRAIN);
+  });
+
+  const badMoveTestCases = [
+    { moveName: "Earthquake", moveId: MoveId.EARTHQUAKE },
+    { moveName: "Bulldoze", moveId: MoveId.BULLDOZE },
+    { moveName: "Magnitude", moveId: MoveId.MAGNITUDE },
+  ];
+
+  it.each(badMoveTestCases)("should be avoided when the user knows $moveName", async ({ moveId }) => {
+    game.override.enemyMoveset([MoveId.GRASSY_TERRAIN, moveId, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.GRASSY_TERRAIN);
+  });
+
+  it.each(badMoveTestCases)("should be preferred when the opponent is known to have $moveName", async ({ moveId }) => {
+    game.override.moveset(moveId);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.GRASSY_TERRAIN);
+
+    game.field.revealAllMoves();
+    expect(enemy).toPreferSelectingMove(MoveId.GRASSY_TERRAIN);
+  });
+});

--- a/test/ai/move-effect-scores/misty-terrain.test.ts
+++ b/test/ai/move-effect-scores/misty-terrain.test.ts
@@ -1,0 +1,97 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Misty Terrain", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.MISTY_TERRAIN, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no synergies are on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.MISTY_TERRAIN);
+  });
+
+  it("should be preferred when the user's opponent is Dragon-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.AXEW);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.MISTY_TERRAIN);
+  });
+
+  it("should be strongly preferred when the player has multiple Dragon-type Pokemon", async () => {
+    await game.classicMode.startBattle(SpeciesId.AXEW, SpeciesId.GIBLE, SpeciesId.BAGON);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.MISTY_TERRAIN);
+  });
+
+  it("should be avoided when the user is Dragon-type", async () => {
+    game.override.enemySpecies(SpeciesId.AXEW);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.MISTY_TERRAIN);
+  });
+
+  it.each([
+    { moveName: "Terrain Pulse", moveId: MoveId.TERRAIN_PULSE },
+    { moveName: "Misty Explosion", moveId: MoveId.MISTY_EXPLOSION },
+  ])("should be preferred when the user knows $moveName", async ({ moveId }) => {
+    game.override.enemyMoveset([MoveId.MISTY_TERRAIN, MoveId.TACKLE, moveId]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.MISTY_TERRAIN);
+  });
+
+  it("should be preferred when the user's opponent is known to have a status-inflicting move", async () => {
+    game.override.moveset(MoveId.POISON_GAS);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.MISTY_TERRAIN);
+
+    game.field.revealAllMoves();
+    expect(enemy).toPreferSelectingMove(MoveId.MISTY_TERRAIN);
+  });
+
+  it("should be avoided when the user has a status-inflicting move", async () => {
+    game.override.enemyMoveset([MoveId.POISON_GAS, MoveId.MISTY_TERRAIN, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.MISTY_TERRAIN);
+  });
+});

--- a/test/ai/move-effect-scores/misty-terrain.test.ts
+++ b/test/ai/move-effect-scores/misty-terrain.test.ts
@@ -1,4 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
+import { Challenges } from "#enums/challenges";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { GameManager } from "#test/test-utils/game-manager";
@@ -62,6 +64,16 @@ describe("AI (Move Effect Scores) - Misty Terrain", () => {
     expect(enemy).toNeverSelectMove(MoveId.MISTY_TERRAIN);
   });
 
+  it("should be avoided when the user's ally is Dragon-type", async () => {
+    game.override.battleType("double");
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.setTemporaryTypes(ElementalType.DRAGON);
+
+    expect(enemy1).toNeverSelectMove(MoveId.MISTY_TERRAIN);
+  });
+
   it.each([
     { moveName: "Terrain Pulse", moveId: MoveId.TERRAIN_PULSE },
     { moveName: "Misty Explosion", moveId: MoveId.MISTY_EXPLOSION },
@@ -93,5 +105,17 @@ describe("AI (Move Effect Scores) - Misty Terrain", () => {
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.MISTY_TERRAIN);
+  });
+
+  it("should not factor challenge-ineligible Pokemon into scoring", async () => {
+    game.challengeMode.addChallenge(Challenges.SINGLE_TYPE, ElementalType.NORMAL, 0);
+
+    await game.challengeMode.startBattle(SpeciesId.WOOLOO, SpeciesId.AXEW);
+
+    const enemy = game.field.getEnemyPokemon();
+
+    // Axew in the player's party would normally incentivize the enemy to use
+    // Misty Terrain, but the Mono-Normal challenge should cause the enemy to ignore it
+    expect(enemy).not.toPreferSelectingMove(MoveId.MISTY_TERRAIN);
   });
 });

--- a/test/ai/move-effect-scores/psychic-terrain.test.ts
+++ b/test/ai/move-effect-scores/psychic-terrain.test.ts
@@ -1,0 +1,112 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Psychic Terrain", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.PSYCHIC_TERRAIN, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  const equalizeSpd = () => {
+    game.scene.getField(true).forEach((p) => p.setStat(Stat.SPD, 50));
+  };
+
+  it("should not be preferred when no synergies are on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    equalizeSpd();
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.PSYCHIC_TERRAIN);
+  });
+
+  it("should be preferred when the user is Psychic-type", async () => {
+    game.override.enemySpecies(SpeciesId.ESPURR);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    equalizeSpd();
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.PSYCHIC_TERRAIN);
+  });
+
+  it("should be avoided when the opponent is Psychic-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.ESPURR);
+
+    equalizeSpd();
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PSYCHIC_TERRAIN);
+  });
+
+  it.each([
+    { moveName: "Terrain Pulse", moveId: MoveId.TERRAIN_PULSE },
+    { moveName: "Expanding Force", moveId: MoveId.EXPANDING_FORCE },
+  ])("should be preferred when the user has $moveName", async ({ moveId }) => {
+    game.override.enemyMoveset([MoveId.PSYCHIC_TERRAIN, moveId, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    equalizeSpd();
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.PSYCHIC_TERRAIN);
+  });
+
+  it("should be avoided when the user has a priority move", async () => {
+    game.override.enemyMoveset([MoveId.PSYCHIC_TERRAIN, MoveId.QUICK_ATTACK, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    equalizeSpd();
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.PSYCHIC_TERRAIN);
+  });
+
+  it("should be preferred when the opponent is known to have a priority move", async () => {
+    game.override.moveset(MoveId.QUICK_ATTACK);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    equalizeSpd();
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.PSYCHIC_TERRAIN);
+
+    game.field.revealAllMoves();
+    expect(enemy).toPreferSelectingMove(MoveId.PSYCHIC_TERRAIN);
+  });
+
+  it("should be preferred when the user is faster than the opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+    const enemy = game.field.getEnemyPokemon();
+    player.setStat(Stat.SPD, 50);
+    enemy.setStat(Stat.SPD, 100);
+
+    expect(enemy).toPreferSelectingMove(MoveId.PSYCHIC_TERRAIN);
+  });
+});

--- a/test/ai/move-effect-scores/rain-dance.test.ts
+++ b/test/ai/move-effect-scores/rain-dance.test.ts
@@ -70,8 +70,7 @@ describe("AI (Move Effect Scores) - Rain Dance", () => {
     { name: "Swift Swim", id: AbilityId.SWIFT_SWIM },
     { name: "Rain Dish", id: AbilityId.RAIN_DISH },
     { name: "Dry Skin", id: AbilityId.DRY_SKIN },
-    // TODO: Hydration's condition interferes with `hasAbility` checks
-    // { name: "Hydration", id: AbilityId.HYDRATION },
+    { name: "Hydration", id: AbilityId.HYDRATION },
     { name: "Forecast", id: AbilityId.FORECAST },
   ];
 

--- a/test/ai/move-effect-scores/rain-dance.test.ts
+++ b/test/ai/move-effect-scores/rain-dance.test.ts
@@ -1,0 +1,118 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { WeatherType } from "#enums/weather-type";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Rain Dance", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.WHISMUR)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.RAIN_DANCE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no synergy is on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.RAIN_DANCE);
+  });
+
+  it("should be preferred when the user is Water-type", async () => {
+    game.override.enemySpecies(SpeciesId.MAGIKARP);
+
+    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.RAIN_DANCE);
+  });
+
+  it("should be avoided when the opponent is Water-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.RAIN_DANCE);
+  });
+
+  it("should be strongly preferred when the user is Water-type under Sun", async () => {
+    game.override.enemySpecies(SpeciesId.MAGIKARP).weather(WeatherType.SUNNY);
+
+    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.RAIN_DANCE);
+  });
+
+  type AbilityTestCase = { name: string; id: AbilityId };
+  const abilityTestCases: AbilityTestCase[] = [
+    { name: "Swift Swim", id: AbilityId.SWIFT_SWIM },
+    { name: "Rain Dish", id: AbilityId.RAIN_DISH },
+    { name: "Dry Skin", id: AbilityId.DRY_SKIN },
+    // TODO: Hydration's condition interferes with `hasAbility` checks
+    // { name: "Hydration", id: AbilityId.HYDRATION },
+    { name: "Forecast", id: AbilityId.FORECAST },
+  ];
+
+  it.each(abilityTestCases)("should be preferred when the user has $name", async ({ id }) => {
+    game.override.enemyAbility(id);
+
+    await game.classicMode.startBattle(SpeciesId.MELTAN);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.RAIN_DANCE);
+  });
+
+  it.each(abilityTestCases)("should be avoided when the opponent is known to have $name", async ({ id }) => {
+    game.override.ability(id);
+
+    await game.classicMode.startBattle(SpeciesId.MELTAN);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toNeverSelectMove(MoveId.RAIN_DANCE);
+
+    game.field.revealAllAbilities();
+    expect(enemy).toNeverSelectMove(MoveId.RAIN_DANCE);
+  });
+
+  type MoveTestCase = { name: string; id: MoveId };
+  const moveTestCases: MoveTestCase[] = [
+    { name: "Weather Ball", id: MoveId.WEATHER_BALL },
+    { name: "Thunder", id: MoveId.THUNDER },
+    { name: "Hurricane", id: MoveId.HURRICANE },
+    { name: "Bleakwind Storm", id: MoveId.BLEAKWIND_STORM },
+    { name: "Wildbolt Storm", id: MoveId.WILDBOLT_STORM },
+    { name: "Sandsear Storm", id: MoveId.SANDSEAR_STORM },
+    { name: "Electro Shot", id: MoveId.ELECTRO_SHOT },
+  ];
+
+  it.each(moveTestCases)("should be preferred when the user knows $name", async ({ id }) => {
+    game.override.enemySpecies(SpeciesId.MUNCHLAX).enemyMoveset([MoveId.RAIN_DANCE, id]);
+
+    await game.classicMode.startBattle(SpeciesId.BLISSEY);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.RAIN_DANCE);
+  });
+});

--- a/test/ai/move-effect-scores/sandstorm.test.ts
+++ b/test/ai/move-effect-scores/sandstorm.test.ts
@@ -1,0 +1,112 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Sandstorm", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SANDSTORM, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no synergy is on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.SANDSTORM);
+  });
+
+  const typeTestCases = [
+    { typeName: "Rock", testSpecies: SpeciesId.NACLI },
+    { typeName: "Ground", testSpecies: SpeciesId.NINCADA },
+    { typeName: "Steel", testSpecies: SpeciesId.BELDUM },
+  ];
+
+  it.each(typeTestCases)("should be preferred when the user is $typeName-type", async ({ testSpecies }) => {
+    game.override.enemySpecies(testSpecies);
+
+    await game.classicMode.startBattle(SpeciesId.AVALUGG);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SANDSTORM);
+  });
+
+  // Ground and Steel are penalized less, so Sandstorm is discouraged, but not avoided.
+  // However, testing for "not preferring" Sandstorm may produce false positives (see "no synergy" test)
+  it.skip.each(typeTestCases)("should be avoided when the opponent is $typeName-type", async ({ testSpecies }) => {
+    await game.classicMode.startBattle(testSpecies);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SANDSTORM);
+  });
+
+  type AbilityTestCase = { name: string; id: AbilityId };
+  const abilityTestCases: AbilityTestCase[] = [
+    // TODO: Sand Force's condition interferes with `hasAbility` checks
+    // { name: "Sand Force", id: AbilityId.SAND_FORCE },
+    { name: "Sand Rush", id: AbilityId.SAND_RUSH },
+    // TODO: Sand Veil's condition interferes with `hasAbility` checks
+    // { name: "Sand Veil", id: AbilityId.SAND_VEIL },
+    { name: "Magic Guard", id: AbilityId.MAGIC_GUARD },
+    { name: "Overcoat", id: AbilityId.OVERCOAT },
+  ];
+
+  it.each(abilityTestCases)("should be preferred when the user has $name", async ({ id }) => {
+    game.override.enemyAbility(id);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SANDSTORM);
+  });
+
+  it.each(abilityTestCases)("should be avoided when the opponent is known to have $name", async ({ id }) => {
+    game.override.ability(id);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toNeverSelectMove(MoveId.SANDSTORM);
+
+    game.field.revealAllAbilities();
+    expect(enemy).toNeverSelectMove(MoveId.SANDSTORM);
+  });
+
+  type MoveTestCase = { name: string; id: MoveId };
+  const moveTestCases: MoveTestCase[] = [
+    { name: "Weather Ball", id: MoveId.WEATHER_BALL },
+    { name: "Shore Up", id: MoveId.SHORE_UP },
+  ];
+
+  it.each(moveTestCases)("should be preferred when the user knows $name", async ({ id }) => {
+    game.override.enemySpecies(SpeciesId.MUNCHLAX).enemyMoveset([MoveId.SANDSTORM, id]);
+
+    await game.classicMode.startBattle(SpeciesId.BLISSEY);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SANDSTORM);
+  });
+});

--- a/test/ai/move-effect-scores/sandstorm.test.ts
+++ b/test/ai/move-effect-scores/sandstorm.test.ts
@@ -65,11 +65,9 @@ describe("AI (Move Effect Scores) - Sandstorm", () => {
 
   type AbilityTestCase = { name: string; id: AbilityId };
   const abilityTestCases: AbilityTestCase[] = [
-    // TODO: Sand Force's condition interferes with `hasAbility` checks
-    // { name: "Sand Force", id: AbilityId.SAND_FORCE },
+    { name: "Sand Force", id: AbilityId.SAND_FORCE },
     { name: "Sand Rush", id: AbilityId.SAND_RUSH },
-    // TODO: Sand Veil's condition interferes with `hasAbility` checks
-    // { name: "Sand Veil", id: AbilityId.SAND_VEIL },
+    { name: "Sand Veil", id: AbilityId.SAND_VEIL },
     { name: "Magic Guard", id: AbilityId.MAGIC_GUARD },
     { name: "Overcoat", id: AbilityId.OVERCOAT },
   ];

--- a/test/ai/move-effect-scores/snowscape.test.ts
+++ b/test/ai/move-effect-scores/snowscape.test.ts
@@ -58,9 +58,9 @@ describe("AI (Move Effect Scores) - Snowscape", () => {
   type AbilityTestCase = { name: string; id: AbilityId };
   const abilityTestCases: AbilityTestCase[] = [
     { name: "Ice Body", id: AbilityId.ICE_BODY },
-    // { name: "Snow Cloak", id: AbilityId.SNOW_CLOAK },
+    { name: "Snow Cloak", id: AbilityId.SNOW_CLOAK },
     { name: "Slush Rush", id: AbilityId.SLUSH_RUSH },
-    // { name: "Ice Face", id: AbilityId.ICE_FACE },
+    { name: "Ice Face", id: AbilityId.ICE_FACE },
   ];
 
   it.each(abilityTestCases)("should be preferred when the user has $name", async ({ id }) => {
@@ -78,7 +78,10 @@ describe("AI (Move Effect Scores) - Snowscape", () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
     const enemy = game.field.getEnemyPokemon();
-    expect(enemy).not.toNeverSelectMove(MoveId.SNOWSCAPE);
+    // This needs to be asserted conditionally because Ice Face reveals itself on summon
+    if (!game.field.getPlayerPokemon().hasRevealedAbility(id)) {
+      expect(enemy).not.toNeverSelectMove(MoveId.SNOWSCAPE);
+    }
 
     game.field.revealAllAbilities();
     expect(enemy).toNeverSelectMove(MoveId.SNOWSCAPE);

--- a/test/ai/move-effect-scores/snowscape.test.ts
+++ b/test/ai/move-effect-scores/snowscape.test.ts
@@ -1,0 +1,102 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Snowscape", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SNOWSCAPE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no synergy is on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.SNOWSCAPE);
+  });
+
+  it("should be preferred when the user is Ice-type", async () => {
+    game.override.enemySpecies(SpeciesId.SNOM);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SNOWSCAPE);
+  });
+
+  it("should be avoided when the opponent is Ice-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.SNOM);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SNOWSCAPE);
+  });
+
+  type AbilityTestCase = { name: string; id: AbilityId };
+  const abilityTestCases: AbilityTestCase[] = [
+    { name: "Ice Body", id: AbilityId.ICE_BODY },
+    // { name: "Snow Cloak", id: AbilityId.SNOW_CLOAK },
+    { name: "Slush Rush", id: AbilityId.SLUSH_RUSH },
+    // { name: "Ice Face", id: AbilityId.ICE_FACE },
+  ];
+
+  it.each(abilityTestCases)("should be preferred when the user has $name", async ({ id }) => {
+    game.override.enemyAbility(id);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SNOWSCAPE);
+  });
+
+  it.each(abilityTestCases)("should be avoided when the opponent is known to have $name", async ({ id }) => {
+    game.override.ability(id);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toNeverSelectMove(MoveId.SNOWSCAPE);
+
+    game.field.revealAllAbilities();
+    expect(enemy).toNeverSelectMove(MoveId.SNOWSCAPE);
+  });
+
+  type MoveTestCase = { name: string; id: MoveId };
+  const moveTestCases: MoveTestCase[] = [
+    { name: "Weather Ball", id: MoveId.WEATHER_BALL },
+    { name: "Blizzard", id: MoveId.BLIZZARD },
+    { name: "Aurora Veil", id: MoveId.AURORA_VEIL },
+  ];
+
+  it.each(moveTestCases)("should be preferred when the user knows $name", async ({ id }) => {
+    game.override.enemyMoveset([MoveId.SNOWSCAPE, id]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SNOWSCAPE);
+  });
+});

--- a/test/ai/move-effect-scores/sunny-day.test.ts
+++ b/test/ai/move-effect-scores/sunny-day.test.ts
@@ -1,0 +1,138 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { WeatherType } from "#enums/weather-type";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Sunny Day", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.WHISMUR)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SUNNY_DAY, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should not be preferred when no synergy is on the field", async () => {
+    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.SUNNY_DAY);
+  });
+
+  it("should be preferred when the user is Fire-type", async () => {
+    game.override.enemySpecies(SpeciesId.MAGBY);
+
+    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SUNNY_DAY);
+  });
+
+  it("should be avoided when the opponent is Fire-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGBY);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SUNNY_DAY);
+  });
+
+  it("should be avoided when the user is Water-type", async () => {
+    game.override.enemySpecies(SpeciesId.MAGIKARP);
+
+    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.SUNNY_DAY);
+  });
+
+  it("should be preferred when the opponent is Water-type", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SUNNY_DAY);
+  });
+
+  it("should be strongly preferred when the user is Fire-type and under Rain", async () => {
+    game.override.enemySpecies(SpeciesId.MAGBY).weather(WeatherType.RAIN);
+
+    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SUNNY_DAY);
+  });
+
+  type AbilityTestCase = { name: string; id: AbilityId };
+  const abilityTestCases: AbilityTestCase[] = [
+    { name: "Chlorophyll", id: AbilityId.CHLOROPHYLL },
+    { name: "Solar Power", id: AbilityId.SOLAR_POWER },
+    { name: "Flower Gift", id: AbilityId.FLOWER_GIFT },
+    // TODO: Ability conditions interfere with the `hasAbility` checks
+    // used in weather scoring calculations
+    // { name: "Leaf Guard", id: AbilityId.LEAF_GUARD },
+    { name: "Protosynthesis", id: AbilityId.PROTOSYNTHESIS },
+    { name: "Forecast", id: AbilityId.FORECAST },
+  ];
+
+  it.each(abilityTestCases)("should be preferred when the user has $name", async ({ id }) => {
+    game.override.enemyAbility(id);
+
+    await game.classicMode.startBattle(SpeciesId.MELTAN);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SUNNY_DAY);
+  });
+
+  it.each(abilityTestCases)("should be avoided when the opponent is known to have $name", async ({ id }) => {
+    game.override.ability(id);
+
+    await game.classicMode.startBattle(SpeciesId.MELTAN);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toNeverSelectMove(MoveId.SUNNY_DAY);
+
+    game.field.revealAllAbilities();
+    expect(enemy).toNeverSelectMove(MoveId.SUNNY_DAY);
+  });
+
+  type MoveTestCase = { name: string; id: MoveId };
+  const moveTestCases: MoveTestCase[] = [
+    { name: "Weather Ball", id: MoveId.WEATHER_BALL },
+    // Growth's stat boost has the same expected score as Sunny Day in the test below
+    // { name: "Growth", id: MoveId.GROWTH },
+    { name: "Solar Beam", id: MoveId.SOLAR_BEAM },
+    { name: "Solar Blade", id: MoveId.SOLAR_BLADE },
+    { name: "Moonlight", id: MoveId.MOONLIGHT },
+    { name: "Synthesis", id: MoveId.SYNTHESIS },
+    { name: "Morning Sun", id: MoveId.MORNING_SUN },
+    { name: "Hydro Steam", id: MoveId.HYDRO_STEAM },
+  ];
+
+  it.each(moveTestCases)("should be preferred when the user knows $name", async ({ id }) => {
+    game.override.enemyMoveset([MoveId.SUNNY_DAY, id, MoveId.TACKLE]);
+
+    await game.classicMode.startBattle(SpeciesId.REGISTEEL);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.SUNNY_DAY);
+  });
+});

--- a/test/ai/move-effect-scores/sunny-day.test.ts
+++ b/test/ai/move-effect-scores/sunny-day.test.ts
@@ -86,9 +86,7 @@ describe("AI (Move Effect Scores) - Sunny Day", () => {
     { name: "Chlorophyll", id: AbilityId.CHLOROPHYLL },
     { name: "Solar Power", id: AbilityId.SOLAR_POWER },
     { name: "Flower Gift", id: AbilityId.FLOWER_GIFT },
-    // TODO: Ability conditions interfere with the `hasAbility` checks
-    // used in weather scoring calculations
-    // { name: "Leaf Guard", id: AbilityId.LEAF_GUARD },
+    { name: "Leaf Guard", id: AbilityId.LEAF_GUARD },
     { name: "Protosynthesis", id: AbilityId.PROTOSYNTHESIS },
     { name: "Forecast", id: AbilityId.FORECAST },
   ];

--- a/test/ai/move-effect-scores/sunny-day.test.ts
+++ b/test/ai/move-effect-scores/sunny-day.test.ts
@@ -1,4 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
+import { Challenges } from "#enums/challenges";
+import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { WeatherType } from "#enums/weather-type";
@@ -26,7 +28,7 @@ describe("AI (Move Effect Scores) - Sunny Day", () => {
       .ability(AbilityId.BALL_FETCH)
       .battleType("single")
       .disableCrits()
-      .enemySpecies(SpeciesId.WHISMUR)
+      .enemySpecies(SpeciesId.WOOLOO)
       .enemyAbility(AbilityId.BALL_FETCH)
       .enemyMoveset([MoveId.SUNNY_DAY, MoveId.SPLASH, MoveId.TACKLE])
       .startingLevel(100)
@@ -34,7 +36,7 @@ describe("AI (Move Effect Scores) - Sunny Day", () => {
   });
 
   it("should not be preferred when no synergy is on the field", async () => {
-    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+    await game.classicMode.startBattle(SpeciesId.WOOLOO);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).not.toPreferSelectingMove(MoveId.SUNNY_DAY);
@@ -43,10 +45,21 @@ describe("AI (Move Effect Scores) - Sunny Day", () => {
   it("should be preferred when the user is Fire-type", async () => {
     game.override.enemySpecies(SpeciesId.MAGBY);
 
-    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+    await game.classicMode.startBattle(SpeciesId.WOOLOO);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toPreferSelectingMove(MoveId.SUNNY_DAY);
+  });
+
+  it("should be preferred when the user's ally is Fire-type", async () => {
+    game.override.battleType("double");
+
+    await game.classicMode.startBattle(SpeciesId.WOOLOO);
+
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+    enemy2.setTemporaryTypes(ElementalType.FIRE);
+
+    expect(enemy1).toPreferSelectingMove(MoveId.SUNNY_DAY);
   });
 
   it("should be avoided when the opponent is Fire-type", async () => {
@@ -59,7 +72,7 @@ describe("AI (Move Effect Scores) - Sunny Day", () => {
   it("should be avoided when the user is Water-type", async () => {
     game.override.enemySpecies(SpeciesId.MAGIKARP);
 
-    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+    await game.classicMode.startBattle(SpeciesId.WOOLOO);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove(MoveId.SUNNY_DAY);
@@ -75,7 +88,7 @@ describe("AI (Move Effect Scores) - Sunny Day", () => {
   it("should be strongly preferred when the user is Fire-type and under Rain", async () => {
     game.override.enemySpecies(SpeciesId.MAGBY).weather(WeatherType.RAIN);
 
-    await game.classicMode.startBattle(SpeciesId.WHISMUR);
+    await game.classicMode.startBattle(SpeciesId.WOOLOO);
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toNeverSelectMove((move) => move.id !== MoveId.SUNNY_DAY);
@@ -132,5 +145,16 @@ describe("AI (Move Effect Scores) - Sunny Day", () => {
 
     const enemy = game.field.getEnemyPokemon();
     expect(enemy).toPreferSelectingMove(MoveId.SUNNY_DAY);
+  });
+
+  it("should not factor challenge-ineligible Pokemon into scoring", async () => {
+    game.challengeMode.addChallenge(Challenges.SINGLE_TYPE, ElementalType.NORMAL, 0);
+
+    await game.challengeMode.startBattle(SpeciesId.WOOLOO, SpeciesId.MAGIKARP);
+
+    const enemy = game.field.getEnemyPokemon();
+    // Magikarp in the player's party would normally incentivize the enemy to use
+    // Sunny Day, but the Mono-Normal challenge should cause the enemy to ignore it
+    expect(enemy).not.toPreferSelectingMove(MoveId.SUNNY_DAY);
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

The AI should now properly evaluate moves that can change the terrain or weather on the field, including:
- Rain Dance et al
- Defog
- Electric Surge et al
- Ice Spinner and Steel Roller

## Why am I making these changes?

Part of the AI Rework.

## What are the changes from a developer perspective?

- Added Effect Score overrides for the following attributes:
  - `ChangeWeatherAttr` (renamed from `WeatherChangeAttr`)
  - `ClearWeatherAttr`
  - `ChangeTerrainAttr` (renamed from `TerrainChangeAttr`)

  Effect Scores are calculated by computing each non-fainted Pokemon's "Terrain/Weather Benefit Score", which checks the Pokemon's type, ability, and moves for synergies to factor into the final score.
- Refactored `ClearTerrainAttr` to extend `ChangeWeatherAttr` (and in turn reuse its Effect Score methods).
- Reorganized some existing localization functions in `terrain.ts` and `weather.ts` to `utils/terrain-utils.ts` and `utils/weather-utils.ts`, respectively. These new files also include some helper functions for AI move scoring.

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`
  - Some unrelated tests seem to be flaky; this will be resolved within the `ai-rework` branch

New unit tests (can be run with `pnpm test[:silent] move-effect-scores/testName`):
- `sunny-day`
- `rain-dance`
- `sandstorm`
- `snowscape`
- `misty-terrain`
- `electric-terrain`
- `grassy-terrain`
- `psychic-terrain`
- `defog` (added tests for terrain removal)

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
