### PR TITLE
dev: update Biome from `2.3.4` to `2.3.8` and add some rules

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -184,7 +184,8 @@
         "noMisusedPromises": "warn", // TODO: refactor and make "error"
         "useExhaustiveSwitchCases": "error",
         "noUnnecessaryConditions": "off", // TODO: enable when the false positives are fixed
-        "noImportCycles": "error" // overlaps with depcruiser but this will allow diagnostics to be shown in the IDE
+        "noImportCycles": "error", // overlaps with depcruiser but this will allow diagnostics to be shown in the IDE
+        "useArraySortCompare": "error"
       },
       "performance": {
         "noNamespaceImport": "error",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -188,7 +188,8 @@
         "noImportCycles": "error", // overlaps with depcruiser but this will allow diagnostics to be shown in the IDE
         "useArraySortCompare": "error",
         "useFind": "error",
-        "noParametersOnlyUsedInRecursion": "error"
+        "noParametersOnlyUsedInRecursion": "error",
+        "useSpread": "error"
       },
       "performance": {
         "noNamespaceImport": "error",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -189,7 +189,9 @@
         "useArraySortCompare": "error",
         "useFind": "error",
         "noParametersOnlyUsedInRecursion": "error",
-        "useSpread": "error"
+        "useSpread": "error",
+        "noProto": "error",
+        "noMultiStr": "error"
       },
       "performance": {
         "noNamespaceImport": "error",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -68,7 +68,8 @@
         "noPrivateImports": "error",
         "noUndeclaredDependencies": "error",
         "useJsonImportAttributes": "off", // "Import attributes are only supported when the '--module' option is set to 'esnext', 'node18', 'nodenext', or 'preserve'. ts(2823)"
-        "useSingleJsDocAsterisk": "error"
+        "useSingleJsDocAsterisk": "error",
+        "noUnusedPrivateClassMembers": "error"
       },
       "style": {
         "useEnumInitializers": "off", // large enums like Moves/Species would make this cumbersome

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -185,7 +185,8 @@
         "useExhaustiveSwitchCases": "error",
         "noUnnecessaryConditions": "off", // TODO: enable when the false positives are fixed
         "noImportCycles": "error", // overlaps with depcruiser but this will allow diagnostics to be shown in the IDE
-        "useArraySortCompare": "error"
+        "useArraySortCompare": "error",
+        "useFind": "error"
       },
       "performance": {
         "noNamespaceImport": "error",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -186,7 +186,8 @@
         "noUnnecessaryConditions": "off", // TODO: enable when the false positives are fixed
         "noImportCycles": "error", // overlaps with depcruiser but this will allow diagnostics to be shown in the IDE
         "useArraySortCompare": "error",
-        "useFind": "error"
+        "useFind": "error",
+        "noParametersOnlyUsedInRecursion": "error"
       },
       "performance": {
         "noNamespaceImport": "error",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "update-locales:remote": "git submodule update --progress --init --recursive --force --remote"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.4",
+    "@biomejs/biome": "2.3.7",
     "@types/crypto-js": "^4.2.2",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.10.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "update-locales:remote": "git submodule update --progress --init --recursive --force --remote"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.7",
+    "@biomejs/biome": "2.3.8",
     "@types/crypto-js": "^4.2.2",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         version: 1.80.17(graphology-types@0.24.8)
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.7
-        version: 2.3.7
+        specifier: 2.3.8
+        version: 2.3.8
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -207,55 +207,55 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.3.7':
-    resolution: {integrity: sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw==}
+  '@biomejs/biome@2.3.8':
+    resolution: {integrity: sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.7':
-    resolution: {integrity: sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA==}
+  '@biomejs/cli-darwin-arm64@2.3.8':
+    resolution: {integrity: sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.7':
-    resolution: {integrity: sha512-Q4TO633kvrMQkKIV7wmf8HXwF0dhdTD9S458LGE24TYgBjSRbuhvio4D5eOQzirEYg6eqxfs53ga/rbdd8nBKg==}
+  '@biomejs/cli-darwin-x64@2.3.8':
+    resolution: {integrity: sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.7':
-    resolution: {integrity: sha512-/afy8lto4CB8scWfMdt+NoCZtatBUF62Tk3ilWH2w8ENd5spLhM77zKlFZEvsKJv9AFNHknMl03zO67CiklL2Q==}
+  '@biomejs/cli-linux-arm64-musl@2.3.8':
+    resolution: {integrity: sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.3.7':
-    resolution: {integrity: sha512-inHOTdlstUBzgjDcx0ge71U4SVTbwAljmkfi3MC5WzsYCRhancqfeL+sa4Ke6v2ND53WIwCFD5hGsYExoI3EZQ==}
+  '@biomejs/cli-linux-arm64@2.3.8':
+    resolution: {integrity: sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.3.7':
-    resolution: {integrity: sha512-CQUtgH1tIN6e5wiYSJqzSwJumHYolNtaj1dwZGCnZXm2PZU1jOJof9TsyiP3bXNDb+VOR7oo7ZvY01If0W3iFQ==}
+  '@biomejs/cli-linux-x64-musl@2.3.8':
+    resolution: {integrity: sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.3.7':
-    resolution: {integrity: sha512-fJMc3ZEuo/NaMYo5rvoWjdSS5/uVSW+HPRQujucpZqm2ZCq71b8MKJ9U4th9yrv2L5+5NjPF0nqqILCl8HY/fg==}
+  '@biomejs/cli-linux-x64@2.3.8':
+    resolution: {integrity: sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.3.7':
-    resolution: {integrity: sha512-aJAE8eCNyRpcfx2JJAtsPtISnELJ0H4xVVSwnxm13bzI8RwbXMyVtxy2r5DV1xT3WiSP+7LxORcApWw0LM8HiA==}
+  '@biomejs/cli-win32-arm64@2.3.8':
+    resolution: {integrity: sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.7':
-    resolution: {integrity: sha512-pulzUshqv9Ed//MiE8MOUeeEkbkSHVDVY5Cz5wVAnH1DUqliCQG3j6s1POaITTFqFfo7AVIx2sWdKpx/GS+Nqw==}
+  '@biomejs/cli-win32-x64@2.3.8':
+    resolution: {integrity: sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -2137,39 +2137,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@2.3.7':
+  '@biomejs/biome@2.3.8':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.7
-      '@biomejs/cli-darwin-x64': 2.3.7
-      '@biomejs/cli-linux-arm64': 2.3.7
-      '@biomejs/cli-linux-arm64-musl': 2.3.7
-      '@biomejs/cli-linux-x64': 2.3.7
-      '@biomejs/cli-linux-x64-musl': 2.3.7
-      '@biomejs/cli-win32-arm64': 2.3.7
-      '@biomejs/cli-win32-x64': 2.3.7
+      '@biomejs/cli-darwin-arm64': 2.3.8
+      '@biomejs/cli-darwin-x64': 2.3.8
+      '@biomejs/cli-linux-arm64': 2.3.8
+      '@biomejs/cli-linux-arm64-musl': 2.3.8
+      '@biomejs/cli-linux-x64': 2.3.8
+      '@biomejs/cli-linux-x64-musl': 2.3.8
+      '@biomejs/cli-win32-arm64': 2.3.8
+      '@biomejs/cli-win32-x64': 2.3.8
 
-  '@biomejs/cli-darwin-arm64@2.3.7':
+  '@biomejs/cli-darwin-arm64@2.3.8':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.7':
+  '@biomejs/cli-darwin-x64@2.3.8':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.7':
+  '@biomejs/cli-linux-arm64-musl@2.3.8':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.7':
+  '@biomejs/cli-linux-arm64@2.3.8':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.7':
+  '@biomejs/cli-linux-x64-musl@2.3.8':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.7':
+  '@biomejs/cli-linux-x64@2.3.8':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.7':
+  '@biomejs/cli-win32-arm64@2.3.8':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.7':
+  '@biomejs/cli-win32-x64@2.3.8':
     optional: true
 
   '@csstools/color-helpers@5.1.0': {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         version: 1.80.17(graphology-types@0.24.8)
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.4
-        version: 2.3.4
+        specifier: 2.3.7
+        version: 2.3.7
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -207,55 +207,55 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.3.4':
-    resolution: {integrity: sha512-TU08LXjBHdy0mEY9APtEtZdNQQijXUDSXR7IK1i45wgoPD5R0muK7s61QcFir6FpOj/RP1+YkPx5QJlycXUU3w==}
+  '@biomejs/biome@2.3.7':
+    resolution: {integrity: sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.4':
-    resolution: {integrity: sha512-w40GvlNzLaqmuWYiDU6Ys9FNhJiclngKqcGld3iJIiy2bpJ0Q+8n3haiaC81uTPY/NA0d8Q/I3Z9+ajc14102Q==}
+  '@biomejs/cli-darwin-arm64@2.3.7':
+    resolution: {integrity: sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.4':
-    resolution: {integrity: sha512-3s7TLVtjJ7ni1xADXsS7x7GMUrLBZXg8SemXc3T0XLslzvqKj/dq1xGeBQ+pOWQzng9MaozfacIHdK2UlJ3jGA==}
+  '@biomejs/cli-darwin-x64@2.3.7':
+    resolution: {integrity: sha512-Q4TO633kvrMQkKIV7wmf8HXwF0dhdTD9S458LGE24TYgBjSRbuhvio4D5eOQzirEYg6eqxfs53ga/rbdd8nBKg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.4':
-    resolution: {integrity: sha512-IruVGQRwMURivWazchiq7gKAqZSFs5so6gi0hJyxk7x6HR+iwZbO2IxNOqyLURBvL06qkIHs7Wffl6Bw30vCbQ==}
+  '@biomejs/cli-linux-arm64-musl@2.3.7':
+    resolution: {integrity: sha512-/afy8lto4CB8scWfMdt+NoCZtatBUF62Tk3ilWH2w8ENd5spLhM77zKlFZEvsKJv9AFNHknMl03zO67CiklL2Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.3.4':
-    resolution: {integrity: sha512-y7efHyyM2gYmHy/AdWEip+VgTMe9973aP7XYKPzu/j8JxnPHuSUXftzmPhkVw0lfm4ECGbdBdGD6+rLmTgNZaA==}
+  '@biomejs/cli-linux-arm64@2.3.7':
+    resolution: {integrity: sha512-inHOTdlstUBzgjDcx0ge71U4SVTbwAljmkfi3MC5WzsYCRhancqfeL+sa4Ke6v2ND53WIwCFD5hGsYExoI3EZQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.3.4':
-    resolution: {integrity: sha512-mzKFFv/w66e4/jCobFmD3kymCqG+FuWE7sVa4Yjqd9v7qt2UhXo67MSZKY9Ih18V2IwPzRKQPCw6KwdZs6AXSA==}
+  '@biomejs/cli-linux-x64-musl@2.3.7':
+    resolution: {integrity: sha512-CQUtgH1tIN6e5wiYSJqzSwJumHYolNtaj1dwZGCnZXm2PZU1jOJof9TsyiP3bXNDb+VOR7oo7ZvY01If0W3iFQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.3.4':
-    resolution: {integrity: sha512-gKfjWR/6/dfIxPJCw8REdEowiXCkIpl9jycpNVHux8aX2yhWPLjydOshkDL6Y/82PcQJHn95VCj7J+BRcE5o1Q==}
+  '@biomejs/cli-linux-x64@2.3.7':
+    resolution: {integrity: sha512-fJMc3ZEuo/NaMYo5rvoWjdSS5/uVSW+HPRQujucpZqm2ZCq71b8MKJ9U4th9yrv2L5+5NjPF0nqqILCl8HY/fg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.3.4':
-    resolution: {integrity: sha512-5TJ6JfVez+yyupJ/iGUici2wzKf0RrSAxJhghQXtAEsc67OIpdwSKAQboemILrwKfHDi5s6mu7mX+VTCTUydkw==}
+  '@biomejs/cli-win32-arm64@2.3.7':
+    resolution: {integrity: sha512-aJAE8eCNyRpcfx2JJAtsPtISnELJ0H4xVVSwnxm13bzI8RwbXMyVtxy2r5DV1xT3WiSP+7LxORcApWw0LM8HiA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.4':
-    resolution: {integrity: sha512-FGCijXecmC4IedQ0esdYNlMpx0Jxgf4zceCaMu6fkjWyjgn50ZQtMiqZZQ0Q/77yqPxvtkgZAvt5uGw0gAAjig==}
+  '@biomejs/cli-win32-x64@2.3.7':
+    resolution: {integrity: sha512-pulzUshqv9Ed//MiE8MOUeeEkbkSHVDVY5Cz5wVAnH1DUqliCQG3j6s1POaITTFqFfo7AVIx2sWdKpx/GS+Nqw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -2137,39 +2137,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@2.3.4':
+  '@biomejs/biome@2.3.7':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.4
-      '@biomejs/cli-darwin-x64': 2.3.4
-      '@biomejs/cli-linux-arm64': 2.3.4
-      '@biomejs/cli-linux-arm64-musl': 2.3.4
-      '@biomejs/cli-linux-x64': 2.3.4
-      '@biomejs/cli-linux-x64-musl': 2.3.4
-      '@biomejs/cli-win32-arm64': 2.3.4
-      '@biomejs/cli-win32-x64': 2.3.4
+      '@biomejs/cli-darwin-arm64': 2.3.7
+      '@biomejs/cli-darwin-x64': 2.3.7
+      '@biomejs/cli-linux-arm64': 2.3.7
+      '@biomejs/cli-linux-arm64-musl': 2.3.7
+      '@biomejs/cli-linux-x64': 2.3.7
+      '@biomejs/cli-linux-x64-musl': 2.3.7
+      '@biomejs/cli-win32-arm64': 2.3.7
+      '@biomejs/cli-win32-x64': 2.3.7
 
-  '@biomejs/cli-darwin-arm64@2.3.4':
+  '@biomejs/cli-darwin-arm64@2.3.7':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.4':
+  '@biomejs/cli-darwin-x64@2.3.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.4':
+  '@biomejs/cli-linux-arm64-musl@2.3.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.4':
+  '@biomejs/cli-linux-arm64@2.3.7':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.4':
+  '@biomejs/cli-linux-x64-musl@2.3.7':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.4':
+  '@biomejs/cli-linux-x64@2.3.7':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.4':
+  '@biomejs/cli-win32-arm64@2.3.7':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.4':
+  '@biomejs/cli-win32-x64@2.3.7':
     optional: true
 
   '@csstools/color-helpers@5.1.0': {}

--- a/src/@types/ability-types.ts
+++ b/src/@types/ability-types.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { PokemonWaveData } from "#types/pokemon-types";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { AbAttrConstructorMap } from "#abilities/ab-attr-constructor-map";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
+import type { PokemonWaveData } from "#types/pokemon-types";
 
 /** Union type of all referable ability attribute class names as strings */
 export type AbAttrKey = keyof AbAttrConstructorMap;

--- a/src/@types/arena-tag-types.ts
+++ b/src/@types/arena-tag-types.ts
@@ -1,9 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
-import type { ElementalType } from "#enums/elemental-type";
-import type { Pokemon } from "#field/pokemon";
-import type { SessionSaveData } from "#types/session-data";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import type { AuroraVeilTag } from "#arena-tags/aurora-veil-tag";
 import type { CraftyShieldTag } from "#arena-tags/crafty-shield-tag";
 import type { DelayedAttackTag } from "#arena-tags/delayed-attack-tag";
@@ -36,7 +30,10 @@ import type { WideGuardTag } from "#arena-tags/wide-guard-tag";
 import type { WishTag } from "#arena-tags/wish-tag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import type { ArenaTagType } from "#enums/arena-tag-type";
+import type { ElementalType } from "#enums/elemental-type";
 import type { MoveId } from "#enums/move-id";
+import type { Pokemon } from "#field/pokemon";
+import type { SessionSaveData } from "#types/session-data";
 import type { ObjectValues } from "#types/utility-types";
 
 /** Subset of {@linkcode ArenaTagType}s that deal type-based damage to pokemon that switch in. */

--- a/src/@types/language.ts
+++ b/src/@types/language.ts
@@ -1,6 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { LoadingScene } from "#app/loading-scene";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 export type SupportedLanguageKey = "en" | "es-ES" | "it" | "fr" | "de" | "pt-BR" | "zh-CN" | "zh-TW" | "ko" | "ja";
 

--- a/src/@types/move-types.ts
+++ b/src/@types/move-types.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
 import type { ConditionalProtectTag } from "#arena-tags/conditional-protect-tag";
-import type { SpeciesId } from "#enums/species-id";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import type { BattlerIndex, FieldBattlerIndex } from "#enums/battler-index";
 import type { ElementalType } from "#enums/elemental-type";
 import type { HitResult } from "#enums/hit-result";
 import type { MoveId } from "#enums/move-id";
 import type { MoveResult } from "#enums/move-result";
+import type { SpeciesId } from "#enums/species-id";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 

--- a/src/@types/pokemon-types.ts
+++ b/src/@types/pokemon-types.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MoveId } from "#enums/move-id";
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { TurnCommand } from "#app/turn-command-manager";
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import type { PokemonSpeciesForm } from "#data/pokemon-species-form";
@@ -11,9 +6,11 @@ import type { AbilityId } from "#enums/ability-id";
 import type { BerryType } from "#enums/berry-type";
 import type { ElementalType } from "#enums/elemental-type";
 import type { Gender } from "#enums/gender";
+import type { MoveId } from "#enums/move-id";
 import type { Nature } from "#enums/nature";
 import type { SpeciesId } from "#enums/species-id";
 import type { StatusEffect } from "#enums/status-effect";
+import type { Pokemon } from "#field/pokemon";
 import type { PokemonMove } from "#field/pokemon-move";
 import type { AttackMoveResult, TurnMove } from "#types/move-types";
 

--- a/src/@types/timed-event.ts
+++ b/src/@types/timed-event.ts
@@ -1,6 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { SupportedLanguage } from "#types/language";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 export interface EventBanner {
   /** The base filename of the banner (without any language key or the extension). e.g. `welcome-event` */

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { BattleAnim } from "#animations/battle-anims";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import type { Variant } from "#data/variant";
 import { PokeballType } from "#enums/pokeball-type";

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1846,9 +1846,11 @@ export class BattleScene extends SceneBase {
   updateUIPositions(): void {
     const enemyModifierCount = this.enemyModifiers.filter((m) => m.isIconVisible()).length;
     const biomeWaveTextHeight = this.biomeWaveText.getBottomLeft().y - this.biomeWaveText.getTopLeft().y;
-    this.biomeWaveText.setY(
-      -GAME_HEIGHT + (enemyModifierCount ? (enemyModifierCount <= 12 ? 15 : 24) : 0) + biomeWaveTextHeight / 2,
-    );
+    let biomeWaveTextYModifier = 0;
+    if (enemyModifierCount) {
+      biomeWaveTextYModifier = enemyModifierCount <= 12 ? 15 : 24;
+    }
+    this.biomeWaveText.setY(-GAME_HEIGHT + biomeWaveTextYModifier + biomeWaveTextHeight / 2);
     this.moneyText.setY(this.biomeWaveText.y + 10);
     this.scoreText.setY(this.moneyText.y + 10);
     [this.luckLabelText, this.luckText].map((l) =>
@@ -1873,9 +1875,12 @@ export class BattleScene extends SceneBase {
     let scoreIncrease =
       enemy.getSpeciesForm().getBaseExp()
       * (enemy.level / this.getMaxExpLevel())
-      * ((enemy.ivs.reduce((iv: number, total: number) => (total += iv), 0) / 93) * 0.2 + 0.8);
+      * ((enemy.ivs.reduce((iv: number, total: number) => total + iv, 0) / 93) * 0.2 + 0.8);
     this.findModifiers((m) => m.isPokemonHeldItemModifier() && m.pokemonId === enemy.id, false).map(
-      (m) => (scoreIncrease *= (m as PokemonHeldItemModifier).getScoreMultiplier()),
+      (m: PokemonHeldItemModifier) => {
+        scoreIncrease *= m.getScoreMultiplier();
+        return scoreIncrease;
+      },
     );
     if (enemy.boss) {
       scoreIncrease *= Math.sqrt(enemy.bossSegments);

--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Ability } from "#abilities/ability";
 import type { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-effect-ab-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { AbilityId } from "#enums/ability-id";
 
 /**

--- a/src/constants/arena-tag-constants.ts
+++ b/src/constants/arena-tag-constants.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import { ArenaTagType } from "#enums/arena-tag-type";
 import type { ElementalType } from "#enums/elemental-type";
 import type { Move } from "#moves/move";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
-import { ArenaTagType } from "#enums/arena-tag-type";
 
 /** All {@linkcode ArenaTagType | ArenaTagTypes} that weaken attacks of a certain {@linkcode ElementalType}. */
 export const WEAKEN_MOVE_TYPE_ARENA_TAG_TYPES = Object.freeze<ArenaTagType[]>([

--- a/src/constants/battler-tag-constants.ts
+++ b/src/constants/battler-tag-constants.ts
@@ -1,4 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CritBoostTag } from "#battler-tags/crit-boost-tag";
 import type { DamagingTrapTag } from "#battler-tags/damaging-trap-tag";
 import type { ExposedTag } from "#battler-tags/exposed-tag";
@@ -12,10 +11,8 @@ import type { RemovedTypeTag } from "#battler-tags/removed-type-tag";
 import type { SemiInvulnerableTag } from "#battler-tags/semi-invulnerable-tag";
 import type { TrappedTag } from "#battler-tags/trapped-tag";
 import type { TypeBoostTag } from "#battler-tags/type-boost-tag";
-import type { ElementalType } from "#enums/elemental-type";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTagType } from "#enums/battler-tag-type";
+import type { ElementalType } from "#enums/elemental-type";
 
 /**
  * All {@linkcode BattlerTagType}s that grant semi-invulnerability.

--- a/src/constants/friendship-constants.ts
+++ b/src/constants/friendship-constants.ts
@@ -1,10 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { PokemonLevelIncrementModifier } from "#modifier/modifier";
 import type { FaintPhase } from "#phases/faint-phase";
 import type { LevelUpPhase } from "#phases/level-up-phase";
 import type { NextEncounterPhase } from "#phases/next-encounter-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 /** Each wave, all unfainted Pokemon gain this much happiness. Used in {@linkcode NextEncounterPhase} */
 export const FRIENDSHIP_GAIN_PER_WAVE = 1;

--- a/src/constants/game-constants.ts
+++ b/src/constants/game-constants.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { BattleStat } from "#enums/stat";
-import type { SystemSaveData } from "#types/system-data";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { SpeciesFormKey } from "#enums/species-form-key";
 import { SpeciesId } from "#enums/species-id";
+import type { BattleStat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
+import type { SystemSaveData } from "#types/system-data";
 
 /** Max value for an integer attribute in {@linkcode SystemSaveData} */
 export const MAX_INT_ATTR_VALUE = 0x80000000;

--- a/src/data/abilities/ab-attrs/damage-boost-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/damage-boost-ab-attr.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { PreAttackAbAttr } from "#abilities/pre-attack-ab-attr";
+import type { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import type { PokemonAttackCondition } from "#types/move-types";

--- a/src/data/abilities/ab-attrs/max-multi-hit-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/max-multi-hit-ab-attr.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MultiHitAttr } from "#moves/multi-hit-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { AbAttr } from "#abilities/ab-attr";
 import type { Pokemon } from "#field/pokemon";
+import type { MultiHitAttr } from "#moves/multi-hit-attr";
 import type { ValueHolder } from "#utils/common-utils";
 
 export class MaxMultiHitAbAttr extends AbAttr {

--- a/src/data/abilities/ab-attrs/pre-leave-field-ab-attrs.ts
+++ b/src/data/abilities/ab-attrs/pre-leave-field-ab-attrs.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
-import type { Weather } from "#data/weather";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import { AbAttr } from "#abilities/ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { Weather } from "#data/weather";
 import { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
 

--- a/src/data/abilities/ab-attrs/reflect-moves-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/reflect-moves-ab-attr.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MovePhase } from "#phases/move-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { PreDefendAbAttr } from "#abilities/pre-defend-ab-attr";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
+import type { MovePhase } from "#phases/move-phase";
 import type { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 

--- a/src/data/abilities/ab-attrs/stab-boost-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/stab-boost-ab-attr.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { AbilityId } from "#enums/ability-id";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { AbAttr } from "#abilities/ab-attr";
+import type { AbilityId } from "#enums/ability-id";
 import { ElementalType } from "#enums/elemental-type";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -12,7 +12,6 @@ import {
   AB_FLAG_WORKS_WHEN_TRANSFORMED,
 } from "#constants/ability-constants";
 import { AbilityId } from "#enums/ability-id";
-// biome-ignore lint/correctness/noUnusedImports: TSDoc import
 import type { MoveId } from "#enums/move-id";
 import type { AbAttrCondition, AbAttrKey, AbAttrMap } from "#types/ability-types";
 import { toCamelCaseString } from "#utils/string-utils";

--- a/src/data/animations/anim-config.ts
+++ b/src/data/animations/anim-config.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { BattleAnim } from "#animations/battle-anims";
 import type { easeFunctions } from "#animations/ease-functions";
 import type { MoveAnim } from "#animations/move-anim";
@@ -11,6 +7,7 @@ import { AnimFocus } from "#enums/anim-focus";
 import { AnimFrameTarget } from "#enums/anim-frame-target";
 import type { AnimTimedEventType } from "#enums/anim-timed-event-type";
 import type { MoveId } from "#enums/move-id";
+import type { Pokemon } from "#field/pokemon";
 import { getFrameMs } from "#utils/common-utils";
 import type Phaser from "phaser";
 

--- a/src/data/battler-tags/crit-boost-tag.ts
+++ b/src/data/battler-tags/crit-boost-tag.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { CRIT_BOOST_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-import type { ElementalType } from "#enums/elemental-type";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { CRIT_BOOST_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
+import type { ElementalType } from "#enums/elemental-type";
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
 import i18next from "i18next";

--- a/src/data/battler-tags/damaging-trap-tag.ts
+++ b/src/data/battler-tags/damaging-trap-tag.ts
@@ -1,12 +1,9 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { DAMAGING_TRAPPED_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import { TrappedTag } from "#battler-tags/trapped-tag";
+import type { DAMAGING_TRAPPED_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { TRAPPED_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";

--- a/src/data/battler-tags/disabled-tag.ts
+++ b/src/data/battler-tags/disabled-tag.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { AbilityId } from "#enums/ability-id";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import { MoveRestrictionBattlerTag } from "#battler-tags/move-restriction-battler-tag";
+import type { AbilityId } from "#enums/ability-id";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/encore-tag.ts
+++ b/src/data/battler-tags/encore-tag.ts
@@ -14,7 +14,7 @@ import i18next from "i18next";
  * Encore forces the target Pokemon to use its most-recent move for 3 turns
  */
 export class EncoreTag extends MoveRestrictionBattlerTag {
-  public moveId: MoveId;
+  public moveId: MoveId | undefined;
 
   constructor(sourceId: number) {
     super(
@@ -36,7 +36,7 @@ export class EncoreTag extends MoveRestrictionBattlerTag {
   }
 
   override onAdd(pokemon: Pokemon): void {
-    const lastMove = pokemon.getLastXMoves(-1).filter((mv) => !mv.virtual)[0];
+    const lastMove = pokemon.getLastXMoves(-1).find((mv) => !mv.virtual);
     this.moveId = lastMove?.move.id;
 
     globalScene.phaseManager.createAndUnshiftPhase(

--- a/src/data/battler-tags/exposed-tag.ts
+++ b/src/data/battler-tags/exposed-tag.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EXPOSED_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { EXPOSED_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { ElementalType } from "#enums/elemental-type";

--- a/src/data/battler-tags/floating-tag.ts
+++ b/src/data/battler-tags/floating-tag.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { TYPE_IMMUNE_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { TypeImmuneTag } from "#battler-tags/type-immune-tag";
+import type { TYPE_IMMUNE_TAG_TYPES } from "#constants/battler-tag-constants";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/highest-stat-boost-tag.ts
+++ b/src/data/battler-tags/highest-stat-boost-tag.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { HIGHEST_STAT_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { AbilityBattlerTag } from "#battler-tags/ability-battler-tag";
 import type { BattlerTag } from "#battler-tags/battler-tag";
+import type { HIGHEST_STAT_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
 import { allAbilities } from "#data/data-lists";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import type { AbilityId } from "#enums/ability-id";

--- a/src/data/battler-tags/move-lock-tag.ts
+++ b/src/data/battler-tags/move-lock-tag.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MOVE_LOCK_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { MOVE_LOCK_TAG_TYPES } from "#constants/battler-tag-constants";
 import { allMoves } from "#data/data-lists";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";

--- a/src/data/battler-tags/move-restriction-battler-tag.ts
+++ b/src/data/battler-tags/move-restriction-battler-tag.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { RESTRICTING_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerTag } from "#battler-tags/battler-tag";
 import type { RestrictingBattlerTag } from "#battler-tags/restricting-battler-tag";
+import type { RESTRICTING_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";

--- a/src/data/battler-tags/protected-tag.ts
+++ b/src/data/battler-tags/protected-tag.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { PROTECTION_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { CommonBattleAnim } from "#animations/common-battle-anim";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { PROTECTION_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { CommonAnim } from "#enums/common-anim";

--- a/src/data/battler-tags/removed-type-tag.ts
+++ b/src/data/battler-tags/removed-type-tag.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { REMOVE_TYPE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { REMOVE_TYPE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import type { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/semi-invulnerable-tag.ts
+++ b/src/data/battler-tags/semi-invulnerable-tag.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { SEMI_INVULNERABLE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { SEMI_INVULNERABLE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/telekinesis-tag.ts
+++ b/src/data/battler-tags/telekinesis-tag.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FloatingTag } from "#battler-tags/floating-tag";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { FloatingTag } from "#battler-tags/floating-tag";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/type-boost-tag.ts
+++ b/src/data/battler-tags/type-boost-tag.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { ElementalType } from "#enums/elemental-type";

--- a/src/data/biome.ts
+++ b/src/data/biome.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Arena } from "#field/arena";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { BiomeId } from "#enums/biome-id";
 import type { BiomePoolTier } from "#enums/biome-pool-tier";
 import type { SpeciesId } from "#enums/species-id";
@@ -9,6 +5,7 @@ import type { TerrainType } from "#enums/terrain-type";
 import type { TimeOfDay } from "#enums/time-of-day";
 import type { TrainerType } from "#enums/trainer-type";
 import type { WeatherType } from "#enums/weather-type";
+import type { Arena } from "#field/arena";
 
 /**
  * @todo

--- a/src/data/moves/move-attrs/call-move-attr.ts
+++ b/src/data/moves/move-attrs/call-move-attr.ts
@@ -1,17 +1,14 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { CopycatAttr } from "#moves/copycat-attr";
-import type { MetronomeAttr } from "#moves/metronome-attr";
-import type { NaturePowerAttr } from "#moves/nature-power-attr";
-import type { RandomMovesetMoveAttr } from "#moves/random-moveset-move-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import type { BattlerIndex } from "#enums/battler-index";
 import type { MoveId } from "#enums/move-id";
 import { MoveTarget } from "#enums/move-target";
 import type { Pokemon } from "#field/pokemon";
+import type { CopycatAttr } from "#moves/copycat-attr";
+import type { MetronomeAttr } from "#moves/metronome-attr";
 import { getMoveTargets, type Move } from "#moves/move";
+import type { NaturePowerAttr } from "#moves/nature-power-attr";
 import { OverrideMoveEffectAttr } from "#moves/override-move-effect-attr";
+import type { RandomMovesetMoveAttr } from "#moves/random-moveset-move-attr";
 import type { BooleanHolder } from "#utils/common-utils";
 
 /**

--- a/src/data/moves/move-attrs/hits-tag-attr.ts
+++ b/src/data/moves/move-attrs/hits-tag-attr.ts
@@ -23,6 +23,9 @@ export class HitsTagAttr extends MoveAttr {
   }
 
   override getTargetBenefitScore(_user: Pokemon, target: Pokemon, _move: Move): number {
-    return target.hasTag(this.tagType) ? (this.doubleDamage ? 10 : 5) : 0;
+    if (target.hasTag(this.tagType)) {
+      return this.doubleDamage ? 10 : 5;
+    }
+    return 0;
   }
 }

--- a/src/data/moves/move-attrs/pursuit-attr.ts
+++ b/src/data/moves/move-attrs/pursuit-attr.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TurnCommandManager } from "#app/turn-command-manager";
 import type { PursuingTag } from "#battler-tags/pursuing-battler-tag";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { MoveAttr } from "#moves/move-attr";
 
 /**

--- a/src/data/moves/move-attrs/variable-def-attr.ts
+++ b/src/data/moves/move-attrs/variable-def-attr.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Stat } from "#enums/stat";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveAttr } from "#moves/move-attr";

--- a/src/data/moves/move-attrs/weather-instant-charge-attr.ts
+++ b/src/data/moves/move-attrs/weather-instant-charge-attr.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { ChargingMove } from "#moves/move";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import type { WeatherType } from "#enums/weather-type";
 import { InstantChargeAttr } from "#moves/instant-charge-attr";
+import type { ChargingMove } from "#moves/move";
 import type { NonEmptyArray } from "#types/utility-types";
 
 /**

--- a/src/data/mystery-encounters/mystery-encounter.ts
+++ b/src/data/mystery-encounters/mystery-encounter.ts
@@ -350,7 +350,7 @@ export class MysteryEncounter implements IMysteryEncounter {
       if (activeMon.length > 0) {
         this.primaryPokemon = activeMon[0];
       } else {
-        this.primaryPokemon = globalScene.getPlayerParty().filter((p) => p.isAllowedInBattle())[0];
+        this.primaryPokemon = globalScene.getPlayerParty().find((p) => p.isAllowedInBattle());
       }
       return true;
     }

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { IMysteryEncounter } from "#mystery-encounters/mystery-encounter";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Battle } from "#app/battle";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -46,6 +42,7 @@ import {
 } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
 import { showEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
+import type { IMysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
 import type { PokemonData } from "#system/pokemon-data";
 import { allTrainerConfigs } from "#trainer-configs/all-trainer-configs";

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -93,29 +93,34 @@ export function getSpriteKeysFromPokemon(pokemon: Pokemon): { spriteKey: string;
 }
 
 // TODO: Move all the helper functions to get player's random/highest level/lowest level/highest BST to a different utils
+// TODO: Refactor to remove the unsafe bangs from various functions
 
 /**
- * Will never remove the player's last non-fainted Pokemon (if they only have 1).
- * Otherwise, picks a Pokemon completely at random and removes from the party
- * @param isAllowed Default `false`. If `true`, only picks from legal mons. If no legal mons are found (or there is 1, with `doNotReturnLastAllowedMon = true`), will return a mon that is not allowed.
- * @param isFainted Default `false`. If `true`, includes fainted mons.
- * @param doNotReturnLastAllowedMon Default `false`. If `true`, will never return the last unfainted pokemon in the party. Useful when this function is being used to determine what Pokemon to remove from the party (Don't want to remove last unfainted)
+ * Will never remove the player's last non-fainted Pokemon (if they only have 1). \
+ * Otherwise, picks a Pokemon completely at random and removes from the party.
+ * @param legalOnly - (Default `false`) Whether to pick only from legal Pokemon. \
+ *   If no legal Pokemon are found (or there is 1, with `doNotReturnLastAllowedMon = true`), will return a mon that is not allowed.
+ * @param allowFainted - (Default `false`) Whether to include fainted Pokemon.
+ * @param doNotReturnLastAllowedMon - (Default `false`) If `true`, will never return the last unfainted pokemon in the party. \
+ *   Useful when this function is being used to determine what Pokemon to remove from the party (Don't want to remove last unfainted)
  * @returns a random player Pokemon
  */
 export function getRandomPlayerPokemon(
-  isAllowed: boolean = false,
-  isFainted: boolean = false,
+  legalOnly: boolean = false,
+  allowFainted: boolean = false,
   doNotReturnLastAllowedMon: boolean = false,
 ): PlayerPokemon {
   const party = globalScene.getPlayerParty();
   let chosenIndex: number;
   let chosenPokemon: PlayerPokemon | null = null;
-  const fullyLegalMons = party.filter((p) => (!isAllowed || p.isAllowedInChallenge()) && (isFainted || !p.isFainted()));
+  const fullyLegalMons = party.filter(
+    (p) => (!legalOnly || p.isAllowedInChallenge()) && (allowFainted || !p.isFainted()),
+  );
   const allowedOnlyMons = party.filter((p) => p.isAllowedInChallenge());
 
   if (doNotReturnLastAllowedMon && fullyLegalMons.length === 1) {
-    // If there is only 1 legal/unfainted mon left, select from fainted legal mons
-    const faintedLegalMons = party.filter((p) => (!isAllowed || p.isAllowedInChallenge()) && p.isFainted());
+    // If there is only 1 legal/unfainted mon left, select from fainted legal Pokemon
+    const faintedLegalMons = party.filter((p) => (!legalOnly || p.isAllowedInChallenge()) && p.isFainted());
     if (faintedLegalMons.length > 0) {
       chosenIndex = randSeedInt(faintedLegalMons.length);
       chosenPokemon = faintedLegalMons[chosenIndex];
@@ -125,7 +130,7 @@ export function getRandomPlayerPokemon(
     chosenIndex = randSeedInt(fullyLegalMons.length);
     chosenPokemon = fullyLegalMons[chosenIndex];
   }
-  if (!chosenPokemon && isAllowed && allowedOnlyMons.length > 0) {
+  if (!chosenPokemon && legalOnly && allowedOnlyMons.length > 0) {
     chosenIndex = randSeedInt(allowedOnlyMons.length);
     chosenPokemon = allowedOnlyMons[chosenIndex];
   }
@@ -139,123 +144,140 @@ export function getRandomPlayerPokemon(
 }
 
 /**
- * Helper function to get a player's Pokemon with the highest level (should be in a general utils rather than ME/utils)
- * Ties are broken by whatever mon is closer to the front of the party
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * Helper function to get a player's Pokemon with the highest level. \
+ * Ties are broken by whatever Pokemon is closer to the front of the party.
+ * @param legalOnly - (Default `false`) Whether to pick only from legal Pokemon.
+ * @param allowFainted - (Default `false`) Whether to include fainted Pokemon.
  * @returns the player's highest leveled Pokemon
  */
-export function getHighestLevelPlayerPokemon(isAllowed: boolean = false, isFainted: boolean = false): PlayerPokemon {
+export function getHighestLevelPlayerPokemon(legalOnly: boolean = false, allowFainted: boolean = false): PlayerPokemon {
   const party = globalScene.getPlayerParty();
   let pokemon: PlayerPokemon | null = null;
 
   for (const p of party) {
-    if (isAllowed && !p.isAllowedInChallenge()) {
+    if (legalOnly && !p.isAllowedInChallenge()) {
       continue;
     }
-    if (!isFainted && p.isFainted()) {
+    if (!allowFainted && p.isFainted()) {
       continue;
     }
 
-    pokemon = pokemon ? (pokemon?.level < p?.level ? p : pokemon) : p;
+    if (pokemon) {
+      pokemon = pokemon.level < p.level ? p : pokemon;
+    } else {
+      pokemon = p;
+    }
   }
 
   return pokemon!;
 }
 
 /**
- * Helper function to get a player's Pokemon with the highest stat (should be in a general utils rather than ME/utils)
- * Ties are broken by whatever mon is closer to the front of the party
- * @param stat Stat to search for
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * Helper function to get a player's Pokemon with the highest stat. \
+ * Ties are broken by whatever Pokemon is closer to the front of the party
+ * @param stat - Stat to search for
+ * @param legalOnly - (Default `false`) Whether to pick only from legal Pokemon.
+ * @param allowFainted - (Default `false`) Whether to include fainted Pokemon.
  * @returns the Player's Pokemon with the highest stat
  */
 export function getHighestStatPlayerPokemon(
   stat: PermanentStat,
-  isAllowed: boolean = false,
-  isFainted: boolean = false,
+  legalOnly: boolean = false,
+  allowFainted: boolean = false,
 ): PlayerPokemon {
   const party = globalScene.getPlayerParty();
   let pokemon: PlayerPokemon | null = null;
 
   for (const p of party) {
-    if (isAllowed && !p.isAllowedInChallenge()) {
+    if (legalOnly && !p.isAllowedInChallenge()) {
       continue;
     }
-    if (!isFainted && p.isFainted()) {
+    if (!allowFainted && p.isFainted()) {
       continue;
     }
 
-    pokemon = pokemon ? (pokemon.getStat(stat) < p?.getStat(stat) ? p : pokemon) : p;
+    if (pokemon) {
+      pokemon = pokemon.getStat(stat) < p.getStat(stat) ? p : pokemon;
+    } else {
+      pokemon = p;
+    }
   }
 
   return pokemon!;
 }
 
 /**
- * Helper function to get a player's Pokemon with the lowest level (should be in a general utils rather than ME/utils)
- * Ties are broken by whatever mon is closer to the front of the party
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * Helper function to get a player's Pokemon with the lowest level. \
+ * Ties are broken by whatever Pokemon is closer to the front of the party
+ * @param legalOnly - (Default `false`) Whether to pick only from legal Pokemon.
+ * @param allowFainted - (Default `false`) Whether to include fainted Pokemon.
  * @returns the player's lowest leveled Pokemon
  */
-export function getLowestLevelPlayerPokemon(isAllowed: boolean = false, isFainted: boolean = false): PlayerPokemon {
+export function getLowestLevelPlayerPokemon(legalOnly: boolean = false, allowFainted: boolean = false): PlayerPokemon {
   const party = globalScene.getPlayerParty();
   let pokemon: PlayerPokemon | null = null;
 
   for (const p of party) {
-    if (isAllowed && !p.isAllowedInChallenge()) {
+    if (legalOnly && !p.isAllowedInChallenge()) {
       continue;
     }
-    if (!isFainted && p.isFainted()) {
+    if (!allowFainted && p.isFainted()) {
       continue;
     }
 
-    pokemon = pokemon ? (pokemon?.level > p?.level ? p : pokemon) : p;
+    if (pokemon) {
+      pokemon = pokemon.level > p.level ? p : pokemon;
+    } else {
+      pokemon = p;
+    }
   }
 
   return pokemon!;
 }
 
 /**
- * Helper function to get a player's Pokemon with the highest BST (should be in a general utils rather than ME/utils)
- * Ties are broken by whatever mon is closer to the front of the party
- * @param isAllowed Default false. If true, only picks from legal mons.
- * @param isFainted Default false. If true, includes fainted mons.
+ * Helper function to get a player's Pokemon with the highest BST. \
+ * Ties are broken by whatever Pokemon is closer to the front of the party
+ * @param legalOnly - (Default `false`) Whether to pick only from legal Pokemon.
+ * @param allowFainted - (Default `false`) Whether to include fainted Pokemon.
  * @returns the player's Pokemon with the highest BST
  */
 export function getHighestStatTotalPlayerPokemon(
-  isAllowed: boolean = false,
-  isFainted: boolean = false,
+  legalOnly: boolean = false,
+  allowFainted: boolean = false,
 ): PlayerPokemon {
   const party = globalScene.getPlayerParty();
   let pokemon: PlayerPokemon | null = null;
 
   for (const p of party) {
-    if (isAllowed && !p.isAllowedInChallenge()) {
+    if (legalOnly && !p.isAllowedInChallenge()) {
       continue;
     }
-    if (!isFainted && p.isFainted()) {
+    if (!allowFainted && p.isFainted()) {
       continue;
     }
 
-    pokemon = pokemon ? (pokemon?.stats.reduce((a, b) => a + b) < p?.stats.reduce((a, b) => a + b) ? p : pokemon) : p;
+    if (pokemon) {
+      pokemon = pokemon.stats.reduce((a, b) => a + b) < p.stats.reduce((a, b) => a + b) ? p : pokemon;
+    } else {
+      pokemon = p;
+    }
   }
 
   return pokemon!;
 }
 
 /**
- * Function to get a random starter
- * NOTE: This returns ANY random species, including those locked behind eggs, etc.
+ * Function to get a random starter.
+ * @remarks
+ * This returns ANY random species, including those locked behind eggs, etc.
  * @param starterTiers - either a starter tier or a list representing the min and max starter tiers
  * @param excludedSpecies - species to be excluded
  * @param types - list of types to filter for
  * @param allowSubLegendary - whether or not sub legends are allowed
  * @param allowLegendary - whether or not legends are allowed
  * @param allowMythical - whether or not mythicals are allowed
- * @returns a randomly generated Species (dfeault Bulbasaur if all filters fail)
+ * @returns a randomly generated Species (or Bulbasaur if all filters fail)
  */
 export function getRandomSpeciesByStarterCost(
   starterTiers: number | [number, number],

--- a/src/data/pokemon-form-level-moves.ts
+++ b/src/data/pokemon-form-level-moves.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { SpeciesFormChange } from "#data/pokemon-forms";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { EVOLVE_MOVE, FORM_CHANGE_MOVE } from "#constants/move-constants";
+import type { SpeciesFormChange } from "#data/pokemon-forms";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import type { LevelMoves } from "#types/move-types";

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -1,11 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FORM_CHANGE_MOVE } from "#constants/move-constants";
-import type { FormChangePhase } from "#phases/form-change-phase";
-import type { QuietFormChangePhase } from "#phases/quiet-form-change-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import type { FORM_CHANGE_MOVE } from "#constants/move-constants";
 import { RAINY_WEATHER_TYPES, SNOWY_WEATHER_TYPES, SUNNY_WEATHER_TYPES } from "#constants/weather-constants";
 import { allMoves } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
@@ -24,6 +19,8 @@ import { SpeciesFormChangeManualTrigger } from "#form-change-triggers/species-fo
 import { SpeciesFormChangeMoveLearnedTrigger } from "#form-change-triggers/species-form-change-move-learned-trigger";
 import { SpeciesFormChangePreMoveTrigger } from "#form-change-triggers/species-form-change-pre-move-trigger";
 import { SpeciesFormChangeTrigger } from "#form-change-triggers/species-form-change-trigger";
+import type { FormChangePhase } from "#phases/form-change-phase";
+import type { QuietFormChangePhase } from "#phases/quiet-form-change-phase";
 import type { AbstractConstructor, NonEmptyArray, nil } from "#types/utility-types";
 import i18next from "i18next";
 

--- a/src/enums/arena-tag-relative-side.ts
+++ b/src/enums/arena-tag-relative-side.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/arena-tag-type.ts
+++ b/src/enums/arena-tag-type.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
 import type { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagTypeMap, NonSerializableArenaTagType, SerializableArenaTagType } from "#types/arena-tag-types";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/battle-command.ts
+++ b/src/enums/battle-command.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CommandPhase } from "#phases/command-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/event-modifier-type.ts
+++ b/src/enums/event-modifier-type.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TimedEvent } from "#types/timed-event";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/item-rarity.ts
+++ b/src/enums/item-rarity.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { ModifierTier } from "#enums/modifier-tier";
 import type { Item } from "#types/item";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/switch-type.ts
+++ b/src/enums/switch-type.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { SwitchPhase } from "#phases/switch-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /** Indicates the type of switch functionality that a {@linkcode SwitchPhase} will carry out. */

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -1071,19 +1071,23 @@ export class ArenaBase extends Phaser.GameObjects.Container {
     if (!this.player) {
       globalScene.executeWithSeedOffset(
         () => {
-          this.propValue = propValue === undefined ? (hasProps ? randSeedInt(8) : 0) : propValue;
+          if (propValue === undefined) {
+            this.propValue = hasProps ? randSeedInt(8) : 0;
+          } else {
+            this.propValue = propValue;
+          }
           this.props.forEach((prop, p) => {
             const propKey = `${biomeKey}_b${hasProps ? `_${p + 1}` : ""}`;
             prop.setTexture(propKey);
 
             if (hasProps && prop.texture.frameTotal > 1) {
-              const propFrameNames = globalScene.anims.generateFrameNames(propKey, {
-                zeroPad: 4,
-                suffix: ".png",
-                start: 1,
-                end: prop.texture.frameTotal - 1,
-              });
               if (!globalScene.anims.exists(propKey)) {
+                const propFrameNames = globalScene.anims.generateFrameNames(propKey, {
+                  zeroPad: 4,
+                  suffix: ".png",
+                  start: 1,
+                  end: prop.texture.frameTotal - 1,
+                });
                 globalScene.anims.create({
                   key: propKey,
                   frames: propFrameNames,

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -266,7 +266,7 @@ export class PlayerPokemon extends Pokemon {
       };
       // TODO: should this be done in "handleSpecialEvolutions" to keep all species-specific things in the same spot?
       if (preEvolutionSpecies.speciesId === SpeciesId.GIMMIGHOUL) {
-        const evotracker = this.getHeldItems().filter((m) => m instanceof EvoTrackerModifier)[0] ?? null;
+        const evotracker = this.getHeldItems().find((m) => m instanceof EvoTrackerModifier);
         if (evotracker) {
           globalScene.removeModifier(evotracker);
         }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1,12 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Battle } from "#app/battle";
-import type { BattleScene } from "#app/battle-scene";
-import type { FaintPhase } from "#phases/faint-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Ability } from "#abilities/ability";
 import { applyAbAttrs, getAbApplyFunc } from "#abilities/apply-ab-attrs";
 import type { AnySound } from "#app/audio-manager";
+import type { Battle } from "#app/battle";
+import type { BattleScene } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { activeOverrides } from "#app/overrides";
 import { timedEventManager } from "#app/timed-event-manager";
@@ -146,6 +142,7 @@ import { VariableMoveCategoryAttr } from "#moves/variable-move-category-attr";
 import { VariableMoveTypeAttr } from "#moves/variable-move-type-attr";
 import { VariableMoveTypeChartAttr } from "#moves/variable-move-type-chart-attr";
 import { VariableMoveTypeMultiplierAttr } from "#moves/variable-move-type-multiplier-attr";
+import type { FaintPhase } from "#phases/faint-phase";
 import { settings } from "#system/settings-manager";
 import type { AbAttrKey, AbAttrMap, AbilityFilterOptions } from "#types/ability-types";
 import type { DamageCalculationResult, DamageResult, LevelMoves, TurnMove } from "#types/move-types";

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -439,7 +439,7 @@ export class Trainer extends Phaser.GameObjects.Container {
         species = battle.enemyParty[offset].species;
       } else {
         // If none of the above applies, pick a random species from the trainer's regular pool.
-        species = this.genNewPartyMemberSpecies(level, strength);
+        species = this.genNewPartyMemberSpecies(level);
       }
 
       const trainerSlot = !this.isDouble() || !(index % 2) ? TrainerSlot.TRAINER : TrainerSlot.TRAINER_PARTNER;
@@ -450,7 +450,7 @@ export class Trainer extends Phaser.GameObjects.Container {
     return ret;
   }
 
-  genNewPartyMemberSpecies(level: number, strength: PartyMemberStrength, attempt?: number): PokemonSpecies {
+  private genNewPartyMemberSpecies(level: number, attempt: number = 0): PokemonSpecies {
     const battle = globalScene.currentBattle;
     const template = this.getPartyTemplate();
 
@@ -468,7 +468,7 @@ export class Trainer extends Phaser.GameObjects.Container {
         tier = TrainerPoolTier.SUPER_RARE;
       }
       console.log("trainer pool tier:", enumValueToKey(TrainerPoolTier, tier));
-      while (!Object.hasOwn(this.config.speciesPools, tier) || !this.config.speciesPools[tier].length) {
+      while (!Object.hasOwn(this.config.speciesPools, tier) || this.config.speciesPools[tier].length === 0) {
         console.log(
           `Downgraded trainer Pokemon rarity tier from ${enumValueToKey(TrainerPoolTier, tier)} to ${enumValueToKey(TrainerPoolTier, (tier - 1) as TrainerPoolTier)}`,
         );
@@ -497,7 +497,7 @@ export class Trainer extends Phaser.GameObjects.Container {
       }
     }
 
-    if (!retry && this.config.specialtyTypes.length && !this.config.specialtyTypes.find((t) => ret.isOfType(t))) {
+    if (!retry && this.config.specialtyTypes.length > 0 && !this.config.specialtyTypes.find((t) => ret.isOfType(t))) {
       retry = true;
       console.log("Attempting reroll of species evolution to fit specialty type...");
       let evoAttempt = 0;
@@ -516,9 +516,9 @@ export class Trainer extends Phaser.GameObjects.Container {
       retry = true;
     }
 
-    if (retry && (attempt ?? 0) < 10) {
+    if (retry && attempt < 10) {
       console.log("Rerolling party member...");
-      ret = this.genNewPartyMemberSpecies(level, strength, (attempt ?? 0) + 1);
+      ret = this.genNewPartyMemberSpecies(level, attempt + 1);
     }
 
     return ret;

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { UiWindowStyle } from "#enums/ui-window-style";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { api } from "#api/api";
 import { CacheBustedLoaderPlugin } from "#app/plugins/cache-busted-loader-plugin";
 import { SceneBase } from "#app/scene-base";
@@ -51,7 +47,7 @@ export class LoadingScene extends SceneBase {
     this.loadImage("loading_bg", ImagesFolder.ARENAS);
     this.loadImage("logo");
 
-    /** UI Elements that change based on the {@linkcode UiWindowStyle} */
+    // UI Elements that change based on the UI Window Style
     for (const windowVariant of Object.values(WindowVariant)) {
       this.loadSpritesheet(`window${getWindowVariantSuffix(windowVariant)}`, ImagesFolder.UI_WINDOWS, 24, 24, {
         windowStyleDependant: true,

--- a/src/phase-tree.ts
+++ b/src/phase-tree.ts
@@ -1,7 +1,5 @@
-// biome-ignore lint/correctness/noUnusedImports: suppression needed until Biome 2.3.8 update PR is merged
 import type { DynamicPhaseManager } from "#app/dynamic-phase-manager";
 import type { Phase } from "#app/phase";
-// biome-ignore lint/correctness/noUnusedImports: suppression needed until Biome 2.3.8 update PR is merged
 import type { PhaseConditionFunc, PhaseKey, PhaseManager, PhaseMap } from "#types/phase-types";
 import type { NonEmptyArray } from "#types/utility-types";
 

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { NewBiomeEncounterPhase } from "#phases/new-biome-encounter-phase";
-import type { NextEncounterPhase } from "#phases/next-encounter-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -38,6 +33,8 @@ import { getEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
 import { doTrainerExclamation } from "#mystery-encounters/encounter-phase-utils";
 import { getGoldenBugNetSpecies } from "#mystery-encounters/encounter-pokemon-utils";
 import { BattlePhase } from "#phases/base/battle-phase";
+import type { NewBiomeEncounterPhase } from "#phases/new-biome-encounter-phase";
+import type { NextEncounterPhase } from "#phases/next-encounter-phase";
 import { achvs } from "#system/achievements";
 import { settings } from "#system/settings-manager";
 import type { PhaseKey } from "#types/phase-types";

--- a/src/phases/enemy-command-phase.ts
+++ b/src/phases/enemy-command-phase.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EnemyPokemon } from "#field/enemy-pokemon";
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { activeOverrides } from "#app/overrides";
 import { AbilityId } from "#enums/ability-id";
 import { BattleCommand } from "#enums/battle-command";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
+import type { Pokemon } from "#field/pokemon";
 import { BattlePhase } from "#phases/base/battle-phase";
 
 /**

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FormChangePhase } from "#phases/form-change-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { AnySound } from "#app/audio-manager";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -12,6 +8,7 @@ import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { FormChangeBasePhase } from "#phases/base/form-change-base-phase";
+import type { FormChangePhase } from "#phases/form-change-phase";
 import type { ConfirmModeConfig } from "#ui/confirm-menu-config";
 import type { ConfirmUiHandler } from "#ui/confirm-ui-handler";
 import { delay, playNumberTween, playTween } from "#utils/anim-utils";

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -1,15 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { PostFaintAbAttr } from "#abilities/post-faint-ab-attr";
 import type { PostKnockOutAbAttr } from "#abilities/post-knock-out-ab-attr";
 import type { PostVictoryAbAttr } from "#abilities/post-victory-ab-attr";
-import type { BattlerTag } from "#battler-tags/battler-tag";
-import type { GameOverPhase } from "#phases/game-over-phase";
-import type { MovePhase } from "#phases/move-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
-import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import type { BattlerTag } from "#battler-tags/battler-tag";
 import type { DestinyBondTag } from "#battler-tags/destiny-bond-tag";
 import type { GrudgeTag } from "#battler-tags/grudge-tag";
 import type { SkyDropTag } from "#battler-tags/sky-drop-tag";
@@ -28,6 +23,8 @@ import { SpeciesFormChangeActiveTrigger } from "#form-change-triggers/species-fo
 import { PokemonInstantReviveModifier } from "#modifier/modifier";
 import { PostVictoryStatStageChangeAttr } from "#moves/post-victory-stat-stage-change-attr";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { GameOverPhase } from "#phases/game-over-phase";
+import type { MovePhase } from "#phases/move-phase";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import i18next from "i18next";
 

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EvolutionPhase } from "#phases/evolution-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { SpeciesFormChange } from "#data/pokemon-forms";
@@ -12,6 +8,7 @@ import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { FormChangeBasePhase } from "#phases/base/form-change-base-phase";
+import type { EvolutionPhase } from "#phases/evolution-phase";
 import { achvs } from "#system/achievements";
 import type { FormChangeSceneUiHandler } from "#ui/form-change-scene-ui-handler";
 import type { PartyUiHandler } from "#ui/party-ui-handler";

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -1,8 +1,3 @@
-// biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports
-import type { allMoves } from "#data/data-lists";
-import type { Move } from "#moves/move";
-// biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { MoveAnim } from "#animations/move-anim";
 import { globalScene } from "#app/global-scene";
@@ -11,6 +6,7 @@ import type { BideTag } from "#battler-tags/bide-tag";
 import type { SubstituteTag } from "#battler-tags/substitute-tag";
 import type { TypeBoostTag } from "#battler-tags/type-boost-tag";
 import { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
+import type { allMoves } from "#data/data-lists";
 import type { TypeDamageMultiplier } from "#data/type";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { BattlerIndex, type FieldBattlerIndex } from "#enums/battler-index";
@@ -35,6 +31,7 @@ import {
 import { DelayedAttackAttr } from "#moves/delayed-attack-attr";
 import { FlinchAttr } from "#moves/flinch-attr";
 import { MissEffectAttr } from "#moves/miss-effect-attr";
+import type { Move } from "#moves/move";
 import type { MoveAttr } from "#moves/move-attr";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
 import { MultiHitAttr } from "#moves/multi-hit-attr";

--- a/src/phases/mystery-encounter-phases/battle-phase.ts
+++ b/src/phases/mystery-encounter-phases/battle-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { PostSummonPhase } from "#phases/post-summon-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { getCharVariantFromDialogue } from "#data/dialogue";
@@ -10,6 +6,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { IvScannerModifier } from "#modifier/modifier";
+import type { PostSummonPhase } from "#phases/post-summon-phase";
 import { randSeedItem } from "#utils/random-utils";
 import i18next from "i18next";
 

--- a/src/phases/mystery-encounter-phases/battle-start-cleanup-phase.ts
+++ b/src/phases/mystery-encounter-phases/battle-start-cleanup-phase.ts
@@ -1,14 +1,11 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { handleMysteryEncounterBattleStartEffects } from "#mystery-encounters/encounter-phase-utils";
-import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
-import type { TurnEndPhase } from "#phases/turn-end-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { SwitchType } from "#enums/switch-type";
+import type { handleMysteryEncounterBattleStartEffects } from "#mystery-encounters/encounter-phase-utils";
+import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
+import type { TurnEndPhase } from "#phases/turn-end-phase";
 
 /**
  * Runs at the beginning of an Encounter's battle.

--- a/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
@@ -1,12 +1,9 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounterDialogue, OptionTextDisplay } from "#mystery-encounters/mystery-encounter-dialogue";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { UiMode } from "#enums/ui-mode";
 import { getEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
 import type { OptionSelectSettings } from "#mystery-encounters/encounter-phase-utils";
+import type { MysteryEncounterDialogue, OptionTextDisplay } from "#mystery-encounters/mystery-encounter-dialogue";
 import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
 import { SeenEncounterData } from "#mystery-encounters/mystery-encounter-save-data";
 import type { MysteryEncounterUiHandler } from "#ui/mystery-encounter-ui-handler";

--- a/src/phases/mystery-encounter-phases/option-selected-phase.ts
+++ b/src/phases/mystery-encounter-phases/option-selected-phase.ts
@@ -1,11 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { transitionMysteryEncounterIntroVisuals } from "#mystery-encounters/encounter-visuals-utils";
-import type { OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
+import type { MysteryEncounterOption, OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
 
 /**
  * Will handle (in order):

--- a/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
@@ -1,11 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { getEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
-import type { OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
+import type { MysteryEncounterOption, OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
 /**
  * Will handle (in order):
  * - {@linkcode MysteryEncounterOption.onPostOptionPhase} logic (based on an option that was selected)

--- a/src/phases/mystery-encounter-phases/rewards-phase.ts
+++ b/src/phases/mystery-encounter-phases/rewards-phase.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
+import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 
 /**
  * Will handle (in order):

--- a/src/phases/post-action-phase.ts
+++ b/src/phases/post-action-phase.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { TurnCommand } from "#app/turn-command-manager";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
+import type { TurnCommand } from "#app/turn-command-manager";
 import type { FieldBattlerIndex } from "#enums/battler-index";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { PokemonPhase } from "#phases/base/pokemon-phase";

--- a/src/phases/revival-blessing-phase.ts
+++ b/src/phases/revival-blessing-phase.ts
@@ -1,9 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FaintPhase } from "#phases/faint-phase";
-import type { SwitchPhase } from "#phases/switch-phase";
-import type { TurnEndPhase } from "#phases/turn-end-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerIndex } from "#enums/battler-index";
 import { FieldPosition } from "#enums/field-position";
@@ -13,6 +7,9 @@ import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { BattlePhase } from "#phases/base/battle-phase";
+import type { FaintPhase } from "#phases/faint-phase";
+import type { SwitchPhase } from "#phases/switch-phase";
+import type { TurnEndPhase } from "#phases/turn-end-phase";
 import type { PartyUiHandler } from "#ui/party-ui-handler";
 import { toDmgValue } from "#utils/common-utils";
 import { PartyFilterFainted } from "#utils/party-ui-utils";

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EncounterPhase } from "#phases/encounter-phase";
-import type { PostSummonPhase } from "#phases/post-summon-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { getPokeballAtlasKey, getPokeballTintColor } from "#data/pokeball";
@@ -14,6 +9,8 @@ import { PlayerGender } from "#enums/player-gender";
 import type { Pokemon } from "#field/pokemon";
 import { SpeciesFormChangeActiveTrigger } from "#form-change-triggers/species-form-change-active-trigger";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { EncounterPhase } from "#phases/encounter-phase";
+import type { PostSummonPhase } from "#phases/post-summon-phase";
 import { settings } from "#system/settings-manager";
 import { playTween } from "#utils/anim-utils";
 import i18next from "i18next";

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { RecallPhase } from "#phases/recall-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import type { SubstituteTag } from "#battler-tags/substitute-tag";
@@ -15,6 +11,7 @@ import { UiMode } from "#enums/ui-mode";
 import type { Pokemon } from "#field/pokemon";
 import type { SwitchEffectTransferModifier } from "#modifier/modifier";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { RecallPhase } from "#phases/recall-phase";
 import type { PartyUiHandler } from "#ui/party-ui-handler";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { GameOverPhase } from "#phases/game-over-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { EVIL_BOSS_2_WAVE } from "#constants/wave-constants";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -9,6 +5,7 @@ import { BattleType } from "#enums/battle-type";
 import type { CustomModifierSettings } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { GameOverPhase } from "#phases/game-over-phase";
 
 /**
  * Handles various effects when the player clears a wave:

--- a/src/plugins/api/savedata-api.ts
+++ b/src/plugins/api/savedata-api.ts
@@ -28,9 +28,12 @@ export class SavedataApi extends ApiBase {
    */
   public async updateAll(bodyData: UpdateAllSavedataRequest) {
     try {
-      const rawBodyData = JSON.stringify(bodyData, (_k: any, v: any) =>
-        typeof v === "bigint" ? (v <= MAX_INT_ATTR_VALUE ? Number(v) : v.toString()) : v,
-      );
+      const rawBodyData = JSON.stringify(bodyData, (_k: any, v: any) => {
+        if (typeof v === "bigint") {
+          return v <= MAX_INT_ATTR_VALUE ? Number(v) : v.toString();
+        }
+        return v;
+      });
       const response = await this.doPost("/savedata/updateall", rawBodyData);
       return await response.text();
     } catch (err) {

--- a/src/queues/pokemon-priority-queue.ts
+++ b/src/queues/pokemon-priority-queue.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Stat } from "#enums/stat";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { ShuffledPriorityQueue } from "#app/queues/shuffled-priority-queue";
+import type { Stat } from "#enums/stat";
 import type { Pokemon } from "#field/pokemon";
 import { speedOrderComparator } from "#utils/speed-order-utils";
 

--- a/src/scene-base.ts
+++ b/src/scene-base.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import { ImagesFolder } from "#enums/images-folder";
 import { UiTheme } from "#enums/ui-theme";
 import { UiWindowStyle } from "#enums/ui-window-style";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
-import { ImagesFolder } from "#enums/images-folder";
 import { settings } from "#system/settings-manager";
 import { windowStyleDependantAtlases } from "#ui/ui-theme";
 import { coerceArray, enumValueToKey } from "#utils/common-utils";

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -470,8 +470,9 @@ export class GameData {
     let timestamps = Object.keys(runHistoryData).map(Number);
 
     // Arbitrary limit of 25 entries per user --> Can increase or decrease
+    // TODO: Would something like `timestamps.sort(...).splice(RUN_HISTORY_LIMIT)` be better?
     while (timestamps.length >= RUN_HISTORY_LIMIT) {
-      const oldestTimestamp = Math.min.apply(Math, timestamps).toString();
+      const oldestTimestamp = Math.min(...timestamps).toString();
       delete runHistoryData[oldestTimestamp];
       timestamps = Object.keys(runHistoryData).map(Number);
     }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -246,9 +246,12 @@ export class GameData {
       globalScene.ui.savingIcon.show();
       const data = this.getSystemSaveData();
 
-      const systemData = JSON.stringify(data, (_k: any, v: any) =>
-        typeof v === "bigint" ? (v <= MAX_INT_ATTR_VALUE ? Number(v) : v.toString()) : v,
-      );
+      const systemData = JSON.stringify(data, (_k: any, v: any) => {
+        if (typeof v === "bigint") {
+          return v <= MAX_INT_ATTR_VALUE ? Number(v) : v.toString();
+        }
+        return v;
+      });
 
       localStorage.setItem(getLocalStorageKey(GameDataType.SYSTEM), encrypt(systemData, BYPASS_LOGIN));
 
@@ -1146,9 +1149,12 @@ export class GameData {
         localStorage.setItem(
           systemStorageKey,
           encrypt(
-            JSON.stringify(systemData, (_k: any, v: any) =>
-              typeof v === "bigint" ? (v <= MAX_INT_ATTR_VALUE ? Number(v) : v.toString()) : v,
-            ),
+            JSON.stringify(systemData, (_k: any, v: any) => {
+              if (typeof v === "bigint") {
+                return v <= MAX_INT_ATTR_VALUE ? Number(v) : v.toString();
+              }
+              return v;
+            }),
             BYPASS_LOGIN,
           ),
         );

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -1,11 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-attr";
-import type { Phase } from "#app/phase";
-import type { MovePhase } from "#phases/move-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
+import type { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { Phase } from "#app/phase";
 import { ShuffledPriorityQueue } from "#app/queues/shuffled-priority-queue";
 import { AbilityId } from "#enums/ability-id";
 import { BattleCommand } from "#enums/battle-command";
@@ -19,6 +15,7 @@ import { PokemonMove } from "#field/pokemon-move";
 import { BypassSpeedChanceModifier } from "#modifier/modifier";
 import { MoveHeaderAttr } from "#moves/move-header-attr";
 import { PursuitAttr } from "#moves/pursuit-attr";
+import type { MovePhase } from "#phases/move-phase";
 import type { TurnMove } from "#types/move-types";
 import { speedOrderComparator } from "#utils/speed-order-utils";
 

--- a/src/ui/handlers/party-ui-handler.ts
+++ b/src/ui/handlers/party-ui-handler.ts
@@ -290,7 +290,7 @@ export class PartyUiHandler extends MessageUiHandler {
                 && m.pokemonId === newPokemon.id
                 && m.matchType(getTransferrableItemsFromPokemon(pokemon)[this.transferOptionCursor]),
             );
-            const partySlot = this.partySlots.filter((m) => m.getPokemon() === newPokemon)[0]; // this gets pokemon [p] for us
+            const partySlot = this.partySlots.find((m) => m.getPokemon() === newPokemon); // this gets pokemon [p] for us
             if (p !== this.transferCursor) {
               // this skips adding the able/not able labels on the pokemon doing the transfer
               if (matchingModifier) {
@@ -310,11 +310,11 @@ export class PartyUiHandler extends MessageUiHandler {
               // this else relates to the transfer pokemon. We set the text to be blank so there's no "Able"/"Not able" text
               ableToTransfer = "";
             }
-            partySlot.slotHpBar.setVisible(false);
-            partySlot.slotHpOverlay.setVisible(false);
-            partySlot.slotHpText.setVisible(false);
-            partySlot.slotDescriptionLabel.setText(ableToTransfer);
-            partySlot.slotDescriptionLabel.setVisible(true);
+            partySlot?.slotHpBar.setVisible(false);
+            partySlot?.slotHpOverlay.setVisible(false);
+            partySlot?.slotHpText.setVisible(false);
+            partySlot?.slotDescriptionLabel.setText(ableToTransfer);
+            partySlot?.slotDescriptionLabel.setVisible(true);
           }
 
           this.clearOptions();
@@ -616,12 +616,22 @@ export class PartyUiHandler extends MessageUiHandler {
       const battlerCount = globalScene.currentBattle.getBattlerCount();
 
       switch (button) {
-        case Button.UP:
-          success = this.setCursor(this.cursor ? (this.cursor < 6 ? this.cursor - 1 : slotCount - 1) : 6);
+        case Button.UP: {
+          let cursorVal = 6;
+          if (this.cursor) {
+            cursorVal = this.cursor < 6 ? this.cursor - 1 : slotCount - 1;
+          }
+          success = this.setCursor(cursorVal);
           break;
-        case Button.DOWN:
-          success = this.setCursor(this.cursor < 6 ? (this.cursor < slotCount - 1 ? this.cursor + 1 : 6) : 0);
+        }
+        case Button.DOWN: {
+          let cursorVal = 0;
+          if (this.cursor < 6) {
+            cursorVal = this.cursor < slotCount - 1 ? this.cursor + 1 : 6;
+          }
+          success = this.setCursor(cursorVal);
           break;
+        }
         case Button.LEFT:
           if (this.cursor >= battlerCount && this.cursor <= 6) {
             success = this.setCursor(0);

--- a/src/ui/handlers/test-dialogue-ui-handler.ts
+++ b/src/ui/handlers/test-dialogue-ui-handler.ts
@@ -15,19 +15,21 @@ export class TestDialogueUiHandler extends FormModalUiHandler {
   protected override setup() {
     super.setup();
 
-    const flattenKeys = (object?: any, topKey?: string, middleKey?: string[]): any[] => {
-      return Object.keys(object ?? {})
+    const flattenKeys = (i18nObject: object = {}, topKey?: string, middleKey?: string[]): any[] => {
+      return Object.keys(i18nObject)
         .map((t, i) => {
-          const value = Object.values(object)[i];
+          const value = Object.values(i18nObject)[i];
 
           if (typeof value === "object" && value != null) {
             // We check for not null or undefined here because if the language json file has a null key,
             // the typeof will still be an object, but that object will be null, causing issues.
             // If the value is an object, execute the same process.
 
-            return flattenKeys(value, topKey ?? t, topKey ? (middleKey ? [...middleKey, t] : [t]) : undefined).filter(
-              (t2) => t2.length > 0,
-            );
+            let midKey: string[] | undefined;
+            if (topKey) {
+              midKey = middleKey ? [...middleKey, t] : [t];
+            }
+            return flattenKeys(value, topKey ?? t, midKey).filter((t2) => t2.length > 0);
           }
           if (typeof value === "string" || value == null) {
             // We check for null or undefined here as per above - the typeof is still an object

--- a/src/ui/interfaces/confirm-menu-config.ts
+++ b/src/ui/interfaces/confirm-menu-config.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { UiMode } from "#enums/ui-mode";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { OptionMenuSettings } from "#ui/option-select-config";
 
 /**

--- a/src/ui/interfaces/option-select-config.ts
+++ b/src/ui/interfaces/option-select-config.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { UiMode } from "#enums/ui-mode";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { TextStyle } from "#enums/text-style";
+import type { UiMode } from "#enums/ui-mode";
 
 /**
  * Customizations options for UI's {@linkcode UiMode.OPTION_SELECT}

--- a/src/ui/interfaces/option-select-ui-item.ts
+++ b/src/ui/interfaces/option-select-ui-item.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import { BaseOptionSelectUiHandler } from "#ui/base-option-select-ui-handler";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { OptionSelectItem } from "#ui/option-select-config";
 
 /**

--- a/src/ui/settings/settings-ui-items.ts
+++ b/src/ui/settings/settings-ui-items.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { GeneralSettingsUiHandler } from "#ui/general-settings-ui-handler";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { GAME_SPEEDS } from "#constants/app-constants";
 import { BattleStyle } from "#enums/battle-style";
 import { DamageNumbersMode } from "#enums/damage-numbers-mode";
@@ -187,7 +183,7 @@ export const generalSettingsUiItems: SettingsUiItem<GeneralSettingsKey>[] = [
     options: [
       {
         value: 0,
-        /** Replaced with the actual label in {@linkcode GeneralSettingsUiHandler.updateMoveTouchControlsSettingsLabel} */
+        // Replaced with the actual label in `GeneralSettingsUiHandler#updateMoveTouchControlsSettingsLabel`
         label: "ORIENTATION",
       },
       {

--- a/src/utils/anim-utils.ts
+++ b/src/utils/anim-utils.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { initCommonAnims } from "#init/init-common-anims";
-import type { initEncounterAnims } from "#init/init-encounter-anims";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { LegacyAnimConfig } from "#animations/anim-config";
 import { commonAnims } from "#animations/common-anims";
 import { encounterAnims } from "#animations/encounter-anims";
 import { globalScene } from "#app/global-scene";
 import { ImagesFolder } from "#enums/images-folder";
+import type { initCommonAnims } from "#init/init-common-anims";
+import type { initEncounterAnims } from "#init/init-encounter-anims";
 import type { Scene } from "phaser";
 
 type TweenBuilderConfig = Phaser.Types.Tweens.TweenBuilderConfig;

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { initGameSpeed } from "#system/game-speed";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { MAX_STAT_STAGE, MIN_STAT_STAGE } from "#constants/game-constants";
 import type { Pokemon } from "#field/pokemon";
+import type { initGameSpeed } from "#system/game-speed";
 
 export function getFrameMs(frameCount: number): number {
   return Math.floor((1 / 60) * 1000 * frameCount);

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import "vitest";
 
 import type { AbilityId } from "#enums/ability-id";
@@ -12,12 +8,13 @@ import type { EffectiveStat, PermanentStat, Stat } from "#enums/stat";
 import type { StatusEffect } from "#enums/status-effect";
 import type { TerrainType } from "#enums/terrain-type";
 import type { WeatherType } from "#enums/weather-type";
+import type { Pokemon } from "#field/pokemon";
 import type { ToHaveEffectiveStatMatcherOptions } from "#test/test-utils/matchers/to-have-effective-stat-matcher";
 import type { ToHaveMoveResultMatcherOptions } from "#test/test-utils/matchers/to-have-move-result-matcher";
 import type { ToHaveStatMatcherOptions } from "#test/test-utils/matchers/to-have-stat-matcher";
 import type { ToHaveStatusEffectMatcherOptions } from "#test/test-utils/matchers/to-have-status-effect-matcher";
-import type { ToHaveUsedMoveMatcherOptions } from "#test/test-utils/matchers/to-have-used-move-matcher";
 import type { ToHaveTakenDamageMatcherOptions } from "#test/test-utils/matchers/to-have-taken-damage-matcher";
+import type { ToHaveUsedMoveMatcherOptions } from "#test/test-utils/matchers/to-have-used-move-matcher";
 
 declare module "vitest" {
   interface Assertion {

--- a/test/abilities/bad-dreams.test.ts
+++ b/test/abilities/bad-dreams.test.ts
@@ -111,28 +111,25 @@ describe("Ability - Bad Dreams", () => {
     ["Hydration", AbilityId.HYDRATION, WeatherType.RAIN],
     ["Shed Skin", AbilityId.SHED_SKIN, WeatherType.NONE],
     ["Healer", AbilityId.HEALER, WeatherType.NONE],
-  ])(
-    "should not damage if enemy is woken up by '%s' ability in the same turn",
-    async (_abilityName, abilityId, weatherType) => {
-      const { override, classicMode, field, move } = game;
-      override.weather(weatherType).battleType("double").enemyAbility(abilityId);
+  ])("should not damage if enemy is woken up by '%s' ability in the same turn", async (_abilityName, abilityId, weatherType) => {
+    const { override, classicMode, field, move } = game;
+    override.weather(weatherType).battleType("double").enemyAbility(abilityId);
 
-      await classicMode.runToSummon(SpeciesId.DARKRAI);
-      for (const enemyPkm of game.scene.getEnemyParty()) {
-        vi.spyOn(enemyPkm, "randSeedInt").mockReturnValueOnce(0); // Make sure that Shed Skin/Healer always triggers.
-      }
-      const enemy = field.getEnemyPokemon();
-      enemy.trySetStatus(StatusEffect.SLEEP);
+    await classicMode.runToSummon(SpeciesId.DARKRAI);
+    for (const enemyPkm of game.scene.getEnemyParty()) {
+      vi.spyOn(enemyPkm, "randSeedInt").mockReturnValueOnce(0); // Make sure that Shed Skin/Healer always triggers.
+    }
+    const enemy = field.getEnemyPokemon();
+    enemy.trySetStatus(StatusEffect.SLEEP);
 
-      expect(enemy).toHaveStatusEffect(StatusEffect.SLEEP);
+    expect(enemy).toHaveStatusEffect(StatusEffect.SLEEP);
 
-      move.use(MoveId.SPLASH);
-      await game.toEndOfTurn();
+    move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
 
-      expect(enemy).not.toHaveStatusEffect(StatusEffect.SLEEP);
-      expect(enemy).toHaveFullHp();
-    },
-  );
+    expect(enemy).not.toHaveStatusEffect(StatusEffect.SLEEP);
+    expect(enemy).toHaveFullHp();
+  });
 
   it("should damage if enemy is not woken up by 'Hydration' ability due to rain ending in the same turn", async () => {
     const { override, classicMode, field, move } = game;
@@ -155,26 +152,23 @@ describe("Ability - Bad Dreams", () => {
   it.each([
     ["Shed Skin", AbilityId.SHED_SKIN, WeatherType.NONE],
     ["Healer", AbilityId.HEALER, WeatherType.NONE],
-  ])(
-    "should damage if enemy is not woken up by '%s' ability in the same turn",
-    async (_abilityName, abilityId, weatherType) => {
-      const { override, classicMode, field, move } = game;
-      override.weather(weatherType).battleType("double").enemyAbility(abilityId);
+  ])("should damage if enemy is not woken up by '%s' ability in the same turn", async (_abilityName, abilityId, weatherType) => {
+    const { override, classicMode, field, move } = game;
+    override.weather(weatherType).battleType("double").enemyAbility(abilityId);
 
-      await classicMode.runToSummon(SpeciesId.DARKRAI);
-      for (const pokemon of game.scene.getEnemyParty()) {
-        vi.spyOn(pokemon, "randSeedInt").mockReturnValueOnce(3); // Make sure that Shed Skin/Healer never triggers.
-      }
-      const enemy = field.getEnemyPokemon();
-      enemy.trySetStatus(StatusEffect.SLEEP, false, null, Number.MAX_SAFE_INTEGER);
+    await classicMode.runToSummon(SpeciesId.DARKRAI);
+    for (const pokemon of game.scene.getEnemyParty()) {
+      vi.spyOn(pokemon, "randSeedInt").mockReturnValueOnce(3); // Make sure that Shed Skin/Healer never triggers.
+    }
+    const enemy = field.getEnemyPokemon();
+    enemy.trySetStatus(StatusEffect.SLEEP, false, null, Number.MAX_SAFE_INTEGER);
 
-      expect(enemy).toHaveStatusEffect(StatusEffect.SLEEP);
+    expect(enemy).toHaveStatusEffect(StatusEffect.SLEEP);
 
-      move.use(MoveId.SPLASH);
-      await game.toEndOfTurn();
+    move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
 
-      expect(enemy).toHaveStatusEffect(StatusEffect.SLEEP);
-      expect(enemy).toHaveTakenDamage(enemy.getMaxHp() / 8);
-    },
-  );
+    expect(enemy).toHaveStatusEffect(StatusEffect.SLEEP);
+    expect(enemy).toHaveTakenDamage(enemy.getMaxHp() / 8);
+  });
 });

--- a/test/abilities/drizzle.test.ts
+++ b/test/abilities/drizzle.test.ts
@@ -63,7 +63,7 @@ describe("Ability - Drizzle", () => {
       .enemyLevel(100);
   });
 
-  it("should last the rain for 5 turns", async () => {
+  it("should set up 5 turns of rain", async () => {
     const { classicMode, move } = game;
 
     await classicMode.startBattle(SpeciesId.FEEBAS);
@@ -102,23 +102,14 @@ describe("Ability - Drizzle", () => {
     expect(game).toHaveWeather(WeatherType.RAIN);
   });
 
-  it.each(weatherSuppressingAbilities)(
-    "should not be stopped from setting weather by %s ability",
-    async (_name, abilityId) => {
-      const { override, classicMode, move, textInterceptor } = game;
-      override.enemyAbility(abilityId);
+  it.each(weatherSuppressingAbilities)(//
+  "should not be stopped from setting weather by %s ability", async (_name, abilityId) => {
+    const { override, classicMode, textInterceptor } = game;
+    override.enemyAbility(abilityId);
 
-      await classicMode.startBattle(SpeciesId.FEEBAS);
+    await classicMode.startBattle(SpeciesId.FEEBAS);
 
-      expect(textInterceptor.logs).toContain(t("abilityTriggers:weatherEffectDisappeared"));
-
-      for (let i = 0; i < 5; i++) {
-        expect(game).toHaveWeather(WeatherType.RAIN);
-
-        move.use(MoveId.SPLASH);
-        await game.toEndOfTurn();
-      }
-
-      expect(game).not.toHaveWeather(WeatherType.RAIN);
+    expect(textInterceptor.logs).toContain(t("abilityTriggers:weatherEffectDisappeared"));
+    expect(game).toHaveWeather(WeatherType.RAIN);
   });
 });

--- a/test/abilities/drizzle.test.ts
+++ b/test/abilities/drizzle.test.ts
@@ -120,6 +120,5 @@ describe("Ability - Drizzle", () => {
       }
 
       expect(game).not.toHaveWeather(WeatherType.RAIN);
-    },
-  );
+  });
 });

--- a/test/abilities/guts.test.ts
+++ b/test/abilities/guts.test.ts
@@ -79,9 +79,8 @@ describe("Ability - Guts", () => {
     expect(player).toHaveBattlerTag(BattlerTagType.CONFUSED);
   });
 
-  it.each(
-    nonVolatileStatusEffects,
-  )("should apply a 1.5x attack boost with '%s' status effect", async (_name, statusEffect) => {
+  it.each(nonVolatileStatusEffects)(//
+  "should apply a 1.5x attack boost with '%s' status effect", async (_name, statusEffect) => {
     const { override, classicMode, field, move } = game;
     override.statusEffect(statusEffect);
 

--- a/test/abilities/guts.test.ts
+++ b/test/abilities/guts.test.ts
@@ -79,22 +79,21 @@ describe("Ability - Guts", () => {
     expect(player).toHaveBattlerTag(BattlerTagType.CONFUSED);
   });
 
-  it.each(nonVolatileStatusEffects)(
-    "should apply a 1.5x attack boost with '%s' status effect",
-    async (_name, statusEffect) => {
-      const { override, classicMode, field, move } = game;
-      override.statusEffect(statusEffect);
+  it.each(
+    nonVolatileStatusEffects,
+  )("should apply a 1.5x attack boost with '%s' status effect", async (_name, statusEffect) => {
+    const { override, classicMode, field, move } = game;
+    override.statusEffect(statusEffect);
 
-      await classicMode.startBattle(SpeciesId.FEEBAS);
-      const player = field.getPlayerPokemon();
-      move.use(MoveId.SPLASH);
-      await game.toEndOfTurn();
-      const playerAtk = player.getStat(Stat.ATK);
+    await classicMode.startBattle(SpeciesId.FEEBAS);
+    const player = field.getPlayerPokemon();
+    move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
+    const playerAtk = player.getStat(Stat.ATK);
 
-      expect(player).toHaveStatusEffect(statusEffect);
-      expect(player).toHaveEffectiveStat(Stat.ATK, Math.floor(playerAtk * 1.5));
-    },
-  );
+    expect(player).toHaveStatusEffect(statusEffect);
+    expect(player).toHaveEffectiveStat(Stat.ATK, Math.floor(playerAtk * 1.5));
+  });
 
   it.each([
     { id: AbilityId.HUSTLE, name: "Hustle", multiplier: 1.5 },

--- a/test/abilities/low-hp-type-attack-multiplier.test.ts
+++ b/test/abilities/low-hp-type-attack-multiplier.test.ts
@@ -37,69 +37,69 @@ describe("Abilities - Overgrow/Blaze/Torrent/Swarm", () => {
     { abilityName: "Blaze", ability: AbilityId.BLAZE, moveId: MoveId.FIRE_FANG },
     { abilityName: "Torrent", ability: AbilityId.TORRENT, moveId: MoveId.AQUA_JET },
     { abilityName: "Swarm", ability: AbilityId.SWARM, moveId: MoveId.BUG_BITE },
-  ])(
-    "$abilityName should multiply the user's attack stat by 1.5 if it uses a physical move of the relevant type at low HP",
-    async ({ ability, moveId }) => {
-      game.override.ability(ability).moveset(moveId);
-      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-      const playerPokemon = game.scene.getPlayerPokemon()!;
-      playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
-      vi.spyOn(playerPokemon, "getEffectiveStat");
+  ])("$abilityName should multiply the user's attack stat by 1.5 if it uses a physical move of the relevant type at low HP", async ({
+    ability,
+    moveId,
+  }) => {
+    game.override.ability(ability).moveset(moveId);
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
+    vi.spyOn(playerPokemon, "getEffectiveStat");
 
-      game.move.select(moveId);
-      await game.move.forceHit();
-      await game.phaseInterceptor.to("PostActionPhase", false);
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("PostActionPhase", false);
 
-      expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.ATK] * 1.5));
-    },
-  );
-
-  it.each([
-    { abilityName: "Overgrow", ability: AbilityId.OVERGROW, moveId: MoveId.ABSORB },
-    { abilityName: "Blaze", ability: AbilityId.BLAZE, moveId: MoveId.EMBER },
-    { abilityName: "Torrent", ability: AbilityId.TORRENT, moveId: MoveId.WATER_GUN },
-    { abilityName: "Swarm", ability: AbilityId.SWARM, moveId: MoveId.INFESTATION },
-  ])(
-    "$abilityName should multiply the user's sp. attack stat by 1.5 if it uses a special move of the relevant type at low HP",
-    async ({ ability, moveId }) => {
-      game.override.ability(ability).moveset(moveId);
-      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-      const playerPokemon = game.scene.getPlayerPokemon()!;
-      playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
-      vi.spyOn(playerPokemon, "getEffectiveStat");
-
-      game.move.select(moveId);
-      await game.move.forceHit();
-      await game.phaseInterceptor.to("PostActionPhase", false);
-
-      expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.SPATK] * 1.5));
-    },
-  );
+    expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.ATK] * 1.5));
+  });
 
   it.each([
     { abilityName: "Overgrow", ability: AbilityId.OVERGROW, moveId: MoveId.ABSORB },
     { abilityName: "Blaze", ability: AbilityId.BLAZE, moveId: MoveId.EMBER },
     { abilityName: "Torrent", ability: AbilityId.TORRENT, moveId: MoveId.WATER_GUN },
     { abilityName: "Swarm", ability: AbilityId.SWARM, moveId: MoveId.INFESTATION },
-  ])(
-    "$abilityName should not take effect if the ability-holder is above the HP threshold",
-    async ({ ability, moveId }) => {
-      game.override.ability(ability).moveset(moveId);
-      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-      const playerPokemon = game.scene.getPlayerPokemon()!;
-      vi.spyOn(playerPokemon, "getEffectiveStat");
+  ])("$abilityName should multiply the user's sp. attack stat by 1.5 if it uses a special move of the relevant type at low HP", async ({
+    ability,
+    moveId,
+  }) => {
+    game.override.ability(ability).moveset(moveId);
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
+    vi.spyOn(playerPokemon, "getEffectiveStat");
 
-      game.move.select(moveId);
-      await game.move.forceHit();
-      await game.phaseInterceptor.to("PostActionPhase", false);
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("PostActionPhase", false);
 
-      const statUsed =
-        playerPokemon.getMoveCategory(game.scene.getEnemyPokemon()!, allMoves.get(moveId)) === MoveCategory.PHYSICAL
-          ? Stat.ATK
-          : Stat.SPATK;
-      expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[statUsed]));
-    },
-  );
+    expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.SPATK] * 1.5));
+  });
+
+  it.each([
+    { abilityName: "Overgrow", ability: AbilityId.OVERGROW, moveId: MoveId.ABSORB },
+    { abilityName: "Blaze", ability: AbilityId.BLAZE, moveId: MoveId.EMBER },
+    { abilityName: "Torrent", ability: AbilityId.TORRENT, moveId: MoveId.WATER_GUN },
+    { abilityName: "Swarm", ability: AbilityId.SWARM, moveId: MoveId.INFESTATION },
+  ])("$abilityName should not take effect if the ability-holder is above the HP threshold", async ({
+    ability,
+    moveId,
+  }) => {
+    game.override.ability(ability).moveset(moveId);
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+    const playerPokemon = game.scene.getPlayerPokemon()!;
+    vi.spyOn(playerPokemon, "getEffectiveStat");
+
+    game.move.select(moveId);
+    await game.move.forceHit();
+    await game.phaseInterceptor.to("PostActionPhase", false);
+
+    const statUsed =
+      playerPokemon.getMoveCategory(game.scene.getEnemyPokemon()!, allMoves.get(moveId)) === MoveCategory.PHYSICAL
+        ? Stat.ATK
+        : Stat.SPATK;
+    expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[statUsed]));
+  });
 
   it.each([
     { abilityName: "Overgrow", ability: AbilityId.OVERGROW },

--- a/test/abilities/low-hp-type-attack-multiplier.test.ts
+++ b/test/abilities/low-hp-type-attack-multiplier.test.ts
@@ -32,74 +32,77 @@ describe("Abilities - Overgrow/Blaze/Torrent/Swarm", () => {
       .enemyMoveset(MoveId.SPLASH);
   });
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     { abilityName: "Overgrow", ability: AbilityId.OVERGROW, moveId: MoveId.LEAFAGE },
     { abilityName: "Blaze", ability: AbilityId.BLAZE, moveId: MoveId.FIRE_FANG },
     { abilityName: "Torrent", ability: AbilityId.TORRENT, moveId: MoveId.AQUA_JET },
     { abilityName: "Swarm", ability: AbilityId.SWARM, moveId: MoveId.BUG_BITE },
-  ])("$abilityName should multiply the user's attack stat by 1.5 if it uses a physical move of the relevant type at low HP", async ({
-    ability,
-    moveId,
-  }) => {
-    game.override.ability(ability).moveset(moveId);
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-    const playerPokemon = game.scene.getPlayerPokemon()!;
-    playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
-    vi.spyOn(playerPokemon, "getEffectiveStat");
+  ])(
+    "$abilityName should multiply the user's attack stat by 1.5 if it uses a physical move of the relevant type at low HP",
+    async ({ ability, moveId }) => {
+      game.override.ability(ability).moveset(moveId);
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+      const playerPokemon = game.scene.getPlayerPokemon()!;
+      playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
+      vi.spyOn(playerPokemon, "getEffectiveStat");
 
-    game.move.select(moveId);
-    await game.move.forceHit();
-    await game.phaseInterceptor.to("PostActionPhase", false);
+      game.move.select(moveId);
+      await game.move.forceHit();
+      await game.phaseInterceptor.to("PostActionPhase", false);
 
-    expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.ATK] * 1.5));
-  });
+      expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.ATK] * 1.5));
+    },
+  );
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     { abilityName: "Overgrow", ability: AbilityId.OVERGROW, moveId: MoveId.ABSORB },
     { abilityName: "Blaze", ability: AbilityId.BLAZE, moveId: MoveId.EMBER },
     { abilityName: "Torrent", ability: AbilityId.TORRENT, moveId: MoveId.WATER_GUN },
     { abilityName: "Swarm", ability: AbilityId.SWARM, moveId: MoveId.INFESTATION },
-  ])("$abilityName should multiply the user's sp. attack stat by 1.5 if it uses a special move of the relevant type at low HP", async ({
-    ability,
-    moveId,
-  }) => {
-    game.override.ability(ability).moveset(moveId);
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-    const playerPokemon = game.scene.getPlayerPokemon()!;
-    playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
-    vi.spyOn(playerPokemon, "getEffectiveStat");
+  ])(
+    "$abilityName should multiply the user's sp. attack stat by 1.5 if it uses a special move of the relevant type at low HP",
+    async ({ ability, moveId }) => {
+      game.override.ability(ability).moveset(moveId);
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+      const playerPokemon = game.scene.getPlayerPokemon()!;
+      playerPokemon.hp = playerPokemon.getMaxHp() * 0.33 - 1;
+      vi.spyOn(playerPokemon, "getEffectiveStat");
 
-    game.move.select(moveId);
-    await game.move.forceHit();
-    await game.phaseInterceptor.to("PostActionPhase", false);
+      game.move.select(moveId);
+      await game.move.forceHit();
+      await game.phaseInterceptor.to("PostActionPhase", false);
 
-    expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.SPATK] * 1.5));
-  });
+      expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[Stat.SPATK] * 1.5));
+    },
+  );
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     { abilityName: "Overgrow", ability: AbilityId.OVERGROW, moveId: MoveId.ABSORB },
     { abilityName: "Blaze", ability: AbilityId.BLAZE, moveId: MoveId.EMBER },
     { abilityName: "Torrent", ability: AbilityId.TORRENT, moveId: MoveId.WATER_GUN },
     { abilityName: "Swarm", ability: AbilityId.SWARM, moveId: MoveId.INFESTATION },
-  ])("$abilityName should not take effect if the ability-holder is above the HP threshold", async ({
-    ability,
-    moveId,
-  }) => {
-    game.override.ability(ability).moveset(moveId);
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
-    const playerPokemon = game.scene.getPlayerPokemon()!;
-    vi.spyOn(playerPokemon, "getEffectiveStat");
+  ])(
+    "$abilityName should not take effect if the ability-holder is above the HP threshold",
+    async ({ ability, moveId }) => {
+      game.override.ability(ability).moveset(moveId);
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+      const playerPokemon = game.scene.getPlayerPokemon()!;
+      vi.spyOn(playerPokemon, "getEffectiveStat");
 
-    game.move.select(moveId);
-    await game.move.forceHit();
-    await game.phaseInterceptor.to("PostActionPhase", false);
+      game.move.select(moveId);
+      await game.move.forceHit();
+      await game.phaseInterceptor.to("PostActionPhase", false);
 
-    const statUsed =
-      playerPokemon.getMoveCategory(game.scene.getEnemyPokemon()!, allMoves.get(moveId)) === MoveCategory.PHYSICAL
-        ? Stat.ATK
-        : Stat.SPATK;
-    expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[statUsed]));
-  });
+      const statUsed =
+        playerPokemon.getMoveCategory(game.scene.getEnemyPokemon()!, allMoves.get(moveId)) === MoveCategory.PHYSICAL
+          ? Stat.ATK
+          : Stat.SPATK;
+      expect(playerPokemon.getEffectiveStat).toHaveLastReturnedWith(Math.floor(playerPokemon.stats[statUsed]));
+    },
+  );
 
   it.each([
     { abilityName: "Overgrow", ability: AbilityId.OVERGROW },

--- a/test/abilities/marvel-scale.test.ts
+++ b/test/abilities/marvel-scale.test.ts
@@ -77,22 +77,21 @@ describe("Ability - Marvel Scale", () => {
     expect(player).toHaveEffectiveStat(Stat.DEF, playerDef);
   });
 
-  it.each(nonVolatileStatusEffects)(
-    "should apply a 1.5x defense boost with $statusEffectName status effect",
-    async ({ statusEffectId }) => {
-      const { override, classicMode, field } = game;
-      override.statusEffect(statusEffectId);
+  it.each(nonVolatileStatusEffects)("should apply a 1.5x defense boost with $statusEffectName status effect", async ({
+    statusEffectId,
+  }) => {
+    const { override, classicMode, field } = game;
+    override.statusEffect(statusEffectId);
 
-      await classicMode.startBattle(SpeciesId.FEEBAS);
-      const player = field.getPlayerPokemon();
-      game.move.use(MoveId.SPLASH);
-      await game.toEndOfTurn();
-      const playerDef = player.getStat(Stat.DEF);
+    await classicMode.startBattle(SpeciesId.FEEBAS);
+    const player = field.getPlayerPokemon();
+    game.move.use(MoveId.SPLASH);
+    await game.toEndOfTurn();
+    const playerDef = player.getStat(Stat.DEF);
 
-      expect(player.hasNonVolatileStatusEffect()).toBe(true);
-      expect(player).toHaveEffectiveStat(Stat.DEF, Math.floor(playerDef * 1.5));
-    },
-  );
+    expect(player.hasNonVolatileStatusEffect()).toBe(true);
+    expect(player).toHaveEffectiveStat(Stat.DEF, Math.floor(playerDef * 1.5));
+  });
 
   it("should stack with 'Fur Coat' ability", async () => {
     const { override, field, classicMode } = game;

--- a/test/abilities/marvel-scale.test.ts
+++ b/test/abilities/marvel-scale.test.ts
@@ -77,9 +77,8 @@ describe("Ability - Marvel Scale", () => {
     expect(player).toHaveEffectiveStat(Stat.DEF, playerDef);
   });
 
-  it.each(nonVolatileStatusEffects)("should apply a 1.5x defense boost with $statusEffectName status effect", async ({
-    statusEffectId,
-  }) => {
+  it.each(nonVolatileStatusEffects)(//
+  "should apply a 1.5x defense boost with $statusEffectName status effect", async ({ statusEffectId }) => {
     const { override, classicMode, field } = game;
     override.statusEffect(statusEffectId);
 

--- a/test/abilities/move-flag-power-boost.test.ts
+++ b/test/abilities/move-flag-power-boost.test.ts
@@ -32,6 +32,7 @@ describe("Abilities - Move Flag Power Boost Ability Attr", () => {
   });
 
   // Note: All affected moves have been verified to have the flag required by all_moves
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     {
       ability: AbilityId.MEGA_LAUNCHER,
@@ -82,24 +83,21 @@ describe("Abilities - Move Flag Power Boost Ability Attr", () => {
       moveFlag: MoveFlags.SLICING_MOVE,
       factor: 1.5,
     },
-  ])("$abilityName should boost the damage of specific moves by a factor of $factor", async ({
-    ability,
-    moveId: move,
-    moveFlag,
-    factor,
-  }) => {
-    game.override.moveset(move).ability(ability);
-    await game.classicMode.startBattle(SpeciesId.FEEBAS);
-    const playerPokemon = game.field.getPlayerPokemon();
-    const moveUsed = allMoves.get(move);
-    vi.spyOn(moveUsed, "calculateBattlePower");
+  ])(
+    "$abilityName should boost the damage of specific moves by a factor of $factor",
+    async ({ ability, moveId: move, moveFlag, factor }) => {
+      game.override.moveset(move).ability(ability);
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+      const playerPokemon = game.field.getPlayerPokemon();
+      const moveUsed = allMoves.get(move);
+      vi.spyOn(moveUsed, "calculateBattlePower");
 
-    game.move.select(move);
-    await game.move.forceHit();
-    await game.toEndOfTurn();
-    // @ts-expect-error - `hasFlag()` is private but we want to validate the flag is set
-    expect(moveUsed.hasFlag(moveFlag)).toBe(true);
-    expect(moveUsed.checkFlag(moveFlag, playerPokemon)).toBe(true);
-    expect(moveUsed.calculateBattlePower).toHaveLastReturnedWith(moveUsed.power * factor);
-  });
+      game.move.select(move);
+      await game.move.forceHit();
+      await game.toEndOfTurn();
+      expect(moveUsed["hasFlag"](moveFlag)).toBe(true);
+      expect(moveUsed.checkFlag(moveFlag, playerPokemon)).toBe(true);
+      expect(moveUsed.calculateBattlePower).toHaveLastReturnedWith(moveUsed.power * factor);
+    },
+  );
 });

--- a/test/abilities/move-flag-power-boost.test.ts
+++ b/test/abilities/move-flag-power-boost.test.ts
@@ -82,22 +82,24 @@ describe("Abilities - Move Flag Power Boost Ability Attr", () => {
       moveFlag: MoveFlags.SLICING_MOVE,
       factor: 1.5,
     },
-  ])(
-    "$abilityName should boost the damage of specific moves by a factor of $factor",
-    async ({ ability, moveId: move, moveFlag, factor }) => {
-      game.override.moveset(move).ability(ability);
-      await game.classicMode.startBattle(SpeciesId.FEEBAS);
-      const playerPokemon = game.field.getPlayerPokemon();
-      const moveUsed = allMoves.get(move);
-      vi.spyOn(moveUsed, "calculateBattlePower");
+  ])("$abilityName should boost the damage of specific moves by a factor of $factor", async ({
+    ability,
+    moveId: move,
+    moveFlag,
+    factor,
+  }) => {
+    game.override.moveset(move).ability(ability);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    const playerPokemon = game.field.getPlayerPokemon();
+    const moveUsed = allMoves.get(move);
+    vi.spyOn(moveUsed, "calculateBattlePower");
 
-      game.move.select(move);
-      await game.move.forceHit();
-      await game.toEndOfTurn();
-      // @ts-expect-error - `hasFlag()` is private but we want to validate the flag is set
-      expect(moveUsed.hasFlag(moveFlag)).toBe(true);
-      expect(moveUsed.checkFlag(moveFlag, playerPokemon)).toBe(true);
-      expect(moveUsed.calculateBattlePower).toHaveLastReturnedWith(moveUsed.power * factor);
-    },
-  );
+    game.move.select(move);
+    await game.move.forceHit();
+    await game.toEndOfTurn();
+    // @ts-expect-error - `hasFlag()` is private but we want to validate the flag is set
+    expect(moveUsed.hasFlag(moveFlag)).toBe(true);
+    expect(moveUsed.checkFlag(moveFlag, playerPokemon)).toBe(true);
+    expect(moveUsed.calculateBattlePower).toHaveLastReturnedWith(moveUsed.power * factor);
+  });
 });

--- a/test/abilities/moxie.test.ts
+++ b/test/abilities/moxie.test.ts
@@ -48,25 +48,21 @@ describe("Abilities - Moxie", () => {
   }, 20000);
 
   // TODO: Activate this test when MOXIE is corrected to work on faint and not on battle victory
-  it.todo(
-    "should raise ATK stat stage by 1 when defeating an ally Pokemon",
-    async () => {
-      game.override.battleType("double");
-      const moveToUse = MoveId.AERIAL_ACE;
-      await game.classicMode.startBattle(SpeciesId.MIGHTYENA, SpeciesId.MIGHTYENA);
+  it.todo("should raise ATK stat stage by 1 when defeating an ally Pokemon", async () => {
+    game.override.battleType("double");
+    const moveToUse = MoveId.AERIAL_ACE;
+    await game.classicMode.startBattle(SpeciesId.MIGHTYENA, SpeciesId.MIGHTYENA);
 
-      const [firstPokemon, secondPokemon] = game.scene.getPlayerField();
+    const [firstPokemon, secondPokemon] = game.scene.getPlayerField();
 
-      expect(firstPokemon.getStatStage(Stat.ATK)).toBe(0);
+    expect(firstPokemon.getStatStage(Stat.ATK)).toBe(0);
 
-      secondPokemon.hp = 1;
+    secondPokemon.hp = 1;
 
-      game.move.select(moveToUse, BattlerIndex.PLAYER_2);
+    game.move.select(moveToUse, BattlerIndex.PLAYER_2);
 
-      await game.phaseInterceptor.to("TurnEndPhase");
+    await game.phaseInterceptor.to("TurnEndPhase");
 
-      expect(firstPokemon.getStatStage(Stat.ATK)).toBe(1);
-    },
-    20000,
-  );
+    expect(firstPokemon.getStatStage(Stat.ATK)).toBe(1);
+  }, 20000);
 });

--- a/test/abilities/sticky-hold.test.ts
+++ b/test/abilities/sticky-hold.test.ts
@@ -34,17 +34,15 @@ describe("Abilities - Sticky Hold", () => {
       .enemyLevel(100);
   });
 
-  it.each(
-    [MoveId.THIEF, MoveId.PLUCK, MoveId.INCINERATE, MoveId.KNOCK_OFF].map((moveId) => ({
-      moveId,
-      name: MoveId[moveId],
-    })),
-  )("should prevent the user from losing a held item when hit by the move $name", async ({ moveId: move }) => {
-    vi.spyOn(allMoves.get(move), "chance", "get").mockReturnValue(-1);
+  const stealMoves = [MoveId.THIEF, MoveId.PLUCK, MoveId.INCINERATE, MoveId.KNOCK_OFF] as const;
+  const stealMovesObj = stealMoves.map((moveId) => ({ moveId, name: MoveId[moveId] }));
+  it.each(stealMovesObj)(//
+  "should prevent the user from losing a held item when hit by the move $name", async ({ moveId }) => {
+    vi.spyOn(allMoves.get(moveId), "chance", "get").mockReturnValue(-1);
 
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-    game.move.use(move);
+    game.move.use(moveId);
     await game.move.forceEnemyMove(MoveId.SPLASH);
     await game.toNextTurn();
 
@@ -52,13 +50,12 @@ describe("Abilities - Sticky Hold", () => {
     expect(enemyPokemon.getHeldItems().length).toBe(1);
   });
 
-  // TODO: Enable this test, and add it to the above test block, once Corrosive Gas is implemented
-  it.todo("should prevent the user from losing a held item when hit by the move 'CORROSIVE_GAS'", () => {});
-
-  it.each(
-    [AbilityId.MAGICIAN, AbilityId.PICKPOCKET].map((ability) => ({ ability, name: AbilityId[ability] })),
-  )("should prevent the user's held item from being stolen by the ability $name", async ({ ability }) => {
-    game.override.ability(ability);
+  // TODO: add Corrosive Gas to this test block when it's implemented
+  const stealAbilities = [AbilityId.MAGICIAN, AbilityId.PICKPOCKET] as const;
+  const stealAbilitiesObj = stealAbilities.map((abilityId) => ({ abilityId, name: AbilityId[abilityId] }));
+  it.each(stealAbilitiesObj)(//
+  "should prevent the user's held item from being stolen by the ability $name", async ({ abilityId }) => {
+    game.override.ability(abilityId);
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
     game.move.use(MoveId.FALSE_SWIPE);

--- a/test/abilities/sticky-hold.test.ts
+++ b/test/abilities/sticky-hold.test.ts
@@ -55,18 +55,17 @@ describe("Abilities - Sticky Hold", () => {
   // TODO: Enable this test, and add it to the above test block, once Corrosive Gas is implemented
   it.todo("should prevent the user from losing a held item when hit by the move 'CORROSIVE_GAS'", () => {});
 
-  it.each([AbilityId.MAGICIAN, AbilityId.PICKPOCKET].map((ability) => ({ ability, name: AbilityId[ability] })))(
-    "should prevent the user's held item from being stolen by the ability $name",
-    async ({ ability }) => {
-      game.override.ability(ability);
-      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+  it.each(
+    [AbilityId.MAGICIAN, AbilityId.PICKPOCKET].map((ability) => ({ ability, name: AbilityId[ability] })),
+  )("should prevent the user's held item from being stolen by the ability $name", async ({ ability }) => {
+    game.override.ability(ability);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-      game.move.use(MoveId.FALSE_SWIPE);
-      await game.move.forceEnemyMove(MoveId.FALSE_SWIPE);
-      await game.toNextTurn();
+    game.move.use(MoveId.FALSE_SWIPE);
+    await game.move.forceEnemyMove(MoveId.FALSE_SWIPE);
+    await game.toNextTurn();
 
-      const enemyPokemon = game.field.getEnemyPokemon();
-      expect(enemyPokemon.getHeldItems().length).toBe(1);
-    },
-  );
+    const enemyPokemon = game.field.getEnemyPokemon();
+    expect(enemyPokemon.getHeldItems().length).toBe(1);
+  });
 });

--- a/test/abilities/tangled-feet.test.ts
+++ b/test/abilities/tangled-feet.test.ts
@@ -138,30 +138,31 @@ describe("Ability - Tangled Feet", () => {
         weatherType: WeatherType.HAIL,
         passiveAbilityMultiplier: 1.2,
       },
-    ])(
-      "should stack with $passiveAbilityName Ability",
-      async ({ passiveAbilityId, weatherType, passiveAbilityMultiplier }) => {
-        const { override, classicMode, move, field } = game;
-        override.passiveAbility(passiveAbilityId).weather(weatherType);
-        await classicMode.startBattle(SpeciesId.FEEBAS);
-        const playerPkm = field.getPlayerPokemon();
-        const enemyPkm = field.getEnemyPokemon();
-        vi.spyOn(enemyPkm, "getAccuracyMultiplier");
+    ])("should stack with $passiveAbilityName Ability", async ({
+      passiveAbilityId,
+      weatherType,
+      passiveAbilityMultiplier,
+    }) => {
+      const { override, classicMode, move, field } = game;
+      override.passiveAbility(passiveAbilityId).weather(weatherType);
+      await classicMode.startBattle(SpeciesId.FEEBAS);
+      const playerPkm = field.getPlayerPokemon();
+      const enemyPkm = field.getEnemyPokemon();
+      vi.spyOn(enemyPkm, "getAccuracyMultiplier");
 
-        game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-        move.use(MoveId.SPLASH);
-        await move.selectEnemyMove(MoveId.CONFUSE_RAY);
-        await move.forceHit();
-        await game.toEndOfTurn();
-        move.use(MoveId.SPLASH);
-        await move.selectEnemyMove(MoveId.TACKLE);
-        await game.toEndOfTurn();
+      game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+      move.use(MoveId.SPLASH);
+      await move.selectEnemyMove(MoveId.CONFUSE_RAY);
+      await move.forceHit();
+      await game.toEndOfTurn();
+      move.use(MoveId.SPLASH);
+      await move.selectEnemyMove(MoveId.TACKLE);
+      await game.toEndOfTurn();
 
-        expect(playerPkm).toHaveBattlerTag(BattlerTagType.CONFUSED);
-        expect(enemyPkm.getAccuracyMultiplier).toHaveLastReturnedWith(
-          1 / passiveAbilityMultiplier / tangledFeetMultiplier,
-        );
-      },
-    );
+      expect(playerPkm).toHaveBattlerTag(BattlerTagType.CONFUSED);
+      expect(enemyPkm.getAccuracyMultiplier).toHaveLastReturnedWith(
+        1 / passiveAbilityMultiplier / tangledFeetMultiplier,
+      );
+    });
   });
 });

--- a/test/abilities/tangled-feet.test.ts
+++ b/test/abilities/tangled-feet.test.ts
@@ -125,6 +125,7 @@ describe("Ability - Tangled Feet", () => {
       expect(enemyPkm.getAccuracyMultiplier).toHaveLastReturnedWith(1);
     });
 
+    // biome-ignore format: prefer pre-2.3.6 formatting
     it.each([
       {
         passiveAbilityName: "Sand Veil",
@@ -138,31 +139,29 @@ describe("Ability - Tangled Feet", () => {
         weatherType: WeatherType.HAIL,
         passiveAbilityMultiplier: 1.2,
       },
-    ])("should stack with $passiveAbilityName Ability", async ({
-      passiveAbilityId,
-      weatherType,
-      passiveAbilityMultiplier,
-    }) => {
-      const { override, classicMode, move, field } = game;
-      override.passiveAbility(passiveAbilityId).weather(weatherType);
-      await classicMode.startBattle(SpeciesId.FEEBAS);
-      const playerPkm = field.getPlayerPokemon();
-      const enemyPkm = field.getEnemyPokemon();
-      vi.spyOn(enemyPkm, "getAccuracyMultiplier");
+    ])(
+      "should stack with $passiveAbilityName Ability",
+      async ({ passiveAbilityId, weatherType, passiveAbilityMultiplier }) => {
+        const { override, classicMode, move, field } = game;
+        override.passiveAbility(passiveAbilityId).weather(weatherType);
+        await classicMode.startBattle(SpeciesId.FEEBAS);
+        const playerPkm = field.getPlayerPokemon();
+        const enemyPkm = field.getEnemyPokemon();
+        vi.spyOn(enemyPkm, "getAccuracyMultiplier");
 
-      game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
-      move.use(MoveId.SPLASH);
-      await move.selectEnemyMove(MoveId.CONFUSE_RAY);
-      await move.forceHit();
-      await game.toEndOfTurn();
-      move.use(MoveId.SPLASH);
-      await move.selectEnemyMove(MoveId.TACKLE);
-      await game.toEndOfTurn();
+        game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+        move.use(MoveId.SPLASH);
+        await move.selectEnemyMove(MoveId.CONFUSE_RAY);
+        await move.forceHit();
+        await game.toEndOfTurn();
+        move.use(MoveId.SPLASH);
+        await move.selectEnemyMove(MoveId.TACKLE);
+        await game.toEndOfTurn();
 
-      expect(playerPkm).toHaveBattlerTag(BattlerTagType.CONFUSED);
-      expect(enemyPkm.getAccuracyMultiplier).toHaveLastReturnedWith(
-        1 / passiveAbilityMultiplier / tangledFeetMultiplier,
-      );
-    });
+        expect(playerPkm).toHaveBattlerTag(BattlerTagType.CONFUSED);
+        const finalMultiplier = 1 / passiveAbilityMultiplier / tangledFeetMultiplier;
+        expect(enemyPkm.getAccuracyMultiplier).toHaveLastReturnedWith(finalMultiplier);
+      },
+    );
   });
 });

--- a/test/items/multi-lens.test.ts
+++ b/test/items/multi-lens.test.ts
@@ -38,26 +38,26 @@ describe.todo("Items - Multi Lens", () => {
   it.each([
     { stackCount: 1, firstHitDamage: 0.75 },
     { stackCount: 2, firstHitDamage: 0.5 },
-  ])(
-    "$stackCount count: should deal {$firstHitDamage}x damage on the first hit, then hit $stackCount times for 0.25x",
-    async ({ stackCount, firstHitDamage }) => {
-      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+  ])("$stackCount count: should deal {$firstHitDamage}x damage on the first hit, then hit $stackCount times for 0.25x", async ({
+    stackCount,
+    firstHitDamage,
+  }) => {
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      const spy = vi.spyOn(enemyPokemon, "getAttackDamage");
-      vi.spyOn(enemyPokemon, "getBaseDamage").mockReturnValue(100);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    const spy = vi.spyOn(enemyPokemon, "getAttackDamage");
+    vi.spyOn(enemyPokemon, "getBaseDamage").mockReturnValue(100);
 
-      game.move.select(MoveId.TACKLE);
-      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    game.move.select(MoveId.TACKLE);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-      await game.phaseInterceptor.to("PostActionPhase");
-      const damageResults = spy.mock.results.map((result) => result.value?.damage);
+    await game.phaseInterceptor.to("PostActionPhase");
+    const damageResults = spy.mock.results.map((result) => result.value?.damage);
 
-      expect(damageResults).toHaveLength(1 + stackCount);
-      expect(damageResults[0]).toBe(firstHitDamage * 100);
-      damageResults.slice(1).forEach((dmg) => expect(dmg).toBe(25));
-    },
-  );
+    expect(damageResults).toHaveLength(1 + stackCount);
+    expect(damageResults[0]).toBe(firstHitDamage * 100);
+    damageResults.slice(1).forEach((dmg) => expect(dmg).toBe(25));
+  });
 
   it("should stack additively with Parental Bond", async () => {
     game.override.ability(AbilityId.PARENTAL_BOND);

--- a/test/items/multi-lens.test.ts
+++ b/test/items/multi-lens.test.ts
@@ -35,29 +35,30 @@ describe.todo("Items - Multi Lens", () => {
       .enemyLevel(99);
   });
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     { stackCount: 1, firstHitDamage: 0.75 },
     { stackCount: 2, firstHitDamage: 0.5 },
-  ])("$stackCount count: should deal {$firstHitDamage}x damage on the first hit, then hit $stackCount times for 0.25x", async ({
-    stackCount,
-    firstHitDamage,
-  }) => {
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+  ])(
+    "$stackCount count: should deal {$firstHitDamage}x damage on the first hit, then hit $stackCount times for 0.25x",
+    async ({ stackCount, firstHitDamage }) => {
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    const enemyPokemon = game.scene.getEnemyPokemon()!;
-    const spy = vi.spyOn(enemyPokemon, "getAttackDamage");
-    vi.spyOn(enemyPokemon, "getBaseDamage").mockReturnValue(100);
+      const enemyPokemon = game.scene.getEnemyPokemon()!;
+      const spy = vi.spyOn(enemyPokemon, "getAttackDamage");
+      vi.spyOn(enemyPokemon, "getBaseDamage").mockReturnValue(100);
 
-    game.move.select(MoveId.TACKLE);
-    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+      game.move.select(MoveId.TACKLE);
+      game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
 
-    await game.phaseInterceptor.to("PostActionPhase");
-    const damageResults = spy.mock.results.map((result) => result.value?.damage);
+      await game.phaseInterceptor.to("PostActionPhase");
+      const damageResults = spy.mock.results.map((result) => result.value?.damage);
 
-    expect(damageResults).toHaveLength(1 + stackCount);
-    expect(damageResults[0]).toBe(firstHitDamage * 100);
-    damageResults.slice(1).forEach((dmg) => expect(dmg).toBe(25));
-  });
+      expect(damageResults).toHaveLength(1 + stackCount);
+      expect(damageResults[0]).toBe(firstHitDamage * 100);
+      damageResults.slice(1).forEach((dmg) => expect(dmg).toBe(25));
+    },
+  );
 
   it("should stack additively with Parental Bond", async () => {
     game.override.ability(AbilityId.PARENTAL_BOND);

--- a/test/moves/conversion-2.test.ts
+++ b/test/moves/conversion-2.test.ts
@@ -97,26 +97,26 @@ describe("Moves - Conversion 2", () => {
       abilityName: "Refrigerate",
       resistingTypes: [ElementalType.STEEL, ElementalType.FIRE, ElementalType.ICE],
     },
-  ])(
-    "should change the user's type to resist $moveType if the target's last move was affected by $abilityName",
-    async ({ ability, resistingTypes }) => {
-      game.override.enemyAbility(ability);
+  ])("should change the user's type to resist $moveType if the target's last move was affected by $abilityName", async ({
+    ability,
+    resistingTypes,
+  }) => {
+    game.override.enemyAbility(ability);
 
-      await game.classicMode.startBattle(SpeciesId.FEEBAS);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-      const player = game.field.getPlayerPokemon();
+    const player = game.field.getPlayerPokemon();
 
-      game.move.use(MoveId.CONVERSION_2);
-      await game.move.forceEnemyMove(MoveId.TACKLE);
-      game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.use(MoveId.CONVERSION_2);
+    await game.move.forceEnemyMove(MoveId.TACKLE);
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 
-      await game.toEndOfTurn();
+    await game.toEndOfTurn();
 
-      const playerTypes = player.getTypes();
-      expect(playerTypes).toHaveLength(1);
-      expect(playerTypes[0]).toBeOneOf(resistingTypes);
-    },
-  );
+    const playerTypes = player.getTypes();
+    expect(playerTypes).toHaveLength(1);
+    expect(playerTypes[0]).toBeOneOf(resistingTypes);
+  });
 
   it("should change the user's type according to the target move's changed type, if applicable", async () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);

--- a/test/moves/conversion-2.test.ts
+++ b/test/moves/conversion-2.test.ts
@@ -72,6 +72,7 @@ describe("Moves - Conversion 2", () => {
     expect(playerTypes[0]).toBeOneOf([ElementalType.STEEL, ElementalType.POISON, ElementalType.FIRE]);
   });
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     {
       moveType: "Fairy",
@@ -97,26 +98,26 @@ describe("Moves - Conversion 2", () => {
       abilityName: "Refrigerate",
       resistingTypes: [ElementalType.STEEL, ElementalType.FIRE, ElementalType.ICE],
     },
-  ])("should change the user's type to resist $moveType if the target's last move was affected by $abilityName", async ({
-    ability,
-    resistingTypes,
-  }) => {
-    game.override.enemyAbility(ability);
+  ])(
+    "should change the user's type to resist $moveType if the target's last move was affected by $abilityName",
+    async ({ ability, resistingTypes }) => {
+      game.override.enemyAbility(ability);
 
-    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+      await game.classicMode.startBattle(SpeciesId.FEEBAS);
 
-    const player = game.field.getPlayerPokemon();
+      const player = game.field.getPlayerPokemon();
 
-    game.move.use(MoveId.CONVERSION_2);
-    await game.move.forceEnemyMove(MoveId.TACKLE);
-    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+      game.move.use(MoveId.CONVERSION_2);
+      await game.move.forceEnemyMove(MoveId.TACKLE);
+      game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 
-    await game.toEndOfTurn();
+      await game.toEndOfTurn();
 
-    const playerTypes = player.getTypes();
-    expect(playerTypes).toHaveLength(1);
-    expect(playerTypes[0]).toBeOneOf(resistingTypes);
-  });
+      const playerTypes = player.getTypes();
+      expect(playerTypes).toHaveLength(1);
+      expect(playerTypes[0]).toBeOneOf(resistingTypes);
+    },
+  );
 
   it("should change the user's type according to the target move's changed type, if applicable", async () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);

--- a/test/moves/order-up.test.ts
+++ b/test/moves/order-up.test.ts
@@ -44,31 +44,31 @@ describe("Moves - Order Up", () => {
     { formIndex: 0, formName: "Curly", stat: Stat.ATK, statName: "Attack" },
     { formIndex: 1, formName: "Droopy", stat: Stat.DEF, statName: "Defense" },
     { formIndex: 2, formName: "Stretchy", stat: Stat.SPD, statName: "Speed" },
-  ])(
-    "should raise the user's $statName when the user is commanded by a $formName Tatsugiri",
-    async ({ formIndex, stat }) => {
-      game.override.starterForms({ [SpeciesId.TATSUGIRI]: formIndex });
+  ])("should raise the user's $statName when the user is commanded by a $formName Tatsugiri", async ({
+    formIndex,
+    stat,
+  }) => {
+    game.override.starterForms({ [SpeciesId.TATSUGIRI]: formIndex });
 
-      await game.classicMode.startBattle(SpeciesId.TATSUGIRI, SpeciesId.DONDOZO);
+    await game.classicMode.startBattle(SpeciesId.TATSUGIRI, SpeciesId.DONDOZO);
 
-      const [tatsugiri, dondozo] = game.scene.getPlayerField();
+    const [tatsugiri, dondozo] = game.scene.getPlayerField();
 
-      expect(game.scene.triggerPokemonBattleAnim).toHaveBeenLastCalledWith(tatsugiri, PokemonAnimType.COMMANDER_APPLY);
-      expect(dondozo.getTag(BattlerTagType.COMMANDED)).toBeDefined();
+    expect(game.scene.triggerPokemonBattleAnim).toHaveBeenLastCalledWith(tatsugiri, PokemonAnimType.COMMANDER_APPLY);
+    expect(dondozo.getTag(BattlerTagType.COMMANDED)).toBeDefined();
 
-      game.move.select(MoveId.ORDER_UP, 1, BattlerIndex.ENEMY);
+    game.move.select(MoveId.ORDER_UP, 1, BattlerIndex.ENEMY);
 
-      await game.phaseInterceptor.to("TurnStartPhase", false);
+    await game.phaseInterceptor.to("TurnStartPhase", false);
 
-      const { turnManager } = game.scene.currentBattle;
-      expect(turnManager.findCommandFromPokemon(tatsugiri)).toBeUndefined();
+    const { turnManager } = game.scene.currentBattle;
+    expect(turnManager.findCommandFromPokemon(tatsugiri)).toBeUndefined();
 
-      await game.toEndOfTurn();
+    await game.toEndOfTurn();
 
-      const affectedStats: EffectiveStat[] = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD];
-      affectedStats.forEach((st) => expect(dondozo.getStatStage(st)).toBe(st === stat ? 3 : 2));
-    },
-  );
+    const affectedStats: EffectiveStat[] = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD];
+    affectedStats.forEach((st) => expect(dondozo.getStatStage(st)).toBe(st === stat ? 3 : 2));
+  });
 
   it("should be boosted by Sheer Force while still applying a stat boost", async () => {
     game.override.passiveAbility(AbilityId.SHEER_FORCE).starterForms({ [SpeciesId.TATSUGIRI]: 0 });

--- a/test/moves/order-up.test.ts
+++ b/test/moves/order-up.test.ts
@@ -40,35 +40,36 @@ describe("Moves - Order Up", () => {
     vi.spyOn(game.scene, "triggerPokemonBattleAnim").mockReturnValue(true);
   });
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     { formIndex: 0, formName: "Curly", stat: Stat.ATK, statName: "Attack" },
     { formIndex: 1, formName: "Droopy", stat: Stat.DEF, statName: "Defense" },
     { formIndex: 2, formName: "Stretchy", stat: Stat.SPD, statName: "Speed" },
-  ])("should raise the user's $statName when the user is commanded by a $formName Tatsugiri", async ({
-    formIndex,
-    stat,
-  }) => {
-    game.override.starterForms({ [SpeciesId.TATSUGIRI]: formIndex });
+  ])(
+    "should raise the user's $statName when the user is commanded by a $formName Tatsugiri",
+    async ({ formIndex, stat }) => {
+      game.override.starterForms({ [SpeciesId.TATSUGIRI]: formIndex });
 
-    await game.classicMode.startBattle(SpeciesId.TATSUGIRI, SpeciesId.DONDOZO);
+      await game.classicMode.startBattle(SpeciesId.TATSUGIRI, SpeciesId.DONDOZO);
 
-    const [tatsugiri, dondozo] = game.scene.getPlayerField();
+      const [tatsugiri, dondozo] = game.scene.getPlayerField();
 
-    expect(game.scene.triggerPokemonBattleAnim).toHaveBeenLastCalledWith(tatsugiri, PokemonAnimType.COMMANDER_APPLY);
-    expect(dondozo.getTag(BattlerTagType.COMMANDED)).toBeDefined();
+      expect(game.scene.triggerPokemonBattleAnim).toHaveBeenLastCalledWith(tatsugiri, PokemonAnimType.COMMANDER_APPLY);
+      expect(dondozo.getTag(BattlerTagType.COMMANDED)).toBeDefined();
 
-    game.move.select(MoveId.ORDER_UP, 1, BattlerIndex.ENEMY);
+      game.move.select(MoveId.ORDER_UP, 1, BattlerIndex.ENEMY);
 
-    await game.phaseInterceptor.to("TurnStartPhase", false);
+      await game.phaseInterceptor.to("TurnStartPhase", false);
 
-    const { turnManager } = game.scene.currentBattle;
-    expect(turnManager.findCommandFromPokemon(tatsugiri)).toBeUndefined();
+      const { turnManager } = game.scene.currentBattle;
+      expect(turnManager.findCommandFromPokemon(tatsugiri)).toBeUndefined();
 
-    await game.toEndOfTurn();
+      await game.toEndOfTurn();
 
-    const affectedStats: EffectiveStat[] = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD];
-    affectedStats.forEach((st) => expect(dondozo.getStatStage(st)).toBe(st === stat ? 3 : 2));
-  });
+      const affectedStats: EffectiveStat[] = [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD];
+      affectedStats.forEach((st) => expect(dondozo.getStatStage(st)).toBe(st === stat ? 3 : 2));
+    },
+  );
 
   it("should be boosted by Sheer Force while still applying a stat boost", async () => {
     game.override.passiveAbility(AbilityId.SHEER_FORCE).starterForms({ [SpeciesId.TATSUGIRI]: 0 });

--- a/test/moves/parting-shot.test.ts
+++ b/test/moves/parting-shot.test.ts
@@ -59,132 +59,117 @@ describe("Moves - Parting Shot", () => {
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
   });
 
-  it.todo(
-    // TODO: fix this bug to pass the test!
-    "Parting shot should fail if target is -6/-6 de-buffed",
-    async () => {
-      game.override.moveset([MoveId.PARTING_SHOT, MoveId.MEMENTO, MoveId.SPLASH]);
-      await game.classicMode.startBattle(
-        SpeciesId.MEOWTH,
-        SpeciesId.MEOWTH,
-        SpeciesId.MEOWTH,
-        SpeciesId.MURKROW,
-        SpeciesId.ABRA,
-      );
+  it.todo(// TODO: fix this bug to pass the test!
+  "Parting shot should fail if target is -6/-6 de-buffed", async () => {
+    game.override.moveset([MoveId.PARTING_SHOT, MoveId.MEMENTO, MoveId.SPLASH]);
+    await game.classicMode.startBattle(
+      SpeciesId.MEOWTH,
+      SpeciesId.MEOWTH,
+      SpeciesId.MEOWTH,
+      SpeciesId.MURKROW,
+      SpeciesId.ABRA,
+    );
 
-      // use Memento 3 times to debuff enemy
-      game.move.select(MoveId.MEMENTO);
-      await game.phaseInterceptor.to("FaintPhase");
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      game.selectPartyPokemon(1);
+    // use Memento 3 times to debuff enemy
+    game.move.select(MoveId.MEMENTO);
+    await game.phaseInterceptor.to("FaintPhase");
+    expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+    game.selectPartyPokemon(1);
 
-      await game.phaseInterceptor.to("TurnInitPhase", false);
-      game.move.select(MoveId.MEMENTO);
-      await game.phaseInterceptor.to("FaintPhase");
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      game.selectPartyPokemon(2);
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+    game.move.select(MoveId.MEMENTO);
+    await game.phaseInterceptor.to("FaintPhase");
+    expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+    game.selectPartyPokemon(2);
 
-      await game.phaseInterceptor.to("TurnInitPhase", false);
-      game.move.select(MoveId.MEMENTO);
-      await game.phaseInterceptor.to("FaintPhase");
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      game.selectPartyPokemon(3);
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+    game.move.select(MoveId.MEMENTO);
+    await game.phaseInterceptor.to("FaintPhase");
+    expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+    game.selectPartyPokemon(3);
 
-      // set up done
-      await game.phaseInterceptor.to("TurnInitPhase", false);
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).toBeDefined();
+    // set up done
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon).toBeDefined();
 
-      expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-6);
-      expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-6);
+    expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-6);
+    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-6);
 
-      // now parting shot should fail
-      game.move.select(MoveId.PARTING_SHOT);
+    // now parting shot should fail
+    game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to("BerryPhase", false);
-      expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-6);
-      expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-6);
-      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
-    },
-  );
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-6);
+    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-6);
+    expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
+  });
 
-  it.todo(
-    // TODO: fix this bug to pass the test!
-    "Parting shot shouldn't allow switch out when mist is active",
-    async () => {
-      game.override.enemySpecies(SpeciesId.ALTARIA).enemyAbility(AbilityId.NONE).enemyMoveset([MoveId.MIST]);
-      await game.classicMode.startBattle(SpeciesId.SNORLAX, SpeciesId.MEOWTH);
+  it.todo(// TODO: fix this bug to pass the test!
+  "Parting shot shouldn't allow switch out when mist is active", async () => {
+    game.override.enemySpecies(SpeciesId.ALTARIA).enemyAbility(AbilityId.NONE).enemyMoveset([MoveId.MIST]);
+    await game.classicMode.startBattle(SpeciesId.SNORLAX, SpeciesId.MEOWTH);
 
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).toBeDefined();
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon).toBeDefined();
 
-      game.move.select(MoveId.PARTING_SHOT);
+    game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to("BerryPhase", false);
-      expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
-      expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
-      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
-    },
-  );
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
+    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
+    expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
+  });
 
-  it.todo(
-    // TODO: fix this bug to pass the test!
-    "Parting shot shouldn't allow switch out against clear body ability",
-    async () => {
-      game.override.enemySpecies(SpeciesId.TENTACOOL).enemyAbility(AbilityId.CLEAR_BODY);
-      await game.classicMode.startBattle(SpeciesId.SNORLAX, SpeciesId.MEOWTH);
+  it.todo(// TODO: fix this bug to pass the test!
+  "Parting shot shouldn't allow switch out against clear body ability", async () => {
+    game.override.enemySpecies(SpeciesId.TENTACOOL).enemyAbility(AbilityId.CLEAR_BODY);
+    await game.classicMode.startBattle(SpeciesId.SNORLAX, SpeciesId.MEOWTH);
 
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).toBeDefined();
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon).toBeDefined();
 
-      game.move.select(MoveId.PARTING_SHOT);
+    game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to("BerryPhase", false);
-      expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
-      expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
-      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
-    },
-  );
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
+    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
+    expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
+  });
 
-  it.todo(
-    // TODO: fix this bug to pass the test!
-    "Parting shot should de-buff and not fail if no party available to switch - party size 1",
-    async () => {
-      await game.classicMode.startBattle(SpeciesId.MURKROW);
+  it.todo(// TODO: fix this bug to pass the test!
+  "Parting shot should de-buff and not fail if no party available to switch - party size 1", async () => {
+    await game.classicMode.startBattle(SpeciesId.MURKROW);
 
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon).toBeDefined();
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon).toBeDefined();
 
-      game.move.select(MoveId.PARTING_SHOT);
+    game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to("BerryPhase", false);
-      expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-1);
-      expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-1);
-      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
-    },
-  );
+    await game.phaseInterceptor.to("BerryPhase", false);
+    expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(-1);
+    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-1);
+    expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
+  });
 
-  it.todo(
-    // TODO: fix this bug to pass the test!
-    "Parting shot regularly not fail if no party available to switch - party fainted",
-    async () => {
-      await game.classicMode.startBattle(SpeciesId.MURKROW, SpeciesId.MEOWTH);
-      game.move.select(MoveId.SPLASH);
+  it.todo(// TODO: fix this bug to pass the test!
+  "Parting shot regularly not fail if no party available to switch - party fainted", async () => {
+    await game.classicMode.startBattle(SpeciesId.MURKROW, SpeciesId.MEOWTH);
+    game.move.select(MoveId.SPLASH);
 
-      // intentionally kill party pokemon, switch to second slot (now 1 party mon is fainted)
-      await game.faintPokemon(game.scene.getPlayerParty()[0]);
-      expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
-      await game.phaseInterceptor.to("MessagePhase");
-      game.selectPartyPokemon(1);
+    // intentionally kill party pokemon, switch to second slot (now 1 party mon is fainted)
+    await game.faintPokemon(game.scene.getPlayerParty()[0]);
+    expect(game.scene.getPlayerParty()[0].isFainted()).toBe(true);
+    await game.phaseInterceptor.to("MessagePhase");
+    game.selectPartyPokemon(1);
 
-      await game.phaseInterceptor.to("TurnInitPhase", false);
-      game.move.select(MoveId.PARTING_SHOT);
+    await game.phaseInterceptor.to("TurnInitPhase", false);
+    game.move.select(MoveId.PARTING_SHOT);
 
-      await game.phaseInterceptor.to("BerryPhase", false);
-      const enemyPokemon = game.scene.getEnemyPokemon()!;
-      expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
-      expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
-      expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MEOWTH);
-    },
-  );
+    await game.phaseInterceptor.to("BerryPhase", false);
+    const enemyPokemon = game.scene.getEnemyPokemon()!;
+    expect(enemyPokemon.getStatStage(Stat.ATK)).toBe(0);
+    expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(0);
+    expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MEOWTH);
+  });
 });

--- a/test/moves/parting-shot.test.ts
+++ b/test/moves/parting-shot.test.ts
@@ -59,8 +59,8 @@ describe("Moves - Parting Shot", () => {
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
   });
 
-  it.todo(// TODO: fix this bug to pass the test!
-  "Parting shot should fail if target is -6/-6 de-buffed", async () => {
+  // TODO: fix this bug to pass the test!
+  it.todo("Parting shot should fail if target is -6/-6 de-buffed", async () => {
     game.override.moveset([MoveId.PARTING_SHOT, MoveId.MEMENTO, MoveId.SPLASH]);
     await game.classicMode.startBattle(
       SpeciesId.MEOWTH,
@@ -105,8 +105,8 @@ describe("Moves - Parting Shot", () => {
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
   });
 
-  it.todo(// TODO: fix this bug to pass the test!
-  "Parting shot shouldn't allow switch out when mist is active", async () => {
+  // TODO: fix this bug to pass the test!
+  it.todo("Parting shot shouldn't allow switch out when mist is active", async () => {
     game.override.enemySpecies(SpeciesId.ALTARIA).enemyAbility(AbilityId.NONE).enemyMoveset([MoveId.MIST]);
     await game.classicMode.startBattle(SpeciesId.SNORLAX, SpeciesId.MEOWTH);
 
@@ -121,8 +121,8 @@ describe("Moves - Parting Shot", () => {
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
   });
 
-  it.todo(// TODO: fix this bug to pass the test!
-  "Parting shot shouldn't allow switch out against clear body ability", async () => {
+  // TODO: fix this bug to pass the test!
+  it.todo("Parting shot shouldn't allow switch out against clear body ability", async () => {
     game.override.enemySpecies(SpeciesId.TENTACOOL).enemyAbility(AbilityId.CLEAR_BODY);
     await game.classicMode.startBattle(SpeciesId.SNORLAX, SpeciesId.MEOWTH);
 
@@ -137,8 +137,8 @@ describe("Moves - Parting Shot", () => {
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
   });
 
-  it.todo(// TODO: fix this bug to pass the test!
-  "Parting shot should de-buff and not fail if no party available to switch - party size 1", async () => {
+  // TODO: fix this bug to pass the test!
+  it.todo("Parting shot should de-buff and not fail if no party available to switch - party size 1", async () => {
     await game.classicMode.startBattle(SpeciesId.MURKROW);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
@@ -152,8 +152,8 @@ describe("Moves - Parting Shot", () => {
     expect(game.scene.getPlayerField()[0].species.speciesId).toBe(SpeciesId.MURKROW);
   });
 
-  it.todo(// TODO: fix this bug to pass the test!
-  "Parting shot regularly not fail if no party available to switch - party fainted", async () => {
+  // TODO: fix this bug to pass the test!
+  it.todo("Parting shot regularly not fail if no party available to switch - party fainted", async () => {
     await game.classicMode.startBattle(SpeciesId.MURKROW, SpeciesId.MEOWTH);
     game.move.select(MoveId.SPLASH);
 

--- a/test/moves/protect.test.ts
+++ b/test/moves/protect.test.ts
@@ -136,31 +136,28 @@ describe("Moves - Protect", () => {
     [1 / 3, 1],
     [1 / 9, 2],
     [1 / 27, 3],
-  ])(
-    "should have a success rate of %d after being used %d consecutive time(s) successfully",
-    async (expectedRate, numUses) => {
-      await game.classicMode.startBattle(SpeciesId.CHARIZARD);
+  ])("should have a success rate of %d after being used %d consecutive time(s) successfully", async (expectedRate, numUses) => {
+    await game.classicMode.startBattle(SpeciesId.CHARIZARD);
 
-      const protect = allMoves.get(MoveId.PROTECT);
-      const protectAttr = protect.getAttrs(ProtectAttr)[0];
-      vi.spyOn(protect, "applyConditions").mockReturnValue(true);
+    const protect = allMoves.get(MoveId.PROTECT);
+    const protectAttr = protect.getAttrs(ProtectAttr)[0];
+    vi.spyOn(protect, "applyConditions").mockReturnValue(true);
 
-      for (let i = 0; i < numUses; i++) {
-        game.move.use(MoveId.PROTECT);
-        await game.toNextTurn();
+    for (let i = 0; i < numUses; i++) {
+      game.move.use(MoveId.PROTECT);
+      await game.toNextTurn();
+    }
+
+    const player = game.field.getPlayerPokemon();
+
+    let successes = 0;
+    const numTrials = 1000;
+    await game.rng.equalSample(numTrials, () => {
+      if (protectAttr.getCondition()(player, player, allMoves.get(MoveId.PROTECT))) {
+        successes++;
       }
+    });
 
-      const player = game.field.getPlayerPokemon();
-
-      let successes = 0;
-      const numTrials = 1000;
-      await game.rng.equalSample(numTrials, () => {
-        if (protectAttr.getCondition()(player, player, allMoves.get(MoveId.PROTECT))) {
-          successes++;
-        }
-      });
-
-      expect(successes / numTrials).toBeCloseTo(expectedRate);
-    },
-  );
+    expect(successes / numTrials).toBeCloseTo(expectedRate);
+  });
 });

--- a/test/moves/spectral-thief.test.ts
+++ b/test/moves/spectral-thief.test.ts
@@ -101,29 +101,30 @@ describe("Moves - Spectral Thief", () => {
     expect(enemy.waveData.abilitiesApplied.includes(AbilityId.CLEAR_BODY)).toBeFalsy();
   });
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     { abilityName: "Simple", abilityId: AbilityId.SIMPLE, multiplier: 2 },
     { abilityName: "Contrary", abilityId: AbilityId.CONTRARY, multiplier: -1 },
-  ])("$abilityName should multiply the stolen stat stages from this effect by $multiplier", async ({
-    abilityId,
-    multiplier,
-  }) => {
-    game.override.ability(abilityId);
+  ])(
+    "$abilityName should multiply the stolen stat stages from this effect by $multiplier",
+    async ({ abilityId, multiplier }) => {
+      game.override.ability(abilityId);
 
-    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-    const player = game.scene.getPlayerPokemon()!;
-    const enemy = game.scene.getEnemyPokemon()!;
+      const player = game.scene.getPlayerPokemon()!;
+      const enemy = game.scene.getEnemyPokemon()!;
 
-    game.move.select(MoveId.SPECTRAL_THIEF);
-    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+      game.move.select(MoveId.SPECTRAL_THIEF);
+      game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 
-    await game.phaseInterceptor.to("PostActionPhase");
-    await game.phaseInterceptor.to("MoveEffectPhase");
+      await game.phaseInterceptor.to("PostActionPhase");
+      await game.phaseInterceptor.to("MoveEffectPhase");
 
-    expect(player.getStatStage(Stat.DEF)).toBe(2 * multiplier);
-    expect(enemy.getStatStage(Stat.DEF)).toBe(0);
-  });
+      expect(player.getStatStage(Stat.DEF)).toBe(2 * multiplier);
+      expect(enemy.getStatStage(Stat.DEF)).toBe(0);
+    },
+  );
 
   it("should not activate Defiant when stealing stat stages", async () => {
     game.override.enemyAbility(AbilityId.DEFIANT);

--- a/test/moves/spectral-thief.test.ts
+++ b/test/moves/spectral-thief.test.ts
@@ -104,26 +104,26 @@ describe("Moves - Spectral Thief", () => {
   it.each([
     { abilityName: "Simple", abilityId: AbilityId.SIMPLE, multiplier: 2 },
     { abilityName: "Contrary", abilityId: AbilityId.CONTRARY, multiplier: -1 },
-  ])(
-    "$abilityName should multiply the stolen stat stages from this effect by $multiplier",
-    async ({ abilityId, multiplier }) => {
-      game.override.ability(abilityId);
+  ])("$abilityName should multiply the stolen stat stages from this effect by $multiplier", async ({
+    abilityId,
+    multiplier,
+  }) => {
+    game.override.ability(abilityId);
 
-      await game.classicMode.startBattle(SpeciesId.MAGIKARP);
+    await game.classicMode.startBattle(SpeciesId.MAGIKARP);
 
-      const player = game.scene.getPlayerPokemon()!;
-      const enemy = game.scene.getEnemyPokemon()!;
+    const player = game.scene.getPlayerPokemon()!;
+    const enemy = game.scene.getEnemyPokemon()!;
 
-      game.move.select(MoveId.SPECTRAL_THIEF);
-      game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    game.move.select(MoveId.SPECTRAL_THIEF);
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
 
-      await game.phaseInterceptor.to("PostActionPhase");
-      await game.phaseInterceptor.to("MoveEffectPhase");
+    await game.phaseInterceptor.to("PostActionPhase");
+    await game.phaseInterceptor.to("MoveEffectPhase");
 
-      expect(player.getStatStage(Stat.DEF)).toBe(2 * multiplier);
-      expect(enemy.getStatStage(Stat.DEF)).toBe(0);
-    },
-  );
+    expect(player.getStatStage(Stat.DEF)).toBe(2 * multiplier);
+    expect(enemy.getStatStage(Stat.DEF)).toBe(0);
+  });
 
   it("should not activate Defiant when stealing stat stages", async () => {
     game.override.enemyAbility(AbilityId.DEFIANT);

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -124,7 +124,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
 
-      const statStagePhases = unshiftPhaseSpy.mock.calls.filter((p) => p[0].is("StatStageChangePhase"))[0][0] as any;
+      const statStagePhases = unshiftPhaseSpy.mock.calls.find((p) => p[0].is("StatStageChangePhase"))?.[0] as any;
       expect(statStagePhases.stats).toEqual([Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD]);
 
       // Should have used its egg move pre-battle
@@ -151,7 +151,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
 
-      const statStagePhases = unshiftPhaseSpy.mock.calls.filter((p) => p[0].is("StatStageChangePhase"))[0][0] as any;
+      const statStagePhases = unshiftPhaseSpy.mock.calls.find((p) => p[0].is("StatStageChangePhase"))?.[0] as any;
       expect(statStagePhases.stats).toEqual([Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.SPD]);
 
       // Should have used its egg move pre-battle

--- a/test/system/set-pokemon-caught.test.ts
+++ b/test/system/set-pokemon-caught.test.ts
@@ -572,6 +572,7 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(lycanrocDexData.caughtAttr & gameData.getFormAttr(2)).toBeFalsy(); // midnight
   });
 
+  // biome-ignore format: prefer pre-2.3.6 formatting
   it.each([
     {
       caughtFormIndex: 4,
@@ -585,12 +586,9 @@ describe("Dex Data - Set Pokemon caught", () => {
       unlockedFormIndex: 3,
       unlockedFormName: "10% Forme Power Construct",
     },
-  ])("should unlock $unlockedFormName when catching $caughtFormName Zygarde", async ({
-    caughtFormIndex,
-    caughtFormName,
-    unlockedFormIndex,
-    unlockedFormName,
-  }) => {
+  ])(
+    "should unlock $unlockedFormName when catching $caughtFormName Zygarde",
+    async ({ caughtFormIndex, caughtFormName, unlockedFormIndex, unlockedFormName }) => {
       await game.scene.initStarterColors();
       const species = getPokemonSpecies(SpeciesId.ZYGARDE);
       const zygardeDexData = gameData.dexData[species.speciesId];
@@ -615,5 +613,6 @@ describe("Dex Data - Set Pokemon caught", () => {
 
       expect(zygardeDexData.caughtAttr & gameData.getFormAttr(unlockedFormIndex)).toBeTruthy();
       expect(zygardeDexData.caughtAttr & gameData.getFormAttr(caughtFormIndex)).toBeFalsy();
-  });
+    },
+  );
 });

--- a/test/system/set-pokemon-caught.test.ts
+++ b/test/system/set-pokemon-caught.test.ts
@@ -585,9 +585,12 @@ describe("Dex Data - Set Pokemon caught", () => {
       unlockedFormIndex: 3,
       unlockedFormName: "10% Forme Power Construct",
     },
-  ])(
-    "should unlock $unlockedFormName when catching $caughtFormName Zygarde",
-    async ({ caughtFormIndex, caughtFormName, unlockedFormIndex, unlockedFormName }) => {
+  ])("should unlock $unlockedFormName when catching $caughtFormName Zygarde", async ({
+    caughtFormIndex,
+    caughtFormName,
+    unlockedFormIndex,
+    unlockedFormName,
+  }) => {
       await game.scene.initStarterColors();
       const species = getPokemonSpecies(SpeciesId.ZYGARDE);
       const zygardeDexData = gameData.dexData[species.speciesId];
@@ -612,6 +615,5 @@ describe("Dex Data - Set Pokemon caught", () => {
 
       expect(zygardeDexData.caughtAttr & gameData.getFormAttr(unlockedFormIndex)).toBeTruthy();
       expect(zygardeDexData.caughtAttr & gameData.getFormAttr(caughtFormIndex)).toBeFalsy();
-    },
-  );
+  });
 });

--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { CommandPhase } from "#phases/command-phase";
-import type { TurnEndPhase } from "#phases/turn-end-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { updateUserInfo } from "#app/account";
 import { BattleScene } from "#app/battle-scene";
 import { getGameMode } from "#app/game-mode";
@@ -27,6 +22,8 @@ import type { Pokemon } from "#field/pokemon";
 import { Trainer } from "#field/trainer";
 import { ModifierTypeOption } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
+import type { CommandPhase } from "#phases/command-phase";
+import type { TurnEndPhase } from "#phases/turn-end-phase";
 import { settings } from "#system/settings-manager";
 import { ErrorInterceptor } from "#test/test-utils/error-interceptor";
 import { generateStarter, waitUntil } from "#test/test-utils/game-manager-utils";

--- a/test/test-utils/helpers/field-helper.ts
+++ b/test/test-utils/helpers/field-helper.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { globalScene } from "#app/global-scene";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Ability } from "#abilities/ability";
+import type { globalScene } from "#app/global-scene";
 import { allAbilities } from "#data/data-lists";
 import type { AbilityId } from "#enums/ability-id";
 import type { FieldBattlerIndex } from "#enums/battler-index";

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -1,10 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { NewArenaEvent } from "#events/battle-scene";
-import type { Arena } from "#field/arena";
-import type { AttemptRunPhase } from "#phases/attempt-run-phase";
-import type { GameManager } from "#test/test-utils/game-manager";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { BattleStyle } from "#app/overrides";
 import { activeOverrides, defaultOverrides } from "#app/overrides";
 import { timedEventManager } from "#app/timed-event-manager";
@@ -22,7 +15,11 @@ import { TerrainType } from "#enums/terrain-type";
 import { TrainerType } from "#enums/trainer-type";
 import type { Unlockables } from "#enums/unlockables";
 import { WeatherType } from "#enums/weather-type";
+import type { NewArenaEvent } from "#events/battle-scene";
+import type { Arena } from "#field/arena";
 import type { ModifierOverride } from "#modifier/modifier-type";
+import type { AttemptRunPhase } from "#phases/attempt-run-phase";
+import type { GameManager } from "#test/test-utils/game-manager";
 import { GameManagerHelper } from "#test/test-utils/helpers/game-manager-helper";
 import type { TimedEvent } from "#types/timed-event";
 import { coerceArray, enumValueToKey } from "#utils/common-utils";

--- a/test/test-utils/matchers/to-have-ability-applied-matcher.ts
+++ b/test/test-utils/matchers/to-have-ability-applied-matcher.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { getPokemonNameWithAffix } from "#app/messages";
 import { AbilityId } from "#enums/ability-id";
+import type { Pokemon } from "#field/pokemon";
 import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 

--- a/test/test-utils/matchers/to-have-battler-tag-type-matcher.ts
+++ b/test/test-utils/matchers/to-have-battler-tag-type-matcher.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import type { Pokemon } from "#field/pokemon";
 import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
 import { enumValueToKey } from "#utils/common-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";

--- a/test/test-utils/matchers/to-have-status-effect-matcher.ts
+++ b/test/test-utils/matchers/to-have-status-effect-matcher.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { getPokemonNameWithAffix } from "#app/messages";
 import { StatusEffect } from "#enums/status-effect";
+import type { Pokemon } from "#field/pokemon";
 import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
 import { enumValueToKey } from "#utils/common-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";

--- a/test/test-utils/mocks/mock-texture-manager.ts
+++ b/test/test-utils/mocks/mock-texture-manager.ts
@@ -13,13 +13,14 @@ import { MockText } from "#test/test-utils/mocks/mocks-container/mock-text";
 import { MockTexture } from "#test/test-utils/mocks/mocks-container/mock-texture";
 
 /**
- * Stub class for Phaser.Textures.TextureManager
+ * Stub class for {@linkcode Phaser.Textures.TextureManager}
  */
 export class MockTextureManager {
   private readonly textures: Map<string, any>;
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: TODO: is this needed?
   private readonly scene: BattleScene;
-  public add;
-  public displayList;
+  public add; // Phaser.GameObjects.GameObjectFactory
+  public displayList: Phaser.GameObjects.DisplayList;
   public list: MockGameObject[] = [];
 
   constructor(scene: BattleScene) {
@@ -44,7 +45,7 @@ export class MockTextureManager {
     };
   }
 
-  container(x, y) {
+  container(x: number, y: number) {
     const container = new MockContainer(this, x, y);
     this.list.push(container);
     return container;
@@ -68,7 +69,7 @@ export class MockTextureManager {
    * Returns a mock texture
    * @param key
    */
-  get(key) {
+  get(key: string) {
     return new MockTexture(this, key, null);
   }
 

--- a/test/ui/battle-info.test.ts
+++ b/test/ui/battle-info.test.ts
@@ -39,19 +39,20 @@ describe.todo("UI - Battle Info", () => {
       .enemySpecies(SpeciesId.CATERPIE);
   });
 
-  it.each([ExpGainSpeed.FAST, ExpGainSpeed.FASTER, ExpGainSpeed.SKIP])(
-    "should increase exp gains animation by 2^%i",
-    async (expGainSpeed) => {
-      game.settings.expGainSpeed(expGainSpeed);
-      vi.spyOn(Math, "pow");
+  it.each([
+    ExpGainSpeed.FAST,
+    ExpGainSpeed.FASTER,
+    ExpGainSpeed.SKIP,
+  ])("should increase exp gains animation by 2^%i", async (expGainSpeed) => {
+    game.settings.expGainSpeed(expGainSpeed);
+    vi.spyOn(Math, "pow");
 
-      await game.classicMode.startBattle(SpeciesId.CHARIZARD);
+    await game.classicMode.startBattle(SpeciesId.CHARIZARD);
 
-      game.move.select(MoveId.SPLASH);
-      await game.faintOpponents();
-      await game.phaseInterceptor.to("ExpPhase", true);
+    game.move.select(MoveId.SPLASH);
+    await game.faintOpponents();
+    await game.phaseInterceptor.to("ExpPhase", true);
 
-      expect(Math.pow).not.toHaveBeenCalledWith(2, expGainSpeed);
-    },
-  );
+    expect(Math.pow).not.toHaveBeenCalledWith(2, expGainSpeed);
+  });
 });


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Keep deps up-to-date, improve codebase with lint rules.
After Biome is updated, most of the `noUnusedImports` suppressions will be removed (except for 5, due to a bug where TSDoc usage on object properties is not detected).

## What are the changes from a developer perspective?
- The `lint/style/noNestedTernary` rule was fixed in `2.3.6` to properly detect nested ternaries within parentheses, requiring updating the codebase to fix the newly-detected issues.
- Some TSDocs and parameter names were updated in `encounter-pokemon-utils.ts` while fixing the nearby lint issues.
- Parsing of test functions for linting was fixed in `2.3.6` which incidentally caused the formatter to format them differently. Changes were minimized via specifically placed comments and suppression comments.

### New Rules
#### Nursery
- https://biomejs.dev/linter/rules/use-array-sort-compare/
- https://biomejs.dev/linter/rules/use-find/
- https://biomejs.dev/linter/rules/no-parameters-only-used-in-recursion/
- https://biomejs.dev/linter/rules/use-spread/
- https://biomejs.dev/linter/rules/no-multi-str/
- https://biomejs.dev/linter/rules/no-proto/

#### Correctness
- https://biomejs.dev/linter/rules/no-unused-private-class-members/

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?