### PR TITLE
misc: remove now-obsolete `noUnusedImports` suppressions

### DIFF
--- a/src/@types/ability-types.ts
+++ b/src/@types/ability-types.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { PokemonWaveData } from "#types/pokemon-types";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { AbAttrConstructorMap } from "#abilities/ab-attr-constructor-map";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
+import type { PokemonWaveData } from "#types/pokemon-types";
 
 /** Union type of all referable ability attribute class names as strings */
 export type AbAttrKey = keyof AbAttrConstructorMap;

--- a/src/@types/arena-tag-types.ts
+++ b/src/@types/arena-tag-types.ts
@@ -1,9 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
-import type { ElementalType } from "#enums/elemental-type";
-import type { Pokemon } from "#field/pokemon";
-import type { SessionSaveData } from "#types/session-data";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import type { AuroraVeilTag } from "#arena-tags/aurora-veil-tag";
 import type { CraftyShieldTag } from "#arena-tags/crafty-shield-tag";
 import type { DelayedAttackTag } from "#arena-tags/delayed-attack-tag";
@@ -36,7 +30,10 @@ import type { WideGuardTag } from "#arena-tags/wide-guard-tag";
 import type { WishTag } from "#arena-tags/wish-tag";
 import type { ArenaTagSide } from "#enums/arena-tag-side";
 import type { ArenaTagType } from "#enums/arena-tag-type";
+import type { ElementalType } from "#enums/elemental-type";
 import type { MoveId } from "#enums/move-id";
+import type { Pokemon } from "#field/pokemon";
+import type { SessionSaveData } from "#types/session-data";
 import type { ObjectValues } from "#types/utility-types";
 
 /** Subset of {@linkcode ArenaTagType}s that deal type-based damage to pokemon that switch in. */

--- a/src/@types/language.ts
+++ b/src/@types/language.ts
@@ -1,6 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { LoadingScene } from "#app/loading-scene";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 export type SupportedLanguageKey = "en" | "es-ES" | "it" | "fr" | "de" | "pt-BR" | "zh-CN" | "zh-TW" | "ko" | "ja";
 

--- a/src/@types/move-types.ts
+++ b/src/@types/move-types.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
 import type { ConditionalProtectTag } from "#arena-tags/conditional-protect-tag";
-import type { SpeciesId } from "#enums/species-id";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import type { BattlerIndex, FieldBattlerIndex } from "#enums/battler-index";
 import type { ElementalType } from "#enums/elemental-type";
 import type { HitResult } from "#enums/hit-result";
 import type { MoveId } from "#enums/move-id";
 import type { MoveResult } from "#enums/move-result";
+import type { SpeciesId } from "#enums/species-id";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 

--- a/src/@types/pokemon-types.ts
+++ b/src/@types/pokemon-types.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MoveId } from "#enums/move-id";
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { TurnCommand } from "#app/turn-command-manager";
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import type { PokemonSpeciesForm } from "#data/pokemon-species-form";
@@ -11,9 +6,11 @@ import type { AbilityId } from "#enums/ability-id";
 import type { BerryType } from "#enums/berry-type";
 import type { ElementalType } from "#enums/elemental-type";
 import type { Gender } from "#enums/gender";
+import type { MoveId } from "#enums/move-id";
 import type { Nature } from "#enums/nature";
 import type { SpeciesId } from "#enums/species-id";
 import type { StatusEffect } from "#enums/status-effect";
+import type { Pokemon } from "#field/pokemon";
 import type { PokemonMove } from "#field/pokemon-move";
 import type { AttackMoveResult, TurnMove } from "#types/move-types";
 

--- a/src/@types/timed-event.ts
+++ b/src/@types/timed-event.ts
@@ -1,6 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { SupportedLanguage } from "#types/language";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 export interface EventBanner {
   /** The base filename of the banner (without any language key or the extension). e.g. `welcome-event` */

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { BattleAnim } from "#animations/battle-anims";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import type { Variant } from "#data/variant";
 import { PokeballType } from "#enums/pokeball-type";

--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Ability } from "#abilities/ability";
 import type { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-effect-ab-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { AbilityId } from "#enums/ability-id";
 
 /**

--- a/src/constants/arena-tag-constants.ts
+++ b/src/constants/arena-tag-constants.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import { ArenaTagType } from "#enums/arena-tag-type";
 import type { ElementalType } from "#enums/elemental-type";
 import type { Move } from "#moves/move";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
-import { ArenaTagType } from "#enums/arena-tag-type";
 
 /** All {@linkcode ArenaTagType | ArenaTagTypes} that weaken attacks of a certain {@linkcode ElementalType}. */
 export const WEAKEN_MOVE_TYPE_ARENA_TAG_TYPES = Object.freeze<ArenaTagType[]>([

--- a/src/constants/battler-tag-constants.ts
+++ b/src/constants/battler-tag-constants.ts
@@ -1,4 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CritBoostTag } from "#battler-tags/crit-boost-tag";
 import type { DamagingTrapTag } from "#battler-tags/damaging-trap-tag";
 import type { ExposedTag } from "#battler-tags/exposed-tag";
@@ -12,10 +11,8 @@ import type { RemovedTypeTag } from "#battler-tags/removed-type-tag";
 import type { SemiInvulnerableTag } from "#battler-tags/semi-invulnerable-tag";
 import type { TrappedTag } from "#battler-tags/trapped-tag";
 import type { TypeBoostTag } from "#battler-tags/type-boost-tag";
-import type { ElementalType } from "#enums/elemental-type";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTagType } from "#enums/battler-tag-type";
+import type { ElementalType } from "#enums/elemental-type";
 
 /**
  * All {@linkcode BattlerTagType}s that grant semi-invulnerability.

--- a/src/constants/friendship-constants.ts
+++ b/src/constants/friendship-constants.ts
@@ -1,10 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { PokemonLevelIncrementModifier } from "#modifier/modifier";
 import type { FaintPhase } from "#phases/faint-phase";
 import type { LevelUpPhase } from "#phases/level-up-phase";
 import type { NextEncounterPhase } from "#phases/next-encounter-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
 /** Each wave, all unfainted Pokemon gain this much happiness. Used in {@linkcode NextEncounterPhase} */
 export const FRIENDSHIP_GAIN_PER_WAVE = 1;

--- a/src/constants/game-constants.ts
+++ b/src/constants/game-constants.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { BattleStat } from "#enums/stat";
-import type { SystemSaveData } from "#types/system-data";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { SpeciesFormKey } from "#enums/species-form-key";
 import { SpeciesId } from "#enums/species-id";
+import type { BattleStat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
+import type { SystemSaveData } from "#types/system-data";
 
 /** Max value for an integer attribute in {@linkcode SystemSaveData} */
 export const MAX_INT_ATTR_VALUE = 0x80000000;

--- a/src/data/abilities/ab-attrs/damage-boost-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/damage-boost-ab-attr.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { PreAttackAbAttr } from "#abilities/pre-attack-ab-attr";
+import type { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import type { PokemonAttackCondition } from "#types/move-types";

--- a/src/data/abilities/ab-attrs/max-multi-hit-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/max-multi-hit-ab-attr.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MultiHitAttr } from "#moves/multi-hit-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { AbAttr } from "#abilities/ab-attr";
 import type { Pokemon } from "#field/pokemon";
+import type { MultiHitAttr } from "#moves/multi-hit-attr";
 import type { ValueHolder } from "#utils/common-utils";
 
 export class MaxMultiHitAbAttr extends AbAttr {

--- a/src/data/abilities/ab-attrs/pre-leave-field-ab-attrs.ts
+++ b/src/data/abilities/ab-attrs/pre-leave-field-ab-attrs.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
-import type { Weather } from "#data/weather";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import { AbAttr } from "#abilities/ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { Weather } from "#data/weather";
 import { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
 

--- a/src/data/abilities/ab-attrs/reflect-moves-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/reflect-moves-ab-attr.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MovePhase } from "#phases/move-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { PreDefendAbAttr } from "#abilities/pre-defend-ab-attr";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
+import type { MovePhase } from "#phases/move-phase";
 import type { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 

--- a/src/data/abilities/ab-attrs/stab-boost-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/stab-boost-ab-attr.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { AbilityId } from "#enums/ability-id";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { AbAttr } from "#abilities/ab-attr";
+import type { AbilityId } from "#enums/ability-id";
 import { ElementalType } from "#enums/elemental-type";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -12,7 +12,6 @@ import {
   AB_FLAG_WORKS_WHEN_TRANSFORMED,
 } from "#constants/ability-constants";
 import { AbilityId } from "#enums/ability-id";
-// biome-ignore lint/correctness/noUnusedImports: TSDoc import
 import type { MoveId } from "#enums/move-id";
 import type { AbAttrCondition, AbAttrKey, AbAttrMap } from "#types/ability-types";
 import { toCamelCaseString } from "#utils/string-utils";

--- a/src/data/animations/anim-config.ts
+++ b/src/data/animations/anim-config.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { BattleAnim } from "#animations/battle-anims";
 import type { easeFunctions } from "#animations/ease-functions";
 import type { MoveAnim } from "#animations/move-anim";
@@ -11,6 +7,7 @@ import { AnimFocus } from "#enums/anim-focus";
 import { AnimFrameTarget } from "#enums/anim-frame-target";
 import type { AnimTimedEventType } from "#enums/anim-timed-event-type";
 import type { MoveId } from "#enums/move-id";
+import type { Pokemon } from "#field/pokemon";
 import { getFrameMs } from "#utils/common-utils";
 import type Phaser from "phaser";
 

--- a/src/data/battler-tags/crit-boost-tag.ts
+++ b/src/data/battler-tags/crit-boost-tag.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { CRIT_BOOST_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-import type { ElementalType } from "#enums/elemental-type";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { CRIT_BOOST_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
+import type { ElementalType } from "#enums/elemental-type";
 import type { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";
 import i18next from "i18next";

--- a/src/data/battler-tags/damaging-trap-tag.ts
+++ b/src/data/battler-tags/damaging-trap-tag.ts
@@ -1,12 +1,9 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { DAMAGING_TRAPPED_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import { TrappedTag } from "#battler-tags/trapped-tag";
+import type { DAMAGING_TRAPPED_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { TRAPPED_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";

--- a/src/data/battler-tags/disabled-tag.ts
+++ b/src/data/battler-tags/disabled-tag.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { AbilityId } from "#enums/ability-id";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { BattlerTag } from "#battler-tags/battler-tag";
 import { MoveRestrictionBattlerTag } from "#battler-tags/move-restriction-battler-tag";
+import type { AbilityId } from "#enums/ability-id";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/exposed-tag.ts
+++ b/src/data/battler-tags/exposed-tag.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EXPOSED_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { EXPOSED_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { ElementalType } from "#enums/elemental-type";

--- a/src/data/battler-tags/floating-tag.ts
+++ b/src/data/battler-tags/floating-tag.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { TYPE_IMMUNE_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { TypeImmuneTag } from "#battler-tags/type-immune-tag";
+import type { TYPE_IMMUNE_TAG_TYPES } from "#constants/battler-tag-constants";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/highest-stat-boost-tag.ts
+++ b/src/data/battler-tags/highest-stat-boost-tag.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { HIGHEST_STAT_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { AbilityBattlerTag } from "#battler-tags/ability-battler-tag";
 import type { BattlerTag } from "#battler-tags/battler-tag";
+import type { HIGHEST_STAT_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
 import { allAbilities } from "#data/data-lists";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import type { AbilityId } from "#enums/ability-id";

--- a/src/data/battler-tags/move-lock-tag.ts
+++ b/src/data/battler-tags/move-lock-tag.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MOVE_LOCK_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { MOVE_LOCK_TAG_TYPES } from "#constants/battler-tag-constants";
 import { allMoves } from "#data/data-lists";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";

--- a/src/data/battler-tags/move-restriction-battler-tag.ts
+++ b/src/data/battler-tags/move-restriction-battler-tag.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { RESTRICTING_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerTag } from "#battler-tags/battler-tag";
 import type { RestrictingBattlerTag } from "#battler-tags/restricting-battler-tag";
+import type { RESTRICTING_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { MoveId } from "#enums/move-id";
 import type { Pokemon } from "#field/pokemon";

--- a/src/data/battler-tags/protected-tag.ts
+++ b/src/data/battler-tags/protected-tag.ts
@@ -1,11 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { PROTECTION_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { CommonBattleAnim } from "#animations/common-battle-anim";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { PROTECTION_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { CommonAnim } from "#enums/common-anim";

--- a/src/data/battler-tags/removed-type-tag.ts
+++ b/src/data/battler-tags/removed-type-tag.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { REMOVE_TYPE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { REMOVE_TYPE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import type { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/semi-invulnerable-tag.ts
+++ b/src/data/battler-tags/semi-invulnerable-tag.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { SEMI_INVULNERABLE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { SEMI_INVULNERABLE_BATTLER_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/telekinesis-tag.ts
+++ b/src/data/battler-tags/telekinesis-tag.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FloatingTag } from "#battler-tags/floating-tag";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { FloatingTag } from "#battler-tags/floating-tag";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import type { MoveId } from "#enums/move-id";

--- a/src/data/battler-tags/type-boost-tag.ts
+++ b/src/data/battler-tags/type-boost-tag.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { BattlerTag } from "#battler-tags/battler-tag";
+import type { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import type { BattlerTagType } from "#enums/battler-tag-type";
 import type { ElementalType } from "#enums/elemental-type";

--- a/src/data/biome.ts
+++ b/src/data/biome.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Arena } from "#field/arena";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { BiomeId } from "#enums/biome-id";
 import type { BiomePoolTier } from "#enums/biome-pool-tier";
 import type { SpeciesId } from "#enums/species-id";
@@ -9,6 +5,7 @@ import type { TerrainType } from "#enums/terrain-type";
 import type { TimeOfDay } from "#enums/time-of-day";
 import type { TrainerType } from "#enums/trainer-type";
 import type { WeatherType } from "#enums/weather-type";
+import type { Arena } from "#field/arena";
 
 /**
  * @todo

--- a/src/data/moves/move-attrs/call-move-attr.ts
+++ b/src/data/moves/move-attrs/call-move-attr.ts
@@ -1,17 +1,14 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { CopycatAttr } from "#moves/copycat-attr";
-import type { MetronomeAttr } from "#moves/metronome-attr";
-import type { NaturePowerAttr } from "#moves/nature-power-attr";
-import type { RandomMovesetMoveAttr } from "#moves/random-moveset-move-attr";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import type { BattlerIndex } from "#enums/battler-index";
 import type { MoveId } from "#enums/move-id";
 import { MoveTarget } from "#enums/move-target";
 import type { Pokemon } from "#field/pokemon";
+import type { CopycatAttr } from "#moves/copycat-attr";
+import type { MetronomeAttr } from "#moves/metronome-attr";
 import { getMoveTargets, type Move } from "#moves/move";
+import type { NaturePowerAttr } from "#moves/nature-power-attr";
 import { OverrideMoveEffectAttr } from "#moves/override-move-effect-attr";
+import type { RandomMovesetMoveAttr } from "#moves/random-moveset-move-attr";
 import type { BooleanHolder } from "#utils/common-utils";
 
 /**

--- a/src/data/moves/move-attrs/pursuit-attr.ts
+++ b/src/data/moves/move-attrs/pursuit-attr.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TurnCommandManager } from "#app/turn-command-manager";
 import type { PursuingTag } from "#battler-tags/pursuing-battler-tag";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { MoveAttr } from "#moves/move-attr";
 
 /**

--- a/src/data/moves/move-attrs/variable-def-attr.ts
+++ b/src/data/moves/move-attrs/variable-def-attr.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Stat } from "#enums/stat";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { MoveAttr } from "#moves/move-attr";

--- a/src/data/moves/move-attrs/weather-instant-charge-attr.ts
+++ b/src/data/moves/move-attrs/weather-instant-charge-attr.ts
@@ -1,10 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { ChargingMove } from "#moves/move";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import type { WeatherType } from "#enums/weather-type";
 import { InstantChargeAttr } from "#moves/instant-charge-attr";
+import type { ChargingMove } from "#moves/move";
 import type { NonEmptyArray } from "#types/utility-types";
 
 /**

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { IMysteryEncounter } from "#mystery-encounters/mystery-encounter";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Battle } from "#app/battle";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -46,6 +42,7 @@ import {
 } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
 import { showEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
+import type { IMysteryEncounter } from "#mystery-encounters/mystery-encounter";
 import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
 import type { PokemonData } from "#system/pokemon-data";
 import { allTrainerConfigs } from "#trainer-configs/all-trainer-configs";

--- a/src/data/pokemon-form-level-moves.ts
+++ b/src/data/pokemon-form-level-moves.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { SpeciesFormChange } from "#data/pokemon-forms";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { EVOLVE_MOVE, FORM_CHANGE_MOVE } from "#constants/move-constants";
+import type { SpeciesFormChange } from "#data/pokemon-forms";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
 import type { LevelMoves } from "#types/move-types";

--- a/src/data/pokemon-forms.ts
+++ b/src/data/pokemon-forms.ts
@@ -1,11 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FORM_CHANGE_MOVE } from "#constants/move-constants";
-import type { FormChangePhase } from "#phases/form-change-phase";
-import type { QuietFormChangePhase } from "#phases/quiet-form-change-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import type { FORM_CHANGE_MOVE } from "#constants/move-constants";
 import { RAINY_WEATHER_TYPES, SNOWY_WEATHER_TYPES, SUNNY_WEATHER_TYPES } from "#constants/weather-constants";
 import { allMoves } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
@@ -24,6 +19,8 @@ import { SpeciesFormChangeManualTrigger } from "#form-change-triggers/species-fo
 import { SpeciesFormChangeMoveLearnedTrigger } from "#form-change-triggers/species-form-change-move-learned-trigger";
 import { SpeciesFormChangePreMoveTrigger } from "#form-change-triggers/species-form-change-pre-move-trigger";
 import { SpeciesFormChangeTrigger } from "#form-change-triggers/species-form-change-trigger";
+import type { FormChangePhase } from "#phases/form-change-phase";
+import type { QuietFormChangePhase } from "#phases/quiet-form-change-phase";
 import type { AbstractConstructor, NonEmptyArray, nil } from "#types/utility-types";
 import i18next from "i18next";
 

--- a/src/enums/arena-tag-relative-side.ts
+++ b/src/enums/arena-tag-relative-side.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/arena-tag-type.ts
+++ b/src/enums/arena-tag-type.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
 import type { ArenaTag } from "#arena-tags/arena-tag";
 import type { ArenaTagTypeMap, NonSerializableArenaTagType, SerializableArenaTagType } from "#types/arena-tag-types";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/battle-command.ts
+++ b/src/enums/battle-command.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { CommandPhase } from "#phases/command-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/event-modifier-type.ts
+++ b/src/enums/event-modifier-type.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { TimedEvent } from "#types/timed-event";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/item-rarity.ts
+++ b/src/enums/item-rarity.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { ModifierTier } from "#enums/modifier-tier";
 import type { Item } from "#types/item";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /**

--- a/src/enums/switch-type.ts
+++ b/src/enums/switch-type.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { SwitchPhase } from "#phases/switch-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { ObjectValues } from "#types/utility-types";
 
 /** Indicates the type of switch functionality that a {@linkcode SwitchPhase} will carry out. */

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1,12 +1,8 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Battle } from "#app/battle";
-import type { BattleScene } from "#app/battle-scene";
-import type { FaintPhase } from "#phases/faint-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Ability } from "#abilities/ability";
 import { applyAbAttrs, getAbApplyFunc } from "#abilities/apply-ab-attrs";
 import type { AnySound } from "#app/audio-manager";
+import type { Battle } from "#app/battle";
+import type { BattleScene } from "#app/battle-scene";
 import { globalScene } from "#app/global-scene";
 import { activeOverrides } from "#app/overrides";
 import { timedEventManager } from "#app/timed-event-manager";
@@ -146,6 +142,7 @@ import { VariableMoveCategoryAttr } from "#moves/variable-move-category-attr";
 import { VariableMoveTypeAttr } from "#moves/variable-move-type-attr";
 import { VariableMoveTypeChartAttr } from "#moves/variable-move-type-chart-attr";
 import { VariableMoveTypeMultiplierAttr } from "#moves/variable-move-type-multiplier-attr";
+import type { FaintPhase } from "#phases/faint-phase";
 import { settings } from "#system/settings-manager";
 import type { AbAttrKey, AbAttrMap, AbilityFilterOptions } from "#types/ability-types";
 import type { DamageCalculationResult, DamageResult, LevelMoves, TurnMove } from "#types/move-types";

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { UiWindowStyle } from "#enums/ui-window-style";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { api } from "#api/api";
 import { CacheBustedLoaderPlugin } from "#app/plugins/cache-busted-loader-plugin";
 import { SceneBase } from "#app/scene-base";
@@ -51,7 +47,7 @@ export class LoadingScene extends SceneBase {
     this.loadImage("loading_bg", ImagesFolder.ARENAS);
     this.loadImage("logo");
 
-    /** UI Elements that change based on the {@linkcode UiWindowStyle} */
+    // UI Elements that change based on the UI Window Style
     for (const windowVariant of Object.values(WindowVariant)) {
       this.loadSpritesheet(`window${getWindowVariantSuffix(windowVariant)}`, ImagesFolder.UI_WINDOWS, 24, 24, {
         windowStyleDependant: true,

--- a/src/phase-tree.ts
+++ b/src/phase-tree.ts
@@ -1,7 +1,5 @@
-// biome-ignore lint/correctness/noUnusedImports: suppression needed until Biome 2.3.8 update PR is merged
 import type { DynamicPhaseManager } from "#app/dynamic-phase-manager";
 import type { Phase } from "#app/phase";
-// biome-ignore lint/correctness/noUnusedImports: suppression needed until Biome 2.3.8 update PR is merged
 import type { PhaseConditionFunc, PhaseKey, PhaseManager, PhaseMap } from "#types/phase-types";
 import type { NonEmptyArray } from "#types/utility-types";
 

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { NewBiomeEncounterPhase } from "#phases/new-biome-encounter-phase";
-import type { NextEncounterPhase } from "#phases/next-encounter-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -38,6 +33,8 @@ import { getEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
 import { doTrainerExclamation } from "#mystery-encounters/encounter-phase-utils";
 import { getGoldenBugNetSpecies } from "#mystery-encounters/encounter-pokemon-utils";
 import { BattlePhase } from "#phases/base/battle-phase";
+import type { NewBiomeEncounterPhase } from "#phases/new-biome-encounter-phase";
+import type { NextEncounterPhase } from "#phases/next-encounter-phase";
 import { achvs } from "#system/achievements";
 import { settings } from "#system/settings-manager";
 import type { PhaseKey } from "#types/phase-types";

--- a/src/phases/enemy-command-phase.ts
+++ b/src/phases/enemy-command-phase.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EnemyPokemon } from "#field/enemy-pokemon";
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { activeOverrides } from "#app/overrides";
 import { AbilityId } from "#enums/ability-id";
 import { BattleCommand } from "#enums/battle-command";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import type { EnemyPokemon } from "#field/enemy-pokemon";
+import type { Pokemon } from "#field/pokemon";
 import { BattlePhase } from "#phases/base/battle-phase";
 
 /**

--- a/src/phases/evolution-phase.ts
+++ b/src/phases/evolution-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FormChangePhase } from "#phases/form-change-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { AnySound } from "#app/audio-manager";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
@@ -12,6 +8,7 @@ import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { FormChangeBasePhase } from "#phases/base/form-change-base-phase";
+import type { FormChangePhase } from "#phases/form-change-phase";
 import type { ConfirmModeConfig } from "#ui/confirm-menu-config";
 import type { ConfirmUiHandler } from "#ui/confirm-ui-handler";
 import { delay, playNumberTween, playTween } from "#utils/anim-utils";

--- a/src/phases/faint-phase.ts
+++ b/src/phases/faint-phase.ts
@@ -1,15 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import type { PostFaintAbAttr } from "#abilities/post-faint-ab-attr";
 import type { PostKnockOutAbAttr } from "#abilities/post-knock-out-ab-attr";
 import type { PostVictoryAbAttr } from "#abilities/post-victory-ab-attr";
-import type { BattlerTag } from "#battler-tags/battler-tag";
-import type { GameOverPhase } from "#phases/game-over-phase";
-import type { MovePhase } from "#phases/move-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
-import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
+import type { BattlerTag } from "#battler-tags/battler-tag";
 import type { DestinyBondTag } from "#battler-tags/destiny-bond-tag";
 import type { GrudgeTag } from "#battler-tags/grudge-tag";
 import type { SkyDropTag } from "#battler-tags/sky-drop-tag";
@@ -28,6 +23,8 @@ import { SpeciesFormChangeActiveTrigger } from "#form-change-triggers/species-fo
 import { PokemonInstantReviveModifier } from "#modifier/modifier";
 import { PostVictoryStatStageChangeAttr } from "#moves/post-victory-stat-stage-change-attr";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { GameOverPhase } from "#phases/game-over-phase";
+import type { MovePhase } from "#phases/move-phase";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import i18next from "i18next";
 

--- a/src/phases/form-change-phase.ts
+++ b/src/phases/form-change-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EvolutionPhase } from "#phases/evolution-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import type { SpeciesFormChange } from "#data/pokemon-forms";
@@ -12,6 +8,7 @@ import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { FormChangeBasePhase } from "#phases/base/form-change-base-phase";
+import type { EvolutionPhase } from "#phases/evolution-phase";
 import { achvs } from "#system/achievements";
 import type { FormChangeSceneUiHandler } from "#ui/form-change-scene-ui-handler";
 import type { PartyUiHandler } from "#ui/party-ui-handler";

--- a/src/phases/move-effect-phase.ts
+++ b/src/phases/move-effect-phase.ts
@@ -1,8 +1,3 @@
-// biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports
-import type { allMoves } from "#data/data-lists";
-import type { Move } from "#moves/move";
-// biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { MoveAnim } from "#animations/move-anim";
 import { globalScene } from "#app/global-scene";
@@ -11,6 +6,7 @@ import type { BideTag } from "#battler-tags/bide-tag";
 import type { SubstituteTag } from "#battler-tags/substitute-tag";
 import type { TypeBoostTag } from "#battler-tags/type-boost-tag";
 import { TYPE_BOOST_TAG_TYPES } from "#constants/battler-tag-constants";
+import type { allMoves } from "#data/data-lists";
 import type { TypeDamageMultiplier } from "#data/type";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { BattlerIndex, type FieldBattlerIndex } from "#enums/battler-index";
@@ -35,6 +31,7 @@ import {
 import { DelayedAttackAttr } from "#moves/delayed-attack-attr";
 import { FlinchAttr } from "#moves/flinch-attr";
 import { MissEffectAttr } from "#moves/miss-effect-attr";
+import type { Move } from "#moves/move";
 import type { MoveAttr } from "#moves/move-attr";
 import { MoveEffectAttr } from "#moves/move-effect-attr";
 import { MultiHitAttr } from "#moves/multi-hit-attr";

--- a/src/phases/mystery-encounter-phases/battle-phase.ts
+++ b/src/phases/mystery-encounter-phases/battle-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { PostSummonPhase } from "#phases/post-summon-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { getCharVariantFromDialogue } from "#data/dialogue";
@@ -10,6 +6,7 @@ import { BattlerTagType } from "#enums/battler-tag-type";
 import { MysteryEncounterMode } from "#enums/mystery-encounter-mode";
 import { TrainerSlot } from "#enums/trainer-slot";
 import { IvScannerModifier } from "#modifier/modifier";
+import type { PostSummonPhase } from "#phases/post-summon-phase";
 import { randSeedItem } from "#utils/random-utils";
 import i18next from "i18next";
 

--- a/src/phases/mystery-encounter-phases/battle-start-cleanup-phase.ts
+++ b/src/phases/mystery-encounter-phases/battle-start-cleanup-phase.ts
@@ -1,14 +1,11 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { handleMysteryEncounterBattleStartEffects } from "#mystery-encounters/encounter-phase-utils";
-import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
-import type { TurnEndPhase } from "#phases/turn-end-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { BattlerTagType } from "#enums/battler-tag-type";
 import { SwitchType } from "#enums/switch-type";
+import type { handleMysteryEncounterBattleStartEffects } from "#mystery-encounters/encounter-phase-utils";
+import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
+import type { TurnEndPhase } from "#phases/turn-end-phase";
 
 /**
  * Runs at the beginning of an Encounter's battle.

--- a/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/mystery-encounter-phase.ts
@@ -1,12 +1,9 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounterDialogue, OptionTextDisplay } from "#mystery-encounters/mystery-encounter-dialogue";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { UiMode } from "#enums/ui-mode";
 import { getEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
 import type { OptionSelectSettings } from "#mystery-encounters/encounter-phase-utils";
+import type { MysteryEncounterDialogue, OptionTextDisplay } from "#mystery-encounters/mystery-encounter-dialogue";
 import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
 import { SeenEncounterData } from "#mystery-encounters/mystery-encounter-save-data";
 import type { MysteryEncounterUiHandler } from "#ui/mystery-encounter-ui-handler";

--- a/src/phases/mystery-encounter-phases/option-selected-phase.ts
+++ b/src/phases/mystery-encounter-phases/option-selected-phase.ts
@@ -1,11 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { transitionMysteryEncounterIntroVisuals } from "#mystery-encounters/encounter-visuals-utils";
-import type { OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
+import type { MysteryEncounterOption, OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
 
 /**
  * Will handle (in order):

--- a/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
+++ b/src/phases/mystery-encounter-phases/post-mystery-encounter-phase.ts
@@ -1,11 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounterOption } from "#mystery-encounters/mystery-encounter-option";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
 import { getEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
-import type { OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
+import type { MysteryEncounterOption, OptionPhaseCallback } from "#mystery-encounters/mystery-encounter-option";
 /**
  * Will handle (in order):
  * - {@linkcode MysteryEncounterOption.onPostOptionPhase} logic (based on an option that was selected)

--- a/src/phases/mystery-encounter-phases/rewards-phase.ts
+++ b/src/phases/mystery-encounter-phases/rewards-phase.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
+import type { MysteryEncounter } from "#mystery-encounters/mystery-encounter";
 
 /**
  * Will handle (in order):

--- a/src/phases/post-action-phase.ts
+++ b/src/phases/post-action-phase.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { TurnCommand } from "#app/turn-command-manager";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
+import type { TurnCommand } from "#app/turn-command-manager";
 import type { FieldBattlerIndex } from "#enums/battler-index";
 import { BattlerTagLapseType } from "#enums/battler-tag-lapse-type";
 import { PokemonPhase } from "#phases/base/pokemon-phase";

--- a/src/phases/revival-blessing-phase.ts
+++ b/src/phases/revival-blessing-phase.ts
@@ -1,9 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { FaintPhase } from "#phases/faint-phase";
-import type { SwitchPhase } from "#phases/switch-phase";
-import type { TurnEndPhase } from "#phases/turn-end-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { BattlerIndex } from "#enums/battler-index";
 import { FieldPosition } from "#enums/field-position";
@@ -13,6 +7,9 @@ import { UiMode } from "#enums/ui-mode";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { BattlePhase } from "#phases/base/battle-phase";
+import type { FaintPhase } from "#phases/faint-phase";
+import type { SwitchPhase } from "#phases/switch-phase";
+import type { TurnEndPhase } from "#phases/turn-end-phase";
 import type { PartyUiHandler } from "#ui/party-ui-handler";
 import { toDmgValue } from "#utils/common-utils";
 import { PartyFilterFainted } from "#utils/party-ui-utils";

--- a/src/phases/summon-phase.ts
+++ b/src/phases/summon-phase.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { EncounterPhase } from "#phases/encounter-phase";
-import type { PostSummonPhase } from "#phases/post-summon-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { getPokeballAtlasKey, getPokeballTintColor } from "#data/pokeball";
@@ -14,6 +9,8 @@ import { PlayerGender } from "#enums/player-gender";
 import type { Pokemon } from "#field/pokemon";
 import { SpeciesFormChangeActiveTrigger } from "#form-change-triggers/species-form-change-active-trigger";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { EncounterPhase } from "#phases/encounter-phase";
+import type { PostSummonPhase } from "#phases/post-summon-phase";
 import { settings } from "#system/settings-manager";
 import { playTween } from "#utils/anim-utils";
 import i18next from "i18next";

--- a/src/phases/switch-phase.ts
+++ b/src/phases/switch-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { RecallPhase } from "#phases/recall-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
 import { globalScene } from "#app/global-scene";
 import type { SubstituteTag } from "#battler-tags/substitute-tag";
@@ -15,6 +11,7 @@ import { UiMode } from "#enums/ui-mode";
 import type { Pokemon } from "#field/pokemon";
 import type { SwitchEffectTransferModifier } from "#modifier/modifier";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { RecallPhase } from "#phases/recall-phase";
 import type { PartyUiHandler } from "#ui/party-ui-handler";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 

--- a/src/phases/victory-phase.ts
+++ b/src/phases/victory-phase.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { GameOverPhase } from "#phases/game-over-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { globalScene } from "#app/global-scene";
 import { EVIL_BOSS_2_WAVE } from "#constants/wave-constants";
 import { ArenaTagType } from "#enums/arena-tag-type";
@@ -9,6 +5,7 @@ import { BattleType } from "#enums/battle-type";
 import type { CustomModifierSettings } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
 import { PokemonPhase } from "#phases/base/pokemon-phase";
+import type { GameOverPhase } from "#phases/game-over-phase";
 
 /**
  * Handles various effects when the player clears a wave:

--- a/src/queues/pokemon-priority-queue.ts
+++ b/src/queues/pokemon-priority-queue.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Stat } from "#enums/stat";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { ShuffledPriorityQueue } from "#app/queues/shuffled-priority-queue";
+import type { Stat } from "#enums/stat";
 import type { Pokemon } from "#field/pokemon";
 import { speedOrderComparator } from "#utils/speed-order-utils";
 

--- a/src/scene-base.ts
+++ b/src/scene-base.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
+import { ImagesFolder } from "#enums/images-folder";
 import { UiTheme } from "#enums/ui-theme";
 import { UiWindowStyle } from "#enums/ui-window-style";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
-import { ImagesFolder } from "#enums/images-folder";
 import { settings } from "#system/settings-manager";
 import { windowStyleDependantAtlases } from "#ui/ui-theme";
 import { coerceArray, enumValueToKey } from "#utils/common-utils";

--- a/src/turn-command-manager.ts
+++ b/src/turn-command-manager.ts
@@ -1,11 +1,7 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-attr";
-import type { Phase } from "#app/phase";
-import type { MovePhase } from "#phases/move-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { applyAbAttrs } from "#abilities/apply-ab-attrs";
+import type { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-attr";
 import { globalScene } from "#app/global-scene";
+import type { Phase } from "#app/phase";
 import { ShuffledPriorityQueue } from "#app/queues/shuffled-priority-queue";
 import { AbilityId } from "#enums/ability-id";
 import { BattleCommand } from "#enums/battle-command";
@@ -19,6 +15,7 @@ import { PokemonMove } from "#field/pokemon-move";
 import { BypassSpeedChanceModifier } from "#modifier/modifier";
 import { MoveHeaderAttr } from "#moves/move-header-attr";
 import { PursuitAttr } from "#moves/pursuit-attr";
+import type { MovePhase } from "#phases/move-phase";
 import type { TurnMove } from "#types/move-types";
 import { speedOrderComparator } from "#utils/speed-order-utils";
 

--- a/src/ui/interfaces/confirm-menu-config.ts
+++ b/src/ui/interfaces/confirm-menu-config.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import type { UiMode } from "#enums/ui-mode";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { OptionMenuSettings } from "#ui/option-select-config";
 
 /**

--- a/src/ui/interfaces/option-select-config.ts
+++ b/src/ui/interfaces/option-select-config.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { UiMode } from "#enums/ui-mode";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { TextStyle } from "#enums/text-style";
+import type { UiMode } from "#enums/ui-mode";
 
 /**
  * Customizations options for UI's {@linkcode UiMode.OPTION_SELECT}

--- a/src/ui/interfaces/option-select-ui-item.ts
+++ b/src/ui/interfaces/option-select-ui-item.ts
@@ -1,7 +1,4 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
 import { BaseOptionSelectUiHandler } from "#ui/base-option-select-ui-handler";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { OptionSelectItem } from "#ui/option-select-config";
 
 /**

--- a/src/ui/settings/settings-ui-items.ts
+++ b/src/ui/settings/settings-ui-items.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { GeneralSettingsUiHandler } from "#ui/general-settings-ui-handler";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { GAME_SPEEDS } from "#constants/app-constants";
 import { BattleStyle } from "#enums/battle-style";
 import { DamageNumbersMode } from "#enums/damage-numbers-mode";
@@ -187,7 +183,7 @@ export const generalSettingsUiItems: SettingsUiItem<GeneralSettingsKey>[] = [
     options: [
       {
         value: 0,
-        /** Replaced with the actual label in {@linkcode GeneralSettingsUiHandler.updateMoveTouchControlsSettingsLabel} */
+        // Replaced with the actual label in `GeneralSettingsUiHandler#updateMoveTouchControlsSettingsLabel`
         label: "ORIENTATION",
       },
       {

--- a/src/utils/anim-utils.ts
+++ b/src/utils/anim-utils.ts
@@ -1,13 +1,10 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { initCommonAnims } from "#init/init-common-anims";
-import type { initEncounterAnims } from "#init/init-encounter-anims";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { LegacyAnimConfig } from "#animations/anim-config";
 import { commonAnims } from "#animations/common-anims";
 import { encounterAnims } from "#animations/encounter-anims";
 import { globalScene } from "#app/global-scene";
 import { ImagesFolder } from "#enums/images-folder";
+import type { initCommonAnims } from "#init/init-common-anims";
+import type { initEncounterAnims } from "#init/init-encounter-anims";
 import type { Scene } from "phaser";
 
 type TweenBuilderConfig = Phaser.Types.Tweens.TweenBuilderConfig;

--- a/src/utils/common-utils.ts
+++ b/src/utils/common-utils.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { initGameSpeed } from "#system/game-speed";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { MAX_STAT_STAGE, MIN_STAT_STAGE } from "#constants/game-constants";
 import type { Pokemon } from "#field/pokemon";
+import type { initGameSpeed } from "#system/game-speed";
 
 export function getFrameMs(frameCount: number): number {
   return Math.floor((1 / 60) * 1000 * frameCount);

--- a/test/@types/vitest.d.ts
+++ b/test/@types/vitest.d.ts
@@ -1,7 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import "vitest";
 
 import type { AbilityId } from "#enums/ability-id";
@@ -12,12 +8,13 @@ import type { EffectiveStat, PermanentStat, Stat } from "#enums/stat";
 import type { StatusEffect } from "#enums/status-effect";
 import type { TerrainType } from "#enums/terrain-type";
 import type { WeatherType } from "#enums/weather-type";
+import type { Pokemon } from "#field/pokemon";
 import type { ToHaveEffectiveStatMatcherOptions } from "#test/test-utils/matchers/to-have-effective-stat-matcher";
 import type { ToHaveMoveResultMatcherOptions } from "#test/test-utils/matchers/to-have-move-result-matcher";
 import type { ToHaveStatMatcherOptions } from "#test/test-utils/matchers/to-have-stat-matcher";
 import type { ToHaveStatusEffectMatcherOptions } from "#test/test-utils/matchers/to-have-status-effect-matcher";
-import type { ToHaveUsedMoveMatcherOptions } from "#test/test-utils/matchers/to-have-used-move-matcher";
 import type { ToHaveTakenDamageMatcherOptions } from "#test/test-utils/matchers/to-have-taken-damage-matcher";
+import type { ToHaveUsedMoveMatcherOptions } from "#test/test-utils/matchers/to-have-used-move-matcher";
 
 declare module "vitest" {
   interface Assertion {

--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -1,8 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { CommandPhase } from "#phases/command-phase";
-import type { TurnEndPhase } from "#phases/turn-end-phase";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { updateUserInfo } from "#app/account";
 import { BattleScene } from "#app/battle-scene";
 import { getGameMode } from "#app/game-mode";
@@ -27,6 +22,8 @@ import type { Pokemon } from "#field/pokemon";
 import { Trainer } from "#field/trainer";
 import { ModifierTypeOption } from "#modifier/modifier-type";
 import { modifierTypes } from "#modifier/modifier-types";
+import type { CommandPhase } from "#phases/command-phase";
+import type { TurnEndPhase } from "#phases/turn-end-phase";
 import { settings } from "#system/settings-manager";
 import { ErrorInterceptor } from "#test/test-utils/error-interceptor";
 import { generateStarter, waitUntil } from "#test/test-utils/game-manager-utils";

--- a/test/test-utils/helpers/field-helper.ts
+++ b/test/test-utils/helpers/field-helper.ts
@@ -1,8 +1,5 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { globalScene } from "#app/global-scene";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { Ability } from "#abilities/ability";
+import type { globalScene } from "#app/global-scene";
 import { allAbilities } from "#data/data-lists";
 import type { AbilityId } from "#enums/ability-id";
 import type { FieldBattlerIndex } from "#enums/battler-index";

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -1,10 +1,3 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { NewArenaEvent } from "#events/battle-scene";
-import type { Arena } from "#field/arena";
-import type { AttemptRunPhase } from "#phases/attempt-run-phase";
-import type { GameManager } from "#test/test-utils/game-manager";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import type { BattleStyle } from "#app/overrides";
 import { activeOverrides, defaultOverrides } from "#app/overrides";
 import { timedEventManager } from "#app/timed-event-manager";
@@ -22,7 +15,11 @@ import { TerrainType } from "#enums/terrain-type";
 import { TrainerType } from "#enums/trainer-type";
 import type { Unlockables } from "#enums/unlockables";
 import { WeatherType } from "#enums/weather-type";
+import type { NewArenaEvent } from "#events/battle-scene";
+import type { Arena } from "#field/arena";
 import type { ModifierOverride } from "#modifier/modifier-type";
+import type { AttemptRunPhase } from "#phases/attempt-run-phase";
+import type { GameManager } from "#test/test-utils/game-manager";
 import { GameManagerHelper } from "#test/test-utils/helpers/game-manager-helper";
 import type { TimedEvent } from "#types/timed-event";
 import { coerceArray, enumValueToKey } from "#utils/common-utils";

--- a/test/test-utils/matchers/to-have-ability-applied-matcher.ts
+++ b/test/test-utils/matchers/to-have-ability-applied-matcher.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { getPokemonNameWithAffix } from "#app/messages";
 import { AbilityId } from "#enums/ability-id";
+import type { Pokemon } from "#field/pokemon";
 import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 

--- a/test/test-utils/matchers/to-have-battler-tag-type-matcher.ts
+++ b/test/test-utils/matchers/to-have-battler-tag-type-matcher.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { getPokemonNameWithAffix } from "#app/messages";
 import { BattlerTagType } from "#enums/battler-tag-type";
+import type { Pokemon } from "#field/pokemon";
 import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
 import { enumValueToKey } from "#utils/common-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";

--- a/test/test-utils/matchers/to-have-status-effect-matcher.ts
+++ b/test/test-utils/matchers/to-have-status-effect-matcher.ts
@@ -1,9 +1,6 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: tsdoc imports */
-import type { Pokemon } from "#field/pokemon";
-/* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
-
 import { getPokemonNameWithAffix } from "#app/messages";
 import { StatusEffect } from "#enums/status-effect";
+import type { Pokemon } from "#field/pokemon";
 import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
 import { enumValueToKey } from "#utils/common-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";


### PR DESCRIPTION
Add-on to #1392, made separate to not clog up the files changed for easier review of the actual changes.

## What are the changes the user will see?
N/A

## Why am I making these changes?
Simplicity.

## What are the changes from a developer perspective?
Most `noUnusedImports` suppression comments were removed from the codebase, except for 4 that are necessary due to a bug where TSDoc usage on object properties is not detected.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?