### PR TITLE
refactor: remove `randSeedWeightedItem`

### DIFF
--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -22,7 +22,7 @@ import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { PersistentModifier } from "#modifier/modifier";
 import { allTrainerConfigs } from "#trainer-configs/all-trainer-configs";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
-import { randSeedInt, randSeedItem, randSeedWeightedItem } from "#utils/random-utils";
+import { randSeedInt, randSeedItem } from "#utils/random-utils";
 import i18next from "i18next";
 
 export class Trainer extends Phaser.GameObjects.Container {
@@ -51,12 +51,15 @@ export class Trainer extends Phaser.GameObjects.Container {
     }
 
     this.variant = variant;
+
+    const partyTemplates = this.config.partyTemplates;
+    // This formerly used an undocumented weighted pick function
+    // TODO: assign weights to party templates?
     this.partyTemplateIndex = Math.min(
-      partyTemplateIndex !== undefined
-        ? partyTemplateIndex
-        : randSeedWeightedItem(this.config.partyTemplates.map((_, i) => i)),
-      this.config.partyTemplates.length - 1,
+      partyTemplateIndex ?? randSeedItem(partyTemplates.map((_, i) => i)),
+      partyTemplates.length - 1,
     );
+
     if (Object.hasOwn(trainerNamePools, trainerType)) {
       const namePool = trainerNamePools[trainerType];
       this.name =
@@ -75,20 +78,15 @@ export class Trainer extends Phaser.GameObjects.Container {
       }
     }
 
-    switch (this.variant) {
-      case TrainerVariant.FEMALE:
-        if (!this.config.hasGenders) {
-          variant = TrainerVariant.DEFAULT;
-        }
-        break;
-      case TrainerVariant.DOUBLE:
-        if (!this.config.hasDouble) {
-          variant = TrainerVariant.DEFAULT;
-        }
-        break;
+    if (
+      (this.variant === TrainerVariant.FEMALE && !this.config.hasGenders)
+      || (this.variant === TrainerVariant.DOUBLE && !this.config.hasDouble)
+    ) {
+      variant = TrainerVariant.DEFAULT;
     }
 
     console.log(
+      "trainer party template:",
       Object.keys(trainerPartyTemplates)[Object.values(trainerPartyTemplates).indexOf(this.getPartyTemplate())],
     );
 

--- a/src/utils/random-utils.ts
+++ b/src/utils/random-utils.ts
@@ -81,16 +81,6 @@ export function randSeedItem<T>(items: T[]): T {
 }
 
 /**
- * This picks items out of an array with a higher weight for earlier entries
- *
- * Only used for Trainer `partyTemplateIndex` generation
- * @todo figure out how that actually works
- */
-export function randSeedWeightedItem<T>(items: T[]): T {
-  return items.length === 1 ? items[0] : Phaser.Math.RND.weightedPick(items);
-}
-
-/**
  * Function for picking an item out of a mapping based on the given weights
  * @param items - The mapping of item to weight
  * @returns a randomly picked item according to the weights


### PR DESCRIPTION
## What are the changes the user will see?
Slightly more random trainer parties?

## Why am I making these changes?
We added a replacement for `randSeedWeightedItem` but didn't remove it. Now it's gone.

## What are the changes from a developer perspective?
The single use of `randSeedWeightedItem` was replaced with `randSeedItem`. A very minor cleanup of the `Trainer` class constructor was also done.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?