### PR TITLE
refactor: remove luck from Pokemon pending redesign

### DIFF
--- a/src/data/challenge.ts
+++ b/src/data/challenge.ts
@@ -673,7 +673,6 @@ export class FreshStartChallenge extends Challenge {
       .map((lm) => lm[1])
       .slice(0, 4); // No egg moves
     pokemon.setMoveset(...moveset);
-    pokemon.luck = 0; // No luck
     pokemon.shiny = false; // Not shiny
     pokemon.variant = 0; // Not shiny
     pokemon.formIndex = 0; // Froakie should be base form

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -485,9 +485,6 @@ async function postProcessTransformedPokemon(
   // If the previous pokemon had pokerus, transfer to new pokemon
   newPokemon.pokerus = previousPokemon.pokerus;
 
-  // Transfer previous Pokemon's luck value
-  newPokemon.luck = previousPokemon.getLuck();
-
   // If the previous pokemon had higher IVs, override to those (after updating dex IVs > prevents perfect 31s on a new unlock)
   newPokemon.ivs = newPokemon.ivs.map((iv, index) => {
     return previousPokemon.ivs[index] > iv ? previousPokemon.ivs[index] : iv;

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -113,8 +113,6 @@ export class EnemyPokemon extends Pokemon {
         }
       }
 
-      this.luck = this.shiny ? this.variant + 1 : 0;
-
       let preEvolution: SpeciesId;
       let speciesId = species.speciesId;
       while ((preEvolution = pokemonPreEvolutions[speciesId])) {

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -330,7 +330,6 @@ export class PlayerPokemon extends Pokemon {
         );
         newPokemon.passive = this.passive;
         this.copyMoveset(newPokemon);
-        newPokemon.luck = this.luck;
         newPokemon.gender = Gender.GENDERLESS;
         newPokemon.metLevel = this.metLevel;
         newPokemon.metBiome = this.metBiome;

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -278,7 +278,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   public metBiome: BiomeId | -1;
   public metSpecies: SpeciesId;
   public metWave: number;
-  public luck: number;
   public pauseEvolutions: boolean;
   public pokerus: boolean;
   public switchOutStatus: boolean;
@@ -371,7 +370,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.status = dataSource["status"];
       this.friendship = dataSource.friendship ?? this.species.baseFriendship;
       this.metLevel = dataSource.metLevel || 5;
-      this.luck = dataSource.luck;
       this.metBiome = dataSource.metBiome;
       this.metSpecies =
         dataSource.metSpecies ?? (this.metBiome !== -1 ? this.species.speciesId : this.species.getRootSpeciesId(true));
@@ -419,7 +417,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       this.metSpecies = species.speciesId;
       this.metWave = globalScene.currentBattle ? globalScene.currentBattle.waveIndex : -1;
       this.pokerus = false;
-      this.luck = this.shiny ? this.variant + 1 : 0;
     }
 
     this.generateName();
@@ -1380,10 +1377,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   getVariant(): Variant {
     return this.variant;
-  }
-
-  getLuck(): number {
-    return this.luck;
   }
 
   abstract isBoss(): boolean;
@@ -2391,7 +2384,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
     if (this.shiny) {
       this.variant = this.generateShinyVariant();
-      this.luck = this.variant + 1;
       this.initShinySparkle();
     }
 

--- a/src/modifier/modifier-type.ts
+++ b/src/modifier/modifier-type.ts
@@ -73,7 +73,7 @@ import type { PokemonMoveSelectFilter, PokemonSelectFilter } from "#types/ui-typ
 import type { EnumValues } from "#types/utility-types";
 import { getModifierTierTextTint } from "#ui/text-utils";
 import { getBerryEffectDescription, getBerryName } from "#utils/berry-utils";
-import { clamp, enumValueToKey, getTSEnumKeys, getTSEnumValues, isNil, NumberHolder } from "#utils/common-utils";
+import { enumValueToKey, getTSEnumKeys, getTSEnumValues, isNil, NumberHolder } from "#utils/common-utils";
 import { getModifierPoolForType } from "#utils/modifier-pool-utils";
 import { getModifierType } from "#utils/modifier-type-utils";
 import { randSeedInt } from "#utils/random-utils";
@@ -2132,7 +2132,7 @@ export class ModifierTypeOption {
  * @param party The player's party.
  * @returns A number between 0 and 14 based on the party's total luck value, or a random number between 0 and 14 if the player is in Daily Run mode.
  */
-export function getPartyLuckValue(party: Pokemon[]): number {
+export function getPartyLuckValue(_party: Pokemon[]): number {
   if (globalScene.gameMode.isDaily) {
     const DailyLuck = new NumberHolder(0);
     globalScene.executeWithSeedOffset(
@@ -2144,13 +2144,7 @@ export function getPartyLuckValue(party: Pokemon[]): number {
     );
     return DailyLuck.value;
   }
-  const luck = clamp(
-    party
-      .map((p) => (p.isAllowedInBattle() ? p.getLuck() : 0))
-      .reduce((total: number, value: number) => (total += value), 0),
-    0,
-    14,
-  );
+  const luck = 0; // TODO: temporary until luck is reworked
   return luck ?? 0;
 }
 

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -37,11 +37,11 @@ export class SelectStarterPhase extends Phase {
 
   /**
    * Initialize starters before starting the first battle
-   * @param starters {@linkcode Pokemon} with which to start the first battle
+   * @param starters - The {@linkcode Pokemon} to start the first battle with
    */
   public initBattle(starters: StarterConfig[]): void {
-    const { arena, gameMode, gameData, sound, time } = globalScene;
-    const { dexData, gameStats, starterData } = gameData;
+    const { arena, audioManager, gameMode, gameData, sound, time } = globalScene;
+    const { gameStats, starterData } = gameData;
     const { isClassic } = gameMode;
 
     const party = globalScene.getPlayerParty();
@@ -52,18 +52,19 @@ export class SelectStarterPhase extends Phase {
         starter.species = getPokemonSpecies(activeOverrides.STARTER_SPECIES_OVERRIDE);
       }
 
-      const { abilityIndex, dexAttr, moveset, nature, nickname, passive, pokerus, species } = starter;
+      const { abilityIndex, dexAttr, moveset, nature, nickname, passive, pokerus, species, teraType } = starter;
       const { speciesId } = species;
 
       const starterProps = gameData.getSpeciesDexAttrProps(species, dexAttr);
       let starterFormIndex = Math.min(starterProps.formIndex, Math.max(species.forms.length - 1, 0));
 
+      const { STARTER_FORM_OVERRIDES } = activeOverrides;
       if (
-        speciesId in activeOverrides.STARTER_FORM_OVERRIDES
-        && !isNil(activeOverrides.STARTER_FORM_OVERRIDES[speciesId])
-        && species.forms[activeOverrides.STARTER_FORM_OVERRIDES[speciesId]]
+        speciesId in STARTER_FORM_OVERRIDES
+        && !isNil(STARTER_FORM_OVERRIDES[speciesId])
+        && species.forms[STARTER_FORM_OVERRIDES[speciesId]]
       ) {
-        starterFormIndex = activeOverrides.STARTER_FORM_OVERRIDES[speciesId];
+        starterFormIndex = STARTER_FORM_OVERRIDES[speciesId];
       }
 
       const starterGender = activeOverrides.GENDER_OVERRIDE ?? starterProps.gender;
@@ -90,8 +91,6 @@ export class SelectStarterPhase extends Phase {
         starterPokemon.passive = true;
       }
 
-      starterPokemon.luck = gameData.getDexAttrLuck(dexData[speciesId].caughtAttr);
-
       if (pokerus) {
         starterPokemon.pokerus = true;
       }
@@ -100,10 +99,10 @@ export class SelectStarterPhase extends Phase {
         starterPokemon.nickname = nickname;
       }
 
-      if (isNil(starter.teraType)) {
+      if (isNil(teraType)) {
         starterPokemon.teraType = starterPokemon.species.type1;
       } else {
-        starterPokemon.teraType = starter.teraType;
+        starterPokemon.teraType = teraType;
       }
 
       starterPokemon.setVisible(false);
@@ -117,7 +116,7 @@ export class SelectStarterPhase extends Phase {
 
     Promise.all(loadPokemonAssets).then(() => {
       SoundFade.fadeOut(globalScene, sound.get("menu"), 500, true);
-      time.delayedCall(500, () => globalScene.audioManager.playBgm());
+      time.delayedCall(500, () => audioManager.playBgm());
 
       if (isClassic) {
         gameStats.classicSessionsPlayed++;

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -110,7 +110,6 @@ export class PokemonData {
     this.metBiome = source.metBiome ?? -1;
     this.metSpecies = source.metSpecies;
     this.metWave = source.metWave ?? (this.metBiome === -1 ? -1 : 0);
-    this.luck = source.luck ?? (source.shiny ? source.variant + 1 : 0);
     this.pauseEvolutions = source.pauseEvolutions;
     this.evoCounter = source.evoCounter ?? 0;
     this.pokerus = source.pokerus;
@@ -128,8 +127,7 @@ export class PokemonData {
     }
 
     if (isPokemon(source)) {
-      // @ts-expect-error - `Pokemon#moveset` is `protected`
-      this.moveset = source.moveset;
+      this.moveset = source["moveset"];
       this.summonData = source.summonData;
       return;
     }

--- a/src/ui/handlers/run-info-ui-handler.ts
+++ b/src/ui/handlers/run-info-ui-handler.ts
@@ -31,7 +31,7 @@ import type { SessionSaveData } from "#types/session-data";
 import { addBBCodeTextObject, addTextObject, getBBCodeFragment } from "#ui/text-utils";
 import { UiHandler } from "#ui/ui-handler";
 import { addWindow } from "#ui/ui-theme";
-import { clamp, enumValueToKey, isNil } from "#utils/common-utils";
+import { enumValueToKey, isNil } from "#utils/common-utils";
 import { formatLargeNumberFixedDigits, formatMoney, getPlayTimeString, getPokemonLevelText } from "#utils/string-utils";
 import i18next from "i18next";
 import RoundRectangle from "phaser3-rex-plugins/plugins/roundrectangle";
@@ -594,13 +594,8 @@ export class RunInfoUiHandler extends UiHandler {
     runInfoTextContainer.add(runInfoText);
 
     // Luck
-    const luckValue = clamp(
-      this.runInfo.party
-        .map((p) => p.toPokemon().getLuck())
-        .reduce((total: number, value: number) => (total += value), 0),
-      0,
-      14,
-    );
+    // TODO: update when luck design is finalized
+    const luckValue = 0;
     const luckText = addTextObject(windowX - 6, windowY - 4, "", TextStyle.SCORE);
     luckText.setOrigin(1, 1);
     luckText.setText(i18next.t("runHistory:luck") + ": " + getLuckString(luckValue)); // TODO: localize properly

--- a/src/ui/handlers/summary-ui-handler.ts
+++ b/src/ui/handlers/summary-ui-handler.ts
@@ -10,7 +10,7 @@ import { getPokeballAtlasKey } from "#data/pokeball";
 import { starterColors } from "#data/starter-colors";
 import { getCandyProgressRequirement, speciesStarterCosts } from "#data/starters";
 import { getTypeRgb } from "#data/type";
-import { getVariantTint, type Variant } from "#data/variant";
+import { getVariantTint } from "#data/variant";
 import { Button } from "#enums/button";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveCategory } from "#enums/move-category";
@@ -778,22 +778,6 @@ export class SummaryUiHandler extends UiHandler {
         profileContainer.add(getTypeIcon(0, types[0]));
         if (types.length > 1) {
           profileContainer.add(getTypeIcon(1, types[1]));
-        }
-
-        if (this.pokemon?.getLuck()) {
-          const luckLabelText = addTextObject(141, 28, i18next.t("common:luckIndicator"), TextStyle.SUMMARY_ALT);
-          luckLabelText.setOrigin(0, 0);
-          profileContainer.add(luckLabelText);
-
-          const luckText = addTextObject(
-            141 + luckLabelText.displayWidth + 2,
-            28,
-            this.pokemon.getLuck().toString(),
-            TextStyle.SUMMARY,
-          );
-          luckText.setOrigin(0, 0);
-          luckText.setTint(getVariantTint(Math.min(this.pokemon.getLuck() - 1, 2) as Variant));
-          profileContainer.add(luckText);
         }
 
         if (

--- a/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
+++ b/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
@@ -187,7 +187,6 @@ describe("Global Trade System - Mystery Encounter", () => {
 
       expect(receivedPokemon.shiny).toBeTruthy();
       expect(receivedPokemon.variant).toBeDefined();
-      expect(receivedPokemon.luck).toBe(receivedPokemon.variant + 1);
     });
 
     it("should leave encounter without battle", async () => {


### PR DESCRIPTION
## What are the changes the user will see?
Luck is always 0 (except in Daily Run, which sets luck externally to the Pokémon in your party) due to Pokémon not having luck values anymore.

## Why am I making these changes?
Luck is being redesigned and general consensus is to not have it be tied to the Pokémon.

## What are the changes from a developer perspective?
Luck field removed from `Pokemon` class and all references to it are removed.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?