### PR TITLE
feat(move): Fully implement Pursuit

### DIFF
--- a/src/data/battler-tags/pursuing-battler-tag.ts
+++ b/src/data/battler-tags/pursuing-battler-tag.ts
@@ -1,0 +1,21 @@
+import { BattlerTag } from "#battler-tags/battler-tag";
+import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
+import { BattlerTagType } from "#enums/battler-tag-type";
+import type { Pokemon } from "#field/pokemon";
+import type { ValueHolder } from "#utils/common-utils";
+
+/**
+ * Tag to double the power of {@link https://bulbapedia.bulbagarden.net/wiki/Pursuit_(move) | Pursuit}
+ * when used against a retreating Pokemon.
+ * @todo Can this be consolidated with `MeFirstPowerBoostTag`?
+ */
+export class PursuingTag extends BattlerTag {
+  constructor() {
+    super(BattlerTagType.PURSUING, BattlerTagLapseType.AFTER_MOVE, 1);
+  }
+
+  public override apply(_pokemon: Pokemon, _simulated: boolean, power: ValueHolder<number>): boolean {
+    power.value *= 2;
+    return true;
+  }
+}

--- a/src/data/battler-tags/utils/get-battler-tag.ts
+++ b/src/data/battler-tags/utils/get-battler-tag.ts
@@ -56,6 +56,7 @@ import { PowderTag } from "#battler-tags/powder-tag";
 import { PowerTrickTag } from "#battler-tags/power-trick-tag";
 import { ProtectedTag } from "#battler-tags/protected-tag";
 import { PsychoShiftTag } from "#battler-tags/psycho-shift-tag";
+import { PursuingTag } from "#battler-tags/pursuing-battler-tag";
 import { QuashedTag } from "#battler-tags/quashed-tag";
 import { RageTag } from "#battler-tags/rage-tag";
 import { RechargingTag } from "#battler-tags/recharging-tag";
@@ -320,6 +321,8 @@ export function getBattlerTag(
       return new SnatchingTag();
     case BattlerTagType.ME_FIRST_POWER_BOOST:
       return new MeFirstPowerBoostTag();
+    case BattlerTagType.PURSUING:
+      return new PursuingTag();
     case BattlerTagType.BIDE:
       return new BideTag();
     case BattlerTagType.NONE:

--- a/src/data/init/init-moves.ts
+++ b/src/data/init/init-moves.ts
@@ -172,6 +172,7 @@ import { PreMoveMessageAttr } from "#moves/pre-move-message-attr";
 import { PresentPowerAttr } from "#moves/present-power-attr";
 import { ProtectAttr } from "#moves/protect-attr";
 import { PsychoShiftEffectAttr } from "#moves/psycho-shift-effect-attr";
+import { PursuitAttr } from "#moves/pursuit-attr";
 import { QuashAttr } from "#moves/quash-attr";
 import { RageAttr } from "#moves/rage-attr";
 import { RagingBullTypeAttr } from "#moves/raging-bull-type-attr";
@@ -992,7 +993,8 @@ export function initMoves() {
       .bounceable()
       .edgeCase(), // wrongly interacts with moves reflected by Magic Coat/Bounce
     new AttackMove(MoveId.PURSUIT, ElementalType.DARK, MoveCategory.PHYSICAL, 40, 100, 20, -1, 0, 2) //
-      .partial(), // No effect implemented
+      .attr(PursuitAttr)
+      .edgeCase(), // Terastallization can disrupt the order in which multiple Pursuits apply
     new AttackMove(MoveId.RAPID_SPIN, ElementalType.NORMAL, MoveCategory.PHYSICAL, 50, 100, 40, 100, 0, 2) //
       .attr(StatStageChangeAttr, [Stat.SPD], 1, true)
       .attr(RemoveBattlerTagAttr, rapidSpinRemoveTags, true)

--- a/src/data/moves/move-attrs/add-battler-tag-attr.ts
+++ b/src/data/moves/move-attrs/add-battler-tag-attr.ts
@@ -119,9 +119,6 @@ export class AddBattlerTagAttr extends ChanceBasedMoveEffectAttr {
       case BattlerTagType.QUASHED:
         return -1;
       case BattlerTagType.NONE:
-      /**
-       * @todo: Burned Up and Double Shocked terastallization considerations
-       */
       case BattlerTagType.BURNED_UP:
       case BattlerTagType.DOUBLE_SHOCKED:
       case BattlerTagType.MINIMIZED:
@@ -144,6 +141,7 @@ export class AddBattlerTagAttr extends ChanceBasedMoveEffectAttr {
       case BattlerTagType.SKY_DROP:
       case BattlerTagType.MAGIC_COAT:
       case BattlerTagType.ME_FIRST_POWER_BOOST:
+      case BattlerTagType.PURSUING:
       case BattlerTagType.BIDE:
         return 0;
       case BattlerTagType.INGRAIN:

--- a/src/data/moves/move-attrs/pursuit-attr.ts
+++ b/src/data/moves/move-attrs/pursuit-attr.ts
@@ -1,0 +1,3 @@
+import { MoveAttr } from "#moves/move-attr";
+
+export class PursuitAttr extends MoveAttr {}

--- a/src/data/moves/move-attrs/pursuit-attr.ts
+++ b/src/data/moves/move-attrs/pursuit-attr.ts
@@ -7,7 +7,7 @@ import { MoveAttr } from "#moves/move-attr";
 
 /**
  * Attribute for moves that allow the user to attack an opposing Pokemon before it
- * switches out, i.e. {@link https://bulbapedia.bulbagarden.net/wiki/Pursuit_(move) | Pursuit}.
+ * switches out, i.e. {@link https://bulbapedia.bulbagarden.net/wiki/Pursuit_(move) | Pursuit}. \
  * When attacking a retreating target, moves with this attribute double in power.
  * @see {@linkcode TurnCommandManager.tryPursueTarget}
  * @see {@linkcode PursuingTag}

--- a/src/data/moves/move-attrs/pursuit-attr.ts
+++ b/src/data/moves/move-attrs/pursuit-attr.ts
@@ -1,3 +1,15 @@
+/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import type { TurnCommandManager } from "#app/turn-command-manager";
+import type { PursuingTag } from "#battler-tags/pursuing-battler-tag";
+/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
+
 import { MoveAttr } from "#moves/move-attr";
 
+/**
+ * Attribute for moves that allow the user to attack an opposing Pokemon before it
+ * switches out, i.e. {@link https://bulbapedia.bulbagarden.net/wiki/Pursuit_(move) | Pursuit}.
+ * When attacking a retreating target, moves with this attribute double in power.
+ * @see {@linkcode TurnCommandManager.tryPursueTarget}
+ * @see {@linkcode PursuingTag}
+ */
 export class PursuitAttr extends MoveAttr {}

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -12,6 +12,7 @@ import { globalScene } from "#app/global-scene";
 import type { WeakenMoveTypeTag } from "#arena-tags/weaken-move-type-tag";
 import { applyBattlerTags } from "#battler-tags/apply-battler-tags";
 import type { MeFirstPowerBoostTag } from "#battler-tags/me-first-power-boost-tag";
+import type { PursuingTag } from "#battler-tags/pursuing-battler-tag";
 import type { TypeBoostTag } from "#battler-tags/type-boost-tag";
 import { WEAKEN_MOVE_TYPE_ARENA_TAG_TYPES } from "#constants/arena-tag-constants";
 import { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
@@ -887,6 +888,7 @@ export abstract class Move {
     }
 
     applyBattlerTags<MeFirstPowerBoostTag>(BattlerTagType.ME_FIRST_POWER_BOOST, source, simulated, power);
+    applyBattlerTags<PursuingTag>(BattlerTagType.PURSUING, source, simulated, power);
 
     return power.value;
   }

--- a/src/enums/battler-tag-type.ts
+++ b/src/enums/battler-tag-type.ts
@@ -118,6 +118,7 @@ export const BattlerTagType = {
   SNATCHING: 104,
   ME_FIRST_POWER_BOOST: 105,
   BIDE: 106,
+  PURSUING: 107,
 } as const;
 
 export type BattlerTagType = ObjectValues<typeof BattlerTagType>;

--- a/src/phases/base/hit-check-phase.ts
+++ b/src/phases/base/hit-check-phase.ts
@@ -160,7 +160,11 @@ export abstract class HitCheckPhase extends PokemonPhase {
       return [HitCheckResult.HIT, effectiveness];
     }
 
-    if (alwaysHit || (target.hasTag(BattlerTagType.TELEKINESIS) && !move.hasAttr(OneHitKOAttr))) {
+    if (
+      alwaysHit
+      || user.hasTag(BattlerTagType.PURSUING)
+      || (target.hasTag(BattlerTagType.TELEKINESIS) && !move.hasAttr(OneHitKOAttr))
+    ) {
       return [HitCheckResult.HIT, effectiveness];
     }
 

--- a/src/phases/base/pokemon-phase.ts
+++ b/src/phases/base/pokemon-phase.ts
@@ -10,7 +10,7 @@ import type { nil } from "#types/utility-types";
  */
 export abstract class PokemonPhase extends FieldPhase {
   /** FieldBattlerIndex of the target Pokemon, or its ID */
-  protected readonly battlerIndex: FieldBattlerIndex | number;
+  public readonly battlerIndex: FieldBattlerIndex | number;
   public readonly isPlayer: boolean;
   public readonly fieldIndex: number;
 

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -134,7 +134,7 @@ export class FaintPhase extends PokemonPhase {
   }
 
   protected doFaint(): void {
-    const { currentBattle, field, tweens } = globalScene;
+    const { currentBattle, field, phaseManager, tweens } = globalScene;
     const { battleType, double, enemyFaintsHistory, playerFaintsHistory, turn } = currentBattle;
     const pokemon = this.getPokemon();
 
@@ -147,7 +147,7 @@ export class FaintPhase extends PokemonPhase {
       enemyFaintsHistory.push({ pokemon, turn });
     }
 
-    globalScene.phaseManager.createAndUnshiftPhase(
+    phaseManager.createAndUnshiftPhase(
       "MessagePhase",
       i18next.t("battle:fainted", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       undefined,
@@ -186,25 +186,33 @@ export class FaintPhase extends PokemonPhase {
       }
     }
 
+    /*
+     * Remove any scheduled Phases to recall and/or switch out the fainted Pokemon.
+     * These Phases may have been scheduled e.g. if the Pokemon fainted from an opponent's Pursuit.
+     * TODO: Refactor this; Switch phase scheduling around faints is messy.
+     */
+    phaseManager.tryRemovePhase((phase) => phase.is("RecallPhase") && phase.battlerIndex === this.battlerIndex);
+    phaseManager.tryRemovePhase((phase) => phase.is("SwitchPhase") && phase.battlerIndex === this.battlerIndex);
+
     if (this.isPlayer) {
       /** The total number of Pokemon in the player's party that can legally fight */
       const legalPlayerPokemon = globalScene.getPokemonAllowedInBattle();
       /** The total number of legal player Pokemon that aren't currently on the field */
       const legalPlayerPartyPokemon = legalPlayerPokemon.filter((p) => !p.isActive(true));
       if (!legalPlayerPokemon.length) {
-        globalScene.phaseManager.queueGameOverPhase({ clearPhaseQueue: false });
+        phaseManager.queueGameOverPhase({ clearPhaseQueue: false });
       } else if (double && legalPlayerPokemon.length === 1 && legalPlayerPartyPokemon.length === 0) {
         /**
          * If the player has exactly one Pokemon in total at this point in a double battle, and that Pokemon
          * is already on the field, push a phase that moves that Pokemon to center position.
          */
-        globalScene.phaseManager.createAndPushPhase("ToggleDoublePositionPhase", true);
+        phaseManager.createAndPushPhase("ToggleDoublePositionPhase", true);
       } else if (legalPlayerPartyPokemon.length > 0) {
         /**
          * If previous conditions weren't met, and the player has at least 1 legal Pokemon off the field,
          * push a phase that prompts the player to summon a Pokemon from their party.
          */
-        globalScene.phaseManager.createAndPushPhase("SwitchPhase", this.fieldIndex, SwitchType.FAINT_SWITCH);
+        phaseManager.createAndPushPhase("SwitchPhase", this.fieldIndex, SwitchType.FAINT_SWITCH);
       }
     } else {
       globalScene.phaseManager.createAndUnshiftPhase("PostKnockoutPhase", this.battlerIndex);

--- a/src/phases/move-phase.ts
+++ b/src/phases/move-phase.ts
@@ -765,7 +765,10 @@ export class MovePhase extends BattlePhase {
           }
         });
 
-        if (this.pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_REDIRECT)) {
+        if (
+          this.pokemon.hasTag(BattlerTagType.PURSUING)
+          || this.pokemon.hasAbilityWithAttr(AbAttrFlag.BLOCK_REDIRECT)
+        ) {
           redirectTarget.value = currentTarget;
           globalScene.phaseManager.createAndUnshiftPhase(
             "ShowAbilityPhase",

--- a/src/phases/recall-phase.ts
+++ b/src/phases/recall-phase.ts
@@ -29,7 +29,7 @@ export class RecallPhase extends PokemonPhase {
 
   // #region Public methods
 
-  public override start(): void {
+  public override async start(): Promise<void> {
     const pokemon = this.getPokemonAtFieldIndex();
     if (!pokemon?.isActive(true) || !pokemon.isOnField()) {
       super.end();
@@ -41,17 +41,13 @@ export class RecallPhase extends PokemonPhase {
     const { turnManager } = currentBattle;
     if (this.switchType === SwitchType.SWITCH && turnManager.tryPursueTarget(pokemon)) {
       // Reschedule this phase for after the scheduled Pursuit is fully resolved
-      // TODO: this might cause issues if Pursuit KOs the target
       phaseManager.unshiftPhase(this);
       super.end();
       return;
     }
 
-    this.recall()
-      .then(() => this.end())
-      .catch(() => {
-        throw new Error("RecallPhase: Recall process failed unexpectedly");
-      });
+    await this.recall();
+    this.end();
   }
 
   // #endregion

--- a/src/phases/recall-phase.ts
+++ b/src/phases/recall-phase.ts
@@ -31,13 +31,27 @@ export class RecallPhase extends PokemonPhase {
 
   public override start(): void {
     const pokemon = this.getPokemonAtFieldIndex();
-    if (!pokemon?.isOnField()) {
-      this.end();
+    if (!pokemon?.isActive(true) || !pokemon.isOnField()) {
+      super.end();
       return;
     }
     this.pokemon = pokemon;
 
-    this.recall().then(() => this.end());
+    const { currentBattle, phaseManager } = globalScene;
+    const { turnManager } = currentBattle;
+    if (turnManager.tryPursueTarget(pokemon)) {
+      // Reschedule this phase for after the scheduled Pursuit is fully resolved
+      // TODO: this might cause issues if Pursuit KOs the target
+      phaseManager.unshiftPhase(this);
+      super.end();
+      return;
+    }
+
+    this.recall()
+      .then(() => this.end())
+      .catch(() => {
+        throw new Error("RecallPhase: Recall process failed unexpectedly");
+      });
   }
 
   // #endregion

--- a/src/phases/recall-phase.ts
+++ b/src/phases/recall-phase.ts
@@ -39,7 +39,7 @@ export class RecallPhase extends PokemonPhase {
 
     const { currentBattle, phaseManager } = globalScene;
     const { turnManager } = currentBattle;
-    if (turnManager.tryPursueTarget(pokemon)) {
+    if (this.switchType === SwitchType.SWITCH && turnManager.tryPursueTarget(pokemon)) {
       // Reschedule this phase for after the scheduled Pursuit is fully resolved
       // TODO: this might cause issues if Pursuit KOs the target
       phaseManager.unshiftPhase(this);

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -21,6 +21,7 @@ import type { Pokemon } from "#field/pokemon";
 import { PokemonMove } from "#field/pokemon-move";
 import { BypassSpeedChanceModifier } from "#modifier/modifier";
 import { MoveHeaderAttr } from "#moves/move-header-attr";
+import { PursuitAttr } from "#moves/pursuit-attr";
 import type { TurnMove } from "#types/move-types";
 import { BooleanHolder } from "#utils/common-utils";
 import { randSeedShuffle } from "#utils/random-utils";
@@ -271,6 +272,50 @@ export class TurnCommandManager {
     turnCommand.turnMove = newMove;
     turnCommand.targets = targets;
 
+    return true;
+  }
+
+  /**
+   * Forces the first opposing Pokemon in turn order that is intending to use the move Pursuit
+   * to immediately Terastallize (if applicable), then attack the target.
+   * @param target - The {@linkcode Pokemon} attempting to switch out or retreat
+   * @returns `true` if a turn command was scheduled by this call
+   */
+  public tryPursueTarget(target: Pokemon): boolean {
+    const pursuitCommand = this.tryRemoveCommand(
+      (tc) => tc.pokemon.isOpponent(target) && !!tc.turnMove?.move.hasAttr(PursuitAttr),
+    );
+    if (pursuitCommand == null) {
+      return false;
+    }
+
+    const { command, pokemon, cursor } = pursuitCommand;
+    // we know this is defined from the filter above, but TS doesn't
+    const turnMove = pursuitCommand.turnMove!;
+    const { phaseManager } = globalScene;
+
+    // Pursuing Pokemon that intend to Terastallize do so immediately before attacking.
+    // TODO: Terastallizing pursuing Pokemon will always act before non-Tera pursuing
+    // Pokemon, regardless of their Speed order.
+    if (command === BattleCommand.TERA) {
+      phaseManager.createAndUnshiftPhase("TerastallizationPhase", pokemon);
+    }
+
+    pokemon.addTag(BattlerTagType.PURSUING);
+
+    const move =
+      pokemon.getMoveset().find((m) => m.moveId === turnMove.move.id && m.ppUsed < m.getMovePp())
+      ?? new PokemonMove(turnMove.move.id, { pokemonId: pokemon.id });
+
+    phaseManager.unshiftPhase(
+      phaseManager.createPhase("MovePhase", pokemon, [target.getBattlerIndex()], move, {
+        ignorePp: cursor !== -1 && turnMove.ignorePP,
+      }),
+      phaseManager.createPhase("PostActionPhase", pokemon.getBattlerIndex(), true),
+    );
+
+    pokemon.turnData.order = this.orderIndex++;
+    this.commandsInProgress++;
     return true;
   }
 

--- a/test/moves/pursuit.test.ts
+++ b/test/moves/pursuit.test.ts
@@ -1,0 +1,248 @@
+import { allMoves } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
+import { ElementalType } from "#enums/elemental-type";
+import { MoveId } from "#enums/move-id";
+import { MoveResult } from "#enums/move-result";
+import { SpeciesId } from "#enums/species-id";
+import { GameManager } from "#test/test-utils/game-manager";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Move - Pursuit", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .enemyTeraType(ElementalType.DARK)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.PURSUIT)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  describe("in Single Battles", () => {
+    beforeEach(() => {
+      game.override //
+        .battleType("single")
+        .enemyMoveset(MoveId.PURSUIT);
+    });
+
+    it("should attack at 40 power in normal turn order when no opponents switch out", async () => {
+      const pursuit = allMoves.get(MoveId.PURSUIT);
+      vi.spyOn(pursuit, "calculateBattlePower");
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+      game.move.use(MoveId.SPLASH);
+      await game.toEndOfTurn();
+
+      expect(pursuit.calculateBattlePower).toHaveLastReturnedWith(40);
+    });
+
+    it("should attack a retreating opponent before they switch out at 80 power", async () => {
+      const pursuit = allMoves.get(MoveId.PURSUIT);
+      vi.spyOn(pursuit, "calculateBattlePower");
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+      const [magikarp, feebas] = game.scene.getPlayerParty();
+      game.switchPokemon(1);
+      await game.toEndOfTurn();
+
+      expect(pursuit.calculateBattlePower).toHaveLastReturnedWith(80);
+      expect(magikarp).not.toHaveFullHp();
+      expect(feebas).toHaveFullHp();
+    });
+
+    it("should attack a retreating opponent before they switch out via U-turn", async () => {
+      const pursuit = allMoves.get(MoveId.PURSUIT);
+      vi.spyOn(pursuit, "calculateBattlePower");
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+      const [magikarp, feebas] = game.scene.getPlayerParty();
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+      game.move.use(MoveId.U_TURN);
+      game.selectPartyPokemon(1);
+      await game.toEndOfTurn();
+
+      expect(pursuit.calculateBattlePower).toHaveLastReturnedWith(80);
+      expect(magikarp).not.toHaveFullHp();
+      expect(feebas).toHaveFullHp();
+    });
+
+    it("should not attack a retreating opponent before they switch out via Baton Pass", async () => {
+      const pursuit = allMoves.get(MoveId.PURSUIT);
+      vi.spyOn(pursuit, "calculateBattlePower");
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+      const [magikarp, feebas] = game.scene.getPlayerParty();
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+      game.move.use(MoveId.BATON_PASS);
+      game.selectPartyPokemon(1);
+      await game.toEndOfTurn();
+
+      expect(pursuit.calculateBattlePower).toHaveLastReturnedWith(40);
+      expect(magikarp).toHaveFullHp();
+      expect(feebas).not.toHaveFullHp();
+    });
+
+    it("should allow the user to Terastallize before attacking a retreating opponent", async () => {
+      game.override.forceEnemyTera();
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+      const enemy = game.field.getEnemyPokemon();
+      const magikarp = game.field.getPlayerPokemon();
+
+      game.switchPokemon(1);
+      await game.phaseInterceptor.to("MoveEffectPhase", false);
+
+      expect(enemy.isTerastallized).toBe(true);
+      expect(magikarp.isActive(true)).toBe(true);
+    });
+
+    it("should bypass accuracy checks when attacking a retreating opponent", async () => {
+      const pursuit = allMoves.get(MoveId.PURSUIT);
+      vi.spyOn(pursuit, "accuracy", "get").mockReturnValue(0);
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+      const enemy = game.field.getEnemyPokemon();
+      const magikarp = game.field.getPlayerPokemon();
+
+      game.switchPokemon(1);
+      await game.toEndOfTurn();
+
+      expect(magikarp).not.toHaveFullHp();
+      expect(enemy).toHaveMoveResult(MoveResult.SUCCESS);
+    });
+  });
+
+  describe("in Double Battles", () => {
+    beforeEach(() => {
+      game.override //
+        .battleType("double")
+        .enemyMoveset(MoveId.SPLASH);
+    });
+
+    it("should attack a retreating opponent even if the original target was another Pokemon", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.LUVDISC);
+
+      const [magikarp, feebas, luvdisc] = game.scene.getPlayerParty();
+      game.move.use(MoveId.SPLASH, 0);
+      game.switchPokemon(2);
+      await game.move.forceEnemyMove(MoveId.PURSUIT, BattlerIndex.PLAYER);
+      await game.toNextTurn();
+
+      expect(magikarp).toHaveFullHp();
+      expect(feebas).not.toHaveFullHp();
+      expect(luvdisc).toHaveFullHp();
+    });
+
+    it("should not attack retreating allies", async () => {
+      const pursuit = allMoves.get(MoveId.PURSUIT);
+      vi.spyOn(pursuit, "calculateBattlePower");
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.LUVDISC);
+
+      const [enemy1] = game.scene.getEnemyField();
+
+      game.move.use(MoveId.PURSUIT, 0, BattlerIndex.ENEMY);
+      game.switchPokemon(2);
+      await game.toEndOfTurn();
+
+      expect(pursuit.calculateBattlePower).toHaveLastReturnedWith(40);
+      expect(enemy1).not.toHaveFullHp();
+      game.scene.getPlayerParty().forEach((p) => expect(p).toHaveFullHp());
+    });
+
+    // TODO: turn order utils seem to be interfering with this test
+    it.todo("should attack in turn order when used by multiple allies against the same target", async () => {
+      game.override.enemyMoveset(MoveId.PURSUIT);
+
+      const pursuit = allMoves.get(MoveId.PURSUIT);
+      const pursuitSpy = vi.spyOn(pursuit, "calculateBattlePower");
+
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.LUVDISC);
+
+      const [magikarp] = game.scene.getPlayerField();
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.ENEMY, BattlerIndex.PLAYER_2]);
+      game.switchPokemon(2);
+      game.move.use(MoveId.SPLASH, 1);
+      await game.toNextTurn();
+
+      /*
+       * Note: Under Pursuit's current implementation, switch commands are still scheduled first, but may be
+       * interrupted by opponents' uses of Pursuit. Since turn order reflects when commands are scheduled, the
+       * `PLAYER` Pokemon is expected to act first.
+       */
+      // expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.ENEMY, BattlerIndex.PLAYER_2]);
+      expect(magikarp.turnData.attacksReceived).toHaveLength(2);
+
+      const pursuitPower = pursuitSpy.mock.results.map((result) => result.value);
+      expect(pursuitPower).toHaveLength(2);
+      pursuitPower.forEach((power) => expect(power).toBe(80));
+    });
+
+    it("should apply normally when another Pursuit KOs a retreating Pokemon", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.LUVDISC);
+
+      const [magikarp, feebas, luvdisc] = game.scene.getPlayerParty();
+      magikarp.hp = 1;
+
+      game.switchPokemon(2);
+      game.move.use(MoveId.SPLASH, 1);
+      await game.move.forceEnemyMove(MoveId.PURSUIT, BattlerIndex.PLAYER_2);
+      await game.move.forceEnemyMove(MoveId.PURSUIT, BattlerIndex.PLAYER_2);
+      // Select Luvdisc again during the turn; we expect Magikarp to faint before switching out
+      game.selectPartyPokemon(2);
+
+      await game.toNextTurn();
+
+      expect(magikarp).toHaveFainted();
+      expect(feebas).not.toHaveFullHp();
+      expect(luvdisc.isOnField()).toBe(true);
+    });
+
+    it("should not pursue opponents that are forced out", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.LUVDISC);
+
+      const [magikarp, feebas, luvdisc] = game.scene.getPlayerParty();
+
+      game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.ENEMY_2, BattlerIndex.PLAYER, BattlerIndex.PLAYER_2]);
+      game.move.use(MoveId.SPLASH, 0);
+      game.move.use(MoveId.SPLASH, 1);
+      await game.move.forceEnemyMove(MoveId.ROAR, BattlerIndex.PLAYER);
+      await game.move.forceEnemyMove(MoveId.PURSUIT, BattlerIndex.PLAYER_2);
+      game.selectPartyPokemon(2);
+      await game.toEndOfTurn();
+
+      expect(magikarp).toHaveFullHp();
+      expect(feebas).not.toHaveFullHp();
+      expect(luvdisc).toHaveFullHp();
+    });
+  });
+});

--- a/test/moves/pursuit.test.ts
+++ b/test/moves/pursuit.test.ts
@@ -199,7 +199,12 @@ describe("Move - Pursuit", () => {
        * interrupted by opponents' uses of Pursuit. Since turn order reflects when commands are scheduled, the
        * `PLAYER` Pokemon is expected to act first.
        */
-      // expect(game.field.getTurnOrder()).toEqual([BattlerIndex.PLAYER, BattlerIndex.ENEMY_2, BattlerIndex.ENEMY, BattlerIndex.PLAYER_2]);
+      expect(game.field.getTurnOrder()).toEqual([
+        BattlerIndex.PLAYER,
+        BattlerIndex.ENEMY_2,
+        BattlerIndex.ENEMY,
+        BattlerIndex.PLAYER_2,
+      ]);
       expect(magikarp.turnData.attacksReceived).toHaveLength(2);
 
       const pursuitPower = pursuitSpy.mock.results.map((result) => result.value);
@@ -243,6 +248,38 @@ describe("Move - Pursuit", () => {
       expect(magikarp).toHaveFullHp();
       expect(feebas).not.toHaveFullHp();
       expect(luvdisc).toHaveFullHp();
+    });
+
+    it("should bypass redirection when attacking a retreating opponent", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS, SpeciesId.LUVDISC);
+
+      const [magikarp, feebas, luvdisc] = game.scene.getPlayerParty();
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+      game.move.use(MoveId.FOLLOW_ME, 0);
+      game.move.use(MoveId.U_TURN, 1, BattlerIndex.ENEMY);
+      await game.move.forceEnemyMove(MoveId.PURSUIT, BattlerIndex.PLAYER_2);
+      game.selectPartyPokemon(2);
+      await game.toEndOfTurn();
+
+      expect(magikarp).toHaveFullHp();
+      expect(feebas).not.toHaveFullHp();
+      expect(luvdisc).toHaveFullHp();
+    });
+
+    it("should not bypass redirection when not attacking a retreating opponent", async () => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP, SpeciesId.FEEBAS);
+
+      const [magikarp, feebas] = game.scene.getPlayerField();
+
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.PLAYER_2, BattlerIndex.ENEMY, BattlerIndex.ENEMY_2]);
+      game.move.use(MoveId.FOLLOW_ME, 0);
+      game.move.use(MoveId.SPLASH, 1);
+      await game.move.forceEnemyMove(MoveId.PURSUIT, BattlerIndex.PLAYER_2);
+      await game.toEndOfTurn();
+
+      expect(magikarp).not.toHaveFullHp();
+      expect(feebas).toHaveFullHp();
     });
   });
 });


### PR DESCRIPTION
## What are the changes the user will see?

Pursuit now allows the user to attack an opponent before it retreats.

## Why am I making these changes?

closes #1032 📈 

## What are the changes from a developer perspective?

`RecallPhase` now prompts the `TurnCommandManager` to schedule the first command in turn order of an opponent using the move Pursuit against the recalling Pokemon. If a command is scheduled from this prompt, the `RecallPhase` is postponed until the command fully resolves.

> [!NOTE]
> There is a known edge case where if a Pokemon using Pursuit also intends to Terastallize, it will always act before any of its allies that are also using Pursuit, regardless of speed order. 

## Screenshots/Videos

https://github.com/user-attachments/assets/7d845959-4183-4e73-a08c-0786f655d4a2

<details><summary>Overrides</summary>
<p>

```ts
const overrides = {
  BATTLE_TYPE_OVERRIDE: "double",
  ENEMY_SPECIES_OVERRIDE: SpeciesId.MAGIKARP,
  ENEMY_MOVESET_OVERRIDE: MoveId.PURSUIT,
  MOVESET_OVERRIDE: MoveId.SPLASH,
} satisfies Partial<InstanceType<typeof DefaultOverrides>>;
```

</p>
</details> 

## How to test the changes?

`pnpm test[:silent] pursuit`

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [x] Have I provided screenshots/videos of the changes (if applicable)?
  - [x] Have I made sure that any UI change works for both UI themes (dark and light)?
