### PR TITLE
dev: add Lefthook commands to run `pnpm i`

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,9 +19,9 @@ post-merge:
     update-submodules:
       run: git submodule update --init --recursive
     update-packages:
-      run: pnpm i
+      run: pnpm i --ignore-scripts
 
 post-checkout:
   commands:
     update-packages:
-      run: pnpm i
+      run: pnpm i --ignore-scripts

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,10 @@ post-merge:
   commands:
     update-submodules:
       run: git submodule update --init --recursive
+    update-packages:
+      run: pnpm i
+
+post-checkout:
+  commands:
+    update-packages:
+      run: pnpm i


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Devs won't need to run `pnpm i` manually anymore whenever packages are updated.

## What are the changes from a developer perspective?
`pnpm i --ignore-scripts` will be run whenever a branch is checked out or `git pull` is used. `--ignore-scripts` makes sure the `postinstall` script from `package.json` isn't run.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?