### PR TITLE
fix: Fix more memory leaks caused by Pokemon objects

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -915,6 +915,7 @@ export class BattleScene extends SceneBase {
     species: PokemonSpecies,
     level: number,
     options: PokemonOptions | Pokemon = {},
+    skipInit: boolean = false,
     postProcess?: (playerPokemon: PlayerPokemon) => void,
   ): PlayerPokemon {
     const pokemon = new PlayerPokemon(species, level, options);
@@ -922,7 +923,9 @@ export class BattleScene extends SceneBase {
       postProcess(pokemon);
     }
 
-    pokemon.init();
+    if (!skipInit) {
+      pokemon.init();
+    }
     return pokemon;
   }
 
@@ -930,6 +933,7 @@ export class BattleScene extends SceneBase {
     species: PokemonSpecies,
     level: number,
     options: EnemyPokemonOptions | Pokemon = {},
+    skipInit: boolean = false,
     postProcess?: (enemyPokemon: EnemyPokemon) => void,
   ): EnemyPokemon {
     const pokemon = new EnemyPokemon(species, level, options);
@@ -955,7 +959,9 @@ export class BattleScene extends SceneBase {
       postProcess(pokemon);
     }
 
+  if (!skipInit) {
     pokemon.init();
+  }
     return pokemon;
   }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -13,7 +13,7 @@ import { activeOverrides } from "#app/overrides";
 import type { Phase } from "#app/phase";
 import { PhaseManager } from "#app/phase-manager";
 import { SceneBase } from "#app/scene-base";
-import { IV_MAX, IV_MIN, LEVEL_CAP_SCALE_FACTOR, MAX_PARTY_LUCK_VALUE } from "#constants/game-constants";
+import { LEVEL_CAP_SCALE_FACTOR, MAX_PARTY_LUCK_VALUE } from "#constants/game-constants";
 import {
   ME_ANTI_VARIANCE_WEIGHT_MODIFIER,
   ME_AVERAGE_ENCOUNTERS_PER_RUN_TARGET,
@@ -959,9 +959,9 @@ export class BattleScene extends SceneBase {
       postProcess(pokemon);
     }
 
-  if (!skipInit) {
-    pokemon.init();
-  }
+    if (!skipInit) {
+      pokemon.init();
+    }
     return pokemon;
   }
 

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -13,7 +13,7 @@ import { activeOverrides } from "#app/overrides";
 import type { Phase } from "#app/phase";
 import { PhaseManager } from "#app/phase-manager";
 import { SceneBase } from "#app/scene-base";
-import { LEVEL_CAP_SCALE_FACTOR } from "#constants/game-constants";
+import { IV_MAX, IV_MIN, LEVEL_CAP_SCALE_FACTOR, MAX_PARTY_LUCK_VALUE } from "#constants/game-constants";
 import {
   ME_ANTI_VARIANCE_WEIGHT_MODIFIER,
   ME_AVERAGE_ENCOUNTERS_PER_RUN_TARGET,
@@ -1817,7 +1817,7 @@ export class BattleScene extends SceneBase {
     labels.forEach((t) => t.setAlpha(0));
     const luckValue = getPartyLuckValue(this.getPlayerParty());
     this.luckText.setText(getLuckString(luckValue));
-    if (luckValue < 14) {
+    if (luckValue < MAX_PARTY_LUCK_VALUE) {
       this.luckText.setTint(getLuckTextTint(luckValue));
     } else {
       // TODO: create helper function

--- a/src/constants/game-constants.ts
+++ b/src/constants/game-constants.ts
@@ -27,6 +27,11 @@ export const IV_MAX = 31;
 export const DEFAULT_STARTER_IVS = 15;
 
 /**
+ * Maximum value for the cumulated luck of a team.
+ */
+export const MAX_PARTY_LUCK_VALUE = 14;
+
+/**
  * In the mainline games, dynamaxing increases HP from +50% to +100% in 5% intervals.
  * Below is a chart showing what an equivalent damage taken factor would be compared to
  * the increased HP.

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -257,10 +257,11 @@ export class Egg {
           abilityIndex = 2;
         }
 
+        // Todo: why force shiny to false rather than set it to this._isShiny (along with variant)?
         ret = globalScene.addPlayerPokemon(pokemonSpecies, 1, {
           abilityIndex,
           shiny: false,
-        });
+        }); // TODO skip init?
         ret.shiny = this._isShiny;
         ret.variant = this._variantTier;
 

--- a/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
@@ -263,7 +263,7 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
       .withOptionPhase(async () => {
         // Show the Oricorio a dance, and recruit it
         const encounter = globalScene.currentBattle.mysteryEncounter!;
-        const oricorio = encounter.misc.oricorioData.toPokemon() as EnemyPokemon;
+        const oricorio = encounter.misc.oricorioData.toPokemon() as EnemyPokemon; // todo: can we skip init here?
         const moveset = oricorio.getMoveset(true);
         oricorio.passive = true;
 

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -483,7 +483,7 @@ async function doTradeOptionPhaseCallback(): Promise<void> {
     receivedPokemonData.species,
     receivedPokemonData.level,
     dataSource,
-  );
+  ); // TODO: can we skip init?
   globalScene.getPlayerParty().push(newPlayerPokemon);
   await newPlayerPokemon.loadAssets();
 

--- a/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
@@ -159,6 +159,7 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
         // "Catch" purchased pokemon
         const data = new PokemonData(purchasedPokemon);
         data.player = false;
+        // TODO: should the toPokemon result be destroyed here? | can we skip init here?
         await catchPokemon(data.toPokemon() as EnemyPokemon, null, PokeballType.POKEBALL, true, true);
 
         leaveEncounterWithoutBattle(true);

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -107,6 +107,8 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
     // Calculate all the newly transformed Pokemon and begin asset load
     const teamTransformations = getTeamTransformations();
     const loadAssets = teamTransformations.map((t) => (t.newPokemon as PlayerPokemon).loadAssets());
+    // TODO: we should store PokemonData in teamTransformations rather than plain Pokemon objects,
+    // especially since after the ME they are still kept in memory through globalScene.lastMysteryEncounter
     globalScene.currentBattle.mysteryEncounter!.misc = {
       teamTransformations,
       loadAssets,
@@ -264,6 +266,7 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
           enablePassiveMon.passive = true;
           enablePassiveMon.updateInfo(true);
         }
+        destroyTransformedPokemon();
       };
 
       setEncounterRewards(
@@ -307,6 +310,7 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
         await pokemon.updateInfo();
       }
 
+      destroyTransformedPokemon();
       leaveEncounterWithoutBattle(true);
       return true;
     },
@@ -318,6 +322,16 @@ interface PokemonTransformation {
   newSpecies: PokemonSpecies;
   newPokemon: PlayerPokemon;
   heldItems: PokemonHeldItemModifier[];
+}
+
+/**
+ * Destroy the transformed team of Pokemon. For cases where the player does not switch their team.
+ */
+function destroyTransformedPokemon(): void {
+  const transformations: PokemonTransformation[] = globalScene.currentBattle.mysteryEncounter!.misc.teamTransformations;
+  for (const transformation of transformations) {
+    transformation.newPokemon.destroy();
+  }
 }
 
 function getTeamTransformations(): PokemonTransformation[] {

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -381,7 +381,7 @@ function getTeamTransformations(): PokemonTransformation[] {
       transformation.newSpecies,
       transformation.previousPokemon.level,
       { abilityIndex },
-    );
+    ); // TODO: can we skip init?
   }
 
   return pokemonTransformations;

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1689,7 +1689,7 @@ export function getRandomPartyMemberFunc(
     if (!ignoreEvolution) {
       species = getPokemonSpecies(species).getEnemySpeciesForLevel(level, true);
     }
-    return globalScene.addEnemyPokemon(getPokemonSpecies(species), level, { trainerSlot }, postProcess);
+    return globalScene.addEnemyPokemon(getPokemonSpecies(species), level, { trainerSlot }, false, postProcess);
   };
 }
 
@@ -1710,6 +1710,6 @@ export function getSpeciesFilterRandomPartyMemberFunc(
       globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getEnemySpeciesForLevel(level, true),
     );
 
-    return globalScene.addEnemyPokemon(species, level, { trainerSlot }, postProcess);
+    return globalScene.addEnemyPokemon(species, level, { trainerSlot }, false, postProcess);
   };
 }

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -305,7 +305,7 @@ export class PlayerPokemon extends Pokemon {
         newPokemon.metBiome = this.metBiome;
         newPokemon.metSpecies = this.metSpecies;
         newPokemon.metWave = this.metWave;
-        newPokemon.usedTMs = this.usedTMs;
+        newPokemon.usedTMs = this.usedTMs; // TODO: should copy the array
 
         globalScene.getPlayerParty().push(newPokemon);
         newPokemon.evolve(newEvolution);

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -268,7 +268,7 @@ export class AttemptCapturePhase extends PokemonPhase {
         const removePokemon = (): void => {
           globalScene.addFaintedEnemyScore(pokemon);
           globalScene.clearEnemyHeldItemModifiers();
-          pokemon.leaveField(true, true, true);
+          pokemon.leaveField(true, true, true); // TODO: shouldn't we destroy the Pokemon too?
         };
         const addToParty = (slotIndex?: number): void => {
           const newPokemon = pokemon.addToParty(this.pokeballType, slotIndex);
@@ -300,6 +300,7 @@ export class AttemptCapturePhase extends PokemonPhase {
                       SummaryUiPage.PROFILE,
                       () => {
                         ui.setMessageMode().then(() => {
+                          newPokemon.destroy();
                           promptRelease();
                         });
                       },

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -855,11 +855,8 @@ export class GameData {
           globalScene.arena.init();
 
           data.enemyParty.forEach((enemyData, e) => {
-            const enemyPokemon = enemyData.toPokemon(
-              battleType,
-              e,
-              data.trainer?.variant === TrainerVariant.DOUBLE,
-            ) as EnemyPokemon;
+            const doubleBattle = data.trainer?.variant === TrainerVariant.DOUBLE;
+            const enemyPokemon = enemyData.toPokemon(false, battleType, e, doubleBattle) as EnemyPokemon;
             battle.enemyParty[e] = enemyPokemon;
             if (battleType === BattleType.WILD) {
               battle.seenEnemyPartyMemberIds.add(enemyPokemon.id);

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -166,11 +166,16 @@ export class PokemonData implements PokemonOptions {
     // #endregion
   }
 
-  toPokemon(battleType?: BattleType, partyMemberIndex: number = 0, double: boolean = false): Pokemon {
+  toPokemon(
+    skipInit: boolean = false,
+    battleType?: BattleType,
+    partyMemberIndex: number = 0,
+    double: boolean = false,
+  ): Pokemon {
     const species = getPokemonSpecies(this.speciesId);
     let ret: Pokemon;
     if (this.player) {
-      ret = globalScene.addPlayerPokemon(species, this.level, this, (playerPokemon) => {
+      ret = globalScene.addPlayerPokemon(species, this.level, this, skipInit, (playerPokemon) => {
         if (this.nickname) {
           playerPokemon.nickname = this.nickname;
         }
@@ -184,7 +189,7 @@ export class PokemonData implements PokemonOptions {
           trainerSlot = TrainerSlot.TRAINER_PARTNER;
         }
       }
-      ret = globalScene.addEnemyPokemon(species, this.level, { ...this, trainerSlot });
+      ret = globalScene.addEnemyPokemon(species, this.level, { ...this, trainerSlot }, skipInit);
     }
     ret.primeSummonData(this.summonData);
     return ret;

--- a/src/ui/components/battle-info.ts
+++ b/src/ui/components/battle-info.ts
@@ -84,6 +84,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
 
   constructor(x: number, y: number, player: boolean) {
     super(globalScene, x, y);
+    console.log("create battle info");
     this.type = "BattleInfo";
     this.baseY = y;
     this.player = player;
@@ -321,6 +322,11 @@ export class BattleInfo extends Phaser.GameObjects.Container {
     }
   }
 
+  override destroy(fromScene?: boolean): void {
+    console.log("destroy battle info - before delayed call");
+    globalScene.time.delayedCall(1500, () => super.destroy(fromScene));
+  }
+
   getStatsValueContainer(): Phaser.GameObjects.Container {
     return this.statValuesContainer;
   }
@@ -331,6 +337,8 @@ export class BattleInfo extends Phaser.GameObjects.Container {
 
     this.name = pokemon.getNameToRender();
     this.box.name = pokemon.getNameToRender();
+
+    console.log("init battle info", this.name);
 
     this.flyoutMenu?.initInfo(pokemon);
 
@@ -343,7 +351,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
     this.teraIcon.setPositionRelative(this.nameText, nameTextWidth + this.genderText.displayWidth + 1, 2);
     this.teraIcon.setVisible(pokemon.isTerastallized);
     this.teraIcon.setTintFill(Phaser.Display.Color.GetColor(...getTypeRgb(this.lastTeraType)));
-    this.teraIcon.on("pointerover", () => {
+    /*this.teraIcon.on("pointerover", () => {
       if (pokemon.isTerastallized) {
         globalScene.ui.showTooltip(
           "",
@@ -353,7 +361,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
         );
       }
     });
-    this.teraIcon.on("pointerout", () => globalScene.ui.hideTooltip());
+    this.teraIcon.on("pointerout", () => globalScene.ui.hideTooltip());*/
 
     const baseVariant = pokemon.getVariant();
 
@@ -362,7 +370,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
       nameTextWidth + this.genderText.displayWidth + 1 + (this.teraIcon.visible ? this.teraIcon.displayWidth + 1 : 0),
       2.5,
     );
-    this.shinyIcon.setTexture("shiny_star");
+    //this.shinyIcon.setTexture("shiny_star");
     this.shinyIcon.setVisible(pokemon.isShiny());
     this.shinyIcon.setTint(getVariantTint(baseVariant));
     if (this.shinyIcon.visible) {

--- a/src/ui/handlers/run-history-ui-handler.ts
+++ b/src/ui/handlers/run-history-ui-handler.ts
@@ -305,7 +305,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
           enemyIconContainer.setScale(0.75);
           enemyData.boss = false;
           enemyData["player"] = true;
-          const enemy = enemyData.toPokemon();
+          const enemy = enemyData.toPokemon(true);
           const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
           const enemyLevel = addTextObject(32, 20, getPokemonLevelText(enemy), TextStyle.POKEMON_LEVEL);
           enemyLevel.setOrigin(1, 0);
@@ -379,7 +379,7 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
     data.party.forEach((p: PokemonData, i: number) => {
       const iconContainer = globalScene.add.container(26 * i, 0);
       iconContainer.setScale(0.75);
-      const pokemon = p.toPokemon();
+      const pokemon = p.toPokemon(true);
       const icon = globalScene.addPokemonIcon(pokemon, 0, 0, 0, 0);
 
       const text = addTextObject(32, 20, getPokemonLevelText(pokemon), TextStyle.POKEMON_LEVEL);

--- a/src/ui/handlers/run-history-ui-handler.ts
+++ b/src/ui/handlers/run-history-ui-handler.ts
@@ -320,11 +320,12 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
         && data.trainer != null
       ) {
         // Defeats from Trainers show the trainer's title and name
-        const tObj = data.trainer.toTrainer();
+        const trainer = data.trainer.toTrainer();
         // Because of the interesting mechanics behind rival names, the rival name and title have to be retrieved differently
         const RIVAL_TRAINER_ID_THRESHOLD = 375;
         if (data.trainer.trainerType >= RIVAL_TRAINER_ID_THRESHOLD) {
-          const rivalName = tObj.variant === TrainerVariant.FEMALE ? "trainerNames:rival_female" : "trainerNames:rival";
+          const rivalName =
+            trainer.variant === TrainerVariant.FEMALE ? "trainerNames:rival_female" : "trainerNames:rival";
           const gameOutcomeLabel = addTextObject(
             8,
             5,
@@ -336,11 +337,12 @@ class RunEntryContainer extends Phaser.GameObjects.Container {
           const gameOutcomeLabel = addTextObject(
             8,
             5,
-            `${i18next.t("runHistory:defeatedTrainer", { context: genderStr })}${tObj.getName(0, true)}`,
+            `${i18next.t("runHistory:defeatedTrainer", { context: genderStr })}${trainer.getName(0, true)}`,
             TextStyle.WINDOW,
           );
           this.add(gameOutcomeLabel);
         }
+        trainer.destroy();
       }
     }
 

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -341,6 +341,8 @@ export class RunInfoUiHandler extends UiHandler {
       descContainer.add(textBox);
       descContainer.setPosition(55, 32);
       this.runResultContainer.add(descContainer);
+
+      trainerObj.destroy();
     } else if (this.runInfo.battleType === BattleType.MYSTERY_ENCOUNTER) {
       const encounterExclaim = globalScene.add.sprite(0, 0, "encounter_exclaim");
       encounterExclaim.setPosition(34, 26);
@@ -440,21 +442,21 @@ export class RunInfoUiHandler extends UiHandler {
    * @param enemyContainer a Phaser Container that should hold enemy sprites
    */
   private showTrainerSprites(enemyContainer: Phaser.GameObjects.Container) {
-    const { trainer } = this.runInfo;
-    if (trainer == null) {
+    const trainerData = this.runInfo.trainer;
+    if (trainerData == null) {
       console.warn("Missing TrainerData in session data, cannot render trainer sprites");
       return;
     }
     // Creating the trainer sprite and adding it to enemyContainer
-    const tObj = trainer.toTrainer();
+    const trainer = trainerData.toTrainer();
     // Loads trainer assets on demand, as they are not loaded by default in the scene
-    tObj.config.loadAssets(trainer.variant).then(() => {
-      const tObjSpriteKey = tObj.config.getSpriteKey(trainer.variant === TrainerVariant.FEMALE, false);
+    trainer.config.loadAssets(trainerData.variant).then(() => {
+      const tObjSpriteKey = trainer.config.getSpriteKey(trainerData.variant === TrainerVariant.FEMALE, false);
       const tObjSprite = globalScene.add.sprite(0, 5, tObjSpriteKey);
-      if (trainer.variant === TrainerVariant.DOUBLE && !tObj.config.doubleOnly) {
+      if (trainerData.variant === TrainerVariant.DOUBLE && !trainer.config.doubleOnly) {
         const doubleContainer = globalScene.add.container(5, 8);
         tObjSprite.setPosition(-3, -3);
-        const tObjPartnerSpriteKey = tObj.config.getSpriteKey(true, true);
+        const tObjPartnerSpriteKey = trainer.config.getSpriteKey(true, true);
         const tObjPartnerSprite = globalScene.add.sprite(5, -3, tObjPartnerSpriteKey);
         // Double Trainers have smaller sprites than Single Trainers
         if (this.runDisplayMode === RunDisplayMode.RUN_HISTORY) {
@@ -478,6 +480,7 @@ export class RunInfoUiHandler extends UiHandler {
         tObjSprite.setPosition(position[0], position[1]);
         enemyContainer.add(tObjSprite);
       }
+      trainer.destroy();
     });
   }
 

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -399,7 +399,7 @@ export class RunInfoUiHandler extends UiHandler {
     enemyData.boss = false;
     enemyData["player"] = true;
     //addPokemonIcon() throws an error if the Pokemon used is a boss
-    const enemy = enemyData.toPokemon();
+    const enemy = enemyData.toPokemon(true);
     const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
     const enemyLevelStyle = isBoss ? TextStyle.BOSS_POKEMON_LEVEL_SMALL : TextStyle.POKEMON_LEVEL_SMALL;
     const enemyLevel = addTextObject(36, 26, getPokemonLevelText(enemy), enemyLevelStyle);
@@ -422,7 +422,7 @@ export class RunInfoUiHandler extends UiHandler {
       const isBoss = enemyData.boss;
       enemyData.boss = false;
       enemyData["player"] = true;
-      const enemy = enemyData.toPokemon();
+      const enemy = enemyData.toPokemon(true);
       const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
       const enemyLevelStyle = isBoss ? TextStyle.BOSS_POKEMON_LEVEL_SMALL : TextStyle.POKEMON_LEVEL_SMALL;
       const enemyLevel = addTextObject(36, 26, getPokemonLevelText(enemy), enemyLevelStyle);
@@ -511,7 +511,7 @@ export class RunInfoUiHandler extends UiHandler {
       const isBoss = enemyData.boss;
       enemyData.boss = false;
       enemyData["player"] = true;
-      const enemy = enemyData.toPokemon();
+      const enemy = enemyData.toPokemon(true);
       const enemyIcon = globalScene.addPokemonIcon(enemy, 0, 0, 0, 0);
 
       // Applying Terastallizing Type tint to Pokemon icon
@@ -696,7 +696,7 @@ export class RunInfoUiHandler extends UiHandler {
     party.forEach((pokemonData: PokemonData, index: number) => {
       const pokemonInfoWindow = new RoundRectangle(globalScene, 0, 14, this.statsBgWidth * 2 + 10, windowHeight - 2, 3);
 
-      const pokemon = pokemonData.toPokemon();
+      const pokemon = pokemonData.toPokemon(true);
       const pokemonInfoContainer = globalScene.add.container(this.statsBgWidth + 5, (windowHeight - 0.5) * index);
 
       const types = pokemon.getTypes();
@@ -944,7 +944,7 @@ export class RunInfoUiHandler extends UiHandler {
     hallofFameText.setPosition(GAME_WIDTH / 2, GAME_HEIGHT - 16);
     this.hallofFameContainer.add(hallofFameText);
     this.runInfo.party.forEach((p, i) => {
-      const pkmn = p.toPokemon();
+      const pkmn = p.toPokemon(true); // is skipping init correct in the case of hall of fame?
       const row = i % 2;
       const id = pkmn.id;
       const shiny = pkmn.shiny;

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { PLAYER_PARTY_MAX_SIZE } from "#constants/game-constants";
+import { MAX_PARTY_LUCK_VALUE, PLAYER_PARTY_MAX_SIZE } from "#constants/game-constants";
 import { GAME_HEIGHT, GAME_WIDTH, TEXT_SCALE } from "#constants/ui-constants";
 import { getBiomeName } from "#data/biome-utils";
 import { getNatureName, getNatureStatMultiplier } from "#data/nature";
@@ -598,7 +598,7 @@ export class RunInfoUiHandler extends UiHandler {
     const luckText = addTextObject(windowX - 6, windowY - 4, "", TextStyle.SCORE);
     luckText.setOrigin(1, 1);
     luckText.setText(i18next.t("runHistory:luck") + ": " + getLuckString(luckValue)); // TODO: localize properly
-    if (luckValue < 14) {
+    if (luckValue < MAX_PARTY_LUCK_VALUE) {
       luckText.setTint(getLuckTextTint(luckValue));
     } else {
       luckText.setTint(0xffef5c, 0x47ff69, 0x6b6bff, 0xff6969);

--- a/src/ui/handlers/save-slot-select-ui-handler.ts
+++ b/src/ui/handlers/save-slot-select-ui-handler.ts
@@ -392,7 +392,7 @@ class SessionSlot extends Phaser.GameObjects.Container {
       const iconContainer = globalScene.add.container(26 * i, 0);
       iconContainer.setScale(0.75);
 
-      const pokemon = p.toPokemon();
+      const pokemon = p.toPokemon(); // todo: can we skip init here?
       const icon = globalScene.addPokemonIcon(pokemon, 0, 0, 0, 0);
 
       const text = addTextObject(32, 20, getPokemonLevelText(pokemon), TextStyle.POKEMON_LEVEL);

--- a/test/moves/effectiveness.test.ts
+++ b/test/moves/effectiveness.test.ts
@@ -21,8 +21,8 @@ function testMoveEffectiveness(
   vi.spyOn(Messages, "getPokemonNameWithAffix").mockReturnValue("");
   game.override.enemyAbility(targetAbility);
 
-  const user = game.scene.addPlayerPokemon(getPokemonSpecies(SpeciesId.SNORLAX), 5);
-  const target = game.scene.addEnemyPokemon(getPokemonSpecies(targetSpecies), 5);
+  const user = game.scene.addPlayerPokemon(getPokemonSpecies(SpeciesId.SNORLAX), 5, {}, true);
+  const target = game.scene.addEnemyPokemon(getPokemonSpecies(targetSpecies), 5, {}, true);
 
   if (teraType !== undefined) {
     game.field.forceTera(target, teraType);

--- a/test/test-utils/game-manager-utils.ts
+++ b/test/test-utils/game-manager-utils.ts
@@ -35,13 +35,13 @@ export function generateStarter(scene: BattleScene, species: SpeciesId[]): Start
   const starters = getTestRunStarters(species);
   const startingLevel = scene.gameMode.getStartingLevel();
   if (species.length > 6) {
-    console.warn("Don't pass more than 6 starters to `runToSummon` or `startBattle`! Recieved length:", species.length);
+    console.warn("Don't pass more than 6 starters to `runToSummon` or `startBattle`! Received length:", species.length);
     species.splice(6);
   }
   for (const starter of starters) {
-    const { abilityIndex, nature } = starter;
     const starterProps = scene.gameData.getSpeciesDexAttrProps(starter.species, starter.dexAttr);
     const formIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
+    const { abilityIndex, nature } = starter;
     const { gender, shiny, variant } = starterProps;
     const starterPokemon = scene.addPlayerPokemon(starter.species, startingLevel, {
       abilityIndex,
@@ -50,7 +50,7 @@ export function generateStarter(scene: BattleScene, species: SpeciesId[]): Start
       shiny,
       variant,
       nature,
-    });
+    }, true);
     const moveset: MoveId[] = [];
     for (const move of starterPokemon.getMoveset(true)) {
       moveset.push(move.getMove().id);
@@ -96,10 +96,10 @@ export function getMovePosition(scene: BattleScene, pokemonIndex: 0 | 1, moveId:
 export function initSceneWithoutEncounterPhase(scene: BattleScene, species: SpeciesId[]): void {
   const starters = generateStarter(scene, species);
   starters.forEach((starter) => {
-    const { abilityIndex, nature } = starter;
     const starterProps = scene.gameData.getSpeciesDexAttrProps(starter.species, starter.dexAttr);
     const formIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
     const { shiny, variant } = starterProps;
+    const { abilityIndex, nature } = starter;
     const starterSpeciesId = starter.species.getRootSpeciesId(true);
     const ivs = scene.gameData.starterData[starterSpeciesId].ivs.slice(0);
     const starterPokemon = scene.addPlayerPokemon(starter.species, scene.gameMode.getStartingLevel(), {
@@ -110,7 +110,7 @@ export function initSceneWithoutEncounterPhase(scene: BattleScene, species: Spec
       variant,
       ivs,
       nature,
-    });
+    }, true);
     starter.moveset && starterPokemon.tryPopulateMoveset(starter.moveset);
     scene.getPlayerParty().push(starterPokemon);
   });

--- a/test/test-utils/game-manager-utils.ts
+++ b/test/test-utils/game-manager-utils.ts
@@ -43,14 +43,19 @@ export function generateStarter(scene: BattleScene, species: SpeciesId[]): Start
     const formIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
     const { abilityIndex, nature } = starter;
     const { gender, shiny, variant } = starterProps;
-    const starterPokemon = scene.addPlayerPokemon(starter.species, startingLevel, {
-      abilityIndex,
-      formIndex,
-      gender,
-      shiny,
-      variant,
-      nature,
-    }, true);
+    const starterPokemon = scene.addPlayerPokemon(
+      starter.species,
+      startingLevel,
+      {
+        abilityIndex,
+        formIndex,
+        gender,
+        shiny,
+        variant,
+        nature,
+      },
+      true,
+    );
     const moveset: MoveId[] = [];
     for (const move of starterPokemon.getMoveset(true)) {
       moveset.push(move.getMove().id);
@@ -102,15 +107,20 @@ export function initSceneWithoutEncounterPhase(scene: BattleScene, species: Spec
     const { abilityIndex, nature } = starter;
     const starterSpeciesId = starter.species.getRootSpeciesId(true);
     const ivs = scene.gameData.starterData[starterSpeciesId].ivs.slice(0);
-    const starterPokemon = scene.addPlayerPokemon(starter.species, scene.gameMode.getStartingLevel(), {
-      abilityIndex,
-      formIndex,
-      gender: Gender.MALE,
-      shiny,
-      variant,
-      ivs,
-      nature,
-    }, true);
+    const starterPokemon = scene.addPlayerPokemon(
+      starter.species,
+      scene.gameMode.getStartingLevel(),
+      {
+        abilityIndex,
+        formIndex,
+        gender: Gender.MALE,
+        shiny,
+        variant,
+        ivs,
+        nature,
+      },
+      true,
+    );
     starter.moveset && starterPokemon.tryPopulateMoveset(starter.moveset);
     scene.getPlayerParty().push(starterPokemon);
   });


### PR DESCRIPTION
<!-- Once you have read these comments, you are free to remove them -->

<!-- Feel free to look at other PRs for examples -->

<!--
The PR title must match this format (and is ideally less than or equal to 72 characters):

fix(move): Future Sight no longer crashes
^   ^      ^
|   |      |__ Subject
|   |_________ Scope (optional)
|_____________ Prefix

You should add a `!` before the `:` if the PR includes a version increase / save migrator. Example:
refactor!: change Tera mechanic to match mainline

List of valid prefixes:
  balance - Primarily a balance change
  deps - Primarily adding/updating/removing dependencies
  dev - Improving the developer experience (such as by modifying lint rules or creating cli scripts)
  docs - Primarily adding/updating documentation
  feat - Adding a new feature (e.g. adding a new implementation of a move) or redesigning an existing feature
  fix - Fixing a bug
  github - Updating the CI pipeline or otherwise modifying something in the `./github/` directory
  i18n - Updating the localization submodule, adding new translatable text, etc
  misc - A change that doesn't fit any other category
  refactor - A change that doesn't impact functionality or fix any bugs (except incidentally)
  revert - Reverting a previous commit
  test - Primarily adding/updating tests or modifying the test framework

List of valid scopes:
  ability
  ai
  anomaly - Formerly "Mystery Encounters"
  audio
  battle - Relating to the general battle engine
  biomes
  challenge
  data - Data not covered by other scopes, such as TM lists
  event
  graphics - Anything related to art/graphics (adding new sprites, fixing a sprite that isn't displaying, etc)
  item
  move
  ui - UI/UX

List of valid "prefix(scope)" combinations:
  balance - ability, ai, anomaly, biomes, challenge, item, move
  deps - N/A
  dev - N/A
  docs - N/A
  feat - All
  fix - All
  github - N/A
  i18n - N/A
  misc - N/A
  refactor - All
  revert - N/A
  test - N/A
-->

<!--
Make sure that this PR is not overlapping with someone else's work
Please try to keep the PR self-contained (and small)
-->

wip

## What are the changes the user will see?

<!-- Summarize what are the changes from a user perspective on the application -->

## Why am I making these changes?

<!--
Explain why you decided to introduce these changes
Does it come from an issue or another PR? Please link it
Explain why you believe this can enhance user experience
-->
<!--
If there are existing GitHub issues related to the PR that would be fixed,
you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
so that it will automatically be closed when the PR is merged.
-->

## What are the changes from a developer perspective?

<!--
Explicitly state what are the changes introduced by the PR
You can make use of a comparison between what was the state before and after your PR changes
Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
-->

## Screenshots/Videos

<details><summary>Heap Trace</summary>
 
#### Opening and closing run history multiple times
Before: Hundreds of never destroyed Sprite objects
<img width="691" height="195" alt="image" src="https://github.com/user-attachments/assets/d86fa754-e6f1-4538-b8a7-4bc7f655dae4" />
After:

#### Opening and closing save loading multiple times
Before: Hundreds of never destroyed Sprite objects
<img width="698" height="231" alt="image" src="https://github.com/user-attachments/assets/43e80cf9-3d13-45f1-9461-9cb5dbd7a8fe" />
After:

#### Looking at summary for a new catch (when team is full) multiple times
Before: Never destroyed PlayerPokemon object for each time the summary got opened
<img width="437" height="81" alt="image" src="https://github.com/user-attachments/assets/02317271-8e6a-4f12-b0d2-20dadb886587" />
After:

#### Playing through the Weird Dream ME multiple times (so it's easier to see the issue)
Before: Never destroyed PlayerPokemon objects (only the option to change the team clears them properly, but not running or fighting)
<img width="425" height="90" alt="image" src="https://github.com/user-attachments/assets/be8b9cbb-10b6-44b8-9622-ee74ab87c551" />
After:
<img width="423" height="90" alt="image" src="https://github.com/user-attachments/assets/3a815871-f46f-4e38-babf-0b8f3b8167e6" />
The 6 undeleted ones are caused by the globalScene keeping reference to the last ME's data, which contains them. But they will get cleared once that reference is freed by encountering another ME

</details> 

<!--
If your changes are changing anything on the user experience, please provide visual proofs of it
Please take screenshots/videos before and after your changes, to show what is brought by this PR
-->

## How to test the changes?

<!--
How can a reviewer test your changes once they check out on your branch?
Did you make use of the `src/overrides.ts` file?
Did you introduce any automated tests?
Do the reviewers need to do something special in order to test your changes?
-->

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?

#### Are there any localization additions or changes? If so:

- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
  - [ ] If so, please leave a link to it here:
- [ ] Have I added the `Localization` tag to this PR?
<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->

#### If there are no locale changes:
- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
<!-- check the `Files Changed` tab on the PR to be sure. 
`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->

<!-- How to fix it if no: -->
<!-- #### Using the Command Line:
- Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
- If the hash corresponds to the latest commit in the locale repo:
  - `pnpm update-locales:remote`
  - `git add public/locales`
  - make your commit, push etc
- If it's not the latest commit:
  - `git checkout beta`
  - if not up to date: `git pull`. Otherwise: `pnpm update-locales:remote`
  - `git checkout {this pr's branch}`
  - `git add public/locales`
  - make your commit, push etc

 /!\ anyone using another tool, feel free to add instructions there /!\

You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->