### PR TITLE
refactor: Rewrite `AttemptRunPhase`

### DIFF
--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -131,7 +131,8 @@ class DefaultOverrides {
   readonly BYPASS_TUTORIAL_SKIP_OVERRIDE: boolean = false;
   /** Set to `true` to be able to re-earn already unlocked achievements */
   readonly ACHIEVEMENTS_REUNLOCK_OVERRIDE: boolean = false;
-  /** Forces the activation/non-activation of various statuses
+  /**
+   * Forces the activation/non-activation of various statuses
    * - Paralysis: set to `true` to always activate, `false` to do the opposite
    * - Sleep: set to `true` to force the Pokemon to stay asleep, `false` to immediately wake up
    * - Freeze: set to `true` to keep the Pokemon frozen, `false` to defrost
@@ -139,6 +140,8 @@ class DefaultOverrides {
    * - Infatuated: set to `true` to force its activation, set to `false` to do the opposite
    */
   readonly STATUS_ACTIVATION_OVERRIDE: boolean | null = null;
+  /** Forces the Player's attempts to run from battle to succeed (`true`) or fail (`false`) */
+  readonly RUN_RESULT_OVERRIDE: boolean | null = null;
 
   // ----------------
   // PLAYER OVERRIDES

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -1,87 +1,53 @@
-import { applyAbAttrs } from "#abilities/apply-ab-attrs";
-import type { RunSuccessAbAttr } from "#abilities/run-success-ab-attr";
 import { globalScene } from "#app/global-scene";
+import { activeOverrides } from "#app/overrides";
 import { AbAttrFlag } from "#enums/ab-attr-flag";
 import { ArenaTagType } from "#enums/arena-tag-type";
 import { Stat } from "#enums/stat";
-import type { EnemyPokemon } from "#field/enemy-pokemon";
-import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
-import { clamp, NumberHolder } from "#utils/common-utils";
+import { playTween } from "#utils/anim-utils";
+import { clamp } from "#utils/common-utils";
 import i18next from "i18next";
 
-// TODO: refactor this phase
-/**
- * Handles the player attempting to run away from a wild battle
- */
+/** Handles the Player attempting to run away from a Wild Battle via a "Run" command. */
 export class AttemptRunPhase extends PokemonPhase {
   public override readonly phaseName = "AttemptRunPhase";
 
-  /** For testing purposes: this is to force the pokemon to fail to escape */
-  public forceFailEscape = false; // TODO: replace with a new override
-
-  public override start(): void {
-    const playerField = globalScene.getPlayerField();
-    const enemyField = globalScene.getEnemyField();
-
-    const playerPokemon = this.getPokemon();
-
-    const escapeChance = new NumberHolder(0);
-
-    this.attemptRunAway(playerField, enemyField, escapeChance);
-
-    applyAbAttrs<RunSuccessAbAttr>(AbAttrFlag.RUN_SUCCESS, playerPokemon, false, escapeChance);
-
-    if (playerPokemon.randSeedInt(100) < escapeChance.value && !this.forceFailEscape) {
-      globalScene.audioManager.playSound("se/flee");
-      globalScene.phaseManager.createAndUnshiftPhase(
-        "MessagePhase",
-        i18next.t("battle:runAwaySuccess"),
-        undefined,
-        true,
-        500,
-      );
-
-      globalScene.tweens.add({
-        targets: [globalScene.arenaEnemy, enemyField].flat(),
-        alpha: 0,
-        duration: 250,
-        ease: "Sine.easeIn",
-        onComplete: () => enemyField.forEach((enemyPokemon) => enemyPokemon.destroy()),
-      });
-
-      globalScene.clearEnemyHeldItemModifiers();
-      // clear all queued delayed attacks (e.g. from Future Sight)
-      globalScene.arena.removeTag(ArenaTagType.DELAYED_ATTACK);
-
-      enemyField.forEach((enemyPokemon) => {
-        enemyPokemon.hideInfo().then(() => enemyPokemon.destroy());
-        enemyPokemon.faint(); // TODO: why are we fainting the pokemon at all, let alone after using `.destroy()` on them?
-      });
-
-      globalScene.phaseManager.queueNextBattle(false);
+  public override async start(): Promise<void> {
+    if (this.canRunAway()) {
+      await this.handleSuccessfulRunAway();
     } else {
-      playerPokemon.turnData.failedRunAway = true;
-      globalScene.phaseManager.createAndUnshiftPhase(
-        "MessagePhase",
-        i18next.t("battle:runAwayCannotEscape"),
-        undefined,
-        true,
-        500,
-      );
+      this.handleFailedRunAway();
     }
-
     this.end();
   }
 
+  /** @returns `true` if this run attempt is successful */
+  private canRunAway(): boolean {
+    if (activeOverrides.RUN_RESULT_OVERRIDE != null) {
+      return activeOverrides.RUN_RESULT_OVERRIDE;
+    }
+
+    const playerField = globalScene.getPlayerField().filter((p) => p.isActive(true));
+    if (playerField.some((p) => p.hasAbilityWithAttr(AbAttrFlag.RUN_SUCCESS))) {
+      return true;
+    }
+
+    const enemyField = globalScene.getEnemyField().filter((p) => p.isActive(true));
+
+    const escapeChance = this.getEscapeChance(playerField, enemyField);
+
+    return this.getPokemon().randSeedInt(100) < escapeChance;
+  }
+
   /**
-   * Calculates the base escape chance based on the current field.
-   * @param playerField - Array of {@linkcode PlayerPokemon} whose speed stats will be used in the calculation.
-   * @param enemyField - Array of {@linkcode EnemyPokemon} whose speed stats will be used in the calculation.
-   * @param escapeChance - {@linkcode NumberHolder} holding the % chance to escape, will be overwritten by the function
+   * Calculates the chance of the Player escaping battle in the current game state
+   * (assuming Run Away and other external effects are not active).
+   * @param playerField - The active {@linkcode PlayerPokemon} on the field
+   * @param enemyField - The active {@linkcode EnemyPokemon} on the field
+   * @returns the chance (in percent) of the Player to escape safely from battle
    */
-  public attemptRunAway(playerField: PlayerPokemon[], enemyField: EnemyPokemon[], escapeChance: NumberHolder): void {
+  private getEscapeChance(playerField: Pokemon[], enemyField: Pokemon[]): number {
     /** Sum of the speed of all enemy pokemon on the field */
     const enemySpeed = enemyField.reduce(
       (total: number, enemyPokemon: Pokemon) => total + enemyPokemon.getStat(Stat.SPD),
@@ -110,10 +76,7 @@ export class AttemptRunPhase extends PokemonPhase {
      * From the above, we can calculate the below values
      */
 
-    let isBoss = false;
-    for (const enemy of enemyField) {
-      isBoss = isBoss || enemy.isBoss(); // this line checks if any of the enemy pokemon on the field are bosses; if so, the calculation for escaping is different
-    }
+    const isBoss = enemyField.some((p) => p.isBoss());
 
     /** The ratio between the speed of your active pokemon and the speed of the enemy field */
     const speedRatio = playerSpeed / enemySpeed;
@@ -129,10 +92,56 @@ export class AttemptRunPhase extends PokemonPhase {
     const escapeSlope = (maxChance - minChance) / speedCap;
 
     // This will calculate the escape chance given all of the above and clamp it to the range of [`minChance`, `maxChance`]
-    escapeChance.value = clamp(
+    return clamp(
       Math.round(escapeSlope * speedRatio + minChance + escapeBonus * globalScene.currentBattle.escapeAttempts++),
       minChance,
       maxChance,
+    );
+  }
+
+  /**
+   * Applies all data and visual feedback for the Player successfully fleeing from battle, including:
+   * - Playing animations to clear the enemy's side of the field
+   * - Destroying enemy assets (e.g. sprites)
+   * - Scheduling a phase to advance to the next wave
+   */
+  private async handleSuccessfulRunAway(): Promise<void> {
+    const { arena, arenaEnemy, audioManager, phaseManager } = globalScene;
+    const enemyField = globalScene.getEnemyField().filter((p) => p.isActive(true));
+
+    audioManager.playSound("se/flee");
+    phaseManager.createAndUnshiftPhase("MessagePhase", i18next.t("battle:runAwaySuccess"), undefined, true, 500);
+
+    await playTween({
+      targets: [arenaEnemy, ...enemyField],
+      alpha: 0,
+      duration: 250,
+      ease: "Sine.easeIn",
+    });
+
+    globalScene.clearEnemyHeldItemModifiers();
+    // clear all queued delayed attacks (e.g. from Future Sight)
+    arena.removeTag(ArenaTagType.DELAYED_ATTACK);
+
+    // TODO: Should this be run at the same time as the tween?
+    await Promise.allSettled(enemyField.map((p) => p.hideInfo()));
+    enemyField.forEach((p) => p.destroy());
+
+    globalScene.phaseManager.queueNextBattle(false);
+  }
+
+  /** Applies all data and visual feedback for the Player failing to flee from battle. */
+  private handleFailedRunAway(): void {
+    globalScene.getPlayerField().forEach((p) => {
+      // TODO: This flag should be in another scope. Attaching it to Pokemon may lead to duplicate data
+      p.turnData.failedRunAway = true;
+    });
+    globalScene.phaseManager.createAndUnshiftPhase(
+      "MessagePhase",
+      i18next.t("battle:runAwayCannotEscape"),
+      undefined,
+      true,
+      500,
     );
   }
 }

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -127,7 +127,8 @@ export class AttemptRunPhase extends PokemonPhase {
     await Promise.allSettled(enemyField.map((p) => p.hideInfo()));
     enemyField.forEach((p) => p.destroy());
 
-    globalScene.phaseManager.queueNextBattle(false);
+    phaseManager.clearAllPhases();
+    phaseManager.queueNextBattle(false);
   }
 
   /** Applies all data and visual feedback for the Player failing to flee from battle. */

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -48,33 +48,14 @@ export class AttemptRunPhase extends PokemonPhase {
    * @returns the chance (in percent) of the Player to escape safely from battle
    */
   private getEscapeChance(playerField: Pokemon[], enemyField: Pokemon[]): number {
-    /** Sum of the speed of all enemy pokemon on the field */
-    const enemySpeed = enemyField.reduce(
-      (total: number, enemyPokemon: Pokemon) => total + enemyPokemon.getStat(Stat.SPD),
-      0,
-    );
-    /** Sum of the speed of all player pokemon on the field */
-    const playerSpeed = playerField.reduce(
-      (total: number, playerPokemon: Pokemon) => total + playerPokemon.getStat(Stat.SPD),
-      0,
-    );
-
-    /*
-     * The way the escape chance works is by looking at the difference between your speed and the enemy field's average speed as a ratio. The higher this ratio, the higher your chance of success.
-     * However, there is a cap for the ratio of your speed vs enemy speed which beyond that point, you won't gain any advantage. It also looks at how many times you've tried to escape.
-     * Again, the more times you've tried to escape, the higher your odds of escaping. Bosses and non-bosses are calculated differently - bosses are harder to escape from vs non-bosses
-     * Finally, there's a minimum and maximum escape chance as well so that escapes aren't guaranteed, yet they are never 0 either.
-     * The percentage chance to escape from a pokemon for both bosses and non bosses is linear and based on the minimum and maximum chances, and the speed ratio cap.
-     *
-     * At the time of writing, these conditions should be met:
-     * - The minimum escape chance should be 5% for bosses and non bosses
-     * - Bosses should have a maximum escape chance of 25%, whereas non-bosses should be 95%
-     * - The bonus per previous escape attempt should be 2% for bosses and 10% for non-bosses
-     * - The speed ratio cap should be 6x for bosses and 4x for non-bosses
-     * - The "default" escape chance when your speed equals the enemy speed should be 8.33% for bosses and 27.5% for non-bosses
-     *
-     * From the above, we can calculate the below values
-     */
+    /** The average speed of all enemy pokemon on the field */
+    const enemySpeed =
+      enemyField.reduce((total: number, enemyPokemon: Pokemon) => total + enemyPokemon.getStat(Stat.SPD), 0)
+      / enemyField.length;
+    /** The average speed of all player pokemon on the field */
+    const playerSpeed =
+      playerField.reduce((total: number, playerPokemon: Pokemon) => total + playerPokemon.getStat(Stat.SPD), 0)
+      / enemyField.length;
 
     const isBoss = enemyField.some((p) => p.isBoss());
 

--- a/test/abilities/speed-boost.test.ts
+++ b/test/abilities/speed-boost.test.ts
@@ -3,7 +3,6 @@ import { BattleCommand } from "#enums/battle-command";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
-import type { AttemptRunPhase } from "#phases/attempt-run-phase";
 import type { CommandPhase } from "#phases/command-phase";
 import { GameManager } from "#test/test-utils/game-manager";
 import Phaser from "phaser";
@@ -96,12 +95,12 @@ describe("Abilities - Speed Boost", () => {
   });
 
   it("should not trigger if pokemon fails to escape", async () => {
+    game.override.forceRunResult(false);
+
     await game.classicMode.startBattle(SpeciesId.SHUCKLE);
 
     const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
     commandPhase.handleCommand(BattleCommand.RUN, 0);
-    const runPhase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
-    runPhase.forceFailEscape = true;
     await game.phaseInterceptor.to("AttemptRunPhase");
     await game.toNextTurn();
 

--- a/test/battle/escape-calculations.test.ts
+++ b/test/battle/escape-calculations.test.ts
@@ -4,7 +4,6 @@ import { SpeciesId } from "#enums/species-id";
 import type { AttemptRunPhase } from "#phases/attempt-run-phase";
 import type { CommandPhase } from "#phases/command-phase";
 import { GameManager } from "#test/test-utils/game-manager";
-import { NumberHolder } from "#utils/common-utils";
 import Phaser from "phaser";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -45,10 +44,9 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
-    const escapeChances: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
+    const testCases: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
       { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5 },
       { pokemonSpeedRatio: 0.1, escapeAttempts: 0, expectedEscapeChance: 7 },
       { pokemonSpeedRatio: 0.25, escapeAttempts: 0, expectedEscapeChance: 11 },
@@ -75,9 +73,9 @@ describe("Escape chance calculations", () => {
       { pokemonSpeedRatio: 2, escapeAttempts: 3, expectedEscapeChance: 80 },
     ];
 
-    for (const escapeChance of escapeChances) {
+    for (const testCase of testCases) {
       // sets the number of escape attempts to the required amount
-      game.scene.currentBattle.escapeAttempts = escapeChance.escapeAttempts;
+      game.scene.currentBattle.escapeAttempts = testCase.escapeAttempts;
       // set playerPokemon's speed to a multiple of the enemySpeed
       vi.spyOn(playerPokemon[0], "stats", "get").mockReturnValue([
         20,
@@ -85,10 +83,10 @@ describe("Escape chance calculations", () => {
         20,
         20,
         20,
-        escapeChance.pokemonSpeedRatio * enemySpeed,
+        testCase.pokemonSpeedRatio * enemySpeed,
       ]);
-      phase.attemptRunAway(playerPokemon, enemyField, escapePercentage);
-      expect(escapePercentage.value).toBe(escapeChance.expectedEscapeChance);
+      const escapeChance = phase["getEscapeChance"](playerPokemon, enemyField);
+      expect(escapeChance).toBe(testCase.expectedEscapeChance);
     }
   }, 20000);
 
@@ -114,10 +112,9 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
-    const escapeChances: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
+    const testCases: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
       { pokemonSpeedRatio: 0.3, escapeAttempts: 0, expectedEscapeChance: 12 },
       { pokemonSpeedRatio: 0.7, escapeAttempts: 0, expectedEscapeChance: 21 },
       { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 39 },
@@ -143,9 +140,9 @@ describe("Escape chance calculations", () => {
       { pokemonSpeedRatio: 2, escapeAttempts: 10, expectedEscapeChance: 95 },
     ];
 
-    for (const escapeChance of escapeChances) {
+    for (const testCase of testCases) {
       // sets the number of escape attempts to the required amount
-      game.scene.currentBattle.escapeAttempts = escapeChance.escapeAttempts;
+      game.scene.currentBattle.escapeAttempts = testCase.escapeAttempts;
       // set the first playerPokemon's speed to a multiple of the enemySpeed
       vi.spyOn(playerPokemon[0], "stats", "get").mockReturnValue([
         20,
@@ -153,7 +150,7 @@ describe("Escape chance calculations", () => {
         20,
         20,
         20,
-        Math.floor(escapeChance.pokemonSpeedRatio * totalEnemySpeed * playerASpeedPercentage),
+        Math.floor(testCase.pokemonSpeedRatio * totalEnemySpeed * playerASpeedPercentage),
       ]);
       // set the second playerPokemon's speed to the remaining value of speed
       vi.spyOn(playerPokemon[1], "stats", "get").mockReturnValue([
@@ -162,15 +159,13 @@ describe("Escape chance calculations", () => {
         20,
         20,
         20,
-        escapeChance.pokemonSpeedRatio * totalEnemySpeed - playerPokemon[0].stats[5],
+        testCase.pokemonSpeedRatio * totalEnemySpeed - playerPokemon[0].stats[5],
       ]);
-      phase.attemptRunAway(playerPokemon, enemyField, escapePercentage);
+      const escapeChance = phase["getEscapeChance"](playerPokemon, enemyField);
       // checks to make sure the escape values are the same
-      expect(escapePercentage.value).toBe(escapeChance.expectedEscapeChance);
+      expect(escapeChance).toBe(testCase.expectedEscapeChance);
       // checks to make sure the sum of the player's speed for all pokemon is equal to the appropriate ratio of the total enemy speed
-      expect(playerPokemon[0].stats[5] + playerPokemon[1].stats[5]).toBe(
-        escapeChance.pokemonSpeedRatio * totalEnemySpeed,
-      );
+      expect(playerPokemon[0].stats[5] + playerPokemon[1].stats[5]).toBe(testCase.pokemonSpeedRatio * totalEnemySpeed);
     }
   }, 20000);
 
@@ -189,10 +184,9 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
-    const escapeChances: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
+    const testCases: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
       { pokemonSpeedRatio: 0.01, escapeAttempts: 0, expectedEscapeChance: 5 },
       { pokemonSpeedRatio: 0.1, escapeAttempts: 0, expectedEscapeChance: 5 },
       { pokemonSpeedRatio: 0.25, escapeAttempts: 0, expectedEscapeChance: 6 },
@@ -232,9 +226,9 @@ describe("Escape chance calculations", () => {
       { pokemonSpeedRatio: 6.1, escapeAttempts: 3, expectedEscapeChance: 25 },
     ];
 
-    for (const escapeChance of escapeChances) {
+    for (const testCase of testCases) {
       // sets the number of escape attempts to the required amount
-      game.scene.currentBattle.escapeAttempts = escapeChance.escapeAttempts;
+      game.scene.currentBattle.escapeAttempts = testCase.escapeAttempts;
       // set playerPokemon's speed to a multiple of the enemySpeed
       vi.spyOn(playerPokemon[0], "stats", "get").mockReturnValue([
         20,
@@ -242,10 +236,10 @@ describe("Escape chance calculations", () => {
         20,
         20,
         20,
-        escapeChance.pokemonSpeedRatio * enemySpeed,
+        testCase.pokemonSpeedRatio * enemySpeed,
       ]);
-      phase.attemptRunAway(playerPokemon, enemyField, escapePercentage);
-      expect(escapePercentage.value).toBe(escapeChance.expectedEscapeChance);
+      const escapeChance = phase["getEscapeChance"](playerPokemon, enemyField);
+      expect(escapeChance).toBe(testCase.expectedEscapeChance);
     }
   }, 20000);
 
@@ -272,10 +266,9 @@ describe("Escape chance calculations", () => {
 
     await game.phaseInterceptor.to("AttemptRunPhase", false);
     const phase = game.scene.phaseManager.getCurrentPhase() as AttemptRunPhase;
-    const escapePercentage = new NumberHolder(0);
 
     // this sets up an object for multiple attempts. The pokemonSpeedRatio is your speed divided by the enemy speed, the escapeAttempts are the number of escape attempts and the expectedEscapeChance is the chance it should be escaping
-    const escapeChances: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
+    const testCases: { pokemonSpeedRatio: number; escapeAttempts: number; expectedEscapeChance: number }[] = [
       { pokemonSpeedRatio: 0.3, escapeAttempts: 0, expectedEscapeChance: 6 },
       { pokemonSpeedRatio: 0.7, escapeAttempts: 0, expectedEscapeChance: 7 },
       { pokemonSpeedRatio: 1.5, escapeAttempts: 0, expectedEscapeChance: 10 },
@@ -313,9 +306,9 @@ describe("Escape chance calculations", () => {
       { pokemonSpeedRatio: 5.2, escapeAttempts: 2, expectedEscapeChance: 25 },
     ];
 
-    for (const escapeChance of escapeChances) {
+    for (const testCase of testCases) {
       // sets the number of escape attempts to the required amount
-      game.scene.currentBattle.escapeAttempts = escapeChance.escapeAttempts;
+      game.scene.currentBattle.escapeAttempts = testCase.escapeAttempts;
       // set the first playerPokemon's speed to a multiple of the enemySpeed
       vi.spyOn(playerPokemon[0], "stats", "get").mockReturnValue([
         20,
@@ -323,7 +316,7 @@ describe("Escape chance calculations", () => {
         20,
         20,
         20,
-        Math.floor(escapeChance.pokemonSpeedRatio * totalEnemySpeed * playerASpeedPercentage),
+        Math.floor(testCase.pokemonSpeedRatio * totalEnemySpeed * playerASpeedPercentage),
       ]);
       // set the second playerPokemon's speed to the remaining value of speed
       vi.spyOn(playerPokemon[1], "stats", "get").mockReturnValue([
@@ -332,15 +325,13 @@ describe("Escape chance calculations", () => {
         20,
         20,
         20,
-        escapeChance.pokemonSpeedRatio * totalEnemySpeed - playerPokemon[0].stats[5],
+        testCase.pokemonSpeedRatio * totalEnemySpeed - playerPokemon[0].stats[5],
       ]);
-      phase.attemptRunAway(playerPokemon, enemyField, escapePercentage);
+      const escapeChance = phase["getEscapeChance"](playerPokemon, enemyField);
       // checks to make sure the escape values are the same
-      expect(escapePercentage.value).toBe(escapeChance.expectedEscapeChance);
+      expect(escapeChance).toBe(testCase.expectedEscapeChance);
       // checks to make sure the sum of the player's speed for all pokemon is equal to the appropriate ratio of the total enemy speed
-      expect(playerPokemon[0].stats[5] + playerPokemon[1].stats[5]).toBe(
-        escapeChance.pokemonSpeedRatio * totalEnemySpeed,
-      );
+      expect(playerPokemon[0].stats[5] + playerPokemon[1].stats[5]).toBe(testCase.pokemonSpeedRatio * totalEnemySpeed);
     }
   }, 20000);
 });

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -1,6 +1,7 @@
 /* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { NewArenaEvent } from "#events/battle-scene";
 import type { Arena } from "#field/arena";
+import type { AttemptRunPhase } from "#phases/attempt-run-phase";
 import type { GameManager } from "#test/test-utils/game-manager";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
@@ -649,6 +650,25 @@ export class OverridesHelper extends GameManagerHelper {
       this.log("Disabled override for enemy Tera type!");
     } else {
       this.log(`Enemy Tera type set to ${enumValueToKey(ElementalType, type)} (=${type})!`);
+    }
+    return this;
+  }
+
+  /**
+   * Override the result of the Player's attempts to flee from battle.
+   * @param result - The desired outcome for Run attempts:
+   * - If `true`, Run attempts will always succeed.
+   * - If `false`, Run attempts will always fail.
+   * - If `null`, the override is disabled, and Run attempts will use the default algorithm.
+   * @returns `this`
+   * @see {@linkcode AttemptRunPhase}
+   */
+  public forceRunResult(result: boolean | null): this {
+    vi.spyOn(activeOverrides, "RUN_RESULT_OVERRIDE", "get").mockReturnValue(result);
+    if (result === null) {
+      this.log("Disabled override for player Run result!");
+    } else {
+      this.log(`Result for run attempts set to ${result}`);
     }
     return this;
   }


### PR DESCRIPTION
## What are the changes the user will see?

Speed Boost should no longer activate when the Player chooses to run (and fails) from the source's ally's command menu.

## Why am I making these changes?

Another phase to convert to async...

## What are the changes from a developer perspective?

In `AttemptRunPhase`:
- Split `start` into helper methods. `start` is now also the phase's only public method.
- Converted `forceFailEscape` into an override which can force either success or failure.
- Removed redundant calls to faint/destroy enemy Pokemon during a successful escape.
- Other minor optimizations and cleanup...

## Screenshots/Videos

## How to test the changes?

`pnpm test[:silent]`

There are some relevant existing tests scattered in different files, the most relevant of which can be found in the following:
- `escape-calculations`
- `speed-boost`
- `honey-gather`

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [?] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [?] Have I provided screenshots/videos of the changes (if applicable)?
  - [?] Have I made sure that any UI change works for both UI themes (dark and light)?
