### PR TITLE
refactor: add getter for weather type to `Arena`

### DIFF
--- a/src/data/abilities/ab-attrs/post-faint-clear-weather-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-faint-clear-weather-ab-attr.ts
@@ -10,7 +10,7 @@ import type { Move } from "#moves/move";
  */
 export class PostFaintClearWeatherAbAttr extends PostFaintAbAttr {
   public override apply(pokemon: Pokemon, simulated: boolean, _attacker?: Pokemon, _move?: Move): boolean {
-    const weatherType = globalScene.arena.weather?.weatherType;
+    const weatherType = globalScene.arena.weatherType;
     let turnOffWeather = false;
     let weatherAbility: AbilityId | null = null;
 

--- a/src/data/abilities/ab-attrs/post-weather-change-form-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-weather-change-form-change-ab-attr.ts
@@ -31,7 +31,7 @@ export class PostWeatherChangeFormChangeAbAttr extends PostWeatherChangeAbAttr {
         return simulated;
       }
 
-      const weatherType = globalScene.arena.weather?.weatherType;
+      const weatherType = globalScene.arena.weatherType;
 
       if (!weatherType || this.formRevertingWeathers.includes(weatherType)) {
         globalScene.arena.triggerWeatherBasedFormChangesToNormal();

--- a/src/data/abilities/ab-attrs/post-weather-lapse-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-weather-lapse-ab-attr.ts
@@ -1,5 +1,4 @@
 import { AbAttr } from "#abilities/ab-attr";
-import type { Weather } from "#data/weather";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import type { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
@@ -18,12 +17,11 @@ export abstract class PostWeatherLapseAbAttr extends AbAttr {
 
   /**
    * Applies an effect after the weather on the field lapses.
-   * @param pokemon The {@linkcode Pokemon} with this ability
-   * @param simulated If `true`, suppresses changes to game state
-   * @param weather The {@linkcode Weather} on the field
+   * @param pokemon - The {@linkcode Pokemon} with this ability
+   * @param simulated - If `true`, suppresses changes to game state
    * @returns `true` if effects successfully apply
    */
-  public override apply(_pokemon: Pokemon, _simulated: boolean, _weather: Weather): boolean {
+  public override apply(_pokemon: Pokemon, _simulated: boolean): boolean {
     return false;
   }
 

--- a/src/data/abilities/ab-attrs/post-weather-lapse-damage-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-weather-lapse-damage-ab-attr.ts
@@ -1,7 +1,6 @@
 import { PostWeatherLapseAbAttr } from "#abilities/post-weather-lapse-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import type { Weather } from "#data/weather";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { HitResult } from "#enums/hit-result";
 import type { WeatherType } from "#enums/weather-type";
@@ -30,7 +29,7 @@ export class PostWeatherLapseDamageAbAttr extends PostWeatherLapseAbAttr {
     this.damageFactor = damageFactor;
   }
 
-  public override apply(pokemon: Pokemon, simulated: boolean, _weather: Weather): boolean {
+  public override apply(pokemon: Pokemon, simulated: boolean): boolean {
     if (pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
       return false;
     }

--- a/src/data/abilities/ab-attrs/post-weather-lapse-heal-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-weather-lapse-heal-ab-attr.ts
@@ -1,7 +1,6 @@
 import { PostWeatherLapseAbAttr } from "#abilities/post-weather-lapse-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
-import type { Weather } from "#data/weather";
 import type { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
 import { toDmgValue } from "#utils/common-utils";
@@ -32,7 +31,7 @@ export class PostWeatherLapseHealAbAttr extends PostWeatherLapseAbAttr {
     this.healRatio = healRatio;
   }
 
-  public override apply(pokemon: Pokemon, simulated: boolean, _weather: Weather): boolean {
+  public override apply(pokemon: Pokemon, simulated: boolean): boolean {
     if (!pokemon.isFullHp()) {
       const abilityName = this.source.name;
       if (!simulated) {

--- a/src/data/abilities/ab-attrs/pre-switch-out-clear-weather-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/pre-switch-out-clear-weather-ab-attr.ts
@@ -9,7 +9,7 @@ import type { Pokemon } from "#field/pokemon";
  */
 export class PreSwitchOutClearWeatherAbAttr extends PreSwitchOutAbAttr {
   public override apply(pokemon: Pokemon, simulated: boolean): boolean {
-    const weatherType = globalScene.arena.weather?.weatherType;
+    const weatherType = globalScene.arena.weatherType;
     let turnOffWeather = false;
     let weatherAbility: AbilityId | null = null;
 

--- a/src/data/abilities/ab-attrs/terrain-event-type-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/terrain-event-type-change-ab-attr.ts
@@ -23,7 +23,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
       return false;
     }
 
-    const currentTerrain = globalScene.arena.getTerrainType();
+    const currentTerrain = globalScene.arena.terrainType;
 
     // If there is no terrain, only apply ability if the terrain changed to become empty (i.e., `onSummon` is false)
     if (onSummon && currentTerrain === TerrainType.NONE) {
@@ -68,7 +68,7 @@ export class TerrainEventTypeChangeAbAttr extends PostSummonAbAttr {
   }
 
   public override getTriggerMessage(pokemon: Pokemon, _abilityName: string) {
-    const currentTerrain = globalScene.arena.getTerrainType();
+    const currentTerrain = globalScene.arena.terrainType;
     const pokemonNameWithAffix = getPokemonNameWithAffix(pokemon);
     if (currentTerrain === TerrainType.NONE) {
       return i18next.t("abilityTriggers:pokemonTypeChangeRevert", { pokemonNameWithAffix });

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -2969,7 +2969,7 @@ export function initMoves() {
     new AttackMove(MoveId.TERRAIN_PULSE, ElementalType.NORMAL, MoveCategory.SPECIAL, 50, 100, 10, -1, 0, 8) //
       .attr(TerrainPulseTypeAttr)
       .attr(MovePowerMultiplierAttr, (user, _target, _move) =>
-        globalScene.arena.getTerrainType() !== TerrainType.NONE && user.isGrounded() ? 2 : 1,
+        globalScene.arena.terrainType !== TerrainType.NONE && user.isGrounded() ? 2 : 1,
       )
       .pulseMove(),
     new AttackMove(MoveId.SKITTER_SMACK, ElementalType.BUG, MoveCategory.PHYSICAL, 70, 90, 10, 100, 0, 8) //
@@ -3319,7 +3319,7 @@ export function initMoves() {
       .target(MoveTarget.ALL_NEAR_ENEMIES),
     new AttackMove(MoveId.PSYBLADE, ElementalType.PSYCHIC, MoveCategory.PHYSICAL, 80, 100, 15, -1, 0, 9) //
       .attr(MovePowerMultiplierAttr, (user, _target, _move) =>
-        globalScene.arena.getTerrainType() === TerrainType.ELECTRIC && user.isGrounded() ? 1.5 : 1,
+        globalScene.arena.terrainType === TerrainType.ELECTRIC && user.isGrounded() ? 1.5 : 1,
       )
       .slicingMove(),
     new AttackMove(MoveId.HYDRO_STEAM, ElementalType.WATER, MoveCategory.SPECIAL, 80, 100, 15, -1, 0, 9) //

--- a/src/data/moves/move-attrs/copy-biome-type-attr.ts
+++ b/src/data/moves/move-attrs/copy-biome-type-attr.ts
@@ -20,10 +20,10 @@ export class CopyBiomeTypeAttr extends MoveEffectAttr {
   }
 
   override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
-    const terrainType = globalScene.arena.getTerrainType();
+    const terrainType = globalScene.arena.terrainType;
     let typeChange: ElementalType;
     if (terrainType !== TerrainType.NONE) {
-      typeChange = this.getTypeForTerrain(globalScene.arena.getTerrainType());
+      typeChange = this.getTypeForTerrain(globalScene.arena.terrainType);
     } else {
       typeChange = this.getTypeForBiome(globalScene.arena.biomeId);
     }

--- a/src/data/moves/move-attrs/nature-power-attr.ts
+++ b/src/data/moves/move-attrs/nature-power-attr.ts
@@ -99,7 +99,7 @@ export class NaturePowerAttr extends CallMoveAttr {
           return MoveId.CHARGE_BEAM;
       }
     };
-    switch (globalScene.arena.getTerrainType()) {
+    switch (globalScene.arena.terrainType) {
       // terrain takes priority over biome
       case TerrainType.NONE:
         moveId = getBiomeMoveId();

--- a/src/data/moves/move-attrs/secret-power-attr.ts
+++ b/src/data/moves/move-attrs/secret-power-attr.ts
@@ -26,7 +26,7 @@ export class SecretPowerAttr extends ChanceBasedMoveEffectAttr {
   }
 
   override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
-    const terrain = globalScene.arena.getTerrainType();
+    const terrain = globalScene.arena.terrainType;
     const biome = globalScene.arena.biomeId;
     const secondaryEffect = this.determineTerrainEffect(terrain) ?? this.determineBiomeEffect(biome);
     return secondaryEffect.applyEffect(user, target, move);

--- a/src/data/moves/move-attrs/terrain-pulse-type-attr.ts
+++ b/src/data/moves/move-attrs/terrain-pulse-type-attr.ts
@@ -17,7 +17,7 @@ export class TerrainPulseTypeAttr extends VariableMoveTypeAttr {
       return false;
     }
 
-    const currentTerrain = globalScene.arena.getTerrainType();
+    const currentTerrain = globalScene.arena.terrainType;
     switch (currentTerrain) {
       case TerrainType.MISTY:
         moveType.value = ElementalType.FAIRY;

--- a/src/data/moves/move-attrs/thunder-accuracy-attr.ts
+++ b/src/data/moves/move-attrs/thunder-accuracy-attr.ts
@@ -11,7 +11,7 @@ import type { NumberHolder } from "#utils/common-utils";
 export class ThunderAccuracyAttr extends VariableAccuracyAttr {
   override apply(_user: Pokemon, _target: Pokemon, _move: Move, accuracy: NumberHolder): boolean {
     if (!globalScene.arena.weather?.isEffectSuppressed()) {
-      const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
+      const weatherType = globalScene.arena.weatherType;
       switch (weatherType) {
         case WeatherType.SUNNY:
         case WeatherType.HARSH_SUN:

--- a/src/data/moves/move-attrs/weather-ball-type-attr.ts
+++ b/src/data/moves/move-attrs/weather-ball-type-attr.ts
@@ -12,29 +12,28 @@ import type { NumberHolder } from "#utils/common-utils";
  */
 export class WeatherBallTypeAttr extends VariableMoveTypeAttr {
   override apply(_user: Pokemon, _target: Pokemon, _move: Move, moveType: NumberHolder): boolean {
-    if (!globalScene.arena.weather?.isEffectSuppressed()) {
-      switch (globalScene.arena.weather?.weatherType) {
-        case WeatherType.SUNNY:
-        case WeatherType.HARSH_SUN:
-          moveType.value = ElementalType.FIRE;
-          break;
-        case WeatherType.RAIN:
-        case WeatherType.HEAVY_RAIN:
-          moveType.value = ElementalType.WATER;
-          break;
-        case WeatherType.SANDSTORM:
-          moveType.value = ElementalType.ROCK;
-          break;
-        case WeatherType.HAIL:
-        case WeatherType.SNOW:
-          moveType.value = ElementalType.ICE;
-          break;
-        default:
-          return false;
-      }
-      return true;
+    if (globalScene.arena.weather?.isEffectSuppressed()) {
+      return false;
     }
 
-    return false;
+    switch (globalScene.arena.weatherType) {
+      case WeatherType.SUNNY:
+      case WeatherType.HARSH_SUN:
+        moveType.value = ElementalType.FIRE;
+        return true;
+      case WeatherType.RAIN:
+      case WeatherType.HEAVY_RAIN:
+        moveType.value = ElementalType.WATER;
+        return true;
+      case WeatherType.SANDSTORM:
+        moveType.value = ElementalType.ROCK;
+        return true;
+      case WeatherType.HAIL:
+      case WeatherType.SNOW:
+        moveType.value = ElementalType.ICE;
+        return true;
+      default:
+        return false;
+    }
   }
 }

--- a/src/data/moves/move-attrs/weather-heal-attr.ts
+++ b/src/data/moves/move-attrs/weather-heal-attr.ts
@@ -1,5 +1,5 @@
 import { globalScene } from "#app/global-scene";
-import { WeatherType } from "#enums/weather-type";
+import type { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
 import { HealAttr } from "#moves/heal-attr";
 import type { Move } from "#moves/move";
@@ -16,7 +16,7 @@ export abstract class WeatherHealAttr extends HealAttr {
 
   protected override getHealRatio(_user: Pokemon, _target: Pokemon, _move: Move): number {
     if (!globalScene.arena.weather?.isEffectSuppressed()) {
-      const weatherType = globalScene.arena.weather?.weatherType || WeatherType.NONE;
+      const weatherType = globalScene.arena.weatherType;
       return this.getWeatherHealRatio(weatherType);
     }
     return 0.5;

--- a/src/data/mystery-encounters/mystery-encounter-requirements.ts
+++ b/src/data/mystery-encounters/mystery-encounter-requirements.ts
@@ -298,8 +298,12 @@ export class WeatherRequirement extends EncounterSceneRequirement {
   }
 
   override meetsRequirement(): boolean {
-    const currentWeather = globalScene.arena.weather?.weatherType;
-    if (!isNil(currentWeather) && this.requiredWeather?.length > 0 && !this.requiredWeather.includes(currentWeather!)) {
+    const currentWeather = globalScene.arena.weatherType;
+    if (
+      currentWeather !== WeatherType.NONE
+      && this.requiredWeather.length > 0
+      && !this.requiredWeather.includes(currentWeather)
+    ) {
       return false;
     }
 
@@ -307,9 +311,9 @@ export class WeatherRequirement extends EncounterSceneRequirement {
   }
 
   override getDialogueToken(_pokemon?: PlayerPokemon): [string, string] {
-    const currentWeather = globalScene.arena.weather?.weatherType;
+    const currentWeather = globalScene.arena.weatherType;
     let token = "";
-    if (!isNil(currentWeather)) {
+    if (currentWeather !== WeatherType.NONE) {
       token = WeatherType[currentWeather].replace("_", " ").toLocaleLowerCase();
     }
     return ["weather", token];

--- a/src/data/terrain.ts
+++ b/src/data/terrain.ts
@@ -9,7 +9,7 @@ import i18next from "i18next";
 
 /** Class representing Terrain effects */
 export class Terrain {
-  public terrainType: TerrainType;
+  public readonly terrainType: TerrainType;
   public turnsLeft: number;
 
   /**

--- a/src/data/weather.ts
+++ b/src/data/weather.ts
@@ -11,7 +11,7 @@ import i18next from "i18next";
 
 /** Class representing Weather effects */
 export class Weather {
-  public weatherType: WeatherType;
+  public readonly weatherType: WeatherType;
   public turnsLeft: number;
 
   /**

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -524,18 +524,17 @@ export class Arena {
    * @returns whether or not the terrain was successfully set
    */
   trySetTerrain(terrain: TerrainType, hasPokemonSource: boolean, ignoreAnim: boolean = false): boolean {
-    /**
-     * TODO: Refactor into if(this.tryOverrideTerrain()) { return true }
-     */
+    // TODO: Refactor into `if(this.tryOverrideTerrain()) { return true }`
     if (activeOverrides.TERRAIN_OVERRIDE) {
       return this.tryOverrideTerrain(activeOverrides.TERRAIN_OVERRIDE);
     }
 
+    // TODO: create `Arena#canSetTerrain` method
     if (this.terrain?.terrainType === (terrain || undefined)) {
       return false;
     }
 
-    const oldTerrainType = this.terrain?.terrainType || TerrainType.NONE;
+    const oldTerrainType = this.terrainType;
 
     let newTerrainDuration = DEFAULT_NEW_TERRAIN_DURATION;
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -65,6 +65,14 @@ export class Arena {
     this.updatePoolsForTimeOfDay();
   }
 
+  public get terrainType(): TerrainType {
+    return this.terrain?.terrainType ?? TerrainType.NONE;
+  }
+
+  public get weatherType(): WeatherType {
+    return this.weather?.weatherType ?? WeatherType.NONE;
+  }
+
   init() {
     const biomeKey = getBiomeKey(this.biomeId);
 
@@ -95,8 +103,7 @@ export class Arena {
    * @returns `true` if the arena is of the specified terrain, `false` otherwise
    */
   public hasTerrain(terrain: TerrainType | TerrainType[]): boolean {
-    const terrainType = this.getTerrainType();
-    return coerceArray(terrain).includes(terrainType);
+    return coerceArray(terrain).includes(this.terrainType);
   }
 
   /**
@@ -107,8 +114,7 @@ export class Arena {
    * @returns `true` if the arena is of the specified weather, `false` otherwise
    */
   public hasWeather(weather: WeatherType | WeatherType[]): boolean {
-    const weatherType = this.weather?.weatherType ?? WeatherType.NONE;
-    return coerceArray(weather).includes(weatherType);
+    return coerceArray(weather).includes(this.weatherType);
   }
 
   /**
@@ -439,7 +445,7 @@ export class Arena {
       return false;
     }
 
-    const oldWeatherType = this.weather?.weatherType || WeatherType.NONE;
+    const oldWeatherType = this.weatherType;
 
     let newWeatherDuration = DEFAULT_NEW_WEATHER_DURATION;
 
@@ -588,10 +594,6 @@ export class Arena {
    */
   public isMoveTerrainCancelled(user: Pokemon, targets: BattlerIndex[], move: Move): boolean {
     return !!this.terrain?.isMoveTerrainCancelled(user, targets, move);
-  }
-
-  public getTerrainType(): TerrainType {
-    return this.terrain?.terrainType ?? TerrainType.NONE;
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2125,8 +2125,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     // Handle strong winds lowering effectiveness of types super effective against pure flying
     if (
       !ignoreFieldConditions
-      && arena.weather?.weatherType === WeatherType.STRONG_WINDS
-      && !arena.weather.isEffectSuppressed()
+      && arena.weatherType === WeatherType.STRONG_WINDS
+      && !arena.weather?.isEffectSuppressed()
       && this.isOfType(ElementalType.FLYING)
       && typeMultiplierAgainstFlying.value === 2
     ) {
@@ -4119,9 +4119,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       case StatusEffect.FREEZE:
         if (
           this.isOfType(ElementalType.ICE)
-          || (!ignoreField
-            && globalScene?.arena?.weather?.weatherType
-            && [WeatherType.SUNNY, WeatherType.HARSH_SUN].includes(globalScene.arena.weather.weatherType))
+          || (!ignoreField && globalScene.arena.hasWeather([WeatherType.SUNNY, WeatherType.HARSH_SUN]))
         ) {
           return false;
         }

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -615,7 +615,7 @@ export class MovePhase extends BattlePhase {
       let failureMessage = move.getFailedText(this.pokemon, targets[0], move, new BooleanHolder(false));
 
       if (failedDueToWeather) {
-        if (globalScene.arena.weather?.weatherType === WeatherType.HARSH_SUN) {
+        if (globalScene.arena.hasWeather(WeatherType.HARSH_SUN)) {
           failureMessage = i18next.t("weather:harshSunStopAttackMessage");
         } else {
           failureMessage = i18next.t("weather:heavyRainStopAttackMessage");
@@ -625,7 +625,7 @@ export class MovePhase extends BattlePhase {
       if (failureMessage) {
         failedText = failureMessage;
       } else if (failedDueToTerrain) {
-        failedText = getTerrainBlockMessage(targets[0], globalScene.arena.getTerrainType());
+        failedText = getTerrainBlockMessage(targets[0], globalScene.arena.terrainType);
       }
 
       this.showFailedText(failedText);

--- a/src/phases/turn-end-phase.ts
+++ b/src/phases/turn-end-phase.ts
@@ -29,7 +29,7 @@ export class TurnEndPhase extends FieldPhase {
 
         globalScene.applyModifiers(TurnHealModifier, pokemon.isPlayer(), pokemon);
 
-        if (terrain?.terrainType === TerrainType.GRASSY && pokemon.isGrounded()) {
+        if (arena.hasTerrain(TerrainType.GRASSY) && pokemon.isGrounded()) {
           globalScene.phaseManager.createAndUnshiftPhase(
             "PokemonHealPhase",
             pokemon.getBattlerIndex(),
@@ -40,7 +40,7 @@ export class TurnEndPhase extends FieldPhase {
           );
         }
         applyAbAttrs<PostTurnAbAttr>(AbAttrFlag.POST_TURN, pokemon, false);
-        // TODO: Temporary workaround so that bad dreams doesn't hurt Pokemon waking up in the same turn. Has to be fixed with #1211
+        // TODO: Temporary workaround so that bad dreams doesn't hurt Pokemon waking up in the same turn. cf https://github.com/Despair-Games/poketernity/issues/1211
         applyAbAttrs<PostTurnAbAttr>(AbAttrFlag.BAD_DREAMS, pokemon, false);
       }
 
@@ -53,6 +53,7 @@ export class TurnEndPhase extends FieldPhase {
 
     arena.lapseTags();
 
+    // TODO: is this `if` necessary?
     if (terrain && !terrain.lapse()) {
       arena.trySetTerrain(TerrainType.NONE, false);
     }

--- a/src/phases/weather-effect-phase.ts
+++ b/src/phases/weather-effect-phase.ts
@@ -73,7 +73,7 @@ export class WeatherEffectPhase extends FieldPhase {
 
     this.executeForAll((pokemon: Pokemon) => {
       if (!pokemon.switchOutStatus) {
-        applyAbAttrs<PostWeatherLapseAbAttr>(AbAttrFlag.POST_WEATHER_LAPSE, pokemon, false, weather);
+        applyAbAttrs<PostWeatherLapseAbAttr>(AbAttrFlag.POST_WEATHER_LAPSE, pokemon, false);
       }
     });
   }

--- a/src/pipelines/field-sprite.ts
+++ b/src/pipelines/field-sprite.ts
@@ -1,6 +1,5 @@
 import { globalScene } from "#app/global-scene";
 import { getTerrainColor } from "#data/terrain";
-import { TerrainType } from "#enums/terrain-type";
 import { getCurrentTime } from "#utils/common-utils";
 
 const spriteFragShader = `
@@ -255,7 +254,7 @@ export class FieldSpritePipeline extends Phaser.Renderer.WebGL.Pipelines.MultiPi
     );
     this.set3fv(
       "terrainColor",
-      getTerrainColor(globalScene.arena.terrain?.terrainType || TerrainType.NONE).map((c) => c / 255),
+      getTerrainColor(globalScene.arena.terrainType).map((c) => c / 255),
     );
     this.set1f("terrainColorRatio", terrainColorRatio);
   }

--- a/test/abilities/sand-spit.test.ts
+++ b/test/abilities/sand-spit.test.ts
@@ -37,7 +37,7 @@ describe("Abilities - Sand Spit", () => {
     game.move.select(MoveId.TACKLE);
     await game.toNextTurn();
 
-    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SANDSTORM);
+    expect(game).toHaveWeather(WeatherType.SANDSTORM);
   });
 
   it("should trigger when KO'd", async () => {
@@ -47,7 +47,7 @@ describe("Abilities - Sand Spit", () => {
     game.move.select(MoveId.WATERFALL);
     await game.phaseInterceptor.to("FaintPhase");
 
-    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SANDSTORM);
+    expect(game).toHaveWeather(WeatherType.SANDSTORM);
   });
 
   it("should not trigger when targetted with status moves", async () => {
@@ -55,6 +55,6 @@ describe("Abilities - Sand Spit", () => {
     game.move.select(MoveId.GROWL);
     await game.toNextTurn();
 
-    expect(game.scene.arena.weather).toBeUndefined();
+    expect(game).toHaveWeather(WeatherType.NONE);
   });
 });

--- a/test/arena/strong-winds.test.ts
+++ b/test/arena/strong-winds.test.ts
@@ -3,6 +3,7 @@ import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
+import { WeatherType } from "#enums/weather-type";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -87,6 +88,6 @@ describe("Weather - Strong Winds", () => {
     game.move.select(MoveId.SPLASH);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.weather?.weatherType).toBeUndefined();
+    expect(game).toHaveWeather(WeatherType.NONE);
   });
 });

--- a/test/moves/chilly-reception.test.ts
+++ b/test/moves/chilly-reception.test.ts
@@ -36,7 +36,7 @@ describe("Moves - Chilly Reception", () => {
     game.move.use(MoveId.CHILLY_RECEPTION);
 
     await game.toEndOfTurn();
-    expect(game.scene.arena.weather?.weatherType).toBe(WeatherType.SNOW);
+    expect(game).toHaveWeather(WeatherType.SNOW);
   });
 
   it("should switch out even if it's snowing", async () => {

--- a/test/moves/grassy-glide.test.ts
+++ b/test/moves/grassy-glide.test.ts
@@ -42,7 +42,7 @@ describe("Moves - Grassy Glide", () => {
     game.move.use(MoveId.GRASSY_GLIDE);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTerrainType()).toEqual(TerrainType.GRASSY);
+    expect(game.scene.arena.terrainType).toEqual(TerrainType.GRASSY);
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
   });
@@ -59,7 +59,7 @@ describe("Moves - Grassy Glide", () => {
     game.move.use(MoveId.GRASSY_GLIDE);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTerrainType()).toEqual(terrainType);
+    expect(game.scene.arena.terrainType).toEqual(terrainType);
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
   });
@@ -71,7 +71,7 @@ describe("Moves - Grassy Glide", () => {
     game.move.use(MoveId.GRASSY_GLIDE);
     await game.toEndOfTurn();
 
-    expect(game.scene.arena.getTerrainType()).toEqual(TerrainType.GRASSY);
+    expect(game.scene.arena.terrainType).toEqual(TerrainType.GRASSY);
     expect(game.field.getSpeedOrder()).toEqual([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
     expect(game.field.getTurnOrder()).toEqual(game.field.getSpeedOrder());
   });

--- a/test/test-utils/matchers/to-have-terrain-matcher.ts
+++ b/test/test-utils/matchers/to-have-terrain-matcher.ts
@@ -1,6 +1,5 @@
 import { TerrainType } from "#enums/terrain-type";
 import { isGameManagerInstance, receivedStr } from "#test/test-utils/test-utils";
-import { isNil } from "#utils/common-utils";
 import { capitalizeString } from "#utils/string-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
@@ -31,7 +30,7 @@ export function toHaveTerrainMatcher(
 
   const pass = received.scene.arena.hasTerrain(expectedTerrainType);
   const terrainStr = toTerrainStr(expectedTerrainType);
-  const actualTerrainStr = toTerrainStr(received.scene.arena.terrain?.terrainType);
+  const actualTerrainStr = toTerrainStr(received.scene.arena.terrainType);
 
   return {
     pass,
@@ -49,10 +48,7 @@ export function toHaveTerrainMatcher(
  * @param terrainType - The {@linkcode TerrainType} to transform
  * @returns A human readable string
  */
-function toTerrainStr(terrainType?: TerrainType) {
-  if (isNil(terrainType)) {
-    return "undefined";
-  }
+function toTerrainStr(terrainType: TerrainType) {
   return capitalizeString(TerrainType[terrainType], "_", false, true);
 }
 

--- a/test/test-utils/matchers/to-have-weather-matcher.ts
+++ b/test/test-utils/matchers/to-have-weather-matcher.ts
@@ -1,6 +1,5 @@
 import { WeatherType } from "#enums/weather-type";
 import { isGameManagerInstance, receivedStr } from "#test/test-utils/test-utils";
-import { isNil } from "#utils/common-utils";
 import { capitalizeString } from "#utils/string-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
@@ -32,7 +31,7 @@ export function toHaveWeatherMatcher(
   const pass = received.scene.arena.hasWeather(expectedWeatherType);
 
   const weatherStr = toWeatherStr(expectedWeatherType);
-  const actualWeatherStr = toWeatherStr(received.scene.arena.weather?.weatherType);
+  const actualWeatherStr = toWeatherStr(received.scene.arena.weatherType);
 
   return {
     pass,
@@ -50,10 +49,7 @@ export function toHaveWeatherMatcher(
  * @param weatherType - The {@linkcode WeatherType} to transform
  * @returns A human readable string
  */
-function toWeatherStr(weatherType?: WeatherType) {
-  if (isNil(weatherType)) {
-    return "undefined";
-  }
+function toWeatherStr(weatherType: WeatherType) {
   return capitalizeString(WeatherType[weatherType], "_", false, true);
 }
 


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Simplify code.

## What are the changes from a developer perspective?
- Added missing getter for the current weather to `Arena`.
- Replaced `Arena#getTerrainType` method with getter `Arena#terrainType`.
- Updated a few instances where `Arena#hasWeather`, `Arena#hasTerrain` and `Arena#terrainType` should have been used.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?