### PR TITLE
refactor: Rewrite Pokemon generation

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -31,7 +31,7 @@ import { pokemonPreEvolutions } from "#data/pokemon-pre-evolutions";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { resetStarterColors, starterColors } from "#data/starter-colors";
 import { getTypeRgb } from "#data/type";
-import { type Variant, variantData } from "#data/variant";
+import { variantData } from "#data/variant";
 import type { AchvCategory } from "#enums/achv-category";
 import { BattleType } from "#enums/battle-type";
 import { BattlerIndex, type FieldBattlerIndex } from "#enums/battler-index";
@@ -55,15 +55,15 @@ import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { SwitchType } from "#enums/switch-type";
 import { TextStyle } from "#enums/text-style";
-import type { TrainerSlot } from "#enums/trainer-slot";
+import { TrainerSlot } from "#enums/trainer-slot";
 import { TrainerVariant } from "#enums/trainer-variant";
 import type { UiWindowStyle } from "#enums/ui-window-style";
 import { NewArenaEvent } from "#events/battle-scene";
 import { Arena, ArenaBase, getBgTerrainColorRatioForBiome } from "#field/arena";
 import { DamageNumberHandler } from "#field/damage-number-handler";
-import { EnemyPokemon } from "#field/enemy-pokemon";
+import { EnemyPokemon, type EnemyPokemonOptions } from "#field/enemy-pokemon";
 import { PlayerPokemon } from "#field/player-pokemon";
-import type { Pokemon } from "#field/pokemon";
+import type { Pokemon, PokemonOptions } from "#field/pokemon";
 import { PokemonSpriteTeraSparkleHandler } from "#field/pokemon-sprite-tera-sparkle-handler";
 import { Trainer } from "#field/trainer";
 import { SpeciesFormChangeManualTrigger } from "#form-change-triggers/species-form-change-manual-trigger";
@@ -111,7 +111,6 @@ import { SpritePipeline } from "#pipelines/sprite";
 import { type Achievement, achvs } from "#system/achievements";
 import { GameData } from "#system/game-data";
 import { initGameSpeed } from "#system/game-speed";
-import type { PokemonData } from "#system/pokemon-data";
 import { settings } from "#system/settings-manager";
 import type { TrainerData } from "#system/trainer-data";
 import { type Voucher, vouchers } from "#system/voucher";
@@ -907,22 +906,13 @@ export class BattleScene extends SceneBase {
     return findInParty(this.getPlayerParty()) || findInParty(this.getEnemyParty());
   }
 
-  addPlayerPokemon(
+  public addPlayerPokemon(
     species: PokemonSpecies,
     level: number,
-    abilityIndex?: number,
-    formIndex?: number,
-    gender?: Gender,
-    shiny?: boolean,
-    variant?: Variant,
-    ivs?: number[],
-    nature?: Nature,
-    dataSource?: Pokemon | PokemonData,
+    { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource }: PokemonOptions = {},
     postProcess?: (playerPokemon: PlayerPokemon) => void,
   ): PlayerPokemon {
-    const pokemon = new PlayerPokemon(
-      species,
-      level,
+    const pokemon = new PlayerPokemon(species, level, {
       abilityIndex,
       formIndex,
       gender,
@@ -931,7 +921,7 @@ export class BattleScene extends SceneBase {
       ivs,
       nature,
       dataSource,
-    );
+    });
     if (postProcess) {
       postProcess(pokemon);
     }
@@ -964,10 +954,18 @@ export class BattleScene extends SceneBase {
   addEnemyPokemon(
     species: PokemonSpecies,
     level: number,
-    trainerSlot: TrainerSlot,
-    boss: boolean = false,
-    shinyLock: boolean = false,
-    dataSource?: PokemonData,
+    {
+      abilityIndex,
+      formIndex,
+      gender,
+      shiny,
+      variant,
+      ivs,
+      nature,
+      trainerSlot = TrainerSlot.NONE,
+      boss = false,
+      dataSource,
+    }: EnemyPokemonOptions = {},
     postProcess?: (enemyPokemon: EnemyPokemon) => void,
   ): EnemyPokemon {
     if (activeOverrides.ENEMY_LEVEL_OVERRIDE > 0) {
@@ -989,7 +987,18 @@ export class BattleScene extends SceneBase {
       }
     }
 
-    const pokemon = new EnemyPokemon(species, level, trainerSlot, boss, shinyLock, dataSource);
+    const pokemon = new EnemyPokemon(species, level, {
+      abilityIndex,
+      formIndex,
+      gender,
+      shiny,
+      variant,
+      ivs,
+      nature,
+      trainerSlot,
+      boss,
+      dataSource,
+    });
 
     if (boss && !dataSource) {
       const secondaryIvs = pokemon.generateIvs();

--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -13,7 +13,7 @@ import { activeOverrides } from "#app/overrides";
 import type { Phase } from "#app/phase";
 import { PhaseManager } from "#app/phase-manager";
 import { SceneBase } from "#app/scene-base";
-import { IV_MAX, IV_MIN, LEVEL_CAP_SCALE_FACTOR } from "#constants/game-constants";
+import { LEVEL_CAP_SCALE_FACTOR } from "#constants/game-constants";
 import {
   ME_ANTI_VARIANCE_WEIGHT_MODIFIER,
   ME_AVERAGE_ENCOUNTERS_PER_RUN_TARGET,
@@ -55,7 +55,6 @@ import { SpeciesId } from "#enums/species-id";
 import { StatusEffect } from "#enums/status-effect";
 import { SwitchType } from "#enums/switch-type";
 import { TextStyle } from "#enums/text-style";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { TrainerVariant } from "#enums/trainer-variant";
 import type { UiWindowStyle } from "#enums/ui-window-style";
 import { NewArenaEvent } from "#events/battle-scene";
@@ -130,7 +129,7 @@ import { addTextObject } from "#ui/text-utils";
 import { UI } from "#ui/ui";
 import { setDocumentUiTheme, updateWindowStyle } from "#ui/ui-theme";
 import { loadCommonAnimAssets } from "#utils/anim-utils";
-import { BooleanHolder, enumValueToKey, fixedNumber, isBetween, NumberHolder, ValueHolder } from "#utils/common-utils";
+import { BooleanHolder, enumValueToKey, fixedNumber, NumberHolder, ValueHolder } from "#utils/common-utils";
 import { getModifierType } from "#utils/modifier-type-utils";
 import { loadMoveAnimAssets } from "#utils/move-anim-utils";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
@@ -909,42 +908,12 @@ export class BattleScene extends SceneBase {
   public addPlayerPokemon(
     species: PokemonSpecies,
     level: number,
-    { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource }: PokemonOptions = {},
+    options: PokemonOptions | Pokemon = {},
     postProcess?: (playerPokemon: PlayerPokemon) => void,
   ): PlayerPokemon {
-    const pokemon = new PlayerPokemon(species, level, {
-      abilityIndex,
-      formIndex,
-      gender,
-      shiny,
-      variant,
-      ivs,
-      nature,
-      dataSource,
-    });
+    const pokemon = new PlayerPokemon(species, level, options);
     if (postProcess) {
       postProcess(pokemon);
-    }
-
-    if (activeOverrides.IVS_OVERRIDE === null) {
-      // do nothing
-    } else if (Array.isArray(activeOverrides.IVS_OVERRIDE)) {
-      if (activeOverrides.IVS_OVERRIDE.length !== 6) {
-        throw new Error("The Player IVs override must be an array of length 6 or a number!");
-      }
-      if (activeOverrides.IVS_OVERRIDE.some((value) => !isBetween(value, IV_MIN, IV_MAX))) {
-        throw new Error(`All IVs in the player IV override must be between ${IV_MIN} and ${IV_MAX}!`);
-      }
-      pokemon.ivs = activeOverrides.IVS_OVERRIDE;
-    } else {
-      if (!isBetween(activeOverrides.IVS_OVERRIDE, IV_MIN, IV_MAX)) {
-        throw new Error(`The Player IV override must be a value between ${IV_MIN} and ${IV_MAX}!`);
-      }
-      pokemon.ivs = new Array(6).fill(activeOverrides.IVS_OVERRIDE);
-    }
-
-    if (activeOverrides.NATURE_OVERRIDE !== null) {
-      pokemon.nature = activeOverrides.NATURE_OVERRIDE;
     }
 
     pokemon.init();
@@ -954,88 +923,30 @@ export class BattleScene extends SceneBase {
   addEnemyPokemon(
     species: PokemonSpecies,
     level: number,
-    {
-      abilityIndex,
-      formIndex,
-      gender,
-      shiny,
-      variant,
-      ivs,
-      nature,
-      trainerSlot = TrainerSlot.NONE,
-      boss = false,
-      dataSource,
-    }: EnemyPokemonOptions = {},
+    options: EnemyPokemonOptions | Pokemon = {},
     postProcess?: (enemyPokemon: EnemyPokemon) => void,
   ): EnemyPokemon {
-    if (activeOverrides.ENEMY_LEVEL_OVERRIDE > 0) {
-      level = activeOverrides.ENEMY_LEVEL_OVERRIDE;
-    }
-    if (activeOverrides.ENEMY_SPECIES_OVERRIDE) {
-      species = getPokemonSpecies(activeOverrides.ENEMY_SPECIES_OVERRIDE);
+    const pokemon = new EnemyPokemon(species, level, options);
 
-      // The fact that a Pokemon is a boss or not can change based on its Species and level
-      boss = this.getEncounterBossSegments(this.currentBattle.waveIndex, level, species) > 1;
-
-      // Ensure the gender from the data source is valid for the overridden species
-      if (dataSource?.gender != null) {
-        if (dataSource.gender === Gender.GENDERLESS && species.malePercent != null) {
-          dataSource.gender = species.malePercent > 0 ? Gender.MALE : Gender.FEMALE;
-        } else if (dataSource.gender !== Gender.GENDERLESS && species.malePercent == null) {
-          dataSource.gender = Gender.GENDERLESS;
-        }
-      }
-    }
-
-    const pokemon = new EnemyPokemon(species, level, {
-      abilityIndex,
-      formIndex,
-      gender,
-      shiny,
-      variant,
-      ivs,
-      nature,
-      trainerSlot,
-      boss,
-      dataSource,
-    });
-
-    if (boss && !dataSource) {
+    if (pokemon.boss && options.ivs == null) {
+      /*
+       * Boss Pokemon with random IVs have their IVs rolled a second time.
+       * Their final IV for each stat is the weighted average of the two rolls,
+       * with the higher roll at 75% weighting.
+       *
+       * With the additional roll, Bosses' IVs are higher on average (~23 compared to ~15)
+       * and have less variance.
+       */
       const secondaryIvs = pokemon.generateIvs();
 
       for (let s = 0; s < pokemon.ivs.length; s++) {
-        pokemon.ivs[s] = Math.round(
-          Phaser.Math.Linear(
-            Math.min(pokemon.ivs[s], secondaryIvs[s]),
-            Math.max(pokemon.ivs[s], secondaryIvs[s]),
-            0.75,
-          ),
-        );
+        const ivMin = Math.min(pokemon.ivs[s], secondaryIvs[s]);
+        const ivMax = Math.max(pokemon.ivs[s], secondaryIvs[s]);
+        pokemon.ivs[s] = Math.round(0.75 * ivMax + 0.25 * ivMin);
       }
     }
     if (postProcess) {
       postProcess(pokemon);
-    }
-
-    if (activeOverrides.ENEMY_IVS_OVERRIDE === null) {
-      // do nothing
-    } else if (Array.isArray(activeOverrides.ENEMY_IVS_OVERRIDE)) {
-      if (activeOverrides.ENEMY_IVS_OVERRIDE.length !== 6) {
-        throw new Error("The Enemy IVs override must be an array of length 6 or a number!");
-      }
-      if (activeOverrides.ENEMY_IVS_OVERRIDE.some((value) => !isBetween(value, IV_MIN, IV_MAX))) {
-        throw new Error(`All IVs in the enemy IV override must be between ${IV_MIN} and ${IV_MAX}!`);
-      }
-      pokemon.ivs = activeOverrides.ENEMY_IVS_OVERRIDE;
-    } else {
-      if (!isBetween(activeOverrides.ENEMY_IVS_OVERRIDE, IV_MIN, IV_MAX)) {
-        throw new Error(`The Enemy IV override must be a value between ${IV_MIN} and ${IV_MAX}!`);
-      }
-      pokemon.ivs = new Array(6).fill(activeOverrides.ENEMY_IVS_OVERRIDE);
-    }
-
-    if (activeOverrides.ENEMY_NATURE_OVERRIDE !== null) {
-      pokemon.nature = activeOverrides.ENEMY_NATURE_OVERRIDE;
     }
 
     pokemon.init();
@@ -1636,19 +1547,16 @@ export class BattleScene extends SceneBase {
     species?: PokemonSpecies,
     forceBoss: boolean = false,
   ): number {
-    if (activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE > 1) {
-      return activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE;
-    }
-    if (activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE === 1) {
-      // The rest of the code expects to be returned 0 and not 1 if the enemy is not a boss
-      return 0;
+    const override = activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE;
+    if (override != null) {
+      return Math.max(0, override);
     }
 
     if (this.gameMode.isDaily && this.gameMode.isWaveFinal(waveIndex)) {
       return 5;
     }
 
-    let isBoss: boolean | undefined;
+    let isBoss: boolean = false;
     if (forceBoss || species?.isLegendLike()) {
       isBoss = true;
     } else {
@@ -1663,17 +1571,17 @@ export class BattleScene extends SceneBase {
       return 0;
     }
 
-    let ret: number = 2;
+    let segments: number = 2;
 
     if (level >= 100) {
-      ret++;
+      segments++;
     }
     if (species && species.baseTotal >= 670) {
-      ret++;
+      segments++;
     }
-    ret += Math.floor(waveIndex / 250);
+    segments += Math.floor(waveIndex / 250);
 
-    return ret;
+    return segments;
   }
 
   trySpreadPokerus(): void {
@@ -1969,7 +1877,7 @@ export class BattleScene extends SceneBase {
     this.findModifiers((m) => m.isPokemonHeldItemModifier() && m.pokemonId === enemy.id, false).map(
       (m) => (scoreIncrease *= (m as PokemonHeldItemModifier).getScoreMultiplier()),
     );
-    if (enemy.isBoss()) {
+    if (enemy.boss) {
       scoreIncrease *= Math.sqrt(enemy.bossSegments);
     }
     this.currentBattle.battleScore += Math.ceil(scoreIncrease);
@@ -2355,7 +2263,7 @@ export class BattleScene extends SceneBase {
         });
       } else {
         const isBoss =
-          enemyPokemon.isBoss()
+          enemyPokemon.boss
           || (this.currentBattle.battleType === BattleType.TRAINER && !!this.currentBattle.trainer?.config.isBoss);
         let upgradeChance = 32;
         if (isBoss) {
@@ -2761,7 +2669,7 @@ export class BattleScene extends SceneBase {
    * @param pokemon The (enemy) pokemon
    */
   initFinalBossPhaseTwo(pokemon: Pokemon): void {
-    if (pokemon.isEnemy() && pokemon.isBoss() && !pokemon.formIndex && pokemon.bossSegmentIndex < 1) {
+    if (pokemon.isEnemy() && pokemon.boss && !pokemon.formIndex && pokemon.bossSegmentIndex < 1) {
       this.audioManager.fadeOutBgm(fixedNumber(2000), false);
       this.ui.showDialogue(classicFinalBossDialogue.firstStageWin, pokemon.species.name, () => {
         const finalBossMBH = getModifierType(modifierTypes.MINI_BLACK_HOLE).newModifier(
@@ -3015,7 +2923,7 @@ export class BattleScene extends SceneBase {
     if (
       this.currentBattle.battleType !== BattleType.WILD
       || !pokemon.isEnemy()
-      || pokemon.isBoss()
+      || pokemon.boss
       || pokemon.level > source.level
     ) {
       return false;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -231,7 +231,7 @@ export class Battle {
       partyMemberTurnMultiplier /= 1.5;
     }
     for (const p of globalScene.getEnemyParty()) {
-      if (p.isBoss()) {
+      if (p.boss) {
         partyMemberTurnMultiplier *= p.bossSegments / 1.5 / globalScene.getEnemyParty().length;
       }
     }

--- a/src/data/daily-run.ts
+++ b/src/data/daily-run.ts
@@ -63,18 +63,7 @@ function getDailyRunStarter(starterSpeciesForm: PokemonSpeciesForm, startingLeve
       ? (starterSpeciesForm as PokemonSpecies)
       : getPokemonSpecies(starterSpeciesForm.speciesId);
   const formIndex = starterSpeciesForm.type === "PokemonSpecies" ? undefined : starterSpeciesForm.formIndex;
-  const pokemon = new PlayerPokemon(
-    starterSpecies,
-    startingLevel,
-    undefined,
-    formIndex,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-  );
+  const pokemon = new PlayerPokemon(starterSpecies, startingLevel, { formIndex });
   const starter: StarterConfig = {
     species: starterSpecies,
     dexAttr: pokemon.getDexAttr(),

--- a/src/data/egg.ts
+++ b/src/data/egg.ts
@@ -257,7 +257,10 @@ export class Egg {
           abilityIndex = 2;
         }
 
-        ret = globalScene.addPlayerPokemon(pokemonSpecies, 1, abilityIndex, undefined, undefined, false);
+        ret = globalScene.addPlayerPokemon(pokemonSpecies, 1, {
+          abilityIndex,
+          shiny: false,
+        });
         ret.shiny = this._isShiny;
         ret.variant = this._variantTier;
 

--- a/src/data/moves/move-attrs/add-substitute-attr.ts
+++ b/src/data/moves/move-attrs/add-substitute-attr.ts
@@ -45,7 +45,7 @@ export class AddSubstituteAttr extends MoveEffectAttr {
   }
 
   override getUserBenefitScore(user: Pokemon, _target: Pokemon, _move: Move): number {
-    if (user.isBoss()) {
+    if (user.boss) {
       return -10;
     }
     return 5;

--- a/src/data/moves/move-attrs/half-max-hp-recoil-attr.ts
+++ b/src/data/moves/move-attrs/half-max-hp-recoil-attr.ts
@@ -38,7 +38,7 @@ export class HalfMaxHpRecoilAttr extends MoveEffectAttr {
   }
 
   override getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    if (user.isBoss()) {
+    if (user.boss) {
       return -10;
     }
     return Math.ceil(

--- a/src/data/moves/move-attrs/revival-blessing-attr.ts
+++ b/src/data/moves/move-attrs/revival-blessing-attr.ts
@@ -26,7 +26,7 @@ export class RevivalBlessingAttr extends MoveEffectAttr {
     if (user.isEnemy()) {
       // If used by an enemy trainer with at least one fainted non-boss Pokemon, this
       // revives one of said Pokemon selected at random.
-      const faintedPokemon = globalScene.getEnemyParty().filter((p) => p.isFainted() && !p.isBoss());
+      const faintedPokemon = globalScene.getEnemyParty().filter((p) => p.isFainted() && !p.boss);
       const pokemon = faintedPokemon[user.randSeedInt(faintedPokemon.length)];
       const slotIndex = globalScene.getEnemyParty().findIndex((p) => pokemon.id === p.id);
       const { currentBattle, phaseManager } = globalScene;
@@ -60,11 +60,11 @@ export class RevivalBlessingAttr extends MoveEffectAttr {
   override getCondition(): MoveConditionFunc {
     return (user, _target, _move) =>
       (user.isPlayer() && globalScene.getPlayerParty().some((p) => p.isFainted()))
-      || (user.isEnemy() && user.hasTrainer() && globalScene.getEnemyParty().some((p) => p.isFainted() && !p.isBoss()));
+      || (user.isEnemy() && user.hasTrainer() && globalScene.getEnemyParty().some((p) => p.isFainted() && !p.boss));
   }
 
   override getUserBenefitScore(user: Pokemon, _target: Pokemon, _move: Move): number {
-    if (user.hasTrainer() && globalScene.getEnemyParty().some((p) => p.isFainted() && !p.isBoss())) {
+    if (user.hasTrainer() && globalScene.getEnemyParty().some((p) => p.isFainted() && !p.boss)) {
       return 20;
     }
 

--- a/src/data/moves/move-attrs/sacrificial-attr.ts
+++ b/src/data/moves/move-attrs/sacrificial-attr.ts
@@ -23,7 +23,7 @@ export class SacrificialAttr extends MoveEffectAttr {
   }
 
   override getUserBenefitScore(user: Pokemon, target: Pokemon, move: Move): number {
-    if (user.isBoss()) {
+    if (user.boss) {
       return -20;
     }
     return Math.ceil(((1 - user.getHpRatio()) * 10 - 10) * (target.getAttackTypeEffectiveness(move.type, user) - 0.5));

--- a/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
+++ b/src/data/mystery-encounters/encounters/absolute-avarice-encounter.ts
@@ -10,7 +10,6 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PokeballType } from "#enums/pokeball-type";
 import { SpeciesId } from "#enums/species-id";
 import { type BattleStat, Stat } from "#enums/stat";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { PokemonMove } from "#field/pokemon-move";
@@ -376,7 +375,9 @@ export const AbsoluteAvariceEncounter: MysteryEncounter = MysteryEncounterBuilde
         // Let it have the food
         // Greedent joins the team, level equal to 2 below highest party member (shiny locked)
         const level = getHighestLevelPlayerPokemon(false, true).level - 2;
-        const greedent = new EnemyPokemon(getPokemonSpecies(SpeciesId.GREEDENT), level, TrainerSlot.NONE, false, true);
+        const greedent = new EnemyPokemon(getPokemonSpecies(SpeciesId.GREEDENT), level, {
+          shiny: false,
+        });
         greedent.setMoveset(MoveId.THRASH, MoveId.BODY_PRESS, MoveId.STUFF_CHEEKS, MoveId.SLACK_OFF);
         greedent.passive = true;
 

--- a/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
+++ b/src/data/mystery-encounters/encounters/berries-abound-encounter.ts
@@ -9,7 +9,6 @@ import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { type BattleStat, PERMANENT_STATS, Stat } from "#enums/stat";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -76,7 +75,7 @@ export const BerriesAboundEncounter: MysteryEncounter = MysteryEncounterBuilder.
       0,
       getPartyLuckValue(globalScene.getPlayerParty()),
     );
-    const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
+    const bossPokemon = new EnemyPokemon(bossSpecies, level, { boss: true });
     encounter.setDialogueToken("enemyPokemon", getPokemonNameWithAffix(bossPokemon));
     const config: EnemyPartyConfig = {
       pokemonConfigs: [

--- a/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
@@ -95,7 +95,7 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
     enemyPokemon.formIndex = getOricorioFormIndexForBiome(globalScene.arena.biomeId);
 
     const oricorioData = new PokemonData(enemyPokemon);
-    const oricorio = globalScene.addEnemyPokemon(species, level, { dataSource: oricorioData });
+    const oricorio = globalScene.addEnemyPokemon(species, level, oricorioData);
 
     // Adds a real Pokemon sprite to the field (required for the animation)
     globalScene.getEnemyParty().forEach((enemy) => {

--- a/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
+++ b/src/data/mystery-encounters/encounters/dancing-lessons-encounter.ts
@@ -12,7 +12,6 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PokeballType } from "#enums/pokeball-type";
 import { SpeciesId } from "#enums/species-id";
 import { Stat } from "#enums/stat";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -82,7 +81,7 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
 
     const species = getPokemonSpecies(SpeciesId.ORICORIO);
     const level = getEncounterPokemonLevelForWave(STANDARD_ENCOUNTER_BOOSTED_LEVEL_MODIFIER);
-    const enemyPokemon = new EnemyPokemon(species, level, TrainerSlot.NONE, false);
+    const enemyPokemon = new EnemyPokemon(species, level);
     const moveset = enemyPokemon.getMoveset(true);
     if (!moveset.some((m) => m && m.getMove().id === MoveId.REVELATION_DANCE)) {
       if (moveset.length < 4) {
@@ -96,7 +95,7 @@ export const DancingLessonsEncounter: MysteryEncounter = MysteryEncounterBuilder
     enemyPokemon.formIndex = getOricorioFormIndexForBiome(globalScene.arena.biomeId);
 
     const oricorioData = new PokemonData(enemyPokemon);
-    const oricorio = globalScene.addEnemyPokemon(species, level, TrainerSlot.NONE, false, false, oricorioData);
+    const oricorio = globalScene.addEnemyPokemon(species, level, { dataSource: oricorioData });
 
     // Adds a real Pokemon sprite to the field (required for the animation)
     globalScene.getEnemyParty().forEach((enemy) => {

--- a/src/data/mystery-encounters/encounters/fight-or-flight-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fight-or-flight-encounter.ts
@@ -7,7 +7,6 @@ import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import type { BattleStat } from "#enums/stat";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import {
@@ -69,7 +68,7 @@ export const FightOrFlightEncounter: MysteryEncounter = MysteryEncounterBuilder.
       0,
       getPartyLuckValue(globalScene.getPlayerParty()),
     );
-    const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
+    const bossPokemon = new EnemyPokemon(bossSpecies, level, { boss: true });
     encounter.setDialogueToken("enemyPokemon", bossPokemon.getNameToRender());
     const config: EnemyPartyConfig = {
       pokemonConfigs: [

--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -204,9 +204,11 @@ async function summonPlayerPokemon() {
     // Also loads Wobbuffet data (cannot be shiny)
     const enemySpecies = getPokemonSpecies(SpeciesId.WOBBUFFET);
     globalScene.currentBattle.enemyParty = [];
-    const wobbuffet = globalScene.addEnemyPokemon(enemySpecies, encounter.misc.playerPokemon.level, { shiny: false });
-    wobbuffet.ivs = [0, 0, 0, 0, 0, 0];
-    wobbuffet.setNature(Nature.MILD);
+    const wobbuffet = globalScene.addEnemyPokemon(enemySpecies, encounter.misc.playerPokemon.level, {
+      shiny: false,
+      ivs: [0, 0, 0, 0, 0, 0],
+      nature: Nature.MILD,
+    });
     wobbuffet.setAlpha(0);
     wobbuffet.setVisible(false);
     wobbuffet.calculateStats();

--- a/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fun-and-games-encounter.ts
@@ -9,7 +9,6 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { Nature } from "#enums/nature";
 import { PlayerGender } from "#enums/player-gender";
 import { SpeciesId } from "#enums/species-id";
-import { TrainerSlot } from "#enums/trainer-slot";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { SpeciesFormChangeActiveTrigger } from "#form-change-triggers/species-form-change-active-trigger";
@@ -205,13 +204,7 @@ async function summonPlayerPokemon() {
     // Also loads Wobbuffet data (cannot be shiny)
     const enemySpecies = getPokemonSpecies(SpeciesId.WOBBUFFET);
     globalScene.currentBattle.enemyParty = [];
-    const wobbuffet = globalScene.addEnemyPokemon(
-      enemySpecies,
-      encounter.misc.playerPokemon.level,
-      TrainerSlot.NONE,
-      false,
-      true,
-    );
+    const wobbuffet = globalScene.addEnemyPokemon(enemySpecies, encounter.misc.playerPokemon.level, { shiny: false });
     wobbuffet.ivs = [0, 0, 0, 0, 0, 0];
     wobbuffet.setNature(Nature.MILD);
     wobbuffet.setAlpha(0);

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -479,9 +479,11 @@ async function doTradeOptionPhaseCallback(): Promise<void> {
   // Pokeball to Ultra ball, randomly
   receivedPokemonData.pokeball = randInt(3) as PokeballType;
   const dataSource = new PokemonData(receivedPokemonData);
-  const newPlayerPokemon = globalScene.addPlayerPokemon(receivedPokemonData.species, receivedPokemonData.level, {
+  const newPlayerPokemon = globalScene.addPlayerPokemon(
+    receivedPokemonData.species,
+    receivedPokemonData.level,
     dataSource,
-  });
+  );
   globalScene.getPlayerParty().push(newPlayerPokemon);
   await newPlayerPokemon.loadAssets();
 

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -18,7 +18,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import type { PokeballType } from "#enums/pokeball-type";
 import { SpeciesId } from "#enums/species-id";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { PlayerPokemon } from "#field/player-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -218,7 +217,7 @@ export const GlobalTradeSystemEncounter: MysteryEncounter = MysteryEncounterBuil
         const onPokemonSelected = (pokemon: PlayerPokemon) => {
           // Randomly generate a Wonder Trade pokemon
           const randomTradeOption = generateTradeOption(globalScene.getPlayerParty().map((p) => p.species));
-          const tradePokemon = new EnemyPokemon(randomTradeOption, pokemon.level, TrainerSlot.NONE, false);
+          const tradePokemon = new EnemyPokemon(randomTradeOption, pokemon.level);
           // Extra shiny roll at 1/128 odds (boosted by events and charms)
           if (!tradePokemon.shiny) {
             const shinyThreshold = new NumberHolder(WONDER_TRADE_SHINY_CHANCE);
@@ -396,7 +395,7 @@ function getPokemonTradeOptions(): Map<number, EnemyPokemon[]> {
       const generation = pokemon.species.generation;
       const tradeOptions: EnemyPokemon[] = LEGENDARY_TRADE_POOLS[generation].map((s) => {
         const pokemonSpecies = getPokemonSpecies(s);
-        return new EnemyPokemon(pokemonSpecies, 5, TrainerSlot.NONE, false);
+        return new EnemyPokemon(pokemonSpecies, 5);
       });
       tradeOptionsMap.set(pokemon.id, tradeOptions);
     } else {
@@ -413,7 +412,7 @@ function getPokemonTradeOptions(): Map<number, EnemyPokemon[]> {
       tradeOptionsMap.set(
         pokemon.id,
         tradeOptions.map((s) => {
-          return new EnemyPokemon(s, pokemon.level, TrainerSlot.NONE, false);
+          return new EnemyPokemon(s, pokemon.level);
         }),
       );
     }
@@ -480,18 +479,9 @@ async function doTradeOptionPhaseCallback(): Promise<void> {
   // Pokeball to Ultra ball, randomly
   receivedPokemonData.pokeball = randInt(3) as PokeballType;
   const dataSource = new PokemonData(receivedPokemonData);
-  const newPlayerPokemon = globalScene.addPlayerPokemon(
-    receivedPokemonData.species,
-    receivedPokemonData.level,
-    dataSource.abilityIndex,
-    dataSource.formIndex,
-    dataSource.gender,
-    dataSource.shiny,
-    dataSource.variant,
-    dataSource.ivs,
-    dataSource.nature,
+  const newPlayerPokemon = globalScene.addPlayerPokemon(receivedPokemonData.species, receivedPokemonData.level, {
     dataSource,
-  );
+  });
   globalScene.getPlayerParty().push(newPlayerPokemon);
   await newPlayerPokemon.loadAssets();
 

--- a/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
+++ b/src/data/mystery-encounters/encounters/safari-zone-encounter.ts
@@ -10,7 +10,6 @@ import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PlayerGender } from "#enums/player-gender";
 import { PokeballType } from "#enums/pokeball-type";
 import { SpeciesGroups } from "#enums/species-groups";
-import { TrainerSlot } from "#enums/trainer-slot";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
 import { HiddenAbilityRateBoosterModifier, IvScannerModifier } from "#modifier/modifier";
 import { getEncounterText, showEncounterText } from "#mystery-encounters/encounter-dialogue-utils";
@@ -284,7 +283,7 @@ async function summonSafariPokemon() {
     () => {
       const level = globalScene.currentBattle.getLevelForWave();
       enemySpecies = getPokemonSpecies(getSafariSpeciesSpawn().getEnemySpeciesForLevel(level));
-      pokemon = globalScene.addEnemyPokemon(enemySpecies, level, TrainerSlot.NONE, false);
+      pokemon = globalScene.addEnemyPokemon(enemySpecies, level);
 
       // Roll shiny twice
       if (!pokemon.shiny) {

--- a/src/data/mystery-encounters/encounters/teleporting-hijinks-encounter.ts
+++ b/src/data/mystery-encounters/encounters/teleporting-hijinks-encounter.ts
@@ -9,7 +9,6 @@ import { MysteryEncounterOptionMode } from "#enums/mystery-encounter-option-mode
 import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { type BattleStat, Stat } from "#enums/stat";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { getBiomeKey } from "#field/arena";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
@@ -151,7 +150,7 @@ export const TeleportingHijinksEncounter: MysteryEncounter = MysteryEncounterBui
         0,
         getPartyLuckValue(globalScene.getPlayerParty()),
       );
-      const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
+      const bossPokemon = new EnemyPokemon(bossSpecies, level, { boss: true });
       encounter.setDialogueToken("enemyPokemon", getPokemonNameWithAffix(bossPokemon));
       const config: EnemyPartyConfig = {
         pokemonConfigs: [
@@ -194,7 +193,7 @@ async function doBiomeTransitionDialogueAndBattleInit() {
     0,
     getPartyLuckValue(globalScene.getPlayerParty()),
   );
-  const bossPokemon = new EnemyPokemon(bossSpecies, level, TrainerSlot.NONE, true);
+  const bossPokemon = new EnemyPokemon(bossSpecies, level, { boss: true });
   encounter.setDialogueToken("enemyPokemon", getPokemonNameWithAffix(bossPokemon));
 
   // Defense/Spd buffs below wave 50, +1 to all stats otherwise

--- a/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
+++ b/src/data/mystery-encounters/encounters/the-pokemon-salesman-encounter.ts
@@ -85,9 +85,16 @@ export const ThePokemonSalesmanEncounter: MysteryEncounter = MysteryEncounterBui
     ) {
       // If no HA mon found or you roll 1%, give shiny Magikarp with random variant
       species = getPokemonSpecies(SpeciesId.MAGIKARP);
-      pokemon = new PlayerPokemon(species, 5, 2, species.formIndex, undefined, true);
+      pokemon = new PlayerPokemon(species, 5, {
+        abilityIndex: 2,
+        formIndex: species.formIndex,
+        shiny: true,
+      });
     } else {
-      pokemon = new PlayerPokemon(species, 5, 2, species.formIndex);
+      pokemon = new PlayerPokemon(species, 5, {
+        abilityIndex: 2,
+        formIndex: species.formIndex,
+      });
     }
     pokemon.generateAndPopulateMoveset();
 

--- a/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
+++ b/src/data/mystery-encounters/encounters/uncommon-breed-encounter.ts
@@ -8,7 +8,6 @@ import { MysteryEncounterTier } from "#enums/mystery-encounter-tier";
 import { MysteryEncounterType } from "#enums/mystery-encounter-type";
 import { PokeballType } from "#enums/pokeball-type";
 import { type BattleStat, Stat } from "#enums/stat";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { EnemyPokemon } from "#field/enemy-pokemon";
 import type { Pokemon } from "#field/pokemon";
 import { PokemonMove } from "#field/pokemon-move";
@@ -67,7 +66,7 @@ export const UncommonBreedEncounter: MysteryEncounter = MysteryEncounterBuilder.
       0,
       getPartyLuckValue(globalScene.getPlayerParty()),
     );
-    const pokemon = new EnemyPokemon(species, level, TrainerSlot.NONE, true);
+    const pokemon = new EnemyPokemon(species, level, { boss: true });
 
     // Pokemon will always have one of its egg moves in its moveset
     const eggMoves = pokemon.getEggMoves();

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -301,7 +301,6 @@ export const WeirdDreamEncounter: MysteryEncounter = MysteryEncounterBuilder.wit
       for (const pokemon of globalScene.getPlayerParty()) {
         pokemon.level = Math.max(Math.ceil(((100 - PERCENT_LEVEL_LOSS_ON_REFUSE) / 100) * pokemon.level), 1);
         pokemon.exp = getLevelTotalExp(pokemon.level, pokemon.species.growthRate);
-        pokemon.levelExp = 0;
 
         pokemon.calculateStats();
         pokemon.getBattleInfo().setLevel(pokemon.level);

--- a/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
+++ b/src/data/mystery-encounters/encounters/weird-dream-encounter.ts
@@ -377,12 +377,11 @@ function getTeamTransformations(): PokemonTransformation[] {
   }
 
   for (const transformation of pokemonTransformations) {
-    const newAbilityIndex = randSeedInt(transformation.newSpecies.getAbilityCount());
+    const abilityIndex = randSeedInt(transformation.newSpecies.getAbilityCount());
     transformation.newPokemon = globalScene.addPlayerPokemon(
       transformation.newSpecies,
       transformation.previousPokemon.level,
-      newAbilityIndex,
-      undefined,
+      { abilityIndex },
     );
   }
 

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -30,7 +30,6 @@ import type { Nature } from "#enums/nature";
 import type { PartyOption } from "#enums/party-option";
 import { PartyUiMode } from "#enums/party-ui-mode";
 import { StatusEffect } from "#enums/status-effect";
-import { TrainerSlot } from "#enums/trainer-slot";
 import type { TrainerType } from "#enums/trainer-type";
 import { TrainerVariant } from "#enums/trainer-variant";
 import { UiMode } from "#enums/ui-mode";
@@ -225,14 +224,10 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
           dataSource = config.dataSource;
           enemySpecies = config.species;
           isBoss = config.isBoss;
-          battle.enemyParty[e] = globalScene.addEnemyPokemon(
-            enemySpecies,
-            level,
-            TrainerSlot.TRAINER,
-            isBoss,
-            false,
+          battle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, {
+            boss: isBoss,
             dataSource,
-          );
+          });
         } else {
           battle.enemyParty[e] = battle.trainer.genPartyMember(e);
         }
@@ -250,14 +245,10 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
           enemySpecies = globalScene.randomSpecies(battle.waveIndex, level, true);
         }
 
-        battle.enemyParty[e] = globalScene.addEnemyPokemon(
-          enemySpecies,
-          level,
-          TrainerSlot.NONE,
-          isBoss,
-          false,
+        battle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, {
+          boss: isBoss,
           dataSource,
-        );
+        });
       }
     }
 

--- a/src/data/mystery-encounters/utils/encounter-phase-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-phase-utils.ts
@@ -225,8 +225,8 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
           enemySpecies = config.species;
           isBoss = config.isBoss;
           battle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, {
+            ...dataSource,
             boss: isBoss,
-            dataSource,
           });
         } else {
           battle.enemyParty[e] = battle.trainer.genPartyMember(e);
@@ -246,8 +246,8 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
         }
 
         battle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, {
+          ...dataSource,
           boss: isBoss,
-          dataSource,
         });
       }
     }
@@ -425,7 +425,7 @@ export async function initBattleWithEnemyConfig(partyConfig: EnemyPartyConfig): 
     console.log(
       `Ability: ${enemyPokemon.getAbility().name}`,
       `| Passive Ability${enemyPokemon.hasPassive() ? "" : " (inactive)"}: ${enemyPokemon.getPassiveAbility().name}`,
-      `${enemyPokemon.isBoss() ? `| Boss Bars: ${enemyPokemon.bossSegments}` : ""}`,
+      `${enemyPokemon.boss ? `| Boss Bars: ${enemyPokemon.bossSegments}` : ""}`,
     );
     console.log("Moveset:", moveset);
   });

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -653,138 +653,122 @@ export async function catchPokemon(
     globalScene.validateAchv(achvs.CATCH_MYTHICAL);
   }
 
-  globalScene.pokemonInfoContainer.show(pokemon, true);
+  await globalScene.pokemonInfoContainer.show(pokemon, true);
 
   globalScene.gameData.updateSpeciesDexIvs(pokemon.species.getRootSpeciesId(true), pokemon.ivs);
 
-  return new Promise((resolve) => {
-    // TODO: remove all this duplicated code from attempt-capture-phase
-    const doPokemonCatchMenu = () => {
-      const end = () => {
-        // Ensure the pokemon is in the enemy party in all situations
-        if (!globalScene.getEnemyParty().some((p) => p.id === pokemon.id)) {
-          globalScene.getEnemyParty().push(pokemon);
-        }
-        globalScene.phaseManager.createAndUnshiftPhase("PostKnockoutPhase", pokemon.id, true);
-        globalScene.pokemonInfoContainer.hide();
-        if (pokeball) {
-          removePb(pokeball);
-        }
-        resolve();
-      };
-      const removePokemon = () => {
-        pokemon?.leaveField(true, true, true);
-      };
-      const addToParty = (slotIndex?: number) => {
-        const newPokemon = pokemon.addToParty(pokeballType, slotIndex);
-        const modifiers = globalScene.findModifiers((m) => m.isPokemonHeldItemModifier(), false);
-        if (globalScene.getPlayerParty().filter((p) => p.isShiny()).length === 6) {
-          globalScene.validateAchv(achvs.SHINY_PARTY);
-        }
-        Promise.all(modifiers.map((m) => globalScene.addModifier(m, true))).then(() => {
-          globalScene.updateModifiers(true);
-          removePokemon();
-          if (newPokemon) {
-            newPokemon.loadAssets().then(end);
-          } else {
-            end();
-          }
-        });
-      };
-      Promise.all([pokemon.hideInfo(), globalScene.gameData.setPokemonCaught(pokemon)]).then(() => {
-        if (globalScene.getPlayerParty().length === 6) {
-          const addToPartyMenuConfig: OptionSelectModeConfig = {
-            options: [
-              {
-                label: i18next.t("partyUiHandler:SUMMARY"),
-                handler: () => {
-                  globalScene.ui.setMessageMode().then(() => {
-                    removePokemon();
-                    end();
-                  });
-                  return true;
-                },
-              },
-              {
-                label: i18next.t("menu:yes"),
-                handler: () => {
-                  const newPokemon = globalScene.addPlayerPokemon(
-                    pokemon.species,
-                    pokemon.level,
-                    pokemon.abilityIndex,
-                    pokemon.formIndex,
-                    pokemon.gender,
-                    pokemon.shiny,
-                    pokemon.variant,
-                    pokemon.ivs,
-                    pokemon.nature,
-                    pokemon,
-                  );
-                  globalScene.ui.setMode<SummaryUiHandler>(
-                    UiMode.SUMMARY,
-                    newPokemon,
-                    SummaryUiMode.DEFAULT,
-                    SummaryUiPage.PROFILE,
-                    () => {
-                      globalScene.ui.setMessageMode().then(() => {
-                        promptRelease();
-                      });
-                    },
-                    false,
-                    false,
-                  );
-                  return true;
-                },
-              },
-              {
-                label: i18next.t("menu:no"),
-                handler: () => {
-                  globalScene.ui.setMode<PartyUiHandler>(
-                    UiMode.PARTY,
-                    PartyUiMode.RELEASE,
-                    0,
-                    (slotIndex: number, _option: PartyOption) => {
-                      globalScene.ui.setMessageMode().then(() => {
-                        if (slotIndex < 6) {
-                          addToParty(slotIndex);
-                        } else {
-                          promptRelease();
-                        }
-                      });
-                    },
-                  );
-                  return true;
-                },
-              },
-            ],
-            yOffset: 48,
-            onResize: (w: number, _h: number) => {
-              globalScene.pokemonInfoContainer.makeRoomForOptionSelectUi(w);
-            },
-          };
-          const promptRelease = () => {
-            globalScene.ui.showText(i18next.t("battle:partyFull", { pokemonName: pokemon.getNameToRender() }), {
-              callback: () => globalScene.ui.setMode<OptionSelectUiHandler>(UiMode.OPTION_SELECT, addToPartyMenuConfig),
-            });
-          };
-          promptRelease();
-        } else {
-          addToParty();
-        }
-      });
+  // TODO: remove all this duplicated code from attempt-capture-phase
+  const doPokemonCatchMenu = async () => {
+    const end = async () => {
+      // Ensure the pokemon is in the enemy party in all situations
+      if (!globalScene.getEnemyParty().some((p) => p.id === pokemon.id)) {
+        globalScene.getEnemyParty().push(pokemon);
+      }
+      globalScene.phaseManager.createAndUnshiftPhase("PostKnockoutPhase", pokemon.id, true);
+      await globalScene.pokemonInfoContainer.hide();
+      if (pokeball) {
+        removePb(pokeball);
+      }
+    };
+    const removePokemon = () => {
+      pokemon?.leaveField(true, true, true);
+    };
+    const addToParty = async (slotIndex?: number) => {
+      const newPokemon = pokemon.addToParty(pokeballType, slotIndex);
+      const modifiers = globalScene.findModifiers((m) => m.isPokemonHeldItemModifier(), false);
+      if (globalScene.getPlayerParty().filter((p) => p.isShiny()).length === 6) {
+        globalScene.validateAchv(achvs.SHINY_PARTY);
+      }
+      await Promise.all(modifiers.map((m) => globalScene.addModifier(m, true)));
+      globalScene.updateModifiers(true);
+      removePokemon();
+      if (newPokemon) {
+        await newPokemon.loadAssets();
+      }
+      await end();
     };
 
-    if (showCatchObtainMessage) {
-      globalScene.ui.showText(
-        i18next.t(isObtain ? "battle:pokemonObtained" : "battle:pokemonCaught", {
-          pokemonName: pokemon.getNameToRender(),
-        }),
-        { callback: doPokemonCatchMenu, prompt: true },
-      );
+    await Promise.all([pokemon.hideInfo(), globalScene.gameData.setPokemonCaught(pokemon)]);
+    if (globalScene.getPlayerParty().length === 6) {
+      const addToPartyMenuConfig: OptionSelectModeConfig = {
+        options: [
+          {
+            label: i18next.t("partyUiHandler:SUMMARY"),
+            handler: () => {
+              globalScene.ui.setMessageMode().then(async () => {
+                await removePokemon();
+                await end();
+              });
+              return true;
+            },
+          },
+          {
+            label: i18next.t("menu:yes"),
+            handler: () => {
+              const newPokemon = globalScene.addPlayerPokemon(pokemon.species, pokemon.level, { dataSource: pokemon });
+              globalScene.ui.setMode<SummaryUiHandler>(
+                UiMode.SUMMARY,
+                newPokemon,
+                SummaryUiMode.DEFAULT,
+                SummaryUiPage.PROFILE,
+                () => {
+                  globalScene.ui.setMessageMode().then(() => {
+                    promptRelease();
+                  });
+                },
+                false,
+                false,
+              );
+              return true;
+            },
+          },
+          {
+            label: i18next.t("menu:no"),
+            handler: () => {
+              globalScene.ui.setMode<PartyUiHandler>(
+                UiMode.PARTY,
+                PartyUiMode.RELEASE,
+                0,
+                (slotIndex: number, _option: PartyOption) => {
+                  globalScene.ui.setMessageMode().then(async () => {
+                    if (slotIndex < 6) {
+                      await addToParty(slotIndex);
+                    } else {
+                      promptRelease();
+                    }
+                  });
+                },
+              );
+              return true;
+            },
+          },
+        ],
+        yOffset: 48,
+        onResize: (w: number, _h: number) => {
+          globalScene.pokemonInfoContainer.makeRoomForOptionSelectUi(w);
+        },
+      };
+      const promptRelease = () => {
+        globalScene.ui.showText(i18next.t("battle:partyFull", { pokemonName: pokemon.getNameToRender() }), {
+          callback: () => globalScene.ui.setMode<OptionSelectUiHandler>(UiMode.OPTION_SELECT, addToPartyMenuConfig),
+        });
+      };
+      promptRelease();
     } else {
-      doPokemonCatchMenu();
+      await addToParty();
     }
-  });
+  };
+
+  if (showCatchObtainMessage) {
+    globalScene.ui.showText(
+      i18next.t(isObtain ? "battle:pokemonObtained" : "battle:pokemonCaught", {
+        pokemonName: pokemon.getNameToRender(),
+      }),
+      { callback: doPokemonCatchMenu, prompt: true },
+    );
+  } else {
+    await doPokemonCatchMenu();
+  }
 }
 
 /**

--- a/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
+++ b/src/data/mystery-encounters/utils/encounter-pokemon-utils.ts
@@ -705,7 +705,7 @@ export async function catchPokemon(
           {
             label: i18next.t("menu:yes"),
             handler: () => {
-              const newPokemon = globalScene.addPlayerPokemon(pokemon.species, pokemon.level, { dataSource: pokemon });
+              const newPokemon = globalScene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon);
               globalScene.ui.setMode<SummaryUiHandler>(
                 UiMode.SUMMARY,
                 newPokemon,

--- a/src/data/trainer-config.ts
+++ b/src/data/trainer-config.ts
@@ -1689,15 +1689,7 @@ export function getRandomPartyMemberFunc(
     if (!ignoreEvolution) {
       species = getPokemonSpecies(species).getEnemySpeciesForLevel(level, true);
     }
-    return globalScene.addEnemyPokemon(
-      getPokemonSpecies(species),
-      level,
-      trainerSlot,
-      undefined,
-      false,
-      undefined,
-      postProcess,
-    );
+    return globalScene.addEnemyPokemon(getPokemonSpecies(species), level, { trainerSlot }, postProcess);
   };
 }
 
@@ -1718,6 +1710,6 @@ export function getSpeciesFilterRandomPartyMemberFunc(
       globalScene.randomSpecies(waveIndex, level, false, speciesFilter).getEnemySpeciesForLevel(level, true),
     );
 
-    return globalScene.addEnemyPokemon(species, level, trainerSlot, undefined, false, undefined, postProcess);
+    return globalScene.addEnemyPokemon(species, level, { trainerSlot }, postProcess);
   };
 }

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -4,7 +4,6 @@ import type { EncoreTag } from "#battler-tags/encore-tag";
 import { MOVE_LOCK_TAG_TYPES } from "#constants/battler-tag-constants";
 import { DYNAMAX_DAMAGE_TAKEN_FACTOR, PLAYER_PARTY_MAX_SIZE } from "#constants/game-constants";
 import { allMoves } from "#data/data-lists";
-import { pokemonPreEvolutions } from "#data/pokemon-pre-evolutions";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { AbilityApplyMode } from "#enums/ability-apply-mode";
 import { AiType } from "#enums/ai-type";
@@ -26,70 +25,53 @@ import { SpeciesFormChangeActiveTrigger } from "#form-change-triggers/species-fo
 import { CounterDamageAttr } from "#moves/counter-damage-attr";
 import { CritOnlyAttr } from "#moves/crit-only-attr";
 import { getMoveTargets } from "#moves/move";
-import type { PokemonData } from "#system/pokemon-data";
+import { PokemonData } from "#system/pokemon-data";
 import type { TurnMove } from "#types/move-types";
+import type { nil } from "#types/utility-types";
 import { EnemyBattleInfo } from "#ui/battle-info";
-import { isBetween, toDmgValue } from "#utils/common-utils";
+import { isBetween, isPokemon, toDmgValue } from "#utils/common-utils";
+import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { randSeedInt, randSeedItem } from "#utils/random-utils";
 
 export interface EnemyPokemonOptions extends PokemonOptions {
   trainerSlot?: TrainerSlot;
   boss?: boolean;
-  dataSource?: PokemonData;
+  bossSegments?: number;
 }
 
 export class EnemyPokemon extends Pokemon {
   public trainerSlot: TrainerSlot;
   public aiType: AiType;
   /** The amount of hp-segments the boss has (if the pokemon is a boss). */
-  public bossSegments: number;
+  public bossSegments: number = 0;
   /** The index of the current hp-segment (if the pokemon is a boss). E.g. if the boss has 5 segments and the first 2 are cleared, this will be 2 */
-  public bossSegmentIndex: number;
+  public bossSegmentIndex: number = 0;
   public initialTeamIndex: number;
   /** To indicate if the instance was populated with a dataSource -> e.g. loaded & populated from session data */
   public readonly isPopulatedFromDataSource: boolean;
 
-  constructor(
-    species: PokemonSpecies,
-    level: number,
-    {
-      abilityIndex,
-      formIndex,
-      gender,
-      shiny,
-      variant,
-      ivs,
-      nature,
-      trainerSlot = TrainerSlot.NONE,
-      boss = false,
-      dataSource,
-    }: EnemyPokemonOptions = {},
-  ) {
-    super(236, 84, species, level, {
-      abilityIndex,
-      formIndex,
-      gender,
-      shiny,
-      variant,
-      ivs,
-      nature,
-      dataSource,
-    });
+  constructor(species: PokemonSpecies, level: number, options: EnemyPokemonOptions | Pokemon = {}) {
+    const finalSpecies = getPokemonSpecies(activeOverrides.ENEMY_SPECIES_OVERRIDE) ?? species;
+    const finalLevel = activeOverrides.ENEMY_LEVEL_OVERRIDE || level;
 
-    this.trainerSlot = trainerSlot;
+    super(236, 84, finalSpecies, finalLevel, options);
+
     this.initialTeamIndex = globalScene.currentBattle?.enemyParty.length ?? 0;
-    // if a dataSource is provided, then it was populated from dataSource
-    this.isPopulatedFromDataSource = !!dataSource;
-    if (boss) {
-      this.setBoss(boss, dataSource?.bossSegments);
-    }
+    this.isPopulatedFromDataSource = isPokemon(options) || options instanceof PokemonData;
+
+    this.trainerSlot = options["trainerSlot"] ?? TrainerSlot.NONE;
+
+    const bossSegmentsOverride = activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE;
+    const boss =
+      (bossSegmentsOverride == null || bossSegmentsOverride > 0)
+      && (bossSegmentsOverride != null
+        || !!options.boss
+        || (options["bossSegments"] != null && options["bossSegments"] > 0));
+    const bossSegments: number | nil = bossSegmentsOverride != null ? bossSegmentsOverride : options["bossSegments"];
+    this.setBoss(boss, bossSegments);
 
     if (activeOverrides.ENEMY_STATUS_OVERRIDE) {
       this.setStatus(activeOverrides.ENEMY_STATUS_OVERRIDE, { sleepTurnsRemaining: 4 });
-    }
-
-    if (activeOverrides.ENEMY_GENDER_OVERRIDE) {
-      this.gender = activeOverrides.ENEMY_GENDER_OVERRIDE;
     }
 
     const speciesId = this.species.speciesId;
@@ -102,38 +84,27 @@ export class EnemyPokemon extends Pokemon {
       this.formIndex = activeOverrides.ENEMY_FORM_OVERRIDES[speciesId];
     }
 
-    if (!dataSource) {
+    if (options["moveset"] == null) {
       this.generateAndPopulateMoveset();
-
-      if (shiny === false || activeOverrides.ENEMY_SHINY_OVERRIDE === false) {
-        this.shiny = false;
-      } else {
-        this.trySetShiny();
-      }
-
-      if (!this.shiny && activeOverrides.ENEMY_SHINY_OVERRIDE) {
-        this.shiny = true;
-        this.initShinySparkle();
-      }
-
-      if (this.shiny) {
-        this.variant = this.generateShinyVariant();
-        if (activeOverrides.ENEMY_VARIANT_OVERRIDE !== null) {
-          this.variant = activeOverrides.ENEMY_VARIANT_OVERRIDE;
-        }
-      }
-
-      let sId = species.speciesId;
-      let preEvolution: SpeciesId = pokemonPreEvolutions[sId];
-      while (preEvolution) {
-        sId = preEvolution;
-        preEvolution = pokemonPreEvolutions[sId];
-      }
-
-      this.teraType = randSeedItem(this.getTypes(false, false, true));
     }
 
-    this.aiType = boss || this.hasTrainer() ? AiType.SMART : AiType.SMART_RANDOM;
+    this.gender = activeOverrides.ENEMY_GENDER_OVERRIDE ?? this.gender;
+    this.shiny = activeOverrides.ENEMY_SHINY_OVERRIDE ?? this.shiny;
+    this.variant = activeOverrides.ENEMY_VARIANT_OVERRIDE ?? this.variant;
+    if (this.shiny) {
+      this.initShinySparkle();
+    }
+
+    this.nature = activeOverrides.ENEMY_NATURE_OVERRIDE ?? this.nature;
+    this.calculateStats();
+
+    this.teraType = options.teraType ?? randSeedItem(this.getTypes(false, false, true));
+
+    this.aiType = this.boss || this.hasTrainer() ? AiType.SMART : AiType.SMART_RANDOM;
+  }
+
+  public override get boss(): boolean {
+    return this.bossSegments > 0;
   }
 
   initBattleInfo(): void {
@@ -147,17 +118,26 @@ export class EnemyPokemon extends Pokemon {
   }
 
   /**
-   * Sets the pokemons boss status. If true initializes the boss segments either from the arguments
-   * or through the the Scene.getEncounterBossSegments function
+   * Sets the Pokemon's Boss status and boss bars.
+   * @param boss - (Default `true`) Whether or not to set this Pokemon as a Boss
+   * @param bossSegments - (Default `null`) The number of boss bars to grant this Pokemon.
+   * If `null`, the number of boss bars is determined with {@linkcode globalScene.getEncounterBossSegments}.
+   * If {@linkcode boss} is `false`, the Pokemon's boss bars are always set to 0.
    *
-   * @param boss if the pokemon is a boss
-   * @param bossSegments amount of boss segments (health-bar segments)
+   * @privateRemarks
+   * {@linkcode bossSegments} should never be set to 0 when {@linkcode boss} is `true`.
+   * Setting {@linkcode bossSegments} to 0 implies that the Pokemon is not a boss.
    */
-  setBoss(boss: boolean = true, bossSegments: number = 0): void {
+  setBoss(boss: boolean = true, bossSegments: number | null = null): void {
     if (boss) {
       this.bossSegments =
         bossSegments
-        || globalScene.getEncounterBossSegments(globalScene.currentBattle.waveIndex, this.level, this.species, true);
+        ?? globalScene.getEncounterBossSegments(
+          globalScene.currentBattle?.waveIndex ?? 0,
+          this.level,
+          this.species,
+          true,
+        );
       this.bossSegmentIndex = this.bossSegments - 1;
     } else {
       this.bossSegments = 0;
@@ -516,10 +496,6 @@ export class EnemyPokemon extends Pokemon {
     return this.trainerSlot !== TrainerSlot.NONE;
   }
 
-  isBoss(): boolean {
-    return this.bossSegments > 0;
-  }
-
   getBossSegments(): number {
     return this.bossSegments;
   }
@@ -546,7 +522,7 @@ export class EnemyPokemon extends Pokemon {
       return 0;
     }
 
-    let clearedBossSegmentIndex = this.isBoss() ? this.bossSegmentIndex + 1 : 0;
+    let clearedBossSegmentIndex = this.boss ? this.bossSegmentIndex + 1 : 0;
 
     /**
      * Modify the damage with the {@linkcode DYNAMAX_DAMAGE_TAKEN_FACTOR} for the checks
@@ -554,7 +530,7 @@ export class EnemyPokemon extends Pokemon {
      */
     amount = this.isMax(false) && !ignoreDynamaxReduction ? toDmgValue(amount * DYNAMAX_DAMAGE_TAKEN_FACTOR) : amount;
 
-    if (this.isBoss() && !ignoreSegments) {
+    if (this.boss && !ignoreSegments) {
       // To consider a boss Pokemon as 1-hit faint, the damage calculation is different and depends on the hp segments.
       // Every segment past the first one gets a `x SegmentIndex` multiplier.
       // E.g. if the boss has 3 segments and each with 10 hp, the damage for the 1-hit faint must be at least `60`,
@@ -596,7 +572,7 @@ export class EnemyPokemon extends Pokemon {
 
     const damage = super.damage(amount, { preventEndure, ignoreFaintPhase, ignoreDynamaxReduction });
 
-    if (this.isBoss()) {
+    if (this.boss) {
       if (ignoreSegments) {
         const segmentSize = this.getMaxHp() / this.bossSegments;
         clearedBossSegmentIndex = Math.ceil(this.hp / segmentSize);
@@ -699,7 +675,7 @@ export class EnemyPokemon extends Pokemon {
       this.metBiome = globalScene.arena.biomeId;
       this.metWave = globalScene.currentBattle.waveIndex;
       this.metSpecies = this.species.speciesId;
-      const newPokemon = globalScene.addPlayerPokemon(this.species, this.level, { dataSource: this });
+      const newPokemon = globalScene.addPlayerPokemon(this.species, this.level, this);
 
       if (isBetween(slotIndex, 0, PLAYER_PARTY_MAX_SIZE - 1)) {
         party.splice(slotIndex, 0, newPokemon);

--- a/src/field/enemy-pokemon.ts
+++ b/src/field/enemy-pokemon.ts
@@ -20,7 +20,7 @@ import { SpeciesId } from "#enums/species-id";
 import { EFFECTIVE_STATS, type EffectiveStat } from "#enums/stat";
 import { TrainerSlot } from "#enums/trainer-slot";
 import type { PlayerPokemon } from "#field/player-pokemon";
-import { Pokemon } from "#field/pokemon";
+import { Pokemon, type PokemonOptions } from "#field/pokemon";
 import { PokemonMove } from "#field/pokemon-move";
 import { SpeciesFormChangeActiveTrigger } from "#form-change-triggers/species-form-change-active-trigger";
 import { CounterDamageAttr } from "#moves/counter-damage-attr";
@@ -31,6 +31,12 @@ import type { TurnMove } from "#types/move-types";
 import { EnemyBattleInfo } from "#ui/battle-info";
 import { isBetween, toDmgValue } from "#utils/common-utils";
 import { randSeedInt, randSeedItem } from "#utils/random-utils";
+
+export interface EnemyPokemonOptions extends PokemonOptions {
+  trainerSlot?: TrainerSlot;
+  boss?: boolean;
+  dataSource?: PokemonData;
+}
 
 export class EnemyPokemon extends Pokemon {
   public trainerSlot: TrainerSlot;
@@ -46,25 +52,29 @@ export class EnemyPokemon extends Pokemon {
   constructor(
     species: PokemonSpecies,
     level: number,
-    trainerSlot: TrainerSlot,
-    boss: boolean,
-    shinyLock: boolean = false,
-    dataSource?: PokemonData,
-  ) {
-    super(
-      236,
-      84,
-      species,
-      level,
-      dataSource?.abilityIndex,
-      dataSource?.formIndex,
-      dataSource?.gender,
-      !shinyLock && dataSource ? dataSource.shiny : false,
-      !shinyLock && dataSource ? dataSource.variant : undefined,
-      undefined,
-      dataSource ? dataSource.nature : undefined,
+    {
+      abilityIndex,
+      formIndex,
+      gender,
+      shiny,
+      variant,
+      ivs,
+      nature,
+      trainerSlot = TrainerSlot.NONE,
+      boss = false,
       dataSource,
-    );
+    }: EnemyPokemonOptions = {},
+  ) {
+    super(236, 84, species, level, {
+      abilityIndex,
+      formIndex,
+      gender,
+      shiny,
+      variant,
+      ivs,
+      nature,
+      dataSource,
+    });
 
     this.trainerSlot = trainerSlot;
     this.initialTeamIndex = globalScene.currentBattle?.enemyParty.length ?? 0;
@@ -95,7 +105,7 @@ export class EnemyPokemon extends Pokemon {
     if (!dataSource) {
       this.generateAndPopulateMoveset();
 
-      if (shinyLock || activeOverrides.ENEMY_SHINY_OVERRIDE === false) {
+      if (shiny === false || activeOverrides.ENEMY_SHINY_OVERRIDE === false) {
         this.shiny = false;
       } else {
         this.trySetShiny();
@@ -689,18 +699,7 @@ export class EnemyPokemon extends Pokemon {
       this.metBiome = globalScene.arena.biomeId;
       this.metWave = globalScene.currentBattle.waveIndex;
       this.metSpecies = this.species.speciesId;
-      const newPokemon = globalScene.addPlayerPokemon(
-        this.species,
-        this.level,
-        this.abilityIndex,
-        this.formIndex,
-        this.gender,
-        this.shiny,
-        this.variant,
-        this.ivs,
-        this.nature,
-        this,
-      );
+      const newPokemon = globalScene.addPlayerPokemon(this.species, this.level, { dataSource: this });
 
       if (isBetween(slotIndex, 0, PLAYER_PARTY_MAX_SIZE - 1)) {
         party.splice(slotIndex, 0, newPokemon);

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -8,20 +8,17 @@ import type { SpeciesFormChange } from "#data/pokemon-forms";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { CLASSIC_CANDY_FRIENDSHIP_MULTIPLIER, getCandyProgressRequirement, speciesStarterCosts } from "#data/starters";
 import { reverseCompatibleTms, tmSpecies } from "#data/tms";
-import type { Variant } from "#data/variant";
 import { AbilityId } from "#enums/ability-id";
 import type { FieldBattlerIndex } from "#enums/battler-index";
 import { EventModifierType } from "#enums/event-modifier-type";
 import { Gender } from "#enums/gender";
 import type { MoveId } from "#enums/move-id";
-import type { Nature } from "#enums/nature";
 import { SpeciesId } from "#enums/species-id";
 import type { EnemyPokemon } from "#field/enemy-pokemon";
-import { Pokemon } from "#field/pokemon";
+import { Pokemon, type PokemonOptions } from "#field/pokemon";
 import { pokemonEvolutions } from "#init/init-pokemon-evolutions";
 import { EvoTrackerModifier, PokemonFriendshipBoosterModifier, type PokemonHeldItemModifier } from "#modifier/modifier";
 import { achvs } from "#system/achievements";
-import type { PokemonData } from "#system/pokemon-data";
 import type { StarterMoveset } from "#types/starter-data";
 import { PlayerBattleInfo } from "#ui/battle-info";
 import { NumberHolder } from "#utils/common-utils";
@@ -33,16 +30,9 @@ export class PlayerPokemon extends Pokemon {
   constructor(
     species: PokemonSpecies,
     level: number,
-    abilityIndex?: number,
-    formIndex?: number,
-    gender?: Gender,
-    shiny?: boolean,
-    variant?: Variant,
-    ivs?: number[],
-    nature?: Nature,
-    dataSource?: Pokemon | PokemonData,
+    { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource }: PokemonOptions = {},
   ) {
-    super(106, 148, species, level, abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource);
+    super(106, 148, species, level, { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource });
 
     if (activeOverrides.STATUS_OVERRIDE) {
       this.setStatus(activeOverrides.STATUS_OVERRIDE, { sleepTurnsRemaining: 4 });
@@ -220,33 +210,25 @@ export class PlayerPokemon extends Pokemon {
     }
   }
 
-  getPossibleEvolution(evolution: SpeciesFormEvolution | null): Promise<Pokemon> {
+  public async getPossibleEvolution(evolution: SpeciesFormEvolution | null): Promise<Pokemon> {
     if (!evolution) {
-      return new Promise((resolve) => resolve(this));
+      return this;
     }
-    return new Promise((resolve) => {
-      const evolutionSpecies = getPokemonSpecies(evolution.speciesId);
-      const formIndex =
-        evolution.evoFormKey !== null
-          ? Math.max(
-              evolutionSpecies.forms.findIndex((f) => f.formKey === evolution.evoFormKey),
-              0,
-            )
-          : this.formIndex;
-      const ret = globalScene.addPlayerPokemon(
-        evolutionSpecies,
-        this.level,
-        this.abilityIndex,
-        formIndex,
-        this.gender,
-        this.shiny,
-        this.variant,
-        this.ivs,
-        this.nature,
-        this,
-      );
-      ret.loadAssets().then(() => resolve(ret));
+
+    const evolutionSpecies = getPokemonSpecies(evolution.speciesId);
+    const formIndex =
+      evolution.evoFormKey !== null
+        ? Math.max(
+            evolutionSpecies.forms.findIndex((f) => f.formKey === evolution.evoFormKey),
+            0,
+          )
+        : this.formIndex;
+    const ret = globalScene.addPlayerPokemon(evolutionSpecies, this.level, {
+      formIndex,
+      dataSource: this,
     });
+    await ret.loadAssets();
+    return ret;
   }
 
   /**
@@ -312,22 +294,20 @@ export class PlayerPokemon extends Pokemon {
   }
 
   private handleShedinjaEvolution(evolution: SpeciesFormEvolution) {
+    const { abilityIndex, formIndex, shiny, variant, ivs, nature } = this;
     const { speciesId } = this.species;
     if (speciesId === SpeciesId.NINCADA && evolution.speciesId === SpeciesId.NINJASK) {
       const newEvolution = pokemonEvolutions[speciesId][1];
 
       if (newEvolution.conditions?.every((condition) => condition.predicate(this))) {
-        const newPokemon = globalScene.addPlayerPokemon(
-          this.species,
-          this.level,
-          this.abilityIndex,
-          this.formIndex,
-          undefined,
-          this.shiny,
-          this.variant,
-          this.ivs,
-          this.nature,
-        );
+        const newPokemon = globalScene.addPlayerPokemon(this.species, this.level, {
+          abilityIndex,
+          formIndex,
+          shiny,
+          variant,
+          ivs,
+          nature,
+        });
         newPokemon.passive = this.passive;
         this.copyMoveset(newPokemon);
         newPokemon.gender = Gender.GENDERLESS;
@@ -353,26 +333,23 @@ export class PlayerPokemon extends Pokemon {
     }
   }
 
-  getPossibleForm(formChange: SpeciesFormChange): Promise<Pokemon> {
-    return new Promise((resolve) => {
-      const formIndex = Math.max(
-        this.species.forms.findIndex((f) => f.formKey === formChange.formKey),
-        0,
-      );
-      const ret = globalScene.addPlayerPokemon(
-        this.species,
-        this.level,
-        this.abilityIndex,
-        formIndex,
-        this.gender,
-        this.shiny,
-        this.variant,
-        this.ivs,
-        this.nature,
-        this,
-      );
-      ret.loadAssets().then(() => resolve(ret));
+  public async getPossibleForm(formChange: SpeciesFormChange): Promise<Pokemon> {
+    const { abilityIndex, gender, shiny, variant, ivs, nature } = this;
+    const formIndex = Math.max(
+      this.species.forms.findIndex((f) => f.formKey === formChange.formKey),
+      0,
+    );
+    const ret = globalScene.addPlayerPokemon(this.species, this.level, {
+      abilityIndex,
+      formIndex,
+      gender,
+      shiny,
+      variant,
+      ivs,
+      nature,
     });
+    await ret.loadAssets();
+    return ret;
   }
 
   override changeForm(formChange: SpeciesFormChange): Promise<void> {

--- a/src/field/player-pokemon.ts
+++ b/src/field/player-pokemon.ts
@@ -27,29 +27,22 @@ import { getPokemonSpecies } from "#utils/pokemon-utils";
 export class PlayerPokemon extends Pokemon {
   public compatibleTms: MoveId[];
 
-  constructor(
-    species: PokemonSpecies,
-    level: number,
-    { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource }: PokemonOptions = {},
-  ) {
-    super(106, 148, species, level, { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource });
+  constructor(species: PokemonSpecies, level: number, options: PokemonOptions | Pokemon = {}) {
+    super(106, 148, species, level, options);
 
     if (activeOverrides.STATUS_OVERRIDE) {
       this.setStatus(activeOverrides.STATUS_OVERRIDE, { sleepTurnsRemaining: 4 });
     }
 
-    if (activeOverrides.SHINY_OVERRIDE) {
-      this.shiny = true;
+    this.shiny = activeOverrides.SHINY_OVERRIDE ?? this.shiny;
+    this.variant = activeOverrides.VARIANT_OVERRIDE ?? this.variant;
+    if (this.shiny) {
       this.initShinySparkle();
-    } else if (activeOverrides.SHINY_OVERRIDE === false) {
-      this.shiny = false;
     }
 
-    if (activeOverrides.VARIANT_OVERRIDE !== null && this.shiny) {
-      this.variant = activeOverrides.VARIANT_OVERRIDE;
-    }
+    this.nature = activeOverrides.NATURE_OVERRIDE ?? this.nature;
 
-    if (!dataSource) {
+    if (options["moveset"] == null) {
       if (
         globalScene.gameMode.isDaily
         || (activeOverrides.STARTER_SPECIES_OVERRIDE && activeOverrides.STARTER_SPECIES_OVERRIDE !== SpeciesId.KELDEO)
@@ -79,7 +72,7 @@ export class PlayerPokemon extends Pokemon {
     return true;
   }
 
-  isBoss(): boolean {
+  public override get boss(): boolean {
     return false;
   }
 
@@ -223,10 +216,7 @@ export class PlayerPokemon extends Pokemon {
             0,
           )
         : this.formIndex;
-    const ret = globalScene.addPlayerPokemon(evolutionSpecies, this.level, {
-      formIndex,
-      dataSource: this,
-    });
+    const ret = globalScene.addPlayerPokemon(evolutionSpecies, this.level, { ...this, formIndex });
     await ret.loadAssets();
     return ret;
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -146,7 +146,6 @@ import { VariableMoveCategoryAttr } from "#moves/variable-move-category-attr";
 import { VariableMoveTypeAttr } from "#moves/variable-move-type-attr";
 import { VariableMoveTypeChartAttr } from "#moves/variable-move-type-chart-attr";
 import { VariableMoveTypeMultiplierAttr } from "#moves/variable-move-type-multiplier-attr";
-import type { PokemonData } from "#system/pokemon-data";
 import { settings } from "#system/settings-manager";
 import type { AbAttrKey, AbAttrMap, AbilityFilterOptions } from "#types/ability-types";
 import type { DamageCalculationResult, DamageResult, LevelMoves, TurnMove } from "#types/move-types";
@@ -166,6 +165,7 @@ import {
   clamp,
   coerceArray,
   fixedNumber,
+  isBetween,
   NumberHolder,
   toDmgValue,
   ValueHolder,
@@ -178,14 +178,36 @@ import { inSpeedOrder } from "#utils/speed-order-generator";
 import i18next from "i18next";
 
 export interface PokemonOptions {
+  id?: number;
+  nickname?: string | null;
+  personalityValue?: number;
+  stats?: number[];
+  ivs?: number[];
+  nature?: Nature;
+  moveset?: PokemonMove[];
   abilityIndex?: number;
+  passive?: boolean;
   formIndex?: number;
   gender?: Gender;
   shiny?: boolean;
   variant?: Variant;
-  ivs?: number[];
-  nature?: Nature;
-  dataSource?: Pokemon | PokemonData;
+  pokeball?: PokeballType;
+  hp?: number;
+  status?: Status | null;
+  exp?: number;
+  friendship?: number;
+  pokerus?: boolean;
+  metLevel?: number;
+  metBiome?: BiomeId | -1;
+  metSpecies?: SpeciesId;
+  metWave?: number;
+  evoCounter?: number;
+  usedTMs?: MoveId[];
+  pauseEvolutions?: boolean;
+  teraType?: ElementalType;
+  isTerastallized?: boolean;
+  stellarTypesBoosted?: ElementalType[];
+  customPokemonData?: Partial<CustomPokemonData>;
 }
 
 interface AbilityData {
@@ -231,7 +253,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * @see {@link https://bulbapedia.bulbagarden.net/wiki/Personality_value}
    */
   public personalityValue: number;
-  public nickname: string;
+  public nickname: string | null;
   public species: PokemonSpecies;
   public formIndex: number;
   public abilityIndex: number;
@@ -242,14 +264,13 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   protected battleInfo: BattleInfo;
   public level: number;
   public exp: number;
-  public levelExp: number;
   public gender: Gender;
   public hp: number;
   public stats: number[];
   public ivs: number[];
   public nature: Nature;
   protected moveset: PokemonMove[];
-  protected status: Status | null = null;
+  protected status: Status | null;
   public friendship: number;
   public metLevel: number;
   public metBiome: BiomeId | -1;
@@ -285,117 +306,71 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
   private shinySparkle: Phaser.GameObjects.Sprite;
 
-  constructor(
-    x: number,
-    y: number,
-    species: PokemonSpecies,
-    level: number,
-    { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource }: PokemonOptions = {},
-  ) {
+  constructor(x: number, y: number, species: PokemonSpecies, level: number, options: PokemonOptions | Pokemon = {}) {
     super(globalScene, x, y);
     this.type = "Pokemon";
 
     this.species = species;
-    // The `EnemyPokemon` constructor randomly picks from both types if applicable
-    this.teraType = species.type1;
-    this.pokeball = dataSource?.pokeball || PokeballType.POKEBALL;
     this.level = level;
+    this.exp = options.exp ?? getLevelTotalExp(level, species.growthRate);
+    this.friendship = options.friendship ?? this.species.baseFriendship;
+    this.pokeball = options.pokeball ?? PokeballType.POKEBALL;
     this.switchOutStatus = false;
 
-    if (abilityIndex != null) {
-      this.abilityIndex = abilityIndex;
+    // This may increment `nextPokemonID` twice, but shouldn't have any adverse effects...
+    this.id = options.id ?? globalScene.getNextPokemonID();
+    globalScene.updateNextPokemonID(this.id);
+
+    this.nickname = options.nickname ?? null;
+    this.personalityValue = options.personalityValue ?? this.randSeedInt(Math.pow(2, 32) - 1);
+
+    this.gender = options.gender ?? this.generateGender();
+
+    this.shiny = options.shiny ?? this.trySetShiny();
+    this.variant = options.variant ?? this.generateShinyVariant();
+
+    this.formIndex =
+      options.formIndex ?? globalScene.getSpeciesFormIndex(species, this.gender, this.nature, this.isPlayer());
+
+    this.resetCustomPokemonData(options.customPokemonData);
+
+    this.ivs = this.getIvOverrides() ?? options.ivs ?? this.generateIvs();
+    this.nature = options.nature ?? randSeedItem(Object.values(Nature));
+    if (options.stats != null) {
+      this.stats = options.stats;
     } else {
-      this.generateRandomAbility();
-    }
-    if (formIndex != null) {
-      this.formIndex = formIndex;
-    }
-    if (gender != null) {
-      this.gender = gender;
-    }
-    if (shiny != null) {
-      this.shiny = shiny;
-    }
-    if (variant != null) {
-      this.variant = variant;
-    }
-    this.exp = dataSource?.exp || getLevelTotalExp(this.level, species.growthRate);
-    this.levelExp = dataSource?.levelExp || 0;
-    if (dataSource) {
-      this.id = dataSource.id;
-      globalScene.updateNextPokemonID(this.id);
-      this.personalityValue = dataSource.personalityValue;
-      this.hp = dataSource.hp;
-      this.stats = dataSource.stats;
-      this.ivs = dataSource.ivs;
-      this.passive = dataSource.passive;
-      if (this.variant === undefined) {
-        this.variant = 0;
-      }
-      this.nature = dataSource.nature || (0 as Nature);
-      this.nickname = dataSource.nickname;
-      this.moveset = dataSource["moveset"];
-      this.status = dataSource["status"];
-      this.friendship = dataSource.friendship ?? this.species.baseFriendship;
-      this.metLevel = dataSource.metLevel || 5;
-      this.metBiome = dataSource.metBiome;
-      this.metSpecies =
-        dataSource.metSpecies ?? (this.metBiome !== -1 ? this.species.speciesId : this.species.getRootSpeciesId(true));
-      this.metWave = dataSource.metWave ?? (this.metBiome === -1 ? -1 : 0);
-      this.pauseEvolutions = dataSource.pauseEvolutions;
-      this.pokerus = dataSource.pokerus;
-      this.evoCounter = dataSource.evoCounter ?? 0;
-      this.usedTMs = dataSource.usedTMs ?? [];
-      this.resetCustomPokemonData(dataSource.customPokemonData);
-      this.teraType = dataSource.teraType;
-      this.isTerastallized = dataSource.isTerastallized;
-      this.stellarTypesBoosted = dataSource.stellarTypesBoosted ?? [];
-    } else {
-      this.id = globalScene.getNextPokemonID();
-      this.personalityValue = this.randSeedInt(Math.pow(2, 32) - 1);
-      this.ivs = ivs || this.generateIvs();
-
-      if (this.gender === undefined) {
-        this.generateGender();
-      }
-
-      if (this.formIndex === undefined) {
-        this.formIndex = globalScene.getSpeciesFormIndex(species, this.gender, this.nature, this.isPlayer());
-      }
-
-      if (this.shiny === undefined) {
-        this.trySetShiny();
-      }
-
-      if (this.variant === undefined) {
-        this.variant = this.shiny ? this.generateShinyVariant() : 0;
-      }
-
-      this.resetCustomPokemonData();
-
-      if (nature != null) {
-        this.setNature(nature);
-      } else {
-        this.generateNature();
-      }
-
-      this.friendship = species.baseFriendship;
-      this.metLevel = level;
-      this.metBiome = globalScene.currentBattle ? globalScene.arena.biomeId : -1;
-      this.metSpecies = species.speciesId;
-      this.metWave = globalScene.currentBattle ? globalScene.currentBattle.waveIndex : -1;
-      this.pokerus = false;
-    }
-
-    this.generateName();
-
-    if (!dataSource) {
       this.calculateStats();
     }
+    this.hp = options.hp ?? this.getMaxHp();
 
+    this.abilityIndex = options.abilityIndex ?? this.generateRandomAbility();
+    this.passive = options.passive ?? false;
+
+    this.moveset = options["moveset"] ?? [];
+    this.status = options["status"] ?? null;
+
+    this.metLevel = options.metLevel ?? level;
+    this.metBiome = options.metBiome ?? (globalScene.currentBattle ? globalScene.arena.biomeId : -1);
+    this.metSpecies = options.metSpecies ?? species.speciesId;
+    this.metWave = options.metWave ?? globalScene.currentBattle?.waveIndex ?? -1;
+    this.pokerus = options.pokerus ?? false;
+    this.usedTMs = options.usedTMs ?? [];
+    this.pauseEvolutions = options.pauseEvolutions ?? false;
+
+    // The `EnemyPokemon` constructor randomly picks from both types if applicable
+    this.teraType = options.teraType ?? species.type1;
+    this.isTerastallized = options.isTerastallized ?? false;
+    this.stellarTypesBoosted = options.stellarTypesBoosted ?? [];
+
+    this.generateName();
     this.resetWaveData();
     this.resetTurnData();
     this.resetSummonData();
+  }
+
+  /** The amount of exp the Pokemon has earned within its current level */
+  public get levelExp(): number {
+    return this.exp - getLevelTotalExp(this.level, this.species.growthRate);
   }
 
   /**
@@ -477,6 +452,40 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
   }
 
+  /**
+   * Determines the IV override for this Pokemon (either {@linkcode activeOverrides.IVS_OVERRIDE | IVS_OVERRIDE}
+   * or {@linkcode activeOverrides.ENEMY_IVS_OVERRIDE | ENEMY_IVS_OVERRIDE}), validates it, and
+   * returns it as a 6-element array if valid.
+   * If defined, the override must be one of the following:
+   * - A `number` between 0 and 31 (inclusive) to assign a single IV to all {@link PERMANENT_STATS | stats}.
+   * - A `number` array with 6 elements between 0 and 31 to assign a distinct IV to each stat.
+   * @returns The validated override as a 6-element array, or `null` if the override isn't defined.
+   * @throws if the override is defined, but doesn't meet the above conditions.
+   */
+  protected getIvOverrides(): number[] | null {
+    const ivOverride = this.isPlayer() ? activeOverrides.IVS_OVERRIDE : activeOverrides.ENEMY_IVS_OVERRIDE;
+    const errorTarget = this.isPlayer() ? "Player" : "Enemy";
+
+    if (ivOverride == null) {
+      return null;
+    }
+
+    if (Array.isArray(ivOverride)) {
+      if (ivOverride.length !== 6) {
+        throw new Error(`The ${errorTarget} IVs override must be an array of length 6 or a number!`);
+      }
+      if (ivOverride.some((value) => !isBetween(value, IV_MIN, IV_MAX))) {
+        throw new Error(`All IVs in the ${errorTarget} IV override must be between ${IV_MIN} and ${IV_MAX}!`);
+      }
+      return ivOverride;
+    }
+
+    if (!isBetween(ivOverride, IV_MIN, IV_MAX)) {
+      throw new Error(`The ${errorTarget} IV override must be a value between ${IV_MIN} and ${IV_MAX}!`);
+    }
+    return new Array(6).fill(ivOverride);
+  }
+
   /** @returns An array of 6 random numbers, each between `0-31` inclusive */
   public generateIvs(): number[] {
     const ivs: number[] = [];
@@ -489,21 +498,19 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   /**
    * Sets this Pokemon to have a random ability, including a small chance of generating its Hidden Ability.
    */
-  generateRandomAbility(): void {
-    const hiddenAbilityChance = new NumberHolder(BASE_HIDDEN_ABILITY_CHANCE);
+  private generateRandomAbility(): number {
+    const hiddenAbilityChance = new ValueHolder(BASE_HIDDEN_ABILITY_CHANCE);
     if (!this.hasTrainer()) {
       globalScene.applyModifiers(HiddenAbilityRateBoosterModifier, true, hiddenAbilityChance);
     }
 
     const hasHiddenAbility = !randSeedInt(hiddenAbilityChance.value);
     const randAbilityIndex = randSeedInt(2);
+
     if (this.species.abilityHidden && hasHiddenAbility) {
-      // If the species has a hidden ability and the hidden ability is present
-      this.abilityIndex = 2;
-    } else {
-      // If there is no hidden ability or species does not have a hidden ability
-      this.abilityIndex = this.species.ability2 !== this.species.ability1 ? randAbilityIndex : 0; // Use random ability index if species has a second ability, otherwise use 0
+      return 2;
     }
+    return this.species.ability2 !== this.species.ability1 ? randAbilityIndex : 0;
   }
 
   getNameToRender() {
@@ -1301,14 +1308,14 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   /** Sets the pokemon's gender based on its species gender ratios */
-  protected generateGender(): void {
+  private generateGender(): Gender {
     if (this.species.malePercent === null) {
-      this.gender = Gender.GENDERLESS;
-    } else if (Phaser.Math.RND.frac() * 100 < this.species.malePercent) {
-      this.gender = Gender.MALE;
-    } else {
-      this.gender = Gender.FEMALE;
+      return Gender.GENDERLESS;
     }
+    if (Phaser.Math.RND.frac() * 100 < this.species.malePercent) {
+      return Gender.MALE;
+    }
+    return Gender.FEMALE;
   }
 
   public getGender(bypassSummonData: boolean = false): Gender {
@@ -1327,14 +1334,15 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     return this.variant;
   }
 
-  abstract isBoss(): boolean;
+  /** @returns `true` if this Pokemon is a Boss */
+  public abstract get boss(): boolean;
 
   abstract getBossSegments(): number;
 
   abstract getBossSegmentIndex(): number;
 
   /**
-   * @param bypassSummonData - (Default `true`) Whether to get the Pokemon's actual/unmodified moveset (`true`)
+   * @param bypassSummonData - (Default `false`) Whether to get the Pokemon's actual/unmodified moveset (`true`)
    *   or the Pokemon's temporary/modified moveset (such as due to Transform) (`false`).
    * @returns The Pokemon's active moveset
    */
@@ -1701,7 +1709,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       return false;
     }
 
-    return this.passive || this.isBoss();
+    return this.passive || this.boss;
   }
 
   /**
@@ -2140,7 +2148,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       const evolutionChain = this.species.getSimulatedEvolutionChain(
         this.level,
         this.hasTrainer(),
-        this.isBoss(),
+        this.boss,
         this.isPlayer(),
       );
       for (let e = 0; e < evolutionChain.length; e++) {
@@ -2311,6 +2319,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
    * - Has a 60% chance of returning `0` (basic shiny)
    */
   protected generateShinyVariant(): Variant {
+    if (!this.shiny) {
+      return 0;
+    }
     const formIndex: number = this.formIndex;
     let variantDataIndex: string | number = this.species.speciesId;
     if (this.species.forms.length > 0) {
@@ -2320,10 +2331,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
     }
     // Checks if there is no variant data for both the index or index with form
-    if (
-      !this.shiny
-      || (!Object.hasOwn(variantData, variantDataIndex) && !Object.hasOwn(variantData, this.species.speciesId))
-    ) {
+    if (!Object.hasOwn(variantData, variantDataIndex) && !Object.hasOwn(variantData, this.species.speciesId)) {
       return 0;
     }
     const rand = new NumberHolder(0);
@@ -2412,7 +2420,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
           this.level >= 170
           && !movePool.some((m) => m[0] === moveId)
           && !allMoves.get(moveId).name.endsWith(" (N)")
-          && !this.isBoss()
+          && !this.boss
         ) {
           movePool.push([moveId, 30]);
         }
@@ -2420,7 +2428,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
 
     // Bosses never get self ko moves
-    if (this.isBoss()) {
+    if (this.boss) {
       movePool = movePool.filter((m) => !allMoves.get(m[0]).hasAttr(SacrificialAttr));
     }
     if (this.hasTrainer()) {
@@ -2473,7 +2481,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     if (this.hasTrainer()) {
       weightMultiplier += 0.7;
     }
-    if (this.isBoss()) {
+    if (this.boss) {
       weightMultiplier += 0.4;
     }
     const baseWeights: [MoveId, number][] = movePool.map((m) => [
@@ -2482,7 +2490,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     ]);
 
     // Trainers and bosses always force a stab move
-    if (this.hasTrainer() || this.isBoss()) {
+    if (this.hasTrainer() || this.boss) {
       const stabMovePool = baseWeights.filter(
         (m) => allMoves.get(m[0]).category !== MoveCategory.STATUS && this.isOfType(allMoves.get(m[0]).type),
       );
@@ -2580,7 +2588,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       let xOffset = -150;
       if (this.isPlayer()) {
         xOffset = 150;
-      } else if (this.isBoss()) {
+      } else if (this.boss) {
         xOffset = -198;
       }
       this.battleInfo.setX(this.battleInfo.x + xOffset);
@@ -2590,7 +2598,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       }
       globalScene.tweens.add({
         targets: [this.battleInfo, this.battleInfo.expMaskRect],
-        x: this.isPlayer() ? "-=150" : `+=${this.isBoss() ? 246 : 150}`,
+        x: this.isPlayer() ? "-=150" : `+=${this.boss ? 246 : 150}`,
         duration: 1000,
         ease: "Cubic.easeOut",
       });
@@ -2602,7 +2610,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       if (this.battleInfo?.visible) {
         globalScene.tweens.add({
           targets: [this.battleInfo, this.battleInfo.expMaskRect],
-          x: this.isPlayer() ? "+=150" : `-=${this.isBoss() ? 246 : 150}`,
+          x: this.isPlayer() ? "+=150" : `-=${this.boss ? 246 : 150}`,
           duration: 500,
           ease: "Cubic.easeIn",
           onComplete: () => {
@@ -2613,7 +2621,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
             let xOffset = -150;
             if (this.isPlayer()) {
               xOffset = 150;
-            } else if (this.isBoss()) {
+            } else if (this.boss) {
               xOffset = -198;
             }
             this.battleInfo.setX(this.battleInfo.x - xOffset);
@@ -2669,7 +2677,6 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       console.log(initialExp, this.exp, getLevelTotalExp(this.level, this.species.growthRate));
       this.exp = Math.max(getLevelTotalExp(this.level, this.species.growthRate), initialExp);
     }
-    this.levelExp = this.exp - getLevelTotalExp(this.level, this.species.growthRate);
   }
 
   /**
@@ -3078,7 +3085,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     applyMoveAttrs(OneHitKOAttr, source, this, move, isOneHitKo);
 
     let ohkoDamage = 0;
-    if (this.isBoss()) {
+    if (this.boss) {
       // TODO: Potentially can cause a softlock against the pkr Eternatus boss on floor 200
       const segmentIndex = this.getBossSegmentIndex();
       const enemyHpAfter = Math.floor((this.getMaxHp() * segmentIndex) / this.getBossSegments());
@@ -3417,7 +3424,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   isBossImmune(): boolean {
-    return this.isBoss();
+    return this.boss;
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -177,6 +177,17 @@ import { randSeedInt, randSeedItem } from "#utils/random-utils";
 import { inSpeedOrder } from "#utils/speed-order-generator";
 import i18next from "i18next";
 
+export interface PokemonOptions {
+  abilityIndex?: number;
+  formIndex?: number;
+  gender?: Gender;
+  shiny?: boolean;
+  variant?: Variant;
+  ivs?: number[];
+  nature?: Nature;
+  dataSource?: Pokemon | PokemonData;
+}
+
 interface AbilityData {
   ability: Ability;
   passive: boolean;
@@ -279,14 +290,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     y: number,
     species: PokemonSpecies,
     level: number,
-    abilityIndex?: number,
-    formIndex?: number,
-    gender?: Gender,
-    shiny?: boolean,
-    variant?: Variant,
-    ivs?: number[],
-    nature?: Nature,
-    dataSource?: Pokemon | PokemonData,
+    { abilityIndex, formIndex, gender, shiny, variant, ivs, nature, dataSource }: PokemonOptions = {},
   ) {
     super(globalScene, x, y);
     this.type = "Pokemon";
@@ -298,23 +302,21 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.level = level;
     this.switchOutStatus = false;
 
-    // Determine the ability index
-    if (abilityIndex !== undefined) {
-      this.abilityIndex = abilityIndex; // Use the provided ability index if it is defined
+    if (abilityIndex != null) {
+      this.abilityIndex = abilityIndex;
     } else {
-      // If abilityIndex is not provided, determine it based on species and hidden ability
       this.generateRandomAbility();
     }
-    if (formIndex !== undefined) {
+    if (formIndex != null) {
       this.formIndex = formIndex;
     }
-    if (gender !== undefined) {
+    if (gender != null) {
       this.gender = gender;
     }
-    if (shiny !== undefined) {
+    if (shiny != null) {
       this.shiny = shiny;
     }
-    if (variant !== undefined) {
+    if (variant != null) {
       this.variant = variant;
     }
     this.exp = dataSource?.exp || getLevelTotalExp(this.level, species.growthRate);
@@ -371,7 +373,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
       this.resetCustomPokemonData();
 
-      if (nature !== undefined) {
+      if (nature != null) {
         this.setNature(nature);
       } else {
         this.generateNature();

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -317,9 +317,12 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.pokeball = options.pokeball ?? PokeballType.POKEBALL;
     this.switchOutStatus = false;
 
-    // This may increment `nextPokemonID` twice, but shouldn't have any adverse effects...
-    this.id = options.id ?? globalScene.getNextPokemonID();
-    globalScene.updateNextPokemonID(this.id);
+    if (options.id != null) {
+      this.id = options.id;
+      globalScene.updateNextPokemonID(this.id);
+    } else {
+      this.id = globalScene.getNextPokemonID();
+    }
 
     this.nickname = options.nickname ?? null;
     this.personalityValue = options.personalityValue ?? this.randSeedInt(Math.pow(2, 32) - 1);

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -442,11 +442,9 @@ export class Trainer extends Phaser.GameObjects.Container {
         species = this.genNewPartyMemberSpecies(level, strength);
       }
 
-      ret = globalScene.addEnemyPokemon(
-        species,
-        level,
-        !this.isDouble() || !(index % 2) ? TrainerSlot.TRAINER : TrainerSlot.TRAINER_PARTNER,
-      );
+      const trainerSlot = !this.isDouble() || !(index % 2) ? TrainerSlot.TRAINER : TrainerSlot.TRAINER_PARTNER;
+
+      ret = globalScene.addEnemyPokemon(species, level, { trainerSlot });
     }, seedOffset);
 
     return ret;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2210,7 +2210,6 @@ export class PokemonLevelIncrementModifier extends ConsumablePokemonModifier {
     playerPokemon.level += levelCount.value;
     if (playerPokemon.level <= globalScene.getMaxExpLevel(true)) {
       playerPokemon.exp = getLevelTotalExp(playerPokemon.level, playerPokemon.species.growthRate);
-      playerPokemon.levelExp = 0;
     }
 
     playerPokemon.addFriendship(FRIENDSHIP_GAIN_FROM_CANDY);

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -237,11 +237,11 @@ class DefaultOverrides {
   /**
    * Override to give the enemy Pokemon a given amount of health segments
    *
-   * - `0` (default): the health segments will be handled normally based on wave, level and species
-   * - `1`: the Pokemon will have a single health segment and therefore will not be a boss
-   * - `2+`: the Pokemon will be a boss with the given number of health segments
+   * - `null` (default): the health segments will be handled normally based on wave, level and species
+   * - `0` (or less): the Pokemon will not be generated as a boss
+   * - `1` (or more): the Pokemon will be a boss with the given number of health segments
    */
-  readonly ENEMY_HEALTH_SEGMENTS_OVERRIDE: number = 0;
+  readonly ENEMY_HEALTH_SEGMENTS_OVERRIDE: number | null = null;
   /**
    * If `true`, every enemy Pokemon Terastallizes on the first turn that it decides to use a move.
    * If `false`, this override is ignored.

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -292,18 +292,9 @@ export class AttemptCapturePhase extends PokemonPhase {
                 {
                   label: i18next.t("partyUiHandler:SUMMARY"),
                   handler: () => {
-                    const newPokemon = globalScene.addPlayerPokemon(
-                      pokemon.species,
-                      pokemon.level,
-                      pokemon.abilityIndex,
-                      pokemon.formIndex,
-                      pokemon.gender,
-                      pokemon.shiny,
-                      pokemon.variant,
-                      pokemon.ivs,
-                      pokemon.nature,
-                      pokemon,
-                    );
+                    const newPokemon = globalScene.addPlayerPokemon(pokemon.species, pokemon.level, {
+                      dataSource: pokemon,
+                    });
                     ui.setMode<SummaryUiHandler>(
                       UiMode.SUMMARY,
                       newPokemon,

--- a/src/phases/attempt-capture-phase.ts
+++ b/src/phases/attempt-capture-phase.ts
@@ -292,9 +292,7 @@ export class AttemptCapturePhase extends PokemonPhase {
                 {
                   label: i18next.t("partyUiHandler:SUMMARY"),
                   handler: () => {
-                    const newPokemon = globalScene.addPlayerPokemon(pokemon.species, pokemon.level, {
-                      dataSource: pokemon,
-                    });
+                    const newPokemon = globalScene.addPlayerPokemon(pokemon.species, pokemon.level, pokemon);
                     ui.setMode<SummaryUiHandler>(
                       UiMode.SUMMARY,
                       newPokemon,

--- a/src/phases/attempt-run-phase.ts
+++ b/src/phases/attempt-run-phase.ts
@@ -56,7 +56,7 @@ export class AttemptRunPhase extends PokemonPhase {
       playerField.reduce((total: number, playerPokemon: Pokemon) => total + playerPokemon.getStat(Stat.SPD), 0)
       / enemyField.length;
 
-    const isBoss = enemyField.some((p) => p.isBoss());
+    const isBoss = enemyField.some((p) => p.boss);
 
     /** The ratio between the speed of your active pokemon and the speed of the enemy field */
     const speedRatio = playerSpeed / enemySpeed;

--- a/src/phases/command-phase.ts
+++ b/src/phases/command-phase.ts
@@ -274,7 +274,7 @@ export class CommandPhase extends BattlePhase {
               console.warn("Enemy Pokemon is missing when trying to throw Pokeball!");
               failCatchRun("battle:noPokeballForce");
             } else if (
-              targetPokemon.isBoss()
+              targetPokemon.boss
               && targetPokemon.bossSegmentIndex >= 1
               && !targetPokemon.hasAbility(AbilityId.WONDER_GUARD, false, true)
               && cursor !== PokeballType.MASTER_BALL

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -135,12 +135,8 @@ export class EncounterPhase extends BattlePhase {
           ) {
             enemySpecies = getGoldenBugNetSpecies(level);
           }
-          currentBattle.enemyParty[e] = globalScene.addEnemyPokemon(
-            enemySpecies,
-            level,
-            TrainerSlot.NONE,
-            globalScene.getEncounterBossSegments(waveIndex, level, enemySpecies) > 0,
-          );
+          const boss = globalScene.getEncounterBossSegments(waveIndex, level, enemySpecies) > 0;
+          currentBattle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, { boss });
           if (isClassicFinalBoss) {
             currentBattle.enemyParty[e].ivs = new Array(6).fill(31);
           }

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -140,9 +140,9 @@ export class EncounterPhase extends BattlePhase {
           if (speciesOverride) {
             enemySpecies = getPokemonSpecies(speciesOverride);
           }
-          const bossSegments = globalScene.getEncounterBossSegments(waveIndex, level, enemySpecies);
+          const boss = globalScene.getEncounterBossSegments(waveIndex, level, enemySpecies) > 0;
           currentBattle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, {
-            bossSegments,
+            boss,
             ivs: isClassicFinalBoss ? new Array(6).fill(31) : undefined,
           });
           globalScene

--- a/src/phases/encounter-phase.ts
+++ b/src/phases/encounter-phase.ts
@@ -43,6 +43,7 @@ import { settings } from "#system/settings-manager";
 import type { PhaseKey } from "#types/phase-types";
 import { loadEncounterAnimAssets } from "#utils/anim-utils";
 import { enumValueToKey } from "#utils/common-utils";
+import { getPokemonSpecies } from "#utils/pokemon-utils";
 import { randSeedInt, randSeedItem } from "#utils/random-utils";
 import i18next from "i18next";
 
@@ -135,11 +136,15 @@ export class EncounterPhase extends BattlePhase {
           ) {
             enemySpecies = getGoldenBugNetSpecies(level);
           }
-          const boss = globalScene.getEncounterBossSegments(waveIndex, level, enemySpecies) > 0;
-          currentBattle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, { boss });
-          if (isClassicFinalBoss) {
-            currentBattle.enemyParty[e].ivs = new Array(6).fill(31);
+          const speciesOverride = activeOverrides.ENEMY_SPECIES_OVERRIDE;
+          if (speciesOverride) {
+            enemySpecies = getPokemonSpecies(speciesOverride);
           }
+          const bossSegments = globalScene.getEncounterBossSegments(waveIndex, level, enemySpecies);
+          currentBattle.enemyParty[e] = globalScene.addEnemyPokemon(enemySpecies, level, {
+            bossSegments,
+            ivs: isClassicFinalBoss ? new Array(6).fill(31) : undefined,
+          });
           globalScene
             .getPlayerParty()
             .slice(0, double ? 2 : 1)
@@ -200,7 +205,7 @@ export class EncounterPhase extends BattlePhase {
       console.log(
         `Ability: ${enemyPokemon.getAbility().name}`,
         `| Passive Ability${enemyPokemon.hasPassive() ? "" : " (inactive)"}: ${enemyPokemon.getPassiveAbility().name}`,
-        `${enemyPokemon.isBoss() ? `| Boss Bars: ${enemyPokemon.bossSegments}` : ""}`,
+        `${enemyPokemon.boss ? `| Boss Bars: ${enemyPokemon.bossSegments}` : ""}`,
       );
       console.log("Moveset:", moveset);
       return true;
@@ -232,19 +237,19 @@ export class EncounterPhase extends BattlePhase {
           }
         }),
       );
-    } else {
-      const overridedBossSegments = activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE > 1;
+    } else if (
+      !activeOverrides.ENEMY_HEALTH_SEGMENTS_OVERRIDE
+      && currentBattle.enemyParty.filter((p) => p.boss).length > 1
+    ) {
       // for double battles, reduce the health segments for boss Pokemon unless there is an override
-      if (!overridedBossSegments && currentBattle.enemyParty.filter((p) => p.isBoss()).length > 1) {
-        for (const enemyPokemon of currentBattle.enemyParty) {
-          // If the enemy pokemon is a boss and wasn't populated from data source, then update the number of segments
-          if (enemyPokemon.isBoss() && !enemyPokemon.isPopulatedFromDataSource) {
-            enemyPokemon.setBoss(
-              true,
-              Math.ceil(enemyPokemon.bossSegments * (enemyPokemon.getSpeciesForm().baseTotal / totalBst)),
-            );
-            enemyPokemon.initBattleInfo();
-          }
+      for (const enemyPokemon of currentBattle.enemyParty) {
+        // If the enemy pokemon is a boss and wasn't populated from data source, then update the number of segments
+        if (enemyPokemon.boss && !enemyPokemon.isPopulatedFromDataSource) {
+          enemyPokemon.setBoss(
+            true,
+            Math.ceil(enemyPokemon.bossSegments * (enemyPokemon.getSpeciesForm().baseTotal / totalBst)),
+          );
+          enemyPokemon.initBattleInfo();
         }
       }
     }

--- a/src/phases/select-starter-phase.ts
+++ b/src/phases/select-starter-phase.ts
@@ -53,7 +53,8 @@ export class SelectStarterPhase extends Phase {
       const { speciesId } = species;
 
       const starterProps = gameData.getSpeciesDexAttrProps(species, dexAttr);
-      let starterFormIndex = Math.min(starterProps.formIndex, Math.max(species.forms.length - 1, 0));
+      const { shiny, variant } = starterProps;
+      let formIndex = Math.min(starterProps.formIndex, Math.max(species.forms.length - 1, 0));
 
       const { STARTER_FORM_OVERRIDES } = activeOverrides;
       if (
@@ -61,26 +62,24 @@ export class SelectStarterPhase extends Phase {
         && STARTER_FORM_OVERRIDES[speciesId] != null
         && species.forms[STARTER_FORM_OVERRIDES[speciesId]]
       ) {
-        starterFormIndex = STARTER_FORM_OVERRIDES[speciesId];
+        formIndex = STARTER_FORM_OVERRIDES[speciesId];
       }
 
-      const starterGender = activeOverrides.GENDER_OVERRIDE ?? starterProps.gender;
+      const gender = activeOverrides.GENDER_OVERRIDE ?? starterProps.gender;
 
       // Get ivs from the root species in case of an override to a non starter species
       const starterSpeciesId = species.getRootSpeciesId(true);
-      const starterIvs = starterData[starterSpeciesId].ivs.slice(0);
+      const ivs = starterData[starterSpeciesId].ivs.slice(0);
 
-      const starterPokemon = globalScene.addPlayerPokemon(
-        species,
-        gameMode.getStartingLevel(),
+      const starterPokemon = globalScene.addPlayerPokemon(species, gameMode.getStartingLevel(), {
         abilityIndex,
-        starterFormIndex,
-        starterGender,
-        starterProps.shiny,
-        starterProps.variant,
-        starterIvs,
+        formIndex,
+        gender,
+        shiny,
+        variant,
+        ivs,
         nature,
-      );
+      });
 
       moveset && starterPokemon.tryPopulateMoveset(moveset);
 

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -200,18 +200,17 @@ export class TitlePhase extends Phase {
 
         for (const starter of starters) {
           const starterProps = gameData.getSpeciesDexAttrProps(starter.species, starter.dexAttr);
-          const starterFormIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
-          const starterPokemon = globalScene.addPlayerPokemon(
-            starter.species,
-            startingLevel,
-            starter.abilityIndex,
-            starterFormIndex,
-            starterProps.gender,
-            starterProps.shiny,
-            starterProps.variant,
-            undefined,
-            starter.nature,
-          );
+          const { abilityIndex, nature } = starter;
+          const { gender, shiny, variant } = starterProps;
+          const formIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
+          const starterPokemon = globalScene.addPlayerPokemon(starter.species, startingLevel, {
+            abilityIndex,
+            formIndex,
+            gender,
+            shiny,
+            variant,
+            nature,
+          });
           starterPokemon.setVisible(false);
           party.push(starterPokemon);
           loadPokemonAssets.push(starterPokemon.loadAssets());

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -1566,7 +1566,7 @@ export class GameData {
         }
         if (fromEgg) {
           candyMultiplier *= STARTER_CANDY_MULIPLIER_FOR_EGG;
-        } else if (pokemon.isBoss()) {
+        } else if (pokemon.boss) {
           candyMultiplier *= STARTER_CANDY_MULIPLIER_FOR_BOSS;
         }
         this.addStarterCandy(species, STARTER_CANDY_GAIN_FROM_CATCH * candyMultiplier);

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -161,23 +161,11 @@ export class PokemonData {
     const species = getPokemonSpecies(this.speciesId);
     let ret: Pokemon;
     if (this.player) {
-      ret = globalScene.addPlayerPokemon(
-        species,
-        this.level,
-        this.abilityIndex,
-        this.formIndex,
-        this.gender,
-        this.shiny,
-        this.variant,
-        this.ivs,
-        this.nature,
-        this,
-        (playerPokemon) => {
-          if (this.nickname) {
-            playerPokemon.nickname = this.nickname;
-          }
-        },
-      );
+      ret = globalScene.addPlayerPokemon(species, this.level, { dataSource: this }, (playerPokemon) => {
+        if (this.nickname) {
+          playerPokemon.nickname = this.nickname;
+        }
+      });
     } else {
       let trainerSlot: TrainerSlot = TrainerSlot.NONE;
       if (battleType === BattleType.TRAINER) {
@@ -187,7 +175,11 @@ export class PokemonData {
           trainerSlot = TrainerSlot.TRAINER_PARTNER;
         }
       }
-      ret = globalScene.addEnemyPokemon(species, this.level, trainerSlot, this.boss, false, this);
+      ret = globalScene.addEnemyPokemon(species, this.level, {
+        trainerSlot,
+        boss: this.boss,
+        dataSource: this,
+      });
     }
     ret.primeSummonData(this.summonData);
     return ret;

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -12,7 +12,7 @@ import { Nature } from "#enums/nature";
 import type { PokeballType } from "#enums/pokeball-type";
 import type { SpeciesId } from "#enums/species-id";
 import { TrainerSlot } from "#enums/trainer-slot";
-import type { Pokemon } from "#field/pokemon";
+import type { Pokemon, PokemonOptions } from "#field/pokemon";
 import { PokemonMove } from "#field/pokemon-move";
 import type { CustomPokemonData, PokemonSummonData, SerializedSpeciesForm, Status } from "#types/pokemon-types";
 import { clamp, isPokemon } from "#utils/common-utils";
@@ -35,12 +35,12 @@ function deserializePokemonSpeciesForm(value: SerializedSpeciesForm | PokemonSpe
   return getPokemonSpeciesForm(speciesId, formIndex);
 }
 
-export class PokemonData {
+export class PokemonData implements PokemonOptions {
   public id: number;
   public personalityValue: number;
   public player: boolean;
   public speciesId: SpeciesId;
-  public nickname: string;
+  public nickname: string | null;
   public formIndex: number;
   public abilityIndex: number;
   public passive: boolean;
@@ -49,7 +49,6 @@ export class PokemonData {
   public pokeball: PokeballType;
   public level: number;
   public exp: number;
-  public levelExp: number;
   public gender: Gender;
   public hp: number;
   public stats: number[];
@@ -99,7 +98,6 @@ export class PokemonData {
     this.pokeball = source.pokeball;
     this.level = source.level;
     this.exp = source.exp;
-    this.levelExp = source.levelExp;
     this.gender = source.gender;
     this.hp = source.hp;
     this.stats = source.stats;
@@ -161,7 +159,7 @@ export class PokemonData {
     const species = getPokemonSpecies(this.speciesId);
     let ret: Pokemon;
     if (this.player) {
-      ret = globalScene.addPlayerPokemon(species, this.level, { dataSource: this }, (playerPokemon) => {
+      ret = globalScene.addPlayerPokemon(species, this.level, this, (playerPokemon) => {
         if (this.nickname) {
           playerPokemon.nickname = this.nickname;
         }
@@ -175,11 +173,7 @@ export class PokemonData {
           trainerSlot = TrainerSlot.TRAINER_PARTNER;
         }
       }
-      ret = globalScene.addEnemyPokemon(species, this.level, {
-        trainerSlot,
-        boss: this.boss,
-        dataSource: this,
-      });
+      ret = globalScene.addEnemyPokemon(species, this.level, { ...this, trainerSlot });
     }
     ret.primeSummonData(this.summonData);
     return ret;

--- a/test/abilities/sturdy.test.ts
+++ b/test/abilities/sturdy.test.ts
@@ -272,7 +272,7 @@ describe("Abilities - Sturdy", () => {
     await classicMode.startBattle(SpeciesId.LUCARIO);
     const enemy = field.getEnemyPokemon();
 
-    expect(enemy.isBoss()).toBe(true);
+    expect(enemy.boss).toBe(true);
     expect(enemy.bossSegments).toBe(2);
     expect(enemy.bossSegmentIndex).toBe(1);
     expect(enemy).toHaveFullHp();

--- a/test/battle/boss-pokemon.test.ts
+++ b/test/battle/boss-pokemon.test.ts
@@ -69,9 +69,9 @@ describe("Boss Pokemon / Shields", () => {
 
     const boss1: EnemyPokemon = game.scene.getEnemyParty()[0]!;
     const boss2: EnemyPokemon = game.scene.getEnemyParty()[1]!;
-    expect(boss1.isBoss()).toBe(true);
+    expect(boss1.boss).toBe(true);
     expect(boss1.bossSegments).toBe(2);
-    expect(boss2.isBoss()).toBe(true);
+    expect(boss2.boss).toBe(true);
     expect(boss2.bossSegments).toBe(2);
   });
 
@@ -82,7 +82,7 @@ describe("Boss Pokemon / Shields", () => {
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
     const segmentHp = enemyPokemon.getMaxHp() / enemyPokemon.bossSegments;
-    expect(enemyPokemon.isBoss()).toBe(true);
+    expect(enemyPokemon.boss).toBe(true);
     expect(enemyPokemon.bossSegments).toBe(3);
     expect(getTotalStatStageBoosts(enemyPokemon)).toBe(0);
 
@@ -115,7 +115,7 @@ describe("Boss Pokemon / Shields", () => {
     const boss1: EnemyPokemon = game.scene.getEnemyParty()[0]!;
     const boss1SegmentHp = boss1.getMaxHp() / boss1.bossSegments;
     const requiredDamageBoss1 = boss1SegmentHp * (1 + Math.pow(2, brokenShields));
-    expect(boss1.isBoss()).toBe(true);
+    expect(boss1.boss).toBe(true);
     expect(boss1.bossSegments).toBe(5);
     expect(boss1.bossSegmentIndex).toBe(4);
 
@@ -128,7 +128,7 @@ describe("Boss Pokemon / Shields", () => {
     const boss2SegmentHp = boss2.getMaxHp() / boss2.bossSegments;
     const requiredDamageBoss2 = boss2SegmentHp * (1 + Math.pow(2, brokenShields));
 
-    expect(boss2.isBoss()).toBe(true);
+    expect(boss2.boss).toBe(true);
     expect(boss2.bossSegments).toBe(5);
 
     // Enough damage to break through all shields
@@ -147,7 +147,7 @@ describe("Boss Pokemon / Shields", () => {
     const boss1: EnemyPokemon = game.scene.getEnemyParty()[0]!;
     const boss1SegmentHp = boss1.getMaxHp() / boss1.bossSegments;
     const singleShieldDamage = Math.ceil(boss1SegmentHp);
-    expect(boss1.isBoss()).toBe(true);
+    expect(boss1.boss).toBe(true);
     expect(boss1.bossSegments).toBe(shieldsToBreak + 1);
     expect(boss1.bossSegmentIndex).toBe(shieldsToBreak);
     expect(getTotalStatStageBoosts(boss1)).toBe(0);
@@ -171,7 +171,7 @@ describe("Boss Pokemon / Shields", () => {
     const boss2SegmentHp = boss2.getMaxHp() / boss2.bossSegments;
     const requiredDamage = boss2SegmentHp * (1 + Math.pow(2, shieldsToBreak - 1));
 
-    expect(boss2.isBoss()).toBe(true);
+    expect(boss2.boss).toBe(true);
     expect(boss2.bossSegments).toBe(shieldsToBreak + 1);
     expect(boss2.bossSegmentIndex).toBe(shieldsToBreak);
     expect(getTotalStatStageBoosts(boss2)).toBe(0);
@@ -192,7 +192,7 @@ describe("Boss Pokemon / Shields", () => {
     await game.classicMode.startBattle(SpeciesId.MEWTWO);
 
     const enemyPokemon = game.scene.getEnemyPokemon()!;
-    expect(enemyPokemon.isBoss()).toBe(true);
+    expect(enemyPokemon.boss).toBe(true);
     expect(enemyPokemon.bossSegments).toBe(2);
     expect(getTotalStatStageBoosts(enemyPokemon)).toBe(0);
 

--- a/test/items/double-battle-chance-booster.test.ts
+++ b/test/items/double-battle-chance-booster.test.ts
@@ -42,8 +42,8 @@ describe("Items - Double Battle Chance Boosters", () => {
     const enemyField = game.scene.getEnemyField();
 
     expect(enemyField.length).toBe(2);
-    expect(enemyField[0].isBoss()).toBe(true);
-    expect(enemyField[1].isBoss()).toBe(true);
+    expect(enemyField[0].boss).toBe(true);
+    expect(enemyField[1].boss).toBe(true);
   });
 
   it("should renew how many battles are left of existing booster when picking up new booster of same tier", async () => {

--- a/test/moves/effectiveness.test.ts
+++ b/test/moves/effectiveness.test.ts
@@ -4,7 +4,6 @@ import { AbilityId } from "#enums/ability-id";
 import { ElementalType } from "#enums/elemental-type";
 import { MoveId } from "#enums/move-id";
 import { SpeciesId } from "#enums/species-id";
-import { TrainerSlot } from "#enums/trainer-slot";
 import { GameManager } from "#test/test-utils/game-manager";
 import { getPokemonSpecies } from "#utils/pokemon-utils";
 import Phaser from "phaser";
@@ -23,7 +22,7 @@ function testMoveEffectiveness(
   game.override.enemyAbility(targetAbility);
 
   const user = game.scene.addPlayerPokemon(getPokemonSpecies(SpeciesId.SNORLAX), 5);
-  const target = game.scene.addEnemyPokemon(getPokemonSpecies(targetSpecies), 5, TrainerSlot.NONE);
+  const target = game.scene.addEnemyPokemon(getPokemonSpecies(targetSpecies), 5);
 
   if (teraType !== undefined) {
     game.field.forceTera(target, teraType);

--- a/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
+++ b/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
@@ -346,11 +346,11 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
       expect(enemyParty[0].formIndex).toBe(1);
-      expect(enemyParty[0].isBoss()).toBe(true);
+      expect(enemyParty[0].boss).toBe(true);
       expect(enemyParty[0].bossSegments).toBe(2);
       expect(enemyParty[1].species.speciesId).toBe(SpeciesId.BUTTERFREE);
       expect(enemyParty[1].formIndex).toBe(1);
-      expect(enemyParty[1].isBoss()).toBe(true);
+      expect(enemyParty[1].boss).toBe(true);
       expect(enemyParty[1].bossSegments).toBe(2);
       expect(POOL_3_POKEMON.some((config) => enemyParty[2].species.speciesId === config.species)).toBe(true);
       expect(POOL_3_POKEMON.some((config) => enemyParty[3].species.speciesId === config.species)).toBe(true);

--- a/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -189,7 +189,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       const enemyField = scene.getEnemyField();
       expect(enemyField[0].summonData.statStages).toEqual([0, 1, 0, 1, 1, 0, 0]);
-      expect(enemyField[0].isBoss()).toBe(true);
+      expect(enemyField[0].boss).toBe(true);
     });
 
     it("should start a battle against an extra enraged boss above wave 50", { retry: 5 }, async () => {
@@ -198,7 +198,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       const enemyField = scene.getEnemyField();
       expect(enemyField[0].summonData.statStages).toEqual([1, 1, 1, 1, 1, 0, 0]);
-      expect(enemyField[0].isBoss()).toBe(true);
+      expect(enemyField[0].boss).toBe(true);
     });
   });
 
@@ -261,7 +261,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       const enemyField = scene.getEnemyField();
       expect(enemyField[0].summonData.statStages).toEqual([0, 1, 0, 1, 1, 0, 0]);
-      expect(enemyField[0].isBoss()).toBe(true);
+      expect(enemyField[0].boss).toBe(true);
     });
 
     it("should start a battle against an extra enraged boss above wave 50", { retry: 5 }, async () => {
@@ -270,7 +270,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       const enemyField = scene.getEnemyField();
       expect(enemyField[0].summonData.statStages).toEqual([1, 1, 1, 1, 1, 0, 0]);
-      expect(enemyField[0].isBoss()).toBe(true);
+      expect(enemyField[0].boss).toBe(true);
     });
   });
 
@@ -295,7 +295,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 3, undefined, true);
       const enemyField = scene.getEnemyField();
       expect(enemyField[0].summonData.statStages).toEqual([0, 0, 0, 0, 0, 0, 0]);
-      expect(enemyField[0].isBoss()).toBe(true);
+      expect(enemyField[0].boss).toBe(true);
     });
 
     it("should have Magnet and Metal Coat in rewards after battle", async () => {

--- a/test/system/set-pokemon-caught.test.ts
+++ b/test/system/set-pokemon-caught.test.ts
@@ -50,7 +50,15 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(gameData.getUnlockedVariantsAttr(dexData.caughtAttr)).toHaveLength(0);
 
     // bulbasaur
-    const newCatch = new PlayerPokemon(species, 5, 1, 0, Gender.MALE, false, 0, [], Nature.MODEST);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 1,
+      formIndex: 0,
+      gender: Gender.MALE,
+      shiny: false,
+      variant: 0,
+      ivs: [],
+      nature: Nature.MODEST,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
 
     expect(newStarters).toHaveLength(0);
@@ -85,7 +93,15 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(gameData.getUnlockedVariantsAttr(dexData.caughtAttr)).toHaveLength(0);
 
     // Shiny tier 3 bulbasaur
-    const newCatch = new PlayerPokemon(species, 5, 1, 0, Gender.MALE, true, 2, [], Nature.MODEST);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 1,
+      formIndex: 0,
+      gender: Gender.MALE,
+      shiny: true,
+      variant: 2,
+      ivs: [],
+      nature: Nature.MODEST,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, false, false, false);
     expect(newStarters).toHaveLength(0);
 
@@ -120,7 +136,15 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(gameData.getNaturesForAttr(starterData.natureAttr)).toHaveLength(0);
 
     // Shiny tier 3 mewtwo
-    const newCatch = new PlayerPokemon(species, 5, 1, 0, Gender.GENDERLESS, true, 2, [], Nature.MODEST);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 1,
+      formIndex: 0,
+      gender: Gender.GENDERLESS,
+      shiny: true,
+      variant: 2,
+      ivs: [],
+      nature: Nature.MODEST,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, false, false, false);
     expect(newStarters).toHaveLength(0);
 
@@ -162,7 +186,15 @@ describe("Dex Data - Set Pokemon caught", () => {
 
     // Catch shiny tier 2 a Venusaur
     const species = getPokemonSpecies(SpeciesId.VENUSAUR);
-    const newCatch = new PlayerPokemon(species, 5, 2, 0, Gender.FEMALE, true, 1, [], Nature.ADAMANT);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 2,
+      formIndex: 0,
+      gender: Gender.FEMALE,
+      shiny: true,
+      variant: 1,
+      ivs: [],
+      nature: Nature.ADAMANT,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
     expect(newStarters).toHaveLength(0);
 
@@ -213,13 +245,26 @@ describe("Dex Data - Set Pokemon caught", () => {
 
     // Catch a donphan, should unlock phanpy as a starter
     let species = getPokemonSpecies(SpeciesId.DONPHAN);
-    let newCatch = new PlayerPokemon(species, 5, 2, 0, Gender.FEMALE, false, 0, [], Nature.MILD);
+    let newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 2,
+      formIndex: 0,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     let newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
     expect(newStarters).toStrictEqual([SpeciesId.PHANPY]);
 
     // Hatch a shiny Phanpy
     species = getPokemonSpecies(SpeciesId.PHANPY);
-    newCatch = new PlayerPokemon(species, 5, 0, 0, Gender.MALE, true, 0, [], Nature.QUIET);
+    newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex: 0,
+      gender: Gender.MALE,
+      shiny: true,
+      variant: 0,
+      nature: Nature.QUIET,
+    });
     newStarters = await gameData.setPokemonCaught(newCatch, true, true, false);
     expect(newStarters).toHaveLength(0);
 
@@ -268,7 +313,10 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(shedinjaDexData.caughtAttr).toBeFalsy();
 
     // Catch a (genderless) Shedinja
-    const shedinjaCatch = new PlayerPokemon(species, 5, 0, 0, Gender.GENDERLESS, false, 0, [], Nature.MILD);
+    const shedinjaCatch = new PlayerPokemon(species, 5, {
+      shiny: false,
+      nature: Nature.MILD,
+    });
     const newStarters = await gameData.setPokemonCaught(shedinjaCatch, true, false, false);
     expect(newStarters).toStrictEqual([SpeciesId.NINCADA]);
 
@@ -298,7 +346,12 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(shedinjaDexData.caughtAttr).toBeFalsy();
 
     // Catch a female Nincada
-    const ninjaskCatch = new PlayerPokemon(nincadaSpecies, 5, 0, 0, Gender.FEMALE, false, 0, [], Nature.MILD);
+    const ninjaskCatch = new PlayerPokemon(nincadaSpecies, 5, {
+      abilityIndex: 0,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     let newStarters = await gameData.setPokemonCaught(ninjaskCatch, true, false, false);
     expect(newStarters).toStrictEqual([SpeciesId.NINCADA]);
 
@@ -308,7 +361,10 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(shedinjaDexData.caughtAttr).toBeFalsy();
 
     // Catch a (genderless) Shedinja
-    const shedinjaCatch = new PlayerPokemon(shedinjaSpecies, 5, 0, 0, Gender.GENDERLESS, false, 0, [], Nature.MILD);
+    const shedinjaCatch = new PlayerPokemon(shedinjaSpecies, 5, {
+      shiny: false,
+      nature: Nature.MILD,
+    });
     newStarters = await gameData.setPokemonCaught(shedinjaCatch, true, false, false);
     expect(newStarters).toHaveLength(0);
 
@@ -332,7 +388,13 @@ describe("Dex Data - Set Pokemon caught", () => {
     const pikachuDexData = gameData.dexData[SpeciesId.PIKACHU];
 
     // Catch cosplay pikachu > no equivalent form in pichu > unlock default form
-    const newCatch = new PlayerPokemon(species, 5, 0, 2, Gender.FEMALE, false, 0, [], Nature.MILD);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex: 2,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
     expect(newStarters).toStrictEqual([SpeciesId.PIKACHU, SpeciesId.PICHU]);
 
@@ -351,7 +413,13 @@ describe("Dex Data - Set Pokemon caught", () => {
     const pikachuDexData = gameData.dexData[SpeciesId.PIKACHU];
 
     // Catch partner Pikachu
-    let newCatch = new PlayerPokemon(species, 5, 0, 1, Gender.FEMALE, false, 0, [], Nature.MILD);
+    let newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex: 1,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     let newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
     expect(newStarters).toStrictEqual([SpeciesId.PIKACHU, SpeciesId.PICHU]);
 
@@ -360,7 +428,13 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(pichuDexData.caughtAttr & gameData.getFormAttr(1)).toBeTruthy(); // spiky eared pichu
 
     // Catch cosplay pikachu > no equivalent form in pichu > already has a form unlocked > no other form unlock
-    newCatch = new PlayerPokemon(species, 5, 0, 5, Gender.FEMALE, false, 0, [], Nature.MILD);
+    newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex: 5,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
     expect(newStarters).toHaveLength(0);
 
@@ -381,7 +455,13 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(dexData.caughtAttr).toBeFalsy();
 
     // Catch GMax eevee
-    const newCatch = new PlayerPokemon(species, 5, 0, 2, Gender.FEMALE, false, 0, [], Nature.MILD);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex: 2,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
 
     expect(newStarters).toStrictEqual([SpeciesId.EEVEE]);
@@ -405,7 +485,13 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(basculinDexData.caughtAttr).toBeFalsy();
     expect(basculegionDexData.caughtAttr).toBeFalsy();
 
-    const newCatch = new PlayerPokemon(species, 5, 0, formIndex, gender, false, 0, [], Nature.MILD);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex,
+      gender,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
 
     expect(newStarters).toStrictEqual([SpeciesId.BASCULIN]);
@@ -432,7 +518,13 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(frogadierDexData.caughtAttr).toBeFalsy();
 
     // Catch Ash form Greninja
-    const newCatch = new PlayerPokemon(species, 5, 0, 2, Gender.FEMALE, false, 0, [], Nature.MILD);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex: 2,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
 
     expect(newStarters).toHaveLength(0);
@@ -459,7 +551,13 @@ describe("Dex Data - Set Pokemon caught", () => {
     expect(lycanrocDexData.caughtAttr).toBeFalsy();
 
     // Catch Dusk form Lycanroc
-    const newCatch = new PlayerPokemon(species, 5, 0, 1, Gender.FEMALE, false, 0, [], Nature.MILD);
+    const newCatch = new PlayerPokemon(species, 5, {
+      abilityIndex: 0,
+      formIndex: 1,
+      gender: Gender.FEMALE,
+      shiny: false,
+      nature: Nature.MILD,
+    });
     const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
 
     expect(species.forms[newCatch.formIndex].formName).toBe("Dusk Form");
@@ -500,7 +598,13 @@ describe("Dex Data - Set Pokemon caught", () => {
       expect(species.forms[unlockedFormIndex].formName).toBe(unlockedFormName);
       expect(species.forms[unlockedFormIndex].isStarterSelectable).toBeTruthy();
 
-      const newCatch = new PlayerPokemon(species, 5, 0, caughtFormIndex, Gender.GENDERLESS, false, 0, [], Nature.MILD);
+      const newCatch = new PlayerPokemon(species, 5, {
+        abilityIndex: 0,
+        formIndex: caughtFormIndex,
+        gender: Gender.GENDERLESS,
+        shiny: false,
+        nature: Nature.MILD,
+      });
       const newStarters = await gameData.setPokemonCaught(newCatch, true, false, false);
 
       expect(newStarters).toStrictEqual([SpeciesId.ZYGARDE]);

--- a/test/test-utils/game-manager-utils.ts
+++ b/test/test-utils/game-manager-utils.ts
@@ -39,19 +39,18 @@ export function generateStarter(scene: BattleScene, species: SpeciesId[]): Start
     species.splice(6);
   }
   for (const starter of starters) {
+    const { abilityIndex, nature } = starter;
     const starterProps = scene.gameData.getSpeciesDexAttrProps(starter.species, starter.dexAttr);
-    const starterFormIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
-    const starterPokemon = scene.addPlayerPokemon(
-      starter.species,
-      startingLevel,
-      starter.abilityIndex,
-      starterFormIndex,
-      starterProps.gender,
-      starterProps.shiny,
-      starterProps.variant,
-      undefined,
-      starter.nature,
-    );
+    const formIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
+    const { gender, shiny, variant } = starterProps;
+    const starterPokemon = scene.addPlayerPokemon(starter.species, startingLevel, {
+      abilityIndex,
+      formIndex,
+      gender,
+      shiny,
+      variant,
+      nature,
+    });
     const moveset: MoveId[] = [];
     for (const move of starterPokemon.getMoveset(true)) {
       moveset.push(move.getMove().id);
@@ -68,7 +67,7 @@ function getTestRunStarters(species: SpeciesId[]): StarterConfig[] {
   for (const specie of species) {
     const starterSpeciesForm = getPokemonSpeciesForm(specie, 0);
     const starterSpecies = getPokemonSpecies(starterSpeciesForm.speciesId);
-    const pokemon = new PlayerPokemon(starterSpecies, startingLevel, undefined, 0);
+    const pokemon = new PlayerPokemon(starterSpecies, startingLevel, { formIndex: 0 });
     const starter: StarterConfig = {
       species: starterSpecies,
       dexAttr: pokemon.getDexAttr(),
@@ -108,22 +107,21 @@ export function getMovePosition(scene: BattleScene, pokemonIndex: 0 | 1, moveId:
 export function initSceneWithoutEncounterPhase(scene: BattleScene, species: SpeciesId[]): void {
   const starters = generateStarter(scene, species);
   starters.forEach((starter) => {
+    const { abilityIndex, nature } = starter;
     const starterProps = scene.gameData.getSpeciesDexAttrProps(starter.species, starter.dexAttr);
-    const starterFormIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
-    const starterGender = Gender.MALE;
+    const formIndex = Math.min(starterProps.formIndex, Math.max(starter.species.forms.length - 1, 0));
+    const { shiny, variant } = starterProps;
     const starterSpeciesId = starter.species.getRootSpeciesId(true);
-    const starterIvs = scene.gameData.starterData[starterSpeciesId].ivs.slice(0);
-    const starterPokemon = scene.addPlayerPokemon(
-      starter.species,
-      scene.gameMode.getStartingLevel(),
-      starter.abilityIndex,
-      starterFormIndex,
-      starterGender,
-      starterProps.shiny,
-      starterProps.variant,
-      starterIvs,
-      starter.nature,
-    );
+    const ivs = scene.gameData.starterData[starterSpeciesId].ivs.slice(0);
+    const starterPokemon = scene.addPlayerPokemon(starter.species, scene.gameMode.getStartingLevel(), {
+      abilityIndex,
+      formIndex,
+      gender: Gender.MALE,
+      shiny,
+      variant,
+      ivs,
+      nature,
+    });
     starter.moveset && starterPokemon.tryPopulateMoveset(starter.moveset);
     scene.getPlayerParty().push(starterPokemon);
   });


### PR DESCRIPTION
## What are the changes the user will see?

N/A

## Why am I making these changes?

The constructors for `Pokemon` and its subclasses are a mess. This is also a prerequisite for #1394.

## What are the changes from a developer perspective?

- The `Pokemon` constructor's optional parameters have been consolidated into a `PokemonOptions` interface. It also accepts a `Pokemon` in place of the options interface to create shallow copies of Pokemon. Subclasses `PlayerPokemon` and `EnemyPokemon` have also been given similar treatment.
- Enemy overrides for shiny variant, IVs, nature, etc. are now all applied in the `EnemyPokemon` constructor.
- `PokemonData` now implements `PokemonOptions`, meaning it can also be directly plugged into `Pokemon` constructors.
- With the above changes, the `dataSource` constructor parameter has been made obsolete, hence it not being included in `PokemonOptions`.

## Screenshots/Videos

## How to test the changes?

Affected overrides may require playtesting. Unit tests are TBD

## Checklist

- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [ ] Have I tested the changes manually?
- [ ] Are all unit tests still passing? (`pnpm test:silent`)
  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
- [ ] Have I provided screenshots/videos of the changes (if applicable)?
  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?
