### PR TITLE
ai-rework: Add Effect Scores for type-modifying moves

### DIFF
--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -67,7 +67,6 @@ import { BypassSleepAttr } from "#moves/bypass-sleep-attr";
 import { CaptivateAttr } from "#moves/captivate-attr";
 import { CenterOfAttentionAttr } from "#moves/center-of-attention-attr";
 import { ChangeTerrainAttr } from "#moves/change-terrain-attr";
-import { ChangeTypeAttr } from "#moves/change-type-attr";
 import { ChangeWeatherAttr } from "#moves/change-weather-attr";
 import { ChargedAttr } from "#moves/charged-attr";
 import { ChargingAttackMove } from "#moves/charging-attack-move";
@@ -244,6 +243,7 @@ import { SandHealAttr } from "#moves/sand-heal-attr";
 import { ScreenAttr } from "#moves/screen-attr";
 import { SecretPowerAttr } from "#moves/secret-power-attr";
 import { SemiInvulnerableAttr } from "#moves/semi-invulnerable-attr";
+import { SetTypeAttr } from "#moves/set-type-attr";
 import { SheerColdAccuracyAttr } from "#moves/sheer-cold-accuracy-attr";
 import { ShellSideArmCategoryAttr } from "#moves/shell-side-arm-category-attr";
 import { ShellTrapCondition } from "#moves/shell-trap-condition";
@@ -1940,7 +1940,7 @@ export function initMoves() {
       .attr(ElectroBallPowerAttr)
       .bulletMove(),
     new StatusMove(MoveId.SOAK, ElementalType.WATER, 100, 20, -1, 0, 5) //
-      .attr(ChangeTypeAttr, ElementalType.WATER)
+      .attr(SetTypeAttr, ElementalType.WATER)
       .bounceable(),
     new AttackMove(MoveId.FLAME_CHARGE, ElementalType.FIRE, MoveCategory.PHYSICAL, 50, 100, 20, 100, 0, 5) //
       .attr(StatStageChangeAttr, [Stat.SPD], 1, true),
@@ -2838,7 +2838,7 @@ export function initMoves() {
       .attr(TarShotAttr)
       .bounceable(),
     new StatusMove(MoveId.MAGIC_POWDER, ElementalType.PSYCHIC, 100, 20, -1, 0, 8) //
-      .attr(ChangeTypeAttr, ElementalType.PSYCHIC)
+      .attr(SetTypeAttr, ElementalType.PSYCHIC)
       .powderMove()
       .bounceable(),
     new AttackMove(MoveId.DRAGON_DARTS, ElementalType.DRAGON, MoveCategory.PHYSICAL, 50, 100, 10, -1, 0, 8) //

--- a/src/data/moves/move-attrs/add-type-attr.ts
+++ b/src/data/moves/move-attrs/add-type-attr.ts
@@ -1,6 +1,13 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { ALLY_TARGET_PENALTY } from "#constants/ai-constants";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { MINOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
+import { getTypeDamageMultiplier } from "#data/type";
 import { ElementalType } from "#enums/elemental-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -41,5 +48,51 @@ export class AddTypeAttr extends MoveEffectAttr {
 
   override getCondition(): MoveConditionFunc {
     return (_user, target, _move) => !target.isTerastallized && !target.getTypes().includes(this.type);
+  }
+
+  /**
+   * @returns The inverse {@link getTypeChangeScore | score} for adding this effect's type
+   * to the given target.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    return -this.getTypeChangeScore(user, target);
+  }
+
+  /**
+   * @returns A {@link getTypeChangeScore | score} for adding this effect's type to the given target.
+   * If this score is negative, this defers to the {@linkcode ALLY_TARGET_PENALTY} instead
+   */
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, _move: Move): number | null {
+    const typeChangeScore = this.getTypeChangeScore(user, target);
+    return typeChangeScore >= 0 ? typeChangeScore : null;
+  }
+
+  /**
+   * Calculates a score to estimate how much the target would benefit from
+   * gaining this effect's type. A target is perceived to benefit from this effect if
+   * - The added type reduces the effectiveness of all known attacks from the target's opponents.
+   * - The user is faster than all of its active opponents.
+   *
+   * Conversely, this effect is perceived as a drawback if the added type increases the effectiveness
+   * of at least one attack from the target's opponent(s).
+   * @param user - The {@linkcode EnemyPokemon} evaluating this effect
+   * @param target - The {@linkcode Pokemon} this effect is evaluated against
+   * @returns An integer score representing how much this effect benefits the target
+   */
+  private getTypeChangeScore(user: EnemyPokemon, target: Pokemon): number {
+    const oppMoveTypes = new Set(
+      target.getOpponents().flatMap((opp) => {
+        const attackMoves = opp.isOpponent(user) ? opp.estimateAttackMoves() : opp.getAttackMoves(true);
+        return attackMoves.map((mv) => opp.getMoveType(mv));
+      }),
+    );
+
+    const modDamageMultiplier = Math.max(...[...oppMoveTypes].map((t) => getTypeDamageMultiplier(t, this.type)));
+    if (modDamageMultiplier >= 1) {
+      return modDamageMultiplier > 1 ? MINOR_EFFECT_SCORE_PENALTY : 0;
+    }
+
+    const userOutspeeds = user.getOpponents().every((opp) => user.outspeeds(opp, true));
+    return userOutspeeds ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/add-type-attr.ts
+++ b/src/data/moves/move-attrs/add-type-attr.ts
@@ -88,11 +88,17 @@ export class AddTypeAttr extends MoveEffectAttr {
     );
 
     const modDamageMultiplier = Math.max(...[...oppMoveTypes].map((t) => getTypeDamageMultiplier(t, this.type)));
-    if (modDamageMultiplier >= 1) {
-      return modDamageMultiplier > 1 ? MINOR_EFFECT_SCORE_PENALTY : 0;
+    if (modDamageMultiplier > 1) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+    if (modDamageMultiplier === 1) {
+      return 0;
+    }
+    if (!globalScene.currentBattle.double) {
+      return MINOR_EFFECT_SCORE_BONUS;
     }
 
     const userOutspeeds = user.getOpponents().every((opp) => user.outspeeds(opp, true));
-    return userOutspeeds || !globalScene.currentBattle.double ? MINOR_EFFECT_SCORE_BONUS : 0;
+    return userOutspeeds ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/add-type-attr.ts
+++ b/src/data/moves/move-attrs/add-type-attr.ts
@@ -93,6 +93,6 @@ export class AddTypeAttr extends MoveEffectAttr {
     }
 
     const userOutspeeds = user.getOpponents().every((opp) => user.outspeeds(opp, true));
-    return userOutspeeds ? MINOR_EFFECT_SCORE_BONUS : 0;
+    return userOutspeeds || !globalScene.currentBattle.double ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/change-type-attr.ts
+++ b/src/data/moves/move-attrs/change-type-attr.ts
@@ -85,7 +85,6 @@ export abstract class ChangeTypeAttr extends MoveEffectAttr {
    * all of the following conditions are met:
    * - The target's defensive typing against active opponents is improved by the type change
    * - The user outspeeds all active opponents
-   * - The target has an attack that gains STAB from the type change
    *
    * Conversely, this effect is penalized if the target's defensive typing is weakened by the type change.
    * @param user - The {@linkcode EnemyPokemon} evaluating this effect
@@ -111,14 +110,7 @@ export abstract class ChangeTypeAttr extends MoveEffectAttr {
       return avgModDefEffectiveness > avgDefEffectiveness ? MINOR_EFFECT_SCORE_PENALTY : 0;
     }
 
-    const outspeeds = opponents.every((opp) => user.outspeeds(opp, opp.isOpponent(user)));
-    if (!outspeeds) {
-      return 0;
-    }
-
-    const targetMoves = target.isAlly(user) ? target.getAttackMoves(true) : target.estimateAttackMoves();
-    const targetHasModifiedStab = targetMoves.some((move) => target.getMoveType(move) === modifiedType);
-
-    return targetHasModifiedStab ? MINOR_EFFECT_SCORE_BONUS : 0;
+    const outspeeds = user.getOpponents().every((opp) => user.outspeeds(opp, opp.isOpponent(user)));
+    return outspeeds ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/change-type-attr.ts
+++ b/src/data/moves/move-attrs/change-type-attr.ts
@@ -1,7 +1,14 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { ALLY_TARGET_PENALTY } from "#constants/ai-constants";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { MINOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
+import { getTypeDamageMultiplier } from "#data/type";
 import { AbilityId } from "#enums/ability-id";
 import { ElementalType } from "#enums/elemental-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -15,9 +22,9 @@ import i18next from "i18next";
  * @abstract
  */
 export abstract class ChangeTypeAttr extends MoveEffectAttr {
-  public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+  public override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
     const pokemon = this.selfTarget ? user : target;
-    const targetType = this.getType(user, target, move);
+    const targetType = this.getType(user, target);
 
     pokemon.setTemporaryTypes(targetType);
     pokemon.updateInfo();
@@ -33,7 +40,12 @@ export abstract class ChangeTypeAttr extends MoveEffectAttr {
     return true;
   }
 
-  protected abstract getType(_user: Pokemon, _target: Pokemon, _move: Move): ElementalType;
+  /**
+   * @param user - The {@linkcode Pokemon} using the move
+   * @param target - The {@linkcode Pokemon} targeted by the move
+   * @returns The {@linkcode ElementalType} this effect's target is temporarily set to
+   */
+  protected abstract getType(_user: Pokemon, _target: Pokemon): ElementalType;
 
   /**
    * All moves that change type fail if the effect's target
@@ -48,5 +60,65 @@ export abstract class ChangeTypeAttr extends MoveEffectAttr {
         && !pokemon.hasAbility(AbilityId.RKS_SYSTEM)
       );
     };
+  }
+
+  /**
+   * @returns A {@link getTypeChangeScore | score} based on how much the type change benefits this effect's
+   * target. This score is inverted if the target is an opponent to the user.
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    return this.selfTarget ? this.getTypeChangeScore(user, user) : -this.getTypeChangeScore(user, target);
+  }
+
+  /**
+   * @returns A {@link getTypeChangeScore | score} based on how much the type change benefits the target.
+   * If the target is determined to be negatively affected, this defers to the {@linkcode ALLY_TARGET_PENALTY}
+   */
+  public override getAllyTargetScore(user: EnemyPokemon, target: EnemyPokemon, _move: Move): number | null {
+    const typeChangeScore = this.getTypeChangeScore(user, target);
+    return typeChangeScore >= 0 ? typeChangeScore : null;
+  }
+
+  /**
+   * Calculates a score to estimate how much the given target benefits from
+   * this effect changing its type. A target is perceived to benefit from this effect if
+   * all of the following conditions are met:
+   * - The target's defensive typing against active opponents is improved by the type change
+   * - The user outspeeds all active opponents
+   * - The target has an attack that gains STAB from the type change
+   *
+   * Conversely, this effect is penalized if the target's defensive typing is not improved by the type change.
+   * @param user - The {@linkcode EnemyPokemon} evaluating this effect
+   * @param target - The {@linkcode Pokemon} this effect is evaluated against
+   * @returns An integer score reflecting how much the target benefits from the effect
+   */
+  private getTypeChangeScore(user: EnemyPokemon, target: Pokemon): number {
+    const opponents = target.getOpponents();
+    const modifiedType = this.getType(user, target);
+
+    // Current effectiveness is based on the most effective of each opponent's types (including Tera) against the target
+    const defEffectiveness = opponents.map((opp) =>
+      Math.max(...opp.getTypes(true).map((t) => target.getAttackTypeEffectiveness(t, undefined, false, true))),
+    );
+    const modDefEffectiveness = opponents.map((opp) =>
+      Math.max(...opp.getTypes(true).map((t) => getTypeDamageMultiplier(t, modifiedType))),
+    );
+
+    const avgDefEffectiveness = defEffectiveness.reduce((total, de) => total + de) / defEffectiveness.length;
+    const avgModDefEffectiveness = modDefEffectiveness.reduce((total, de) => total + de) / modDefEffectiveness.length;
+
+    if (avgDefEffectiveness === 0 || avgModDefEffectiveness / avgDefEffectiveness >= 1) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+
+    const outspeeds = opponents.every((opp) => user.outspeeds(opp, opp.isOpponent(user)));
+    if (!outspeeds) {
+      return 0;
+    }
+
+    const targetMoves = target.isAlly(user) ? target.getAttackMoves(true) : target.estimateAttackMoves();
+    const targetHasModifiedStab = targetMoves.some((move) => target.getMoveType(move) === modifiedType);
+
+    return targetHasModifiedStab ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/change-type-attr.ts
+++ b/src/data/moves/move-attrs/change-type-attr.ts
@@ -87,7 +87,7 @@ export abstract class ChangeTypeAttr extends MoveEffectAttr {
    * - The user outspeeds all active opponents
    * - The target has an attack that gains STAB from the type change
    *
-   * Conversely, this effect is penalized if the target's defensive typing is not improved by the type change.
+   * Conversely, this effect is penalized if the target's defensive typing is weakened by the type change.
    * @param user - The {@linkcode EnemyPokemon} evaluating this effect
    * @param target - The {@linkcode Pokemon} this effect is evaluated against
    * @returns An integer score reflecting how much the target benefits from the effect
@@ -108,7 +108,7 @@ export abstract class ChangeTypeAttr extends MoveEffectAttr {
     const avgModDefEffectiveness = modDefEffectiveness.reduce((total, de) => total + de) / modDefEffectiveness.length;
 
     if (avgModDefEffectiveness >= avgDefEffectiveness) {
-      return MINOR_EFFECT_SCORE_PENALTY;
+      return avgModDefEffectiveness > avgDefEffectiveness ? MINOR_EFFECT_SCORE_PENALTY : 0;
     }
 
     const outspeeds = opponents.every((opp) => user.outspeeds(opp, opp.isOpponent(user)));

--- a/src/data/moves/move-attrs/change-type-attr.ts
+++ b/src/data/moves/move-attrs/change-type-attr.ts
@@ -107,7 +107,7 @@ export abstract class ChangeTypeAttr extends MoveEffectAttr {
     const avgDefEffectiveness = defEffectiveness.reduce((total, de) => total + de) / defEffectiveness.length;
     const avgModDefEffectiveness = modDefEffectiveness.reduce((total, de) => total + de) / modDefEffectiveness.length;
 
-    if (avgDefEffectiveness === 0 || avgModDefEffectiveness / avgDefEffectiveness >= 1) {
+    if (avgModDefEffectiveness >= avgDefEffectiveness) {
       return MINOR_EFFECT_SCORE_PENALTY;
     }
 

--- a/src/data/moves/move-attrs/change-type-attr.ts
+++ b/src/data/moves/move-attrs/change-type-attr.ts
@@ -10,39 +10,43 @@ import { enumValueToKey } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
- * Attribute to change the target's type to a set type.
- * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Soak_(move) | Soak}
- * and {@link https://bulbapedia.bulbagarden.net/wiki/Magic_Powder_(move) | Magic Powder}.
+ * Abstract attribute to change a Pokemon's type to a single type.
+ * This effect may apply to the move's user or target.
+ * @abstract
  */
-export class ChangeTypeAttr extends MoveEffectAttr {
-  private readonly type: ElementalType;
+export abstract class ChangeTypeAttr extends MoveEffectAttr {
+  public override applyEffect(user: Pokemon, target: Pokemon, move: Move): boolean {
+    const pokemon = this.selfTarget ? user : target;
+    const targetType = this.getType(user, target, move);
 
-  constructor(type: ElementalType) {
-    super(false);
-
-    this.type = type;
-  }
-
-  override applyEffect(_user: Pokemon, target: Pokemon, _move: Move): boolean {
-    target.setTemporaryTypes(this.type);
-    target.updateInfo();
+    pokemon.setTemporaryTypes(targetType);
+    pokemon.updateInfo();
 
     globalScene.phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t("moveTriggers:transformedIntoType", {
-        pokemonName: getPokemonNameWithAffix(target),
-        typeName: i18next.t(`pokemonInfo:Type.${enumValueToKey(ElementalType, this.type)}`),
+        pokemonName: getPokemonNameWithAffix(pokemon),
+        typeName: i18next.t(`pokemonInfo:Type.${enumValueToKey(ElementalType, targetType)}`),
       }),
     );
 
     return true;
   }
 
-  override getCondition(): MoveConditionFunc {
-    return (_user, target, _move) =>
-      !target.isTerastallized
-      && !target.hasAbility(AbilityId.MULTITYPE)
-      && !target.hasAbility(AbilityId.RKS_SYSTEM)
-      && !(target.getTypes().length === 1 && target.getTypes()[0] === this.type);
+  protected abstract getType(_user: Pokemon, _target: Pokemon, _move: Move): ElementalType;
+
+  /**
+   * All moves that change type fail if the effect's target
+   * is Terastallized or has Multitype or RKS System as an ability
+   */
+  public override getCondition(): MoveConditionFunc {
+    return (user, target, _move) => {
+      const pokemon = this.selfTarget ? user : target;
+      return (
+        !pokemon.isTerastallized
+        && !pokemon.hasAbility(AbilityId.MULTITYPE)
+        && !pokemon.hasAbility(AbilityId.RKS_SYSTEM)
+      );
+    };
   }
 }

--- a/src/data/moves/move-attrs/copy-biome-type-attr.ts
+++ b/src/data/moves/move-attrs/copy-biome-type-attr.ts
@@ -1,45 +1,25 @@
 import { globalScene } from "#app/global-scene";
-import { getPokemonNameWithAffix } from "#app/messages";
 import { BiomeId } from "#enums/biome-id";
 import { ElementalType } from "#enums/elemental-type";
 import { TerrainType } from "#enums/terrain-type";
 import type { Pokemon } from "#field/pokemon";
-import type { Move } from "#moves/move";
-import { MoveEffectAttr } from "#moves/move-effect-attr";
-import { enumValueToKey } from "#utils/common-utils";
-import i18next from "i18next";
+import { ChangeTypeAttr } from "#moves/change-type-attr";
 
 /**
  * Attribute to change the user's type based on the current biome.
  * If terrain is active, the user's type is changed to match the terrain instead.
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Camouflage_(move) | Camouflage}.
  */
-export class CopyBiomeTypeAttr extends MoveEffectAttr {
+export class CopyBiomeTypeAttr extends ChangeTypeAttr {
   constructor() {
     super(true);
   }
 
-  override applyEffect(user: Pokemon, _target: Pokemon, _move: Move): boolean {
+  protected override getType(_user: Pokemon, _target: Pokemon): ElementalType {
     const terrainType = globalScene.arena.terrainType;
-    let typeChange: ElementalType;
-    if (terrainType !== TerrainType.NONE) {
-      typeChange = this.getTypeForTerrain(globalScene.arena.terrainType);
-    } else {
-      typeChange = this.getTypeForBiome(globalScene.arena.biomeId);
-    }
-
-    user.setTemporaryTypes(typeChange);
-    user.updateInfo();
-
-    globalScene.phaseManager.createAndUnshiftPhase(
-      "MessagePhase",
-      i18next.t("moveTriggers:transformedIntoType", {
-        pokemonName: getPokemonNameWithAffix(user),
-        typeName: i18next.t(`pokemonInfo:Type.${enumValueToKey(ElementalType, typeChange)}`),
-      }),
-    );
-
-    return true;
+    return terrainType !== TerrainType.NONE
+      ? this.getTypeForTerrain(terrainType)
+      : this.getTypeForBiome(globalScene.arena.biomeId);
   }
 
   /**

--- a/src/data/moves/move-attrs/copy-type-attr.ts
+++ b/src/data/moves/move-attrs/copy-type-attr.ts
@@ -71,12 +71,6 @@ export class CopyTypeAttr extends MoveEffectAttr {
     }
 
     const userOutspeeds = opponents.every((opp) => user.outspeeds(opp, true));
-    if (!userOutspeeds) {
-      return 0;
-    }
-
-    const targetTypes = target.getTypes(true, true);
-    const userHasModifiedStab = user.getAttackMoves(true).some((mv) => targetTypes.includes(user.getMoveType(mv)));
-    return userHasModifiedStab ? MINOR_EFFECT_SCORE_BONUS : 0;
+    return userOutspeeds ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/copy-type-attr.ts
+++ b/src/data/moves/move-attrs/copy-type-attr.ts
@@ -1,6 +1,12 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { ChangeTypeAttr } from "#moves/change-type-attr";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import { MINOR_EFFECT_SCORE_BONUS, MINOR_EFFECT_SCORE_PENALTY } from "#constants/ai-constants";
 import { ElementalType } from "#enums/elemental-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
@@ -16,8 +22,8 @@ export class CopyTypeAttr extends MoveEffectAttr {
     super(false);
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
-    const targetTypes = target.getTypes(true);
+  public override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
+    const targetTypes = target.getTypes(true, true);
     if (targetTypes.includes(ElementalType.UNKNOWN) && targetTypes.indexOf(ElementalType.UNKNOWN) > -1) {
       targetTypes[targetTypes.indexOf(ElementalType.UNKNOWN)] = ElementalType.NORMAL;
     }
@@ -40,8 +46,37 @@ export class CopyTypeAttr extends MoveEffectAttr {
    * - The target is {@linkcode ElementalType.UNKNOWN | typeless}
    * - The target has an added type (e.g. from Forest's Curse).
    */
-  override getCondition(): MoveConditionFunc {
+  public override getCondition(): MoveConditionFunc {
     return (_user, target, _move) =>
       target.getTypes()[0] !== ElementalType.UNKNOWN || target.summonData.addedType !== null;
+  }
+
+  /**
+   * @returns An Effect Score modifier depending on how much the user benefits from this effect's type change.
+   * @see {@linkcode ChangeTypeAttr.getTypeChangeScore}
+   */
+  public override getEffectScore(user: EnemyPokemon, target: Pokemon, _move: Move): number {
+    const opponents = user.getOpponents();
+    const defEffectiveness = opponents.map((opp) =>
+      Math.max(...opp.getTypes(true).map((t) => user.getAttackTypeEffectiveness(t, undefined, false, true))),
+    );
+    const modDefEffectiveness = opponents.map((opp) =>
+      Math.max(...opp.getTypes(true).map((t) => target.getAttackTypeEffectiveness(t, undefined, false, true))),
+    );
+    const avgDefEffectiveness = defEffectiveness.reduce((total, eff) => total + eff) / defEffectiveness.length;
+    const avgModDefEffectiveness = modDefEffectiveness.reduce((total, eff) => total + eff) / modDefEffectiveness.length;
+
+    if (avgModDefEffectiveness >= avgDefEffectiveness) {
+      return MINOR_EFFECT_SCORE_PENALTY;
+    }
+
+    const userOutspeeds = opponents.every((opp) => user.outspeeds(opp, true));
+    if (!userOutspeeds) {
+      return 0;
+    }
+
+    const targetTypes = target.getTypes(true, true);
+    const userHasModifiedStab = user.getAttackMoves(true).some((mv) => targetTypes.includes(user.getMoveType(mv)));
+    return userHasModifiedStab ? MINOR_EFFECT_SCORE_BONUS : 0;
   }
 }

--- a/src/data/moves/move-attrs/first-move-type-attr.ts
+++ b/src/data/moves/move-attrs/first-move-type-attr.ts
@@ -1,32 +1,24 @@
-import { globalScene } from "#app/global-scene";
-import { getPokemonNameWithAffix } from "#app/messages";
-import { ElementalType } from "#enums/elemental-type";
+import type { ElementalType } from "#enums/elemental-type";
 import type { Pokemon } from "#field/pokemon";
+import { ChangeTypeAttr } from "#moves/change-type-attr";
 import type { Move } from "#moves/move";
-import { MoveEffectAttr } from "#moves/move-effect-attr";
-import { enumValueToKey } from "#utils/common-utils";
-import i18next from "i18next";
+import type { MoveConditionFunc } from "#types/move-types";
 
 /**
  * Attribute to change the user's type to match that of the first move in its moveset.
  * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Conversion_(move) | Conversion}.
  */
-export class FirstMoveTypeAttr extends MoveEffectAttr {
+export class FirstMoveTypeAttr extends ChangeTypeAttr {
   constructor() {
     super(true);
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
-    const firstMoveType = target.getMoveset()[0].getMove().type;
-    user.setTemporaryTypes(firstMoveType);
-    globalScene.phaseManager.createAndUnshiftPhase(
-      "MessagePhase",
-      i18next.t("battle:transformedIntoType", {
-        pokemonName: getPokemonNameWithAffix(user),
-        type: i18next.t(`pokemonInfo:Type.${enumValueToKey(ElementalType, firstMoveType)}`),
-      }),
-    );
+  protected override getType(user: Pokemon, _target: Pokemon, _move: Move): ElementalType {
+    return user.getMoveset()[0].getMove().type;
+  }
 
-    return true;
+  public override getCondition(): MoveConditionFunc {
+    return (user, target, move) =>
+      super.getCondition()(user, target, move) && target.getTypes().some((t) => t !== this.getType(user, target, move));
   }
 }

--- a/src/data/moves/move-attrs/first-move-type-attr.ts
+++ b/src/data/moves/move-attrs/first-move-type-attr.ts
@@ -1,7 +1,6 @@
 import type { ElementalType } from "#enums/elemental-type";
 import type { Pokemon } from "#field/pokemon";
 import { ChangeTypeAttr } from "#moves/change-type-attr";
-import type { Move } from "#moves/move";
 import type { MoveConditionFunc } from "#types/move-types";
 
 /**
@@ -13,12 +12,12 @@ export class FirstMoveTypeAttr extends ChangeTypeAttr {
     super(true);
   }
 
-  protected override getType(user: Pokemon, _target: Pokemon, _move: Move): ElementalType {
+  protected override getType(user: Pokemon, _target: Pokemon): ElementalType {
     return user.getMoveset()[0].getMove().type;
   }
 
   public override getCondition(): MoveConditionFunc {
     return (user, target, move) =>
-      super.getCondition()(user, target, move) && target.getTypes().some((t) => t !== this.getType(user, target, move));
+      super.getCondition()(user, target, move) && target.getTypes().some((t) => t !== this.getType(user, target));
   }
 }

--- a/src/data/moves/move-attrs/resist-last-move-type-attr.ts
+++ b/src/data/moves/move-attrs/resist-last-move-type-attr.ts
@@ -9,7 +9,7 @@ import { ChangeTypeAttr } from "#moves/change-type-attr";
 import type { Move } from "#moves/move";
 import type { MoveConditionFunc } from "#types/move-types";
 import { applyChallenges } from "#utils/challenge-utils";
-import { isNil, ValueHolder } from "#utils/common-utils";
+import { ValueHolder } from "#utils/common-utils";
 import { randSeedItem } from "#utils/random-utils";
 
 /**
@@ -65,7 +65,7 @@ export class ResistLastMoveTypeAttr extends ChangeTypeAttr {
       }
 
       const [{ type: moveType }] = target.getLastXMoves();
-      if (isNil(moveType) || moveType === ElementalType.STELLAR || moveType === ElementalType.UNKNOWN) {
+      if (moveType == null || moveType === ElementalType.STELLAR || moveType === ElementalType.UNKNOWN) {
         return false;
       }
 

--- a/src/data/moves/move-attrs/resist-last-move-type-attr.ts
+++ b/src/data/moves/move-attrs/resist-last-move-type-attr.ts
@@ -3,6 +3,7 @@ import { globalScene } from "#app/global-scene";
 import { getTypeDamageMultiplier } from "#data/type";
 import { ChallengeType } from "#enums/challenge-type";
 import { ElementalType } from "#enums/elemental-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { ChangeTypeAttr } from "#moves/change-type-attr";
 import type { Move } from "#moves/move";
@@ -22,7 +23,7 @@ export class ResistLastMoveTypeAttr extends ChangeTypeAttr {
     super(true);
   }
 
-  protected override getType(user: Pokemon, target: Pokemon, _move: Move): ElementalType {
+  protected override getType(user: Pokemon, target: Pokemon): ElementalType {
     const [{ type: targetMoveType }] = target.getLastXMoves(1);
     const userTypes = user.getTypes();
     const validTypes = this.getTypeResistances(globalScene.gameMode, targetMoveType).filter(
@@ -73,5 +74,16 @@ export class ResistLastMoveTypeAttr extends ChangeTypeAttr {
       const validTypes = this.getTypeResistances(globalScene.gameMode, moveType).filter((t) => !userTypes.includes(t));
       return validTypes.length > 0;
     };
+  }
+
+  /**
+   * @returns `0`.
+   *
+   * The base scoring for type-changing effects is disabled for Conversion 2 because
+   * the effect's resolved type is random. Under the base logic, the user may become
+   * stuck repeatedly using Conversion 2 in some game states.
+   */
+  public override getEffectScore(_user: EnemyPokemon, _target: Pokemon, _move: Move): number {
+    return 0;
   }
 }

--- a/src/data/moves/move-attrs/resist-last-move-type-attr.ts
+++ b/src/data/moves/move-attrs/resist-last-move-type-attr.ts
@@ -1,16 +1,15 @@
 import type { GameMode } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
-import { getPokemonNameWithAffix } from "#app/messages";
 import { getTypeDamageMultiplier } from "#data/type";
 import { ChallengeType } from "#enums/challenge-type";
 import { ElementalType } from "#enums/elemental-type";
 import type { Pokemon } from "#field/pokemon";
+import { ChangeTypeAttr } from "#moves/change-type-attr";
 import type { Move } from "#moves/move";
-import { MoveEffectAttr } from "#moves/move-effect-attr";
 import type { MoveConditionFunc } from "#types/move-types";
 import { applyChallenges } from "#utils/challenge-utils";
-import { enumValueToKey, NumberHolder } from "#utils/common-utils";
-import i18next from "i18next";
+import { isNil, ValueHolder } from "#utils/common-utils";
+import { randSeedItem } from "#utils/random-utils";
 
 /**
  * Attribute used for Conversion 2, to convert the user's type to a random type that resists the target's last used move.
@@ -18,44 +17,30 @@ import i18next from "i18next";
  * Fails if the opponent has not used a move yet
  * Fails if the type is unknown or stellar
  */
-export class ResistLastMoveTypeAttr extends MoveEffectAttr {
+export class ResistLastMoveTypeAttr extends ChangeTypeAttr {
   constructor() {
     super(true);
   }
 
-  override applyEffect(user: Pokemon, target: Pokemon, _move: Move): boolean {
-    const [targetMove] = target.getLastXMoves(1); // target's most recent move
-    if (!targetMove) {
-      return false;
-    }
-
-    const moveType = targetMove.type;
+  protected override getType(user: Pokemon, target: Pokemon, _move: Move): ElementalType {
+    const [{ type: targetMoveType }] = target.getLastXMoves(1);
     const userTypes = user.getTypes();
-    const validTypes = this.getTypeResistances(globalScene.gameMode, moveType).filter((t) => !userTypes.includes(t));
-
-    const modifiedType = validTypes[user.randSeedInt(validTypes.length)];
-    user.setTemporaryTypes(modifiedType);
-    globalScene.phaseManager.createAndUnshiftPhase(
-      "MessagePhase",
-      i18next.t("battle:transformedIntoType", {
-        pokemonName: getPokemonNameWithAffix(user),
-        type: i18next.t(`pokemonInfo:Type.${enumValueToKey(ElementalType, modifiedType)}`),
-      }),
+    const validTypes = this.getTypeResistances(globalScene.gameMode, targetMoveType).filter(
+      (t) => !userTypes.includes(t),
     );
-    user.updateInfo();
 
-    return true;
+    return randSeedItem(validTypes);
   }
 
   /**
    * Retrieve the types resisting a given type. Used by Conversion 2
    * @returns An array populated with Types, or an empty array if no resistances exist (Unknown or Stellar type)
    */
-  getTypeResistances(gameMode: GameMode, type: ElementalType): ElementalType[] {
+  private getTypeResistances(gameMode: GameMode, type: ElementalType): ElementalType[] {
     const typeResistances: ElementalType[] = [];
 
     for (const elementalType of Object.values(ElementalType)) {
-      const multiplier = new NumberHolder(1);
+      const multiplier = new ValueHolder(1);
       multiplier.value = getTypeDamageMultiplier(type, elementalType);
       applyChallenges(gameMode, ChallengeType.TYPE_EFFECTIVENESS, multiplier);
       if (multiplier.value < 1) {
@@ -72,17 +57,17 @@ export class ResistLastMoveTypeAttr extends MoveEffectAttr {
    * - The target's last move was either typeless or Stellar-type
    * - The user is already of all types that resist the target's last move
    */
-  override getCondition(): MoveConditionFunc {
-    return (user, target, _move) => {
-      const [targetMove] = target.getLastXMoves();
-      if (!targetMove) {
+  public override getCondition(): MoveConditionFunc {
+    return (user, target, move) => {
+      if (!super.getCondition()(user, target, move)) {
         return false;
       }
 
-      const { move: moveData, type: moveType } = targetMove;
-      if (!moveData || moveType === ElementalType.STELLAR || moveType === ElementalType.UNKNOWN) {
+      const [{ type: moveType }] = target.getLastXMoves();
+      if (isNil(moveType) || moveType === ElementalType.STELLAR || moveType === ElementalType.UNKNOWN) {
         return false;
       }
+
       const userTypes = user.getTypes();
       // valid types are ones that are not already the user's types
       const validTypes = this.getTypeResistances(globalScene.gameMode, moveType).filter((t) => !userTypes.includes(t));

--- a/src/data/moves/move-attrs/set-type-attr.ts
+++ b/src/data/moves/move-attrs/set-type-attr.ts
@@ -1,4 +1,5 @@
 import type { ElementalType } from "#enums/elemental-type";
+import type { Pokemon } from "#field/pokemon";
 import { ChangeTypeAttr } from "#moves/change-type-attr";
 import type { MoveConditionFunc } from "#types/move-types";
 
@@ -16,12 +17,12 @@ export class SetTypeAttr extends ChangeTypeAttr {
     this.type = type;
   }
 
-  protected override getType(): ElementalType {
+  protected override getType(_user: Pokemon, _target: Pokemon): ElementalType {
     return this.type;
   }
 
   public override getCondition(): MoveConditionFunc {
     return (user, target, move) =>
-      super.getCondition()(user, target, move) && target.getTypes().some((type) => type !== this.getType());
+      super.getCondition()(user, target, move) && target.getTypes().some((type) => type !== this.getType(user, target));
   }
 }

--- a/src/data/moves/move-attrs/set-type-attr.ts
+++ b/src/data/moves/move-attrs/set-type-attr.ts
@@ -1,0 +1,27 @@
+import type { ElementalType } from "#enums/elemental-type";
+import { ChangeTypeAttr } from "#moves/change-type-attr";
+import type { MoveConditionFunc } from "#types/move-types";
+
+/**
+ * Attribute to change the target's type to a set type.
+ * Used for {@link https://bulbapedia.bulbagarden.net/wiki/Soak_(move) | Soak}
+ * and {@link https://bulbapedia.bulbagarden.net/wiki/Magic_Powder_(move) | Magic Powder}.
+ */
+export class SetTypeAttr extends ChangeTypeAttr {
+  private readonly type: ElementalType;
+
+  constructor(type: ElementalType) {
+    super(false);
+
+    this.type = type;
+  }
+
+  protected override getType(): ElementalType {
+    return this.type;
+  }
+
+  public override getCondition(): MoveConditionFunc {
+    return (user, target, move) =>
+      super.getCondition()(user, target, move) && target.getTypes().some((type) => type !== this.getType());
+  }
+}

--- a/test/ai/move-effect-scores/conversion.test.ts
+++ b/test/ai/move-effect-scores/conversion.test.ts
@@ -1,0 +1,58 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Conversion", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SMART_STRIKE, MoveId.CONVERSION, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user's type matchup would improve", async () => {
+    await game.classicMode.startBattle(SpeciesId.CHIKORITA);
+    game.field.setSpeed(50, 100);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.CONVERSION);
+  });
+
+  it("should be avoided when the user's type matchup would worsen", async () => {
+    await game.classicMode.startBattle(SpeciesId.MAGBY);
+    game.field.setSpeed(50, 100);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.CONVERSION);
+  });
+
+  it("should not be preferred when the user is slower than its opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.CHIKORITA);
+    game.field.setSpeed(100, 50);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.CONVERSION);
+  });
+});

--- a/test/ai/move-effect-scores/forests-curse.test.ts
+++ b/test/ai/move-effect-scores/forests-curse.test.ts
@@ -1,0 +1,52 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Forests Curse", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  const baseMoveset = [MoveId.FORESTS_CURSE, MoveId.SPLASH, MoveId.TACKLE];
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(baseMoveset)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user has a Fire-type move", async () => {
+    game.override.enemyMoveset([MoveId.EMBER, ...baseMoveset]);
+
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.FORESTS_CURSE);
+  });
+
+  it("should not be preferred when the user does not have a Fire-type move", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.FORESTS_CURSE);
+  });
+});

--- a/test/ai/move-effect-scores/forests-curse.test.ts
+++ b/test/ai/move-effect-scores/forests-curse.test.ts
@@ -34,7 +34,7 @@ describe("AI (Move Effect Scores) - Forests Curse", () => {
       .enemyLevel(100);
   });
 
-  it("should be preferred when the user has a Fire-type move", async () => {
+  it("should be preferred when the user has a move that would gain type effectiveness", async () => {
     game.override.enemyMoveset([MoveId.EMBER, ...baseMoveset]);
 
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
@@ -43,7 +43,7 @@ describe("AI (Move Effect Scores) - Forests Curse", () => {
     expect(enemy).toPreferSelectingMove(MoveId.FORESTS_CURSE);
   });
 
-  it("should not be preferred when the user does not have a Fire-type move", async () => {
+  it("should not be preferred when the user does not have a move that would gain type effectiveness", async () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
     const enemy = game.field.getEnemyPokemon();

--- a/test/ai/move-effect-scores/reflect-type.test.ts
+++ b/test/ai/move-effect-scores/reflect-type.test.ts
@@ -1,0 +1,58 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Reflect Type", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.REFLECT_TYPE, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  it("should be preferred when the user's type matchup would improve", async () => {
+    await game.classicMode.startBattle(SpeciesId.CHIKORITA);
+    game.field.setSpeed(50, 100);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toPreferSelectingMove(MoveId.REFLECT_TYPE);
+  });
+
+  it("should be avoided when the user's type matchup would worsen", async () => {
+    await game.classicMode.startBattle(SpeciesId.DUSKULL);
+    game.field.setSpeed(50, 100);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).toNeverSelectMove(MoveId.REFLECT_TYPE);
+  });
+
+  it("should not be preferred when the user is slower than its opponent", async () => {
+    await game.classicMode.startBattle(SpeciesId.CHIKORITA);
+    game.field.setSpeed(100, 50);
+
+    const enemy = game.field.getEnemyPokemon();
+    expect(enemy).not.toPreferSelectingMove(MoveId.REFLECT_TYPE);
+  });
+});

--- a/test/ai/move-effect-scores/sky-drop.test.ts
+++ b/test/ai/move-effect-scores/sky-drop.test.ts
@@ -2,7 +2,6 @@ import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -33,19 +32,12 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
       .enemyLevel(100);
   });
 
-  const setSpeed = (playerSpd: number, enemySpd: number) => {
-    const players = game.scene.getPlayerField();
-    const enemies = game.scene.getEnemyField();
-    players.forEach((p) => p.setStat(Stat.SPD, playerSpd));
-    enemies.forEach((e) => e.setStat(Stat.SPD, enemySpd));
-  };
-
   describe("in Single Battles", () => {
     beforeEach(() => game.override.battleType("single"));
 
     it("should be preferred when the user is faster than the target", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toPreferSelectingMove(MoveId.SKY_DROP);
@@ -53,7 +45,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
 
     it("should be avoided when the user is slower than the target", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-      setSpeed(100, 50);
+      game.field.setSpeed(100, 50);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toNeverSelectMove(MoveId.SKY_DROP);
@@ -61,7 +53,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
 
     it("should be avoided when the opponent is Flying-type", async () => {
       await game.classicMode.startBattle(SpeciesId.WINGULL);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toNeverSelectMove(MoveId.SKY_DROP);
@@ -69,7 +61,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
 
     it("should be avoided when the opponent is too heavy", async () => {
       await game.classicMode.startBattle(SpeciesId.METAGROSS);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toNeverSelectMove(MoveId.SKY_DROP);
@@ -81,7 +73,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
 
     it("should be preferred when the user is faster than its opponents", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).toPreferSelectingMove(MoveId.SKY_DROP);
@@ -89,7 +81,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
 
     it("should be avoided when the user is slower than its opponents", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
-      setSpeed(100, 50);
+      game.field.setSpeed(100, 50);
 
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).toNeverSelectMove(MoveId.SKY_DROP);
@@ -99,7 +91,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
       game.override.enemyAbility(AbilityId.NO_GUARD);
 
       await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).toNeverSelectMove(MoveId.SKY_DROP);
@@ -109,7 +101,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
       game.override.ability(AbilityId.NO_GUARD);
 
       await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const [enemy] = game.scene.getEnemyField();
 
@@ -122,7 +114,7 @@ describe("AI (Move Effect Scores) - Sky Drop", () => {
 
     it("should be avoided when both opponents have used Lock On on the user", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       game.move.use(MoveId.LOCK_ON, 0, BattlerIndex.ENEMY);
       game.move.use(MoveId.LOCK_ON, 1, BattlerIndex.ENEMY);

--- a/test/ai/move-effect-scores/soak.test.ts
+++ b/test/ai/move-effect-scores/soak.test.ts
@@ -1,7 +1,6 @@
 import { AbilityId } from "#enums/ability-id";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { Stat } from "#enums/stat";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -33,18 +32,10 @@ describe("AI (Move Effect Scores) - Soak", () => {
       .enemyLevel(100);
   });
 
-  const setSpeed = (playerSpd: number, enemySpd: number) => {
-    const players = game.scene.getPlayerField();
-    const enemies = game.scene.getEnemyField();
-
-    players.forEach((p) => p.setStat(Stat.SPD, playerSpd));
-    enemies.forEach((p) => p.setStat(Stat.SPD, enemySpd));
-  };
-
   describe("in Single Battles", () => {
     it("should be avoided when the user is Water-type", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGBY);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toNeverSelectMove(MoveId.SOAK);
@@ -54,7 +45,7 @@ describe("AI (Move Effect Scores) - Soak", () => {
       game.override.enemySpecies(SpeciesId.CHIKORITA);
 
       await game.classicMode.startBattle(SpeciesId.MAGBY);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toPreferSelectingMove(MoveId.SOAK);
@@ -64,7 +55,7 @@ describe("AI (Move Effect Scores) - Soak", () => {
       game.override.enemySpecies(SpeciesId.CHIKORITA);
 
       await game.classicMode.startBattle(SpeciesId.MAGBY);
-      setSpeed(100, 50);
+      game.field.setSpeed(100, 50);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toPreferSelectingMove(MoveId.SOAK);
@@ -74,7 +65,7 @@ describe("AI (Move Effect Scores) - Soak", () => {
       game.override.enemySpecies(SpeciesId.CHIKORITA);
 
       await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const enemy = game.field.getEnemyPokemon();
       expect(enemy).toNeverSelectMove(MoveId.SOAK);
@@ -90,7 +81,7 @@ describe("AI (Move Effect Scores) - Soak", () => {
 
     it("should be preferred when an ally's type matchup would improve", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGBY, SpeciesId.SLUGMA);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).toPreferSelectingMove(MoveId.SOAK);
@@ -98,7 +89,7 @@ describe("AI (Move Effect Scores) - Soak", () => {
 
     it("should be avoided when an ally's type matchup would worsen", async () => {
       await game.classicMode.startBattle(SpeciesId.CHIKORITA, SpeciesId.PANSAGE);
-      setSpeed(50, 100);
+      game.field.setSpeed(50, 100);
 
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).toNeverSelectMove(MoveId.SOAK);
@@ -106,7 +97,7 @@ describe("AI (Move Effect Scores) - Soak", () => {
 
     it("should not be preferred when the user is slower than its opponents", async () => {
       await game.classicMode.startBattle(SpeciesId.MAGBY, SpeciesId.SLUGMA);
-      setSpeed(100, 50);
+      game.field.setSpeed(100, 50);
 
       const [enemy] = game.scene.getEnemyField();
       expect(enemy).not.toPreferSelectingMove(MoveId.SOAK);

--- a/test/ai/move-effect-scores/soak.test.ts
+++ b/test/ai/move-effect-scores/soak.test.ts
@@ -1,0 +1,115 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Move Effect Scores) - Soak", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset([MoveId.SOAK, MoveId.SPLASH, MoveId.TACKLE])
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  const setSpeed = (playerSpd: number, enemySpd: number) => {
+    const players = game.scene.getPlayerField();
+    const enemies = game.scene.getEnemyField();
+
+    players.forEach((p) => p.setStat(Stat.SPD, playerSpd));
+    enemies.forEach((p) => p.setStat(Stat.SPD, enemySpd));
+  };
+
+  describe("in Single Battles", () => {
+    it("should be avoided when the user is Water-type", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGBY);
+      setSpeed(50, 100);
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(MoveId.SOAK);
+    });
+
+    it("should be preferred when the user is Grass-type", async () => {
+      game.override.enemySpecies(SpeciesId.CHIKORITA);
+
+      await game.classicMode.startBattle(SpeciesId.MAGBY);
+      setSpeed(50, 100);
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toPreferSelectingMove(MoveId.SOAK);
+    });
+
+    it("should be preferred even if the user is slower than the opponent", async () => {
+      game.override.enemySpecies(SpeciesId.CHIKORITA);
+
+      await game.classicMode.startBattle(SpeciesId.MAGBY);
+      setSpeed(100, 50);
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toPreferSelectingMove(MoveId.SOAK);
+    });
+
+    it("should be avoided when the opponent is already Water-type", async () => {
+      game.override.enemySpecies(SpeciesId.CHIKORITA);
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+      setSpeed(50, 100);
+
+      const enemy = game.field.getEnemyPokemon();
+      expect(enemy).toNeverSelectMove(MoveId.SOAK);
+    });
+  });
+
+  describe("in Double Battles", () => {
+    beforeEach(() =>
+      game.override //
+        .battleType("double")
+        .enemySpecies(SpeciesId.MELTAN),
+    );
+
+    it("should be preferred when an ally's type matchup would improve", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGBY, SpeciesId.SLUGMA);
+      setSpeed(50, 100);
+
+      const [enemy] = game.scene.getEnemyField();
+      expect(enemy).toPreferSelectingMove(MoveId.SOAK);
+    });
+
+    it("should be avoided when an ally's type matchup would worsen", async () => {
+      await game.classicMode.startBattle(SpeciesId.CHIKORITA, SpeciesId.PANSAGE);
+      setSpeed(50, 100);
+
+      const [enemy] = game.scene.getEnemyField();
+      expect(enemy).toNeverSelectMove(MoveId.SOAK);
+    });
+
+    it("should not be preferred when the user is slower than its opponents", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGBY, SpeciesId.SLUGMA);
+      setSpeed(100, 50);
+
+      const [enemy] = game.scene.getEnemyField();
+      expect(enemy).not.toPreferSelectingMove(MoveId.SOAK);
+    });
+  });
+});

--- a/test/test-utils/helpers/field-helper.ts
+++ b/test/test-utils/helpers/field-helper.ts
@@ -1,5 +1,6 @@
 /* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { globalScene } from "#app/global-scene";
+import type { GameManager } from "#test/test-utils/game-manager";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 import type { Ability } from "#abilities/ability";
@@ -12,6 +13,7 @@ import type { EnemyPokemon } from "#field/enemy-pokemon";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { GameManagerHelper } from "#test/test-utils/helpers/game-manager-helper";
+import { coerceArray } from "#utils/common-utils";
 import { expect, type MockInstance, vi } from "vitest";
 
 /** Helper to manage pokemon */
@@ -63,6 +65,26 @@ export class FieldHelper extends GameManagerHelper {
       .getField(true)
       .sort((pA, pB) => pB.getEffectiveStat(Stat.SPD) - pA.getEffectiveStat(Stat.SPD))
       .map((p) => p.getBattlerIndex());
+  }
+
+  /**
+   * Sets the permanent Speed stat of active Pokemon to the given values.
+   * @param playerSpd - The `number` to set each Player Pokemon's Speed to, or a pair
+   * of numbers to individually set Player Pokemon speeds in a double battle
+   * @param enemySpd - The `number to set each Enemy Pokemon's Speed to, or a pair
+   * of numbers to individually set Enemy Pokemon speeds in a double battle
+   *
+   * @remarks
+   * This method is useful when testing mechanics that directly check or compare Speed between
+   * Pokemon. If you need to control turn order, it is safer to use {@linkcode GameManager.setTurnOrder} instead.
+   */
+  public setSpeed(playerSpd: number | [number, number], enemySpd: number | [number, number]): void {
+    const [playerSpdArr, enemySpdArr] = [playerSpd, enemySpd].map((spd) => coerceArray(spd));
+    const players = this.game.scene.getPlayerField();
+    const enemies = this.game.scene.getEnemyField();
+
+    players.forEach((p, i) => p.setStat(Stat.SPD, playerSpdArr[i] ?? playerSpdArr.at(-1)));
+    enemies.forEach((e, i) => e.setStat(Stat.SPD, enemySpdArr[i] ?? enemySpdArr.at(-1)));
   }
 
   /**


### PR DESCRIPTION
## What are the changes the user will see?

The Enemy AI should now properly evaluate and (sparingly) use moves that modify a Pokemon's type, including:
- Soak and Magic Powder
- Conversion
- Conversion 2
- Camouflage
- Reflect Type
- Forest's Curse and Trick-or-Treat

## Why am I making these changes?

Part of the AI Rework.

## What are the changes from a developer perspective?

- Added a new abstract class `ChangeTypeAttr` for effects that change a Pokemon's type to a single type. The following attributes now extend this class:
  - `SetTypeAttr` (previously `ChangeTypeAttr`, for Soak/Magic Powder)
  - `FirstMoveTypeAttr` (for Conversion)
  - `ResistLastMoveTypeAttr` (for Conversion 2)
  - `CopyBiomeTypeAttr` (for Camouflage)
- Added Effect Score overrides for the following attributes:
  - `ChangeTypeAttr` (the new abstract attr)
  - `CopyTypeAttr` (for Reflect Type)
  - `AddTypeAttr` (for Forest's Curse/Trick-or-Treat) 

## How to test the changes?

- [x] `pnpm typecheck`
- [x] `pnpm depcruise`
- [x] `pnpm test:silent`

New unit tests (can be run with `pnpm test[:silent] move-effect-scores/testName`):
- `soak`
- `conversion`
- `reflect-type`
- `forests-curse`

## Checklist

- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?