### PR TITLE
ai-rework: Add Matchup Score modifiers

### DIFF
--- a/scripts/create-test/create-test.js
+++ b/scripts/create-test/create-test.js
@@ -27,6 +27,7 @@ const choices = [
   { label: "UI", dir: "ui" },
   { label: "AI (Move Effect Scores)", dir: "ai/move-effect-scores" },
   { label: "AI (Move Condition Scores)", dir: "ai/move-condition-scores" },
+  { label: "AI (Matchup Scores)", dir: "ai/matchup-scores" },
 ];
 
 //#endregion

--- a/src/data/arena-tags/arena-tag.ts
+++ b/src/data/arena-tags/arena-tag.ts
@@ -4,6 +4,7 @@ import { ArenaTagSide } from "#enums/arena-tag-side";
 import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
+import type { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /** Base class for any special effects that apply to the {@linkcode Arena | field} during battle. */
@@ -141,5 +142,16 @@ export abstract class ArenaTag {
       default:
         return globalScene.getField(true) ?? [];
     }
+  }
+
+  /**
+   * Modifies a running {@link Pokemon.getMatchupScore | Matchup Score} for the given Pokemon
+   * @param pokemon - The {@linkcode Pokemon} being scored. This can be assumed to
+   * be on a side of the field affected by this tag.
+   * @param matchupScore - The running MUS for the evaluation
+   * @returns `true` if this tag's modification is meant to override modifications from other tags (Default `false`)
+   */
+  public modifyMatchupScore(_pokemon: Pokemon, _matchupScore: ValueHolder<number>): boolean {
+    return false;
   }
 }

--- a/src/data/arena-tags/entry-hazard-tag.ts
+++ b/src/data/arena-tags/entry-hazard-tag.ts
@@ -3,6 +3,7 @@ import { ArenaTagSide } from "#enums/arena-tag-side";
 import type { ArenaTagType } from "#enums/arena-tag-type";
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
+import type { ValueHolder } from "#utils/common-utils";
 
 /**
  * Abstract class to implement arena entry hazards.
@@ -55,18 +56,7 @@ export abstract class EntryHazardTag extends ArenaTag {
    */
   protected abstract activateTrap(_pokemon: Pokemon, _simulated: boolean): boolean;
 
-  /**
-   * Calculates the tag's effect on a Pokemon's matchup score (for enemy switching)
-   * @param pokemon - The {@linkcode Pokemon} to evaluate
-   * @returns the multiplier to the given Pokemon's matchup score
-   * @deprecated To be replaced in the AI Rework
-   * ({@link https://github.com/Despair-Games/poketernity/issues/945 | #945})
-   */
-  public getMatchupScoreMultiplier(pokemon: Pokemon): number {
-    return pokemon.isGrounded()
-      ? 1
-      : Phaser.Math.Linear(0, 1 / Math.pow(2, this.layers), Math.min(pokemon.getHpRatio(), 0.5) * 2);
-  }
+  public abstract override modifyMatchupScore(_pokemon: Pokemon, _matchupScore: ValueHolder<number>): boolean;
 
   override loadTag(source: any): void {
     super.loadTag(source);

--- a/src/data/arena-tags/spikes-tag.ts
+++ b/src/data/arena-tags/spikes-tag.ts
@@ -9,7 +9,7 @@ import { ArenaTagType } from "#enums/arena-tag-type";
 import { HitResult } from "#enums/hit-result";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { BooleanHolder, toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -59,6 +59,20 @@ export class SpikesTag extends EntryHazardTag {
       }
     }
 
+    return false;
+  }
+
+  /**
+   * Reduces MUS by 0.5 per layer if the Pokemon is inactive, grounded, and does not have Magic Guard
+   */
+  public override modifyMatchupScore(pokemon: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (
+      !pokemon.isActive(true)
+      && pokemon.isGrounded()
+      && !pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)
+    ) {
+      matchupScore.value -= 0.5 * this.layers;
+    }
     return false;
   }
 }

--- a/src/data/arena-tags/sticky-web-tag.ts
+++ b/src/data/arena-tags/sticky-web-tag.ts
@@ -2,13 +2,14 @@ import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { ProtectStatAbAttr } from "#abilities/protect-stat-ab-attr";
 import { globalScene } from "#app/global-scene";
 import { EntryHazardTag } from "#arena-tags/entry-hazard-tag";
+import { ALLY_EFFECTIVE_STAT_OPTIONS, OPP_EFFECTIVE_STAT_OPTIONS } from "#constants/ai-constants";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { MoveId } from "#enums/move-id";
 import { Stat } from "#enums/stat";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder, NumberHolder } from "#utils/common-utils";
+import { BooleanHolder, isBetween, NumberHolder, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -65,6 +66,32 @@ export class StickyWebTag extends EntryHazardTag {
       }
     }
 
+    return false;
+  }
+
+  /**
+   * Reduces MUS by 1.5 if the Pokemon would be slower than any of its opponents as a result of
+   * this effect's Speed drop.
+   */
+  public override modifyMatchupScore(pokemon: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (
+      pokemon.isActive(true)
+      || [AbAttrFlag.REFLECT_STAT_STAGE_CHANGE, AbAttrFlag.PROTECT_STAT].some((attrFlag) =>
+        pokemon.hasAbilityWithAttr(attrFlag),
+      )
+    ) {
+      return false;
+    }
+
+    const preSpeed = pokemon.getEffectiveStat(Stat.SPD, ALLY_EFFECTIVE_STAT_OPTIONS);
+    const postSpeed = Math.floor((preSpeed * 2) / 3);
+    const losesSpeedMatchup = pokemon
+      .getOpponents()
+      .some((opp) => isBetween(opp.getEffectiveStat(Stat.SPD, OPP_EFFECTIVE_STAT_OPTIONS), preSpeed, postSpeed));
+
+    if (losesSpeedMatchup) {
+      matchupScore.value -= 1.5;
+    }
     return false;
   }
 }

--- a/src/data/arena-tags/toxic-spikes-tag.ts
+++ b/src/data/arena-tags/toxic-spikes-tag.ts
@@ -1,12 +1,14 @@
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { EntryHazardTag } from "#arena-tags/entry-hazard-tag";
+import { POISON_SYNERGY_ABILITIES } from "#constants/ability-constants";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { StatusEffect } from "#enums/status-effect";
 import type { Pokemon } from "#field/pokemon";
+import type { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -76,13 +78,24 @@ export class ToxicSpikesTag extends EntryHazardTag {
     return false;
   }
 
-  override getMatchupScoreMultiplier(pokemon: Pokemon): number {
-    if (pokemon.isGrounded() || !pokemon.canSetStatus(StatusEffect.POISON, true)) {
-      return 1;
+  /**
+   * Modifies MUS as follows:
+   * - If the Pokemon is on the field or is not grounded, this has no effect.
+   * - Otherwise, if the Pokemon is Poison-type, this increases MUS by 1 per layer.
+   * - Otherwise, if the Pokemon doesn't have a non-volatile status effect or an ability
+   * that benefits from being Poisoned, this reduces MUS by 0.5 per layer.
+   */
+  public override modifyMatchupScore(pokemon: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (!pokemon.isActive(true) && pokemon.isGrounded()) {
+      if (pokemon.isOfType(ElementalType.POISON, true, true)) {
+        matchupScore.value += this.layers;
+      } else if (
+        !pokemon.hasNonVolatileStatusEffect()
+        && !POISON_SYNERGY_ABILITIES.some((abId) => pokemon.hasAbility(abId))
+      ) {
+        matchupScore.value -= 0.5 * this.layers;
+      }
     }
-    if (pokemon.isOfType(ElementalType.POISON)) {
-      return 1.25;
-    }
-    return super.getMatchupScoreMultiplier(pokemon);
+    return false;
   }
 }

--- a/src/data/arena-tags/type-hazard-tag.ts
+++ b/src/data/arena-tags/type-hazard-tag.ts
@@ -10,7 +10,7 @@ import type { ElementalType } from "#enums/elemental-type";
 import { HitResult } from "#enums/hit-result";
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { BooleanHolder, toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -87,8 +87,15 @@ export abstract class TypeHazardTag extends EntryHazardTag {
     return false;
   }
 
-  override getMatchupScoreMultiplier(pokemon: Pokemon): number {
-    const damageHpRatio = this.getDamageHpRatio(pokemon);
-    return Phaser.Math.Linear(super.getMatchupScoreMultiplier(pokemon), 1, 1 - Math.pow(damageHpRatio, damageHpRatio));
+  /**
+   * Reduces MUS by 0.5 times the effectiveness of this hazard's attacking type against the Pokemon
+   * (unless the Pokemon has Magic Guard).
+   */
+  public override modifyMatchupScore(pokemon: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (!pokemon.isActive(true) && !pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
+      matchupScore.value -= 0.5 * pokemon.getAttackTypeEffectiveness(this.damagingType, undefined, true, true);
+    }
+
+    return false;
   }
 }

--- a/src/data/battler-tags/aqua-ring-tag.ts
+++ b/src/data/battler-tags/aqua-ring-tag.ts
@@ -5,7 +5,7 @@ import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { toDmgValue } from "#utils/common-utils";
+import { toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -44,5 +44,14 @@ export class AquaRingTag extends BattlerTag {
     }
 
     return ret;
+  }
+
+  public override modifyMatchupScore(
+    _pokemon: Pokemon,
+    _opponent: Pokemon,
+    matchupScore: ValueHolder<number>,
+  ): boolean {
+    matchupScore.value += 0.5;
+    return false;
   }
 }

--- a/src/data/battler-tags/battler-tag.ts
+++ b/src/data/battler-tags/battler-tag.ts
@@ -43,6 +43,15 @@ export class BattlerTag {
    * @defaultValue `false`
    */
   public isBatonPassable: boolean;
+  /**
+   * Used to determine the order in which tags apply their
+   * Matchup Score modifier (if they have one). The higher the priority,
+   * the earlier the tag will modify MUS in the overall order.
+   * @defaultValue `0`
+   * @see {@linkcode modifyMatchupScore}
+   * @see {@linkcode Pokemon.getMatchupScore}
+   */
+  public musPriority: number = 0;
 
   constructor(
     tagType: BattlerTagType,

--- a/src/data/battler-tags/battler-tag.ts
+++ b/src/data/battler-tags/battler-tag.ts
@@ -4,7 +4,7 @@ import type { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { coerceArray } from "#utils/common-utils";
+import { coerceArray, type ValueHolder } from "#utils/common-utils";
 import { getPokemonMoveName } from "#utils/pokemon-utils";
 
 /**
@@ -182,5 +182,17 @@ export class BattlerTag {
    */
   public isType<T extends BattlerTag>(...types: BattlerTagType[]): this is T {
     return types.includes(this.tagType);
+  }
+
+  /**
+   * Modifies the afflicted Pokemon's {@link Pokemon.getMatchupScore | Matchup Score}
+   * against a given opponent.
+   * @param pokemon - The {@linkcode Pokemon} under this tag's effect
+   * @param opponent - The opposing {@linkcode Pokemon} for which MUS is evaluated
+   * @param matchupScore - The running MUS for the evaluation
+   * @returns `true` if this tag's modification is meant to override modifications from other tags (Default `false`).
+   */
+  public modifyMatchupScore(_pokemon: Pokemon, _opponent: Pokemon, _matchupScore: ValueHolder<number>): boolean {
+    return false;
   }
 }

--- a/src/data/battler-tags/confused-tag.ts
+++ b/src/data/battler-tags/confused-tag.ts
@@ -15,7 +15,7 @@ import { Stat } from "#enums/stat";
 import { TerrainType } from "#enums/terrain-type";
 import type { Pokemon } from "#field/pokemon";
 import type { MovePhase } from "#phases/move-phase";
-import { NumberHolder, toDmgValue } from "#utils/common-utils";
+import { NumberHolder, toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -137,5 +137,14 @@ export class ConfusedTag extends BattlerTag {
 
   override getDescriptor(): string {
     return i18next.t("battlerTags:confusedDesc");
+  }
+
+  public override modifyMatchupScore(
+    _pokemon: Pokemon,
+    _opponent: Pokemon,
+    matchupScore: ValueHolder<number>,
+  ): boolean {
+    matchupScore.value -= 1;
+    return false;
   }
 }

--- a/src/data/battler-tags/cursed-tag.ts
+++ b/src/data/battler-tags/cursed-tag.ts
@@ -9,7 +9,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { CommonAnim } from "#enums/common-anim";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { BooleanHolder, toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -44,5 +44,12 @@ export class CursedTag extends BattlerTag {
     }
 
     return ret;
+  }
+
+  public override modifyMatchupScore(pokemon: Pokemon, _opponent: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (!pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
+      matchupScore.value -= 1.5;
+    }
+    return false;
   }
 }

--- a/src/data/battler-tags/infatuated-tag.ts
+++ b/src/data/battler-tags/infatuated-tag.ts
@@ -7,6 +7,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { CommonAnim } from "#enums/common-anim";
 import type { Pokemon } from "#field/pokemon";
 import type { MovePhase } from "#phases/move-phase";
+import type { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -99,5 +100,14 @@ export class InfatuatedTag extends BattlerTag {
 
   override getDescriptor(): string {
     return i18next.t("battlerTags:infatuatedDesc");
+  }
+
+  public override modifyMatchupScore(
+    _pokemon: Pokemon,
+    _opponent: Pokemon,
+    matchupScore: ValueHolder<number>,
+  ): boolean {
+    matchupScore.value -= 1;
+    return false;
   }
 }

--- a/src/data/battler-tags/nightmare-tag.ts
+++ b/src/data/battler-tags/nightmare-tag.ts
@@ -9,7 +9,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { CommonAnim } from "#enums/common-anim";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { BooleanHolder, toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -63,5 +63,12 @@ export class NightmareTag extends BattlerTag {
 
   override getDescriptor(): string {
     return i18next.t("battlerTags:nightmareDesc");
+  }
+
+  public override modifyMatchupScore(pokemon: Pokemon, _opponent: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (!pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
+      matchupScore.value -= 1.5;
+    }
+    return false;
   }
 }

--- a/src/data/battler-tags/perish-song-tag.ts
+++ b/src/data/battler-tags/perish-song-tag.ts
@@ -6,6 +6,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { HitResult } from "#enums/hit-result";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
+import type { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -15,6 +16,8 @@ import i18next from "i18next";
  * Custom implementation: Boss Pokemon are immune to this effect
  */
 export class PerishSongTag extends BattlerTag {
+  public override musPriority = 2;
+
   constructor(turnCount: number) {
     super(BattlerTagType.PERISH_SONG, BattlerTagLapseType.TURN_END, turnCount, MoveId.PERISH_SONG, undefined, true);
   }
@@ -35,7 +38,6 @@ export class PerishSongTag extends BattlerTag {
         }),
       );
     } else {
-      // The 2 here is just a number big enough to overcome the G-Max damage reduction
       pokemon.damageAndUpdate(pokemon.hp, {
         result: HitResult.ONE_HIT_KO,
         ignoreSegments: true,
@@ -44,5 +46,21 @@ export class PerishSongTag extends BattlerTag {
     }
 
     return ret;
+  }
+
+  /**
+   * Sets MUS to -Infinity on the last turn of this effect, effectively forcing the Pokemon to switch.
+   * This should precede and override all other MUS modifiers.
+   */
+  public override modifyMatchupScore(
+    _pokemon: Pokemon,
+    _opponent: Pokemon,
+    matchupScore: ValueHolder<number>,
+  ): boolean {
+    if (this.turnCount === 1) {
+      matchupScore.value = Number.NEGATIVE_INFINITY;
+      return true;
+    }
+    return false;
   }
 }

--- a/src/data/battler-tags/salt-cured-tag.ts
+++ b/src/data/battler-tags/salt-cured-tag.ts
@@ -10,7 +10,7 @@ import { CommonAnim } from "#enums/common-anim";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { BooleanHolder, toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -73,5 +73,12 @@ export class SaltCuredTag extends BattlerTag {
     }
 
     return ret;
+  }
+
+  public override modifyMatchupScore(pokemon: Pokemon, _opponent: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (!pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
+      matchupScore.value -= 1;
+    }
+    return false;
   }
 }

--- a/src/data/battler-tags/seeded-tag.ts
+++ b/src/data/battler-tags/seeded-tag.ts
@@ -10,7 +10,7 @@ import { CommonAnim } from "#enums/common-anim";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { BooleanHolder, toDmgValue, type ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -89,5 +89,12 @@ export class SeededTag extends BattlerTag {
 
   override getDescriptor(): string {
     return i18next.t("battlerTags:seedDesc");
+  }
+
+  public override modifyMatchupScore(pokemon: Pokemon, _opponent: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    if (!pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_NON_DIRECT_DAMAGE)) {
+      matchupScore.value -= 1;
+    }
+    return false;
   }
 }

--- a/src/data/battler-tags/substitute-tag.ts
+++ b/src/data/battler-tags/substitute-tag.ts
@@ -7,6 +7,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";
 import { PokemonAnimType } from "#enums/pokemon-anim-type";
 import type { Pokemon } from "#field/pokemon";
+import type { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -15,6 +16,8 @@ import i18next from "i18next";
  * onto the tag. This tag also grants immunity to most Status moves and several move effects.
  */
 export class SubstituteTag extends BattlerTag {
+  public override musPriority = 1;
+
   /** The substitute's remaining HP. If HP is depleted, the Substitute fades. */
   public hp: number;
   /** A reference to the sprite representing the Substitute doll */
@@ -126,5 +129,20 @@ export class SubstituteTag extends BattlerTag {
   override loadTag(source: BattlerTag | any): void {
     super.loadTag(source);
     this.hp = source.hp;
+  }
+
+  /**
+   * Sets MUS to Infinity if the affected Pokemon can deal damage to the opponent. This effectively
+   * prevents the affected Pokemon from switching while it has a Substitute up and overrides the
+   * effects of most other MUS modifiers.
+   */
+  public override modifyMatchupScore(pokemon: Pokemon, opponent: Pokemon, matchupScore: ValueHolder<number>): boolean {
+    const attackMoves = pokemon.isPlayer() ? pokemon.estimateAttackMoves() : pokemon.getAttackMoves(true);
+
+    if (attackMoves.some((move) => pokemon.getExpectedAttackScore(opponent, move) > 0)) {
+      matchupScore.value = Number.POSITIVE_INFINITY;
+      return true;
+    }
+    return false;
   }
 }

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -873,7 +873,7 @@ export class Arena {
   getTags<T extends ArenaTag = ArenaTag>(
     tagPredicate: (t: ArenaTag) => boolean,
     side: ArenaTagSide = ArenaTagSide.BOTH,
-  ): T[] | undefined {
+  ): T[] {
     const validSides = new Set<ArenaTagSide>([ArenaTagSide.BOTH, side]);
 
     return this.tags.filter((t) => tagPredicate(t) && (side === ArenaTagSide.BOTH || validSides.has(t.side))) as T[];

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -411,7 +411,14 @@ export class EnemyPokemon extends Pokemon {
       return;
     }
 
-    const nonActiveParty = this.getParty().filter((p) => p.isActive() && !p.isOnField());
+    /** All inactive enemy Pokemon that can switch into this Pokemon's place */
+    const nonActiveParty = this.getParty().filter(
+      (p: EnemyPokemon) => p.isActive() && !p.isOnField() && p.trainerSlot === this.trainerSlot,
+    );
+    if (nonActiveParty.length === 0) {
+      return;
+    }
+
     const matchupScore = this.getAverageMatchupScore();
 
     // If this Pokemon can safely KO at least 1 opponent, it gains an average MUS

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2489,7 +2489,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
 
-    for (const tag of this.summonData.tags) {
+    const battlerTags = this.summonData.tags.slice().sort((tagA, tagB) => tagB.musPriority - tagA.musPriority);
+    for (const tag of battlerTags) {
       if (tag.modifyMatchupScore(this, opponent, matchupScore)) {
         return;
       }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2516,7 +2516,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @param matchupScore - This Pokemon's Matchup Score against {@linkcode opponent}
    * @see {@linkcode getMatchupScore}
    */
-  private cacheMatchupScore(opponent: Pokemon, matchupScore: number) {
+  private cacheMatchupScore(opponent: Pokemon, matchupScore: number): void {
     const oppScoreData = this.turnData.scoreData.get(opponent.id);
     if (oppScoreData == null) {
       this.turnData.scoreData.set(opponent.id, {

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1,6 +1,7 @@
 /* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Battle } from "#app/battle";
 import type { BattleScene } from "#app/battle-scene";
+import type { ArenaTag } from "#arena-tags/arena-tag";
 import type { FaintPhase } from "#phases/faint-phase";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
@@ -2424,16 +2425,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   /**
    * Computes this Pokemon's matchup score (MUS) against the given opponent.
-   * This MUS is a reflection of
+   * MUS is a reflection of
    * 1. How effective this Pokemon's attacks are against the opponent, and
    * 2. How many turns this Pokemon will have to act, assuming the opponent
    * attacks with their perceived best attack every turn.
    *
    * If this Pokemon is on the field and can safely KO the opponent, its MUS
-   * against that opponent will be `Infinity`. Otherwise, MUS falls in the
-   * interval [0, 8]
-   * @param opponent The {@linkcode Pokemon} to score this Pokemon against
-   * @returns the calculated score for the matchup.
+   * against that opponent will be `Infinity`. Otherwise, MUS generally falls
+   * in the interval [0, 8]. Ongoing effects on this Pokemon or on the field
+   * may also modify this score.
+   * @param opponent - The {@linkcode Pokemon} to score this Pokemon against
+   * @returns The decimal score for the matchup.
+   * @see {@linkcode applyMatchupScoreModifiers}
    */
   public getMatchupScore(opponent: Pokemon): number {
     const cachedScore = this.turnData.scoreData.get(opponent.id)?.matchupScore;
@@ -2449,21 +2452,48 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const eas = Math.max(...attackMoves.map((mv) => this.getExpectedAttackScore(opponent, mv)));
     const oppEas = Math.max(...oppAttackMoves.map((mv) => opponent.getExpectedAttackScore(this, mv)));
 
-    let score: number = 0;
+    const score = new ValueHolder(0);
     if (this.isActive(true)) {
       if (eas >= 4 && (canOutspeed || oppEas < eas)) {
-        score = Number.POSITIVE_INFINITY;
+        score.value = Number.POSITIVE_INFINITY;
       } else if (oppEas >= 4 && (!canOutspeed || eas < oppEas)) {
-        score = 0;
+        score.value = 0;
       } else {
-        score = eas * (3 - oppEas + (canOutspeed ? 1 : 0));
+        score.value = eas * (3 - oppEas + (canOutspeed ? 1 : 0));
       }
     } else {
-      score = Math.max(eas * (2 - oppEas + (canOutspeed ? 1 : 0)), 0);
+      score.value = Math.max(eas * (2 - oppEas + (canOutspeed ? 1 : 0)), 0);
     }
 
-    this.cacheMatchupScore(opponent, score);
-    return score;
+    if (score.value !== Number.POSITIVE_INFINITY) {
+      this.applyMatchupScoreModifiers(opponent, score);
+    }
+
+    this.cacheMatchupScore(opponent, score.value);
+    return score.value;
+  }
+
+  /**
+   * Applies modifiers from {@linkcode BattlerTag | BattlerTags}, {@linkcode ArenaTag | ArenaTags},
+   * and other ongoing effects onto the given Matchup Score (MUS).
+   * @param opponent - The opposing {@linkcode Pokemon} the MUS is calculated against
+   * @param matchupScore - A {@linkcode ValueHolder} containing the running MUS
+   * @see {@linkcode getMatchupScore}
+   */
+  private applyMatchupScoreModifiers(opponent: Pokemon, matchupScore: ValueHolder<number>): void {
+    for (const tag of globalScene.arena.getTags(() => true, this.getArenaTagSide())) {
+      // If `modifyMatchupScore` returns `true`, it has overridden the running MUS with a fixed value.
+      // This usually happens when a tag sets MUS to -Infinity or Infinity to force or prevent switching.
+      if (tag.modifyMatchupScore(this, matchupScore)) {
+        return;
+      }
+    }
+
+    for (const tag of this.summonData.tags) {
+      if (tag.modifyMatchupScore(this, opponent, matchupScore)) {
+        return;
+      }
+    }
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -2494,6 +2494,18 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         return;
       }
     }
+
+    const currentWeatherType = globalScene.arena.weatherType;
+    const weatherScore = this.getWeatherBenefitScore(currentWeatherType);
+    const oppWeatherScore = opponent.getWeatherBenefitScore(currentWeatherType, true);
+    matchupScore.value += Math.sign(weatherScore - oppWeatherScore);
+
+    const currentTerrainType = globalScene.arena.terrainType;
+    const terrainScore = this.getTerrainBenefitScore(currentTerrainType);
+    const oppTerrainScore = opponent.getTerrainBenefitScore(currentTerrainType, true);
+    matchupScore.value += Math.sign(terrainScore - oppTerrainScore);
+
+    matchupScore.value = Math.max(matchupScore.value, 0);
   }
 
   /**

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -1,7 +1,5 @@
 import { globalScene } from "#app/global-scene";
 import { getIsInitialized, initI18n } from "#app/plugins/i18n";
-import type { EntryHazardTag } from "#arena-tags/entry-hazard-tag";
-import { ENTRY_HAZARD_ARENA_TAG_TYPES } from "#constants/arena-tag-constants";
 import { LEVEL_CAP_SCALE_FACTOR } from "#constants/game-constants";
 import { getLevelForWaveFunc } from "#data/exp";
 import { pokemonPreEvolutions } from "#data/pokemon-pre-evolutions";
@@ -10,7 +8,6 @@ import { signatureSpecies } from "#data/signature-species";
 import type { TrainerConfig, TrainerPartyTemplate } from "#data/trainer-config";
 import { TrainerPartyCompoundTemplate, trainerPartyTemplates } from "#data/trainer-config";
 import { trainerNamePools } from "#data/trainer-names";
-import { ArenaTagSide } from "#enums/arena-tag-side";
 import { PartyMemberStrength } from "#enums/party-member-strength";
 import { SpeciesId } from "#enums/species-id";
 import { TeraAIMode } from "#enums/tera-ai-mode";
@@ -537,73 +534,25 @@ export class Trainer extends Phaser.GameObjects.Container {
     return currentPartySpecies.includes(species.speciesId) || staticPartyPokemon.includes(baseSpecies.speciesId);
   }
 
-  getPartyMemberMatchupScores(
-    trainerSlot: TrainerSlot = TrainerSlot.NONE,
-    forSwitch: boolean = false,
-  ): [number, number][] {
-    if (trainerSlot && !this.isDouble()) {
-      trainerSlot = TrainerSlot.NONE;
-    }
+  /**
+   * Determines the next Pokemon for the Trainer at the given trainer slot to summon
+   * when the Trainer's active Pokemon is forced off of the field, e.g. from fainting.
+   * @param trainerSlot - The {@linkcode TrainerSlot} of the Trainer summoning a Pokemon
+   * @returns The party index of the next {@linkcode Pokemon} to summon
+   */
+  public getNextSummonIndex(trainerSlot: TrainerSlot = TrainerSlot.NONE): number {
+    /**
+     * Trainer slots are only relevant for double battles. If an irrelevant trainer
+     * slot was passed during a single battle, use {@linkcode TrainerSlot.NONE} instead.
+     * @todo This is adapted from old code. There's probably a better way to manage
+     * trainer slots...
+     */
+    const adjTrainerSlot = this.isDouble() ? trainerSlot : TrainerSlot.NONE;
 
-    const party = globalScene.getEnemyParty();
-    const nonFaintedLegalPartyMembers = party
-      .slice(globalScene.currentBattle.getBattlerCount())
-      .filter((p) => p.isAllowedInBattle())
-      .filter((p) => !trainerSlot || p.trainerSlot === trainerSlot);
-    const partyMemberScores = nonFaintedLegalPartyMembers.map((p) => {
-      const playerField = globalScene.getPlayerField().filter((p) => p.isAllowedInBattle());
-      let score = 0;
+    const sortedValidPartyScores = this.getValidPartyMemberMatchupScores(adjTrainerSlot).sort((a, b) => b[1] - a[1]);
 
-      if (playerField.length > 0) {
-        for (const playerPokemon of playerField) {
-          score += p.getMatchupScore(playerPokemon);
-          if (playerPokemon.species.isLegendary()) {
-            score /= 2;
-          }
-        }
-        score /= playerField.length;
-        if (forSwitch && !p.isOnField()) {
-          globalScene.arena
-            .getTags<EntryHazardTag>((t) => ENTRY_HAZARD_ARENA_TAG_TYPES.includes(t.tagType), ArenaTagSide.ENEMY)
-            ?.map((t) => (score *= t.getMatchupScoreMultiplier(p)));
-        }
-      }
-
-      return [party.indexOf(p), score];
-    }) as [number, number][];
-
-    return partyMemberScores;
-  }
-
-  getSortedPartyMemberMatchupScores(partyMemberScores: [number, number][] = this.getPartyMemberMatchupScores()) {
-    const sortedPartyMemberScores = partyMemberScores.slice(0);
-    sortedPartyMemberScores.sort((a, b) => {
-      const scoreA = a[1];
-      const scoreB = b[1];
-      if (scoreA < scoreB) {
-        return 1;
-      }
-      if (scoreA > scoreB) {
-        return -1;
-      }
-      return 0;
-    });
-
-    return sortedPartyMemberScores;
-  }
-
-  getNextSummonIndex(
-    trainerSlot: TrainerSlot = TrainerSlot.NONE,
-    partyMemberScores: [number, number][] = this.getPartyMemberMatchupScores(trainerSlot),
-  ): number {
-    if (trainerSlot && !this.isDouble()) {
-      trainerSlot = TrainerSlot.NONE;
-    }
-
-    const sortedPartyMemberScores = this.getSortedPartyMemberMatchupScores(partyMemberScores);
-
-    const maxScorePartyMemberIndexes = partyMemberScores
-      .filter((pms) => pms[1] === sortedPartyMemberScores[0][1])
+    const maxScorePartyMemberIndexes = sortedValidPartyScores
+      .filter(([, score]) => score === sortedValidPartyScores[0][1])
       .map((pms) => pms[0]);
 
     if (maxScorePartyMemberIndexes.length > 1) {
@@ -615,6 +564,29 @@ export class Trainer extends Phaser.GameObjects.Container {
     }
 
     return maxScorePartyMemberIndexes[0];
+  }
+
+  /**
+   * Calculates {@link Pokemon.getAverageMatchupScore | Matchup Scores} for all Pokemon in the party of the
+   * Trainer at the given slot.
+   * @param trainerSlot - The {@linkcode TrainerSlot} of the Trainer whose Pokemon
+   * are evaluated
+   * @returns An array of number pairs, with one pair per eligible Pokemon.
+   * The first number in a pair is the Pokemon's current party index,
+   * while the second number is the Pokemon's average MUS against active opponents.
+   */
+  private getValidPartyMemberMatchupScores(trainerSlot: TrainerSlot = TrainerSlot.NONE): [number, number][] {
+    const party = globalScene.getEnemyParty();
+    const nonFaintedLegalPartyMembers = party
+      .slice(globalScene.currentBattle.getBattlerCount())
+      .filter((p) => p.isAllowedInBattle())
+      .filter((p) => !trainerSlot || p.trainerSlot === trainerSlot);
+    const partyMemberScores: [number, number][] = nonFaintedLegalPartyMembers.map((p) => [
+      party.indexOf(p),
+      p.getAverageMatchupScore(),
+    ]);
+
+    return partyMemberScores;
   }
 
   getPartyMemberModifierChanceMultiplier(index: number): number {

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -150,5 +150,13 @@ declare module "vitest" {
      * the enemy's moveset to never be used
      */
     toNeverSelectMove(qualifier: MoveQualifier): void;
+
+    /**
+     * Matcher to check if an {@linkcode EnemyPokemon} prefers switching to
+     * another Pokemon in the current game state.
+     * @param switchInIndex - (Optional) The party slot of the {@linkcode EnemyPokemon}
+     * expected to take the received enemy's place on the field
+     */
+    toPreferSwitching(switchInIndex?: number): void;
   }
 }

--- a/test/ai/matchup-scores/knockouts.test.ts
+++ b/test/ai/matchup-scores/knockouts.test.ts
@@ -1,0 +1,126 @@
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { Stat } from "#enums/stat";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("AI (Matchup Scores) - Knockouts", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .startingWave(8)
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPARK)
+      .startingLevel(100)
+      .enemyLevel(100)
+      .enemyDisableSwitching(false);
+  });
+
+  describe("Safe opponent KOs - should never switch out", () => {
+    it("enemy full HP; player 1 HP", async () => {
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      player.hp = 1;
+
+      expect(enemy).not.toPreferSwitching();
+    });
+
+    it("enemy 1 HP; player 1 HP; enemy outspeeds player", async () => {
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      player.hp = 1;
+      enemy.hp = 1;
+      player.setStat(Stat.SPD, 50);
+      enemy.setStat(Stat.SPD, 100);
+
+      expect(enemy).not.toPreferSwitching();
+    });
+
+    it("enemy 1 HP; player 1 HP; enemy has a priority move", async () => {
+      game.override.enemyMoveset(MoveId.QUICK_ATTACK);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      player.hp = 1;
+      enemy.hp = 1;
+      player.setStat(Stat.SPD, 100);
+      enemy.setStat(Stat.SPD, 50);
+
+      expect(enemy).not.toPreferSwitching();
+    });
+
+    it("enemy 1 HP; player 1 HP; player is known to have no attacks", async () => {
+      game.override.moveset([MoveId.SPLASH, MoveId.CELEBRATE, MoveId.STOCKPILE, MoveId.SWALLOW]);
+
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      player.hp = 1;
+      enemy.hp = 1;
+      game.field.revealAllMoves();
+
+      expect(enemy).not.toPreferSwitching();
+    });
+  });
+
+  describe("Avoidable ally KOs - should always switch out", async () => {
+    it("active enemy 1 HP; inactive enemy full HP", async () => {
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const enemy = game.field.getEnemyPokemon();
+      enemy.hp = 1;
+
+      expect(enemy).toPreferSwitching();
+    });
+
+    it("active enemy 1 HP; player 1 HP; player outspeeds enemy", async () => {
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const player = game.field.getPlayerPokemon();
+      const enemy = game.field.getEnemyPokemon();
+      player.hp = 1;
+      enemy.hp = 1;
+      player.setStat(Stat.SPD, 100);
+      enemy.setStat(Stat.SPD, 50);
+
+      expect(enemy).toPreferSwitching();
+    });
+  });
+
+  describe("Unavoidable ally KOs - should never switch out", async () => {
+    it("all enemies 1 HP", async () => {
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+      const enemy = game.field.getEnemyPokemon();
+      enemy.getParty().forEach((p) => (p.hp = 1));
+
+      expect(enemy).not.toPreferSwitching();
+    });
+  });
+});

--- a/test/matchers.setup.ts
+++ b/test/matchers.setup.ts
@@ -14,6 +14,7 @@ import { toHaveUsedMoveMatcher } from "#test/test-utils/matchers/to-have-used-mo
 import { toHaveWeatherMatcher } from "#test/test-utils/matchers/to-have-weather-matcher";
 import { toNeverSelectMoveMatcher } from "#test/test-utils/matchers/to-never-select-move-matcher";
 import { toPreferSelectingMoveMatcher } from "#test/test-utils/matchers/to-prefer-selecting-move-matcher";
+import { toPreferSwitchingMatcher } from "#test/test-utils/matchers/to-prefer-switching-matcher";
 import { expect } from "vitest";
 
 /*
@@ -38,4 +39,5 @@ expect.extend({
   toHaveFainted: toHaveFaintedMatcher,
   toPreferSelectingMove: toPreferSelectingMoveMatcher,
   toNeverSelectMove: toNeverSelectMoveMatcher,
+  toPreferSwitching: toPreferSwitchingMatcher,
 });

--- a/test/test-utils/matchers/to-prefer-selecting-move-matcher.ts
+++ b/test/test-utils/matchers/to-prefer-selecting-move-matcher.ts
@@ -1,3 +1,7 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { EnemyPokemon } from "#field/enemy-pokemon";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { getPokemonNameWithAffix } from "#app/messages";
 import { MoveId } from "#enums/move-id";
 import { getEnemyMoveChoices } from "#test/test-utils/enemy-command-utils";
@@ -6,7 +10,7 @@ import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
 /**
  * Matcher to check if an {@linkcode EnemyPokemon} prefers selecting a specific
- * move in the current game state
+ * move in the current game state.
  * @param received - The object to check. Should be an {@linkcode EnemyPokemon}.
  * @param expectedMoveId - The {@linkcode MoveId} to check for.
  * @returns Whether the matcher passed, and the message to display in case of failure

--- a/test/test-utils/matchers/to-prefer-switching-matcher.ts
+++ b/test/test-utils/matchers/to-prefer-switching-matcher.ts
@@ -1,0 +1,57 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { EnemyPokemon } from "#field/enemy-pokemon";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
+import { getPokemonNameWithAffix } from "#app/messages";
+import { activeOverrides } from "#app/overrides";
+import { BattleCommand } from "#enums/battle-command";
+import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
+import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
+
+/**
+ * Matcher to check if an {@linkcode EnemyPokemon} prefers switching to another
+ * Pokemon in the current game state.
+ * @param received - The object to check. Should be an {@linkcode EnemyPokemon}
+ * @param switchInIndex - (Optional) The current party slot of the {@linkcode EnemyPokemon}
+ * expected to take the received enemy's place on the field
+ * @returns Whether the matcher passed, and the message to display in case of failure
+ */
+export function toPreferSwitchingMatcher(
+  this: MatcherState,
+  received: unknown,
+  switchInIndex?: number,
+): SyncExpectationResult {
+  if (!isPokemonInstance(received) || !received.isEnemy()) {
+    return {
+      pass: this.isNot,
+      message: () => `Expected EnemyPokemon, but got ${receivedStr(received)}!`,
+    };
+  }
+
+  if (activeOverrides.ENEMY_DISABLE_SWITCHING_OVERRIDE) {
+    return {
+      pass: this.isNot,
+      message: () => "Overrides are preventing the enemy from switching!",
+    };
+  }
+
+  const enemyCommand = received.getNextCommand();
+  const pkmName = getPokemonNameWithAffix(received);
+  const isSwitchCommand = enemyCommand?.command === BattleCommand.POKEMON;
+  const pass = isSwitchCommand && (switchInIndex == null || switchInIndex === enemyCommand.cursor);
+
+  return {
+    pass,
+    message: () => {
+      if (pass) {
+        return switchInIndex == null
+          ? `Expected ${pkmName} to NOT prefer switching, but it does!`
+          : `Expected ${pkmName} to NOT prefer switching with index ${switchInIndex}, but it does!`;
+      }
+
+      return isSwitchCommand
+        ? `Expected ${pkmName}'s preferred switch-in to be index ${switchInIndex}, but got index ${enemyCommand.cursor}!`
+        : `Expected ${pkmName} to prefer switching, but it doesn't!`;
+    },
+  };
+}


### PR DESCRIPTION
## What are the changes the user will see?

The AI should now account for ongoing battle effects when evaluating whether it should switch Pokemon. These battle effects include:
- Volatile status effects (e.g. Confusion)
- Hazards (e.g. Spikes)
- Weather
- Terrain

## Why am I making these changes?

Part of the AI Rework.

## What are the changes from a developer perspective?

- Added `Pokemon.applyMatchupScoreModifiers` to apply Matchup Score (MUS) modifiers outside of the normal damage/EAS-based scoring.
- Added new methods to `BattlerTag` and `ArenaTag` to apply tag-specific MUS modifiers.
- Added Weather- and Terrain-based MUS modifier logic. 

For more information on the new MUS modifiers, see the "Misc. Score Modifiers" tab in the [Effect Scores Sheet](https://docs.google.com/spreadsheets/d/12UprXLHyLdw-ESls6pAQecyBFCG2tVg5cllAiUbp6KA/edit?usp=sharing)

## How to test the changes?

- [ ] `pnpm typecheck`
- [ ] `pnpm depcruise`
- [ ] `pnpm test:silent`

New unit tests are WIP.

## Checklist

- [ ] There is no overlap with another PR?
- [ ] The PR is self-contained and cannot be split into smaller PRs?
- [ ] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
