### PR TITLE
refactor: initializing abilities now uses a builder class

### DIFF
--- a/src/@types/ability-types.ts
+++ b/src/@types/ability-types.ts
@@ -2,7 +2,7 @@
 import type { PokemonWaveData } from "#types/pokemon-types";
 /* biome-ignore-end lint/correctness/noUnusedImports: tsdoc imports */
 
-import type { AbAttrConstructorMap } from "#abilities/ability";
+import type { AbAttrConstructorMap } from "#abilities/ab-attr-constructor-map";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 

--- a/src/constants/ability-constants.ts
+++ b/src/constants/ability-constants.ts
@@ -16,3 +16,23 @@ export const IGNORING_ABILITIES = Object.freeze([AbilityId.MOLD_BREAKER, Ability
  * @see {@linkcode SuppressWeatherEffectAbAttr}
  */
 export const WEATHER_SUPPRESSING_ABILITIES = Object.freeze([AbilityId.CLOUD_NINE, AbilityId.AIR_LOCK]);
+
+/** Bit set for an ability's `bypassFaint` flag */
+export const AB_FLAG_BYPASS_FAINT = 1; // 2 ** 0
+/** Bit set for an ability's `ignorable` flag */
+export const AB_FLAG_IGNORABLE = 2; // 2 ** 1
+/** Bit set for an ability's `suppressable` flag */
+export const AB_FLAG_SUPPRESSABLE = 4; // 2 ** 2
+/** Bit set for an ability's `copiable` flag */
+export const AB_FLAG_COPIABLE = 8; // 2 ** 3
+/** Bit set for an ability's `replaceable` flag */
+export const AB_FLAG_REPLACEABLE = 16; // 2 ** 4
+/** Bit set for an ability's `noTransform` flag */
+export const AB_FLAG_WORKS_WHEN_TRANSFORMED = 32; // 2 ** 5
+/** Bit set for an ability's `partial` flag */
+export const AB_FLAG_PARTIAL = 64; // 2 ** 6
+/** Bit set for an ability's `unimplemented` flag */
+export const AB_FLAG_UNIMPLEMENTED = 128; // 2 ** 7
+
+/** Bits set for a swappable ability */
+export const AB_FLAG_SWAPPABLE = AB_FLAG_COPIABLE | AB_FLAG_REPLACEABLE;

--- a/src/data/abilities/ab-attr-constructor-map.ts
+++ b/src/data/abilities/ab-attr-constructor-map.ts
@@ -1,0 +1,242 @@
+// biome-ignore lint/correctness/noUnusedImports: TSDoc import
+import type { AbAttr } from "#abilities/ab-attr";
+import { AccuracyMultiplierAbAttr } from "#abilities/accuracy-multiplier-ab-attr";
+import { AddSecondStrikeAbAttr } from "#abilities/add-second-strike-ab-attr";
+import { AlliedFieldDamageReductionAbAttr } from "#abilities/allied-field-damage-reduction-ab-attr";
+import { AllyMoveCategoryPowerBoostAbAttr } from "#abilities/ally-move-category-power-boost-ab-attr";
+import { AlwaysHitAbAttr } from "#abilities/always-hit-ab-attr";
+import { ArenaTrapAbAttr } from "#abilities/arena-trap-ab-attr";
+import { BadDreamsAbAttr } from "#abilities/bad-dreams-ab-attr";
+import { BattlerTagImmunityAbAttr } from "#abilities/battler-tag-immunity-ab-attr";
+import { BlockCritAbAttr } from "#abilities/block-crit-ab-attr";
+import { BlockItemTheftAbAttr } from "#abilities/block-item-theft-ab-attr";
+import { BlockNonDirectDamageAbAttr } from "#abilities/block-non-direct-damage-ab-attr";
+import { BlockOneHitKOAbAttr } from "#abilities/block-one-hit-ko-ab-attr";
+import { BlockRecoilDamageAbAttr } from "#abilities/block-recoil-damage-ab-attr";
+import { BlockRedirectAbAttr } from "#abilities/block-redirect-ab-attr";
+import { BlockStatusDamageAbAttr } from "#abilities/block-status-damage-ab-attr";
+import { BonusCritAbAttr } from "#abilities/bonus-crit-ab-attr";
+import { BypassBurnDamageReductionAbAttr } from "#abilities/bypass-burn-damage-reduction-ab-attr";
+import { BypassParaSpeedReductionAbAttr } from "#abilities/bypass-para-speed-reduction-ab-attr";
+import { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-attr";
+import { ChangeMovePriorityAbAttr } from "#abilities/change-move-priority-ab-attr";
+import { CommanderAbAttr } from "#abilities/commander-ab-attr";
+import { ConditionalCritAbAttr } from "#abilities/conditional-crit-ab-attr";
+import { ConfusionOnStatusEffectAbAttr } from "#abilities/confusion-on-status-effect-ab-attr";
+import { DamageBoostAbAttr } from "#abilities/damage-boost-ab-attr";
+import { DoubleBattleChanceAbAttr } from "#abilities/double-battle-chance-ab-attr";
+import { DoubleBerryEffectAbAttr } from "#abilities/double-berry-effect-ab-attr";
+import { EffectSporeAbAttr } from "#abilities/effect-spore-ab-attr";
+import { EffectiveStatMultiplierAbAttr } from "#abilities/effective-stat-multiplier-ab-attr";
+import { EvasivenessMultiplierAbAttr } from "#abilities/evasiveness-multiplier-ab-attr";
+import { FieldAccuracyMultiplierAbAttr } from "#abilities/field-accuracy-multiplier-ab-attr";
+import { FieldMoveTypePowerBoostAbAttr } from "#abilities/field-move-type-power-boost-ab-attr";
+import { FieldPreventExplosionLikeAbAttr } from "#abilities/field-prevent-explosion-like-ab-attr";
+import { FieldPriorityMoveImmunityAbAttr } from "#abilities/field-priority-move-immunity-ab-attr";
+import { FieldStatMultiplierAbAttr } from "#abilities/field-stat-multiplier-ab-attr";
+import { FlinchEffectAbAttr } from "#abilities/flinch-effect-ab-attr";
+import { ForceSwitchOutImmunityAbAttr } from "#abilities/force-switch-out-immunity-ab-attr";
+import { FullHpResistTypeAbAttr } from "#abilities/full-hp-resist-type-ab-attr";
+import { HealFromBerryUseAbAttr } from "#abilities/heal-from-berry-use-ab-attr";
+import { IgnoreContactAbAttr } from "#abilities/ignore-contact-ab-attr";
+import { IgnoreMoveEffectsAbAttr } from "#abilities/ignore-move-effects-ab-attr";
+import { IgnoreOpponentStatStagesAbAttr } from "#abilities/ignore-opponent-stat-stages-ab-attr";
+import { IgnoreProtectOnContactAbAttr } from "#abilities/ignore-protect-on-contact-ab-attr";
+import { IgnoreTypeImmunityAbAttr } from "#abilities/ignore-type-immunity-ab-attr";
+import { IgnoreTypeStatusEffectImmunityAbAttr } from "#abilities/ignore-type-status-effect-immunity-ab-attr";
+import { IncreasePpAbAttr } from "#abilities/increase-pp-ab-attr";
+import { InfiltratorAbAttr } from "#abilities/infiltrator-ab-attr";
+import { IntimidateImmunityAbAttr } from "#abilities/intimidate-immunity-ab-attr";
+import { MaxMultiHitAbAttr } from "#abilities/max-multi-hit-ab-attr";
+import { MockStatusEffectAbAttr } from "#abilities/mock-status-effect-ab-attr";
+import { MoveAbilityBypassAbAttr } from "#abilities/move-ability-bypass-ab-attr";
+import { MoveEffectChanceMultiplierAbAttr } from "#abilities/move-effect-chance-multiplier-ab-attr";
+import { MoveImmunityAbAttr } from "#abilities/move-immunity-ab-attr";
+import { MoveTypeChangeAbAttr } from "#abilities/move-type-change-ab-attr";
+import { MultCritAbAttr } from "#abilities/mult-crit-ab-attr";
+import { PokemonTypeChangeAbAttr } from "#abilities/pokemon-type-change-ab-attr";
+import { PostAttackAbAttr } from "#abilities/post-attack-ab-attr";
+import { PostAttackApplyBattlerTagAbAttr } from "#abilities/post-attack-apply-battler-tag-ab-attr";
+import { PostAttackApplyStatusEffectAbAttr } from "#abilities/post-attack-apply-status-effect-ab-attr";
+import { PostBattleAbAttr } from "#abilities/post-battle-ab-attr";
+import { PostBattleInitAbAttr } from "#abilities/post-battle-init-ab-attr";
+import { PostDamageAbAttr } from "#abilities/post-damage-ab-attr";
+import { PostDamageForceSwitchAbAttr } from "#abilities/post-damage-force-switch-ab-attr";
+import { PostDefendAbAttr } from "#abilities/post-defend-ab-attr";
+import { PostDefendAbilityGiveAbAttr } from "#abilities/post-defend-ability-give-ab-attr";
+import { PostDefendContactApplyStatusEffectAbAttr } from "#abilities/post-defend-contact-apply-status-effect-ab-attr";
+import { PostFaintAbAttr } from "#abilities/post-faint-ab-attr";
+import { PostIntimidateStatStageChangeAbAttr } from "#abilities/post-intimidate-stat-stage-change-ab-attr";
+import { PostItemLostAbAttr } from "#abilities/post-item-lost-ab-attr";
+import { PostKnockOutAbAttr } from "#abilities/post-knock-out-ab-attr";
+import { PostMoveUsedAbAttr } from "#abilities/post-move-used-ab-attr";
+import { PostStatStageChangeAbAttr } from "#abilities/post-stat-stage-change-ab-attr";
+import { PostSummonAbAttr } from "#abilities/post-summon-ab-attr";
+import { PostTeraFormChangeClearWeatherTerrainAbAttr } from "#abilities/post-tera-form-change-clear-weather-terrain-ab-attr";
+import { PostTeraFormChangeStatChangeAbAttr } from "#abilities/post-tera-form-change-stat-change-ab-attr";
+import { PostTerrainChangeAbAttr } from "#abilities/post-terrain-change-ab-attr";
+import { PostTurnAbAttr } from "#abilities/post-turn-ab-attr";
+import { PostVictoryAbAttr } from "#abilities/post-victory-ab-attr";
+import { PostWeatherChangeAbAttr } from "#abilities/post-weather-change-ab-attr";
+import { PostWeatherLapseAbAttr } from "#abilities/post-weather-lapse-ab-attr";
+import { PreLeaveFieldAbAttr } from "#abilities/pre-leave-field-ab-attrs";
+import { PreSwitchOutAbAttr } from "#abilities/pre-switch-out-ab-attr";
+import { PreWeatherDamageAbAttr } from "#abilities/pre-weather-damage-ab-attr";
+import { PreventBerryUseAbAttr } from "#abilities/prevent-berry-use-ab-attr";
+import { PreventBypassSpeedChanceAbAttr } from "#abilities/prevent-bypass-speed-chance-ab-attr";
+import { ProtectStatAbAttr } from "#abilities/protect-stat-ab-attr";
+import { ReceivedMoveDamageMultiplierAbAttr } from "#abilities/received-move-damage-multiplier-ab-attr";
+import { RecoveryBoostAbAttr } from "#abilities/recovery-boost-ab-attr";
+import { RedirectMoveAbAttr } from "#abilities/redirect-move-ab-attr";
+import { ReduceBerryUseThresholdAbAttr } from "#abilities/reduce-berry-use-threshold-ab-attr";
+import { ReduceBurnDamageAbAttr } from "#abilities/reduce-burn-damage-ab-attr";
+import { ReduceSleepDurationAbAttr } from "#abilities/reduce-sleep-duration-ab-attr";
+import { ReflectMovesAbAttr } from "#abilities/reflect-moves-ab-attr";
+import { ReflectStatStageChangeAbAttr } from "#abilities/reflect-stat-stage-change-ab-attr";
+import { ReverseDrainAbAttr } from "#abilities/reverse-drain-ab-attr";
+import { RunSuccessAbAttr } from "#abilities/run-success-ab-attr";
+import { StabBoostAbAttr } from "#abilities/stab-boost-ab-attr";
+import { StatStageChangeCopyAbAttr } from "#abilities/stat-stage-change-copy-ab-attr";
+import { StatStageChangeMultiplierAbAttr } from "#abilities/stat-stage-change-multiplier-ab-attr";
+import { StatusEffectImmunityAbAttr } from "#abilities/status-effect-immunity-ab-attr";
+import { SturdyAbAttr } from "#abilities/sturdy-ab-attr";
+import { SuppressFieldAbilitiesAbAttr } from "#abilities/suppress-field-abilities-ab-attr";
+import { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-effect-ab-attr";
+import { SyncEncounterNatureAbAttr } from "#abilities/sync-encounter-nature-ab-attr";
+import { SynchronizeStatusAbAttr } from "#abilities/synchronize-status-ab-attr";
+import { TerrainEventTypeChangeAbAttr } from "#abilities/terrain-event-type-change-ab-attr";
+import { TypeImmunityAbAttr } from "#abilities/type-immunity-ab-attr";
+import { UserFieldBattlerTagImmunityAbAttr } from "#abilities/user-field-battler-tag-immunity-ab-attr";
+import { UserFieldMoveTypePowerBoostAbAttr } from "#abilities/user-field-move-type-power-boost-ab-attr";
+import { UserFieldStatusEffectImmunityAbAttr } from "#abilities/user-field-status-effect-immunity-ab-attr";
+import { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
+import { WeightMultiplierAbAttr } from "#abilities/weight-multiplier-ab-attr";
+import { WonderSkinAbAttr } from "#abilities/wonder-skin-ab-attr";
+// biome-ignore lint/correctness/noUnusedImports: TSDoc import
+import type { AbAttrKey } from "#types/ability-types";
+
+/**
+ * The complete list of referable {@linkcode AbAttr} types.
+ * All calls to look up and/or apply attributes of a specific type
+ * use an {@linkcode AbAttrKey} based on this object.
+ */
+const AbilityAttrs = {
+  AccuracyMultiplierAbAttr,
+  AddSecondStrikeAbAttr,
+  AllyMoveCategoryPowerBoostAbAttr,
+  AlliedFieldDamageReductionAbAttr,
+  AlwaysHitAbAttr,
+  ArenaTrapAbAttr,
+  BadDreamsAbAttr,
+  BattlerTagImmunityAbAttr,
+  BlockCritAbAttr,
+  BlockItemTheftAbAttr,
+  BlockNonDirectDamageAbAttr,
+  BlockOneHitKOAbAttr,
+  BlockRecoilDamageAbAttr,
+  BlockRedirectAbAttr,
+  BlockStatusDamageAbAttr,
+  BonusCritAbAttr,
+  BypassBurnDamageReductionAbAttr,
+  BypassParaSpeedReductionAbAttr,
+  BypassSpeedChanceAbAttr,
+  ChangeMovePriorityAbAttr,
+  CommanderAbAttr,
+  ConfusionOnStatusEffectAbAttr,
+  ConditionalCritAbAttr,
+  DamageBoostAbAttr,
+  DoubleBattleChanceAbAttr,
+  DoubleBerryEffectAbAttr,
+  EffectSporeAbAttr,
+  EffectiveStatMultiplierAbAttr,
+  EvasivenessMultiplierAbAttr,
+  FieldAccuracyMultiplierAbAttr,
+  FieldMoveTypePowerBoostAbAttr,
+  FieldPreventExplosionLikeAbAttr,
+  FieldPriorityMoveImmunityAbAttr,
+  FieldStatMultiplierAbAttr,
+  FlinchEffectAbAttr,
+  ForceSwitchOutImmunityAbAttr,
+  FullHpResistTypeAbAttr,
+  HealFromBerryUseAbAttr,
+  IgnoreContactAbAttr,
+  IgnoreMoveEffectsAbAttr,
+  IgnoreOpponentStatStagesAbAttr,
+  IgnoreProtectOnContactAbAttr,
+  IgnoreTypeImmunityAbAttr,
+  IgnoreTypeStatusEffectImmunityAbAttr,
+  IncreasePpAbAttr,
+  InfiltratorAbAttr,
+  IntimidateImmunityAbAttr,
+  MaxMultiHitAbAttr,
+  MockStatusEffectAbAttr,
+  MoveAbilityBypassAbAttr,
+  MoveEffectChanceMultiplierAbAttr,
+  MoveImmunityAbAttr,
+  MoveTypeChangeAbAttr,
+  PokemonTypeChangeAbAttr,
+  MultCritAbAttr,
+  PostAttackAbAttr,
+  PostAttackApplyBattlerTagAbAttr,
+  PostAttackApplyStatusEffectAbAttr,
+  PostBattleAbAttr,
+  PostBattleInitAbAttr,
+  PostDamageAbAttr,
+  PostDamageForceSwitchAbAttr,
+  PostDefendAbAttr,
+  PostDefendAbilityGiveAbAttr,
+  PostDefendContactApplyStatusEffectAbAttr,
+  PostFaintAbAttr,
+  PostIntimidateStatStageChangeAbAttr,
+  PostItemLostAbAttr,
+  PostKnockOutAbAttr,
+  PostMoveUsedAbAttr,
+  PostStatStageChangeAbAttr,
+  PostSummonAbAttr,
+  PostTeraFormChangeClearWeatherTerrainAbAttr,
+  PostTeraFormChangeStatChangeAbAttr,
+  PostTerrainChangeAbAttr,
+  PostTurnAbAttr,
+  PostVictoryAbAttr,
+  PostWeatherChangeAbAttr,
+  PostWeatherLapseAbAttr,
+  PreLeaveFieldAbAttr,
+  PreSwitchOutAbAttr,
+  PreWeatherDamageAbAttr,
+  PreventBerryUseAbAttr,
+  PreventBypassSpeedChanceAbAttr,
+  ProtectStatAbAttr,
+  ReceivedMoveDamageMultiplierAbAttr,
+  RedirectMoveAbAttr,
+  RecoveryBoostAbAttr,
+  ReduceBerryUseThresholdAbAttr,
+  ReduceBurnDamageAbAttr,
+  ReduceSleepDurationAbAttr,
+  ReflectMovesAbAttr,
+  ReflectStatStageChangeAbAttr,
+  ReverseDrainAbAttr,
+  RunSuccessAbAttr,
+  StabBoostAbAttr,
+  StatStageChangeCopyAbAttr,
+  StatStageChangeMultiplierAbAttr,
+  StatusEffectImmunityAbAttr,
+  SturdyAbAttr,
+  SuppressFieldAbilitiesAbAttr,
+  SuppressWeatherEffectAbAttr,
+  SynchronizeStatusAbAttr,
+  SyncEncounterNatureAbAttr,
+  TerrainEventTypeChangeAbAttr,
+  TypeImmunityAbAttr,
+  UserFieldBattlerTagImmunityAbAttr,
+  UserFieldMoveTypePowerBoostAbAttr,
+  UserFieldStatusEffectImmunityAbAttr,
+  VariableMovePowerAbAttr,
+  WeightMultiplierAbAttr,
+  WonderSkinAbAttr,
+} as const;
+
+/**
+ * A map of all {@linkcode AbAttr} constructors.
+ * @see {@linkcode AbilityAttrs}
+ */
+export type AbAttrConstructorMap = typeof AbilityAttrs;

--- a/src/data/abilities/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
@@ -22,6 +22,6 @@ export class CopyFaintedAllyAbilityAbAttr extends PostKnockOutAbAttr {
   }
 
   public override canApply(...[pokemon, , knockedOutPokemon]: Parameters<this["apply"]>): boolean {
-    return !pokemon.isOpponent(knockedOutPokemon) && knockedOutPokemon.getAbility().isCopiable;
+    return !pokemon.isOpponent(knockedOutPokemon) && knockedOutPokemon.getAbility().copiable;
   }
 }

--- a/src/data/abilities/ab-attrs/post-defend-ability-give-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-ability-give-ab-attr.ts
@@ -31,7 +31,7 @@ export class PostDefendAbilityGiveAbAttr extends PostDefendAbAttr {
     const ability = attacker.getAbility();
     return (
       move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)
-      && ability.isSuppressable
+      && ability.suppressable
       && !ability.hasAttr("PostDefendAbilityGiveAbAttr")
       && !attacker.isMax()
     );

--- a/src/data/abilities/ab-attrs/post-defend-ability-swap-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-ability-swap-ab-attr.ts
@@ -21,9 +21,7 @@ export class PostDefendAbilitySwapAbAttr extends PostDefendAbAttr {
 
   public override canApply(...[pokemon, , attacker, move]: Parameters<this["apply"]>): boolean {
     return (
-      move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon)
-      && attacker.getAbility().isSwappable
-      && !attacker.isMax()
+      move.checkFlag(MoveFlags.MAKES_CONTACT, attacker, pokemon) && attacker.getAbility().swappable && !attacker.isMax()
     );
   }
 

--- a/src/data/abilities/ab-attrs/post-summon-copy-ability-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-copy-ability-ab-attr.ts
@@ -32,7 +32,7 @@ export class PostSummonCopyAbilityAbAttr extends PostSummonAbAttr {
 
     this.target = randSeedItem(targets);
     // Wonder Guard is uncopiable by other effects, but Trace specifically can copy it
-    return this.target.getAbility().isCopiable || this.target.getAbility().id === AbilityId.WONDER_GUARD;
+    return this.target.getAbility().copiable || this.target.getAbility().id === AbilityId.WONDER_GUARD;
   }
 
   public override getTriggerMessage(pokemon: Pokemon, _abilityName: string): string {

--- a/src/data/abilities/ab-attrs/suppress-field-abilities-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/suppress-field-abilities-ab-attr.ts
@@ -16,6 +16,6 @@ export class SuppressFieldAbilitiesAbAttr extends AbAttr {
   }
 
   public override canApply(...[, , , ability]: Parameters<this["apply"]>): boolean {
-    return ability.isSuppressable && !ability.hasAttr("SuppressFieldAbilitiesAbAttr");
+    return ability.suppressable && !ability.hasAttr("SuppressFieldAbilitiesAbAttr");
   }
 }

--- a/src/data/abilities/ab-builder.ts
+++ b/src/data/abilities/ab-builder.ts
@@ -1,0 +1,128 @@
+import type { AbAttr } from "#abilities/ab-attr";
+import { Ability } from "#abilities/ability";
+import {
+  AB_FLAG_BYPASS_FAINT,
+  AB_FLAG_COPIABLE,
+  AB_FLAG_IGNORABLE,
+  AB_FLAG_PARTIAL,
+  AB_FLAG_REPLACEABLE,
+  AB_FLAG_SUPPRESSABLE,
+  AB_FLAG_UNIMPLEMENTED,
+  AB_FLAG_WORKS_WHEN_TRANSFORMED,
+} from "#constants/ability-constants";
+import type { AbilityId } from "#enums/ability-id";
+// biome-ignore lint/correctness/noUnusedImports: TSDoc import
+import type { MoveId } from "#enums/move-id";
+import type { AbAttrCondition } from "#types/ability-types";
+import type { Constructor } from "#types/utility-types";
+
+export class AbBuilder {
+  public id: AbilityId;
+  /** The generation the ability was introduced in */
+  public generation: number;
+  public flags: number;
+  /** Determines priority bracket for post-summon ability activation */
+  // TODO: implement its effects
+  public postSummonPriority: number;
+  public attrs: AbAttr[] = [];
+  public conditions: AbAttrCondition[] = [];
+
+  constructor(id: AbilityId, generation: number, postSummonPriority: number = 0) {
+    this.id = id;
+    this.generation = generation;
+    this.postSummonPriority = postSummonPriority;
+    this.flags = AB_FLAG_SUPPRESSABLE | AB_FLAG_COPIABLE | AB_FLAG_REPLACEABLE | AB_FLAG_WORKS_WHEN_TRANSFORMED;
+  }
+
+  /**
+   * Construct the ability set by this builder
+   * @returns A new {@linkcode Ability} instance with the parameters set in this builder.
+   */
+  public build(): Ability {
+    // @ts-expect-error: Typescript doesn't support friend classes, but we only
+    // want this builder to be able to create new abilities.
+    return new Ability(this);
+  }
+
+  public attr<T extends Constructor<AbAttr>>(AttrType: T, ...args: ConstructorParameters<T>): this {
+    const attr = new AttrType(...args);
+    this.attrs.push(attr);
+
+    return this;
+  }
+
+  public conditionalAttr<T extends Constructor<AbAttr>>(
+    condition: AbAttrCondition,
+    AttrType: T,
+    ...args: ConstructorParameters<T>
+  ): this {
+    const attr = new AttrType(...args);
+    attr.setCondition(condition);
+    this.attrs.push(attr);
+
+    return this;
+  }
+
+  /** Marks the ability as able to activate even if the ability holder faints. */
+  public bypassFaint(): this {
+    this.flags |= AB_FLAG_BYPASS_FAINT;
+    return this;
+  }
+
+  /** Marks the ability as able to be ignored by effects like {@linkcode AbilityId.MOLD_BREAKER | Mold Breaker} */
+  public ignorable(): this {
+    this.flags |= AB_FLAG_IGNORABLE;
+    return this;
+  }
+
+  /** Marks the ability as unable to be suppressed by effects like {@linkcode AbilityId.NEUTRALIZING_GAS | Neutralizing Gas} */
+  public unsuppressable(): this {
+    this.flags ^= AB_FLAG_SUPPRESSABLE;
+    return this;
+  }
+
+  /** Marks the ability as unable to be copied by effects like {@linkcode MoveId.ROLE_PLAY | Role Play} */
+  public uncopiable(): this {
+    this.flags ^= AB_FLAG_COPIABLE;
+    return this;
+  }
+
+  /** Marks the ability as unable to be replaced by effects like {@linkcode MoveId.SIMPLE_BEAM | Simple Beam} */
+  public unreplaceable(): this {
+    this.flags ^= AB_FLAG_REPLACEABLE;
+    return this;
+  }
+
+  /** Marks the ability as unable to activate if the user is transformed (such as from {@linkcode MoveId.TRANSFORM | Transform}). */
+  // TODO: implement the effects of this flag
+  public noTransform(): this {
+    this.flags ^= AB_FLAG_WORKS_WHEN_TRANSFORMED;
+    return this;
+  }
+
+  public condition(condition: AbAttrCondition): this {
+    this.conditions.push(condition);
+
+    return this;
+  }
+
+  /** Marks the ability as being incomplete (missing functionality) in some way */
+  public partial(): this {
+    this.flags |= AB_FLAG_PARTIAL;
+    return this;
+  }
+
+  /** Marks the ability as being unimplemented (no functionality) */
+  public unimplemented(): this {
+    this.flags |= AB_FLAG_UNIMPLEMENTED;
+    return this;
+  }
+
+  /**
+   * Internal flag used for developers to document edge cases. When using this, please be sure to document the edge case.
+   * @returns the ability
+   */
+  public edgeCase(): this {
+    return this;
+  }
+}

--- a/src/data/abilities/ability.ts
+++ b/src/data/abilities/ability.ts
@@ -1,197 +1,114 @@
-/* biome-ignore-start lint/correctness/noUnusedImports: TSDoc imports */
-import type { MoveId } from "#enums/move-id";
-/* biome-ignore-end lint/correctness/noUnusedImports: TSDoc imports */
-
 import type { AbAttr } from "#abilities/ab-attr";
-import { AccuracyMultiplierAbAttr } from "#abilities/accuracy-multiplier-ab-attr";
-import { AddSecondStrikeAbAttr } from "#abilities/add-second-strike-ab-attr";
-import { AlliedFieldDamageReductionAbAttr } from "#abilities/allied-field-damage-reduction-ab-attr";
-import { AllyMoveCategoryPowerBoostAbAttr } from "#abilities/ally-move-category-power-boost-ab-attr";
-import { AlwaysHitAbAttr } from "#abilities/always-hit-ab-attr";
-import { ArenaTrapAbAttr } from "#abilities/arena-trap-ab-attr";
-import { BadDreamsAbAttr } from "#abilities/bad-dreams-ab-attr";
-import { BattlerTagImmunityAbAttr } from "#abilities/battler-tag-immunity-ab-attr";
-import { BlockCritAbAttr } from "#abilities/block-crit-ab-attr";
-import { BlockItemTheftAbAttr } from "#abilities/block-item-theft-ab-attr";
-import { BlockNonDirectDamageAbAttr } from "#abilities/block-non-direct-damage-ab-attr";
-import { BlockOneHitKOAbAttr } from "#abilities/block-one-hit-ko-ab-attr";
-import { BlockRecoilDamageAbAttr } from "#abilities/block-recoil-damage-ab-attr";
-import { BlockRedirectAbAttr } from "#abilities/block-redirect-ab-attr";
-import { BlockStatusDamageAbAttr } from "#abilities/block-status-damage-ab-attr";
-import { BonusCritAbAttr } from "#abilities/bonus-crit-ab-attr";
-import { BypassBurnDamageReductionAbAttr } from "#abilities/bypass-burn-damage-reduction-ab-attr";
-import { BypassParaSpeedReductionAbAttr } from "#abilities/bypass-para-speed-reduction-ab-attr";
-import { BypassSpeedChanceAbAttr } from "#abilities/bypass-speed-chance-ab-attr";
-import { ChangeMovePriorityAbAttr } from "#abilities/change-move-priority-ab-attr";
-import { CommanderAbAttr } from "#abilities/commander-ab-attr";
-import { ConditionalCritAbAttr } from "#abilities/conditional-crit-ab-attr";
-import { ConfusionOnStatusEffectAbAttr } from "#abilities/confusion-on-status-effect-ab-attr";
-import { DamageBoostAbAttr } from "#abilities/damage-boost-ab-attr";
-import { DoubleBattleChanceAbAttr } from "#abilities/double-battle-chance-ab-attr";
-import { DoubleBerryEffectAbAttr } from "#abilities/double-berry-effect-ab-attr";
-import { EffectSporeAbAttr } from "#abilities/effect-spore-ab-attr";
-import { EffectiveStatMultiplierAbAttr } from "#abilities/effective-stat-multiplier-ab-attr";
-import { EvasivenessMultiplierAbAttr } from "#abilities/evasiveness-multiplier-ab-attr";
-import { FieldAccuracyMultiplierAbAttr } from "#abilities/field-accuracy-multiplier-ab-attr";
-import { FieldMoveTypePowerBoostAbAttr } from "#abilities/field-move-type-power-boost-ab-attr";
-import { FieldPreventExplosionLikeAbAttr } from "#abilities/field-prevent-explosion-like-ab-attr";
-import { FieldPriorityMoveImmunityAbAttr } from "#abilities/field-priority-move-immunity-ab-attr";
-import { FieldStatMultiplierAbAttr } from "#abilities/field-stat-multiplier-ab-attr";
-import { FlinchEffectAbAttr } from "#abilities/flinch-effect-ab-attr";
-import { ForceSwitchOutImmunityAbAttr } from "#abilities/force-switch-out-immunity-ab-attr";
-import { FullHpResistTypeAbAttr } from "#abilities/full-hp-resist-type-ab-attr";
-import { HealFromBerryUseAbAttr } from "#abilities/heal-from-berry-use-ab-attr";
-import { IgnoreContactAbAttr } from "#abilities/ignore-contact-ab-attr";
-import { IgnoreMoveEffectsAbAttr } from "#abilities/ignore-move-effects-ab-attr";
-import { IgnoreOpponentStatStagesAbAttr } from "#abilities/ignore-opponent-stat-stages-ab-attr";
-import { IgnoreProtectOnContactAbAttr } from "#abilities/ignore-protect-on-contact-ab-attr";
-import { IgnoreTypeImmunityAbAttr } from "#abilities/ignore-type-immunity-ab-attr";
-import { IgnoreTypeStatusEffectImmunityAbAttr } from "#abilities/ignore-type-status-effect-immunity-ab-attr";
-import { IncreasePpAbAttr } from "#abilities/increase-pp-ab-attr";
-import { InfiltratorAbAttr } from "#abilities/infiltrator-ab-attr";
-import { IntimidateImmunityAbAttr } from "#abilities/intimidate-immunity-ab-attr";
-import { MaxMultiHitAbAttr } from "#abilities/max-multi-hit-ab-attr";
-import { MockStatusEffectAbAttr } from "#abilities/mock-status-effect-ab-attr";
-import { MoveAbilityBypassAbAttr } from "#abilities/move-ability-bypass-ab-attr";
-import { MoveEffectChanceMultiplierAbAttr } from "#abilities/move-effect-chance-multiplier-ab-attr";
-import { MoveImmunityAbAttr } from "#abilities/move-immunity-ab-attr";
-import { MoveTypeChangeAbAttr } from "#abilities/move-type-change-ab-attr";
-import { MultCritAbAttr } from "#abilities/mult-crit-ab-attr";
-import { PokemonTypeChangeAbAttr } from "#abilities/pokemon-type-change-ab-attr";
-import { PostAttackAbAttr } from "#abilities/post-attack-ab-attr";
-import { PostAttackApplyBattlerTagAbAttr } from "#abilities/post-attack-apply-battler-tag-ab-attr";
-import { PostAttackApplyStatusEffectAbAttr } from "#abilities/post-attack-apply-status-effect-ab-attr";
-import { PostBattleAbAttr } from "#abilities/post-battle-ab-attr";
-import { PostBattleInitAbAttr } from "#abilities/post-battle-init-ab-attr";
-import { PostDamageAbAttr } from "#abilities/post-damage-ab-attr";
-import { PostDamageForceSwitchAbAttr } from "#abilities/post-damage-force-switch-ab-attr";
-import { PostDefendAbAttr } from "#abilities/post-defend-ab-attr";
-import { PostDefendAbilityGiveAbAttr } from "#abilities/post-defend-ability-give-ab-attr";
-import { PostDefendContactApplyStatusEffectAbAttr } from "#abilities/post-defend-contact-apply-status-effect-ab-attr";
-import { PostFaintAbAttr } from "#abilities/post-faint-ab-attr";
-import { PostIntimidateStatStageChangeAbAttr } from "#abilities/post-intimidate-stat-stage-change-ab-attr";
-import { PostItemLostAbAttr } from "#abilities/post-item-lost-ab-attr";
-import { PostKnockOutAbAttr } from "#abilities/post-knock-out-ab-attr";
-import { PostMoveUsedAbAttr } from "#abilities/post-move-used-ab-attr";
-import { PostStatStageChangeAbAttr } from "#abilities/post-stat-stage-change-ab-attr";
-import { PostSummonAbAttr } from "#abilities/post-summon-ab-attr";
-import { PostTeraFormChangeClearWeatherTerrainAbAttr } from "#abilities/post-tera-form-change-clear-weather-terrain-ab-attr";
-import { PostTeraFormChangeStatChangeAbAttr } from "#abilities/post-tera-form-change-stat-change-ab-attr";
-import { PostTerrainChangeAbAttr } from "#abilities/post-terrain-change-ab-attr";
-import { PostTurnAbAttr } from "#abilities/post-turn-ab-attr";
-import { PostVictoryAbAttr } from "#abilities/post-victory-ab-attr";
-import { PostWeatherChangeAbAttr } from "#abilities/post-weather-change-ab-attr";
-import { PostWeatherLapseAbAttr } from "#abilities/post-weather-lapse-ab-attr";
-import { PreLeaveFieldAbAttr } from "#abilities/pre-leave-field-ab-attrs";
-import { PreSwitchOutAbAttr } from "#abilities/pre-switch-out-ab-attr";
-import { PreWeatherDamageAbAttr } from "#abilities/pre-weather-damage-ab-attr";
-import { PreventBerryUseAbAttr } from "#abilities/prevent-berry-use-ab-attr";
-import { PreventBypassSpeedChanceAbAttr } from "#abilities/prevent-bypass-speed-chance-ab-attr";
-import { ProtectStatAbAttr } from "#abilities/protect-stat-ab-attr";
-import { ReceivedMoveDamageMultiplierAbAttr } from "#abilities/received-move-damage-multiplier-ab-attr";
-import { RecoveryBoostAbAttr } from "#abilities/recovery-boost-ab-attr";
-import { RedirectMoveAbAttr } from "#abilities/redirect-move-ab-attr";
-import { ReduceBerryUseThresholdAbAttr } from "#abilities/reduce-berry-use-threshold-ab-attr";
-import { ReduceBurnDamageAbAttr } from "#abilities/reduce-burn-damage-ab-attr";
-import { ReduceSleepDurationAbAttr } from "#abilities/reduce-sleep-duration-ab-attr";
-import { ReflectMovesAbAttr } from "#abilities/reflect-moves-ab-attr";
-import { ReflectStatStageChangeAbAttr } from "#abilities/reflect-stat-stage-change-ab-attr";
-import { ReverseDrainAbAttr } from "#abilities/reverse-drain-ab-attr";
-import { RunSuccessAbAttr } from "#abilities/run-success-ab-attr";
-import { StabBoostAbAttr } from "#abilities/stab-boost-ab-attr";
-import { StatStageChangeCopyAbAttr } from "#abilities/stat-stage-change-copy-ab-attr";
-import { StatStageChangeMultiplierAbAttr } from "#abilities/stat-stage-change-multiplier-ab-attr";
-import { StatusEffectImmunityAbAttr } from "#abilities/status-effect-immunity-ab-attr";
-import { SturdyAbAttr } from "#abilities/sturdy-ab-attr";
-import { SuppressFieldAbilitiesAbAttr } from "#abilities/suppress-field-abilities-ab-attr";
-import { SuppressWeatherEffectAbAttr } from "#abilities/suppress-weather-effect-ab-attr";
-import { SyncEncounterNatureAbAttr } from "#abilities/sync-encounter-nature-ab-attr";
-import { SynchronizeStatusAbAttr } from "#abilities/synchronize-status-ab-attr";
-import { TerrainEventTypeChangeAbAttr } from "#abilities/terrain-event-type-change-ab-attr";
-import { TypeImmunityAbAttr } from "#abilities/type-immunity-ab-attr";
-import { UserFieldBattlerTagImmunityAbAttr } from "#abilities/user-field-battler-tag-immunity-ab-attr";
-import { UserFieldMoveTypePowerBoostAbAttr } from "#abilities/user-field-move-type-power-boost-ab-attr";
-import { UserFieldStatusEffectImmunityAbAttr } from "#abilities/user-field-status-effect-immunity-ab-attr";
-import { VariableMovePowerAbAttr } from "#abilities/variable-move-power-ab-attr";
-import { WeightMultiplierAbAttr } from "#abilities/weight-multiplier-ab-attr";
-import { WonderSkinAbAttr } from "#abilities/wonder-skin-ab-attr";
+import type { AbBuilder } from "#abilities/ab-builder";
+import {
+  AB_FLAG_BYPASS_FAINT,
+  AB_FLAG_COPIABLE,
+  AB_FLAG_IGNORABLE,
+  AB_FLAG_PARTIAL,
+  AB_FLAG_REPLACEABLE,
+  AB_FLAG_SUPPRESSABLE,
+  AB_FLAG_SWAPPABLE,
+  AB_FLAG_UNIMPLEMENTED,
+  AB_FLAG_WORKS_WHEN_TRANSFORMED,
+} from "#constants/ability-constants";
 import { AbilityId } from "#enums/ability-id";
+// biome-ignore lint/correctness/noUnusedImports: TSDoc import
+import type { MoveId } from "#enums/move-id";
 import type { AbAttrCondition, AbAttrKey, AbAttrMap } from "#types/ability-types";
-import type { Constructor } from "#types/utility-types";
 import { toCamelCaseString } from "#utils/string-utils";
 import i18next from "i18next";
 
 export class Ability {
   public id: AbilityId;
-  private nameAppend: string = "";
+  /** The generation the ability was introduced in. */
   public generation: number;
-  /**
-   * If `true`, the ability will activate even if the pokemon faints.
-   * @defaultValue `false`
-   */
-  public isBypassFaint: boolean = false;
-  /**
-   * If `true`, the ability can be ignored by effects like {@linkcode AbilityId.MOLD_BREAKER | Mold Breaker}.
-   * @defaultValue `false`
-   */
-  public isIgnorable: boolean = false;
-  /**
-   * If `true`, the ability can be suppressed by effects like {@linkcode AbilityId.NEUTRALIZING_GAS | Neutralizing Gas}.
-   * @defaultValue `true`
-   */
-  public isSuppressable: boolean = true;
-  /**
-   * If `true`, the ability can be copied by effects like {@linkcode MoveId.ROLE_PLAY | Role Play}.
-   * @defaultValue `true`
-   */
-  public isCopiable: boolean = true;
-  /**
-   * If `true`, the ability can be replaced by effects like {@linkcode MoveId.ROLE_PLAY | Role Play}.
-   * @defaultValue `true`
-   */
-  public isReplaceable: boolean = true;
-  /**
-   * If `true`, the ability will activate if the pokemon is transformed (such as by {@linkcode MoveId.TRANSFORM | Transform}).
-   * @defaultValue `true`
-   * @todo Implement the effects of the flag
-   */
-  public worksWhenTransformed: boolean = true;
-  /** Determines priority bracket for post-summon ability activation */
+  /** The ability's localized name. May include " (P)" or " (N)" if the ability isn't fully implemented. */
+  public readonly name: string;
+  /** The ability's localized description. */
+  public readonly description: string;
+  /** Determines priority bracket for post-summon ability activation. */
   // TODO: implement its effects
   public postSummonPriority: number;
   public attrs: AbAttr[] = [];
   public conditions: AbAttrCondition[] = [];
+  private readonly flags: number;
 
-  constructor(id: AbilityId, generation: number, postSummonPriority: number = 0) {
-    this.id = id;
-    this.generation = generation;
-    this.postSummonPriority = postSummonPriority;
+  private constructor(builder: AbBuilder) {
+    this.id = builder.id;
+
+    /**
+     * The i18n key for this ability in camel-case, i.e. `"abilityName"`.
+     * Used to localize the ability's `name` and `description`.
+     */
+    const i18nKey: string = toCamelCaseString(AbilityId[this.id]);
+    let nameAppend = "";
+    if (this.partial) {
+      nameAppend = " (P)";
+    } else if (this.unimplemented) {
+      nameAppend = " (N);";
+    }
+    this.name = this.id ? `${i18next.t(`ability:${i18nKey}.name`)}${nameAppend}` : "";
+    this.description = this.id ? i18next.t(`ability:${i18nKey}.description`) : "";
+
+    this.generation = builder.generation;
+    this.postSummonPriority = builder.postSummonPriority;
+    this.attrs = builder.attrs;
+    this.conditions = builder.conditions;
+    this.flags = builder.flags;
+
+    for (const attr of this.attrs) {
+      attr.source = this;
+    }
+  }
+
+  /** Whether the ability will activate even if the pokemon faints. */
+  public get bypassFaint(): boolean {
+    return (this.flags & AB_FLAG_BYPASS_FAINT) > 0;
+  }
+
+  /** Whether the ability can be ignored by effects like {@linkcode AbilityId.MOLD_BREAKER | Mold Breaker}. */
+  public get ignorable(): boolean {
+    return (this.flags & AB_FLAG_IGNORABLE) > 0;
+  }
+
+  /** Whether the ability can be suppressed by effects like {@linkcode AbilityId.NEUTRALIZING_GAS | Neutralizing Gas}. */
+  public get suppressable(): boolean {
+    return (this.flags & AB_FLAG_SUPPRESSABLE) > 0;
+  }
+
+  /** Whether the ability can be copied by effects like {@linkcode MoveId.ROLE_PLAY | Role Play}. */
+  public get copiable(): boolean {
+    return (this.flags & AB_FLAG_COPIABLE) > 0;
+  }
+
+  /** Whether the ability can be replaced by effects like {@linkcode MoveId.SIMPLE_BEAM | Simple Beam}. */
+  public get replaceable(): boolean {
+    return (this.flags & AB_FLAG_REPLACEABLE) > 0;
   }
 
   /**
-   * The ability's localized name. May include a {@linkcode nameAppend | tag}
-   * if the ability isn't fully implemented.
+   * Whether the ability can be swapped by effects like {@linkcode MoveId.SKILL_SWAP}.
+   * @remarks
+   * This is `true` if the ability is both {@linkcode copiable} and {@linkcode replaceable}.
    */
-  public get name(): string {
-    return this.id ? `${i18next.t(`ability:${this.i18nKey}.name`)}${this.nameAppend}` : "";
+  public get swappable(): boolean {
+    return (this.flags & AB_FLAG_SWAPPABLE) > 0;
   }
 
-  /** The ability's localized description. */
-  public get description(): string {
-    return this.id ? i18next.t(`ability:${this.i18nKey}.description`) : "";
+  /** Whether the ability will activate if the pokemon is transformed (such as by {@linkcode MoveId.TRANSFORM | Transform}). */
+  // TODO: implement the effects of this flag
+  public get worksWhenTransformed(): boolean {
+    return (this.flags & AB_FLAG_WORKS_WHEN_TRANSFORMED) > 0;
   }
 
-  /**
-   * The i18n key for this ability in camel-case, i.e. "abilityName".
-   * Used to localize the ability's {@linkcode name} and {@linkcode description}.
-   */
-  private get i18nKey(): string {
-    return toCamelCaseString(AbilityId[this.id]);
+  /** Whether the ability is incomplete (missing functionality) in some way. */
+  public get partial(): boolean {
+    return (this.flags & AB_FLAG_PARTIAL) > 0;
   }
 
-  /** @returns `true` if both {@linkcode isCopiable} and {@linkcode isReplaceable} are `true` */
-  public get isSwappable(): boolean {
-    return this.isCopiable && this.isReplaceable;
+  /** Whether the ability is unimplemented (no functionality). */
+  public get unimplemented(): boolean {
+    return (this.flags & AB_FLAG_UNIMPLEMENTED) > 0;
   }
 
   /**
@@ -200,7 +117,7 @@ export class Ability {
    * @returns An array of attributes that match the given {@linkcode key} (can be empty if none match).
    */
   getAttrs<K extends AbAttrKey>(key: K): AbAttrMap[K][] {
-    // TODO: Figure out how to remove `as AbAttrMap[K][]`.
+    // TODO: Find out if it's possible to remove `as AbAttrMap[K][]`.
     // It's likely required due to `apply` and `canApply` not following LSP.
     return this.attrs.filter((abAttr): abAttr is AbAttrMap[K] => abAttr.is(key)) as AbAttrMap[K][];
   }
@@ -213,220 +130,4 @@ export class Ability {
   hasAttr<K extends AbAttrKey>(key: K): boolean {
     return this.attrs.some((abAttr) => abAttr.is(key));
   }
-
-  //#region Builder methods
-
-  attr<T extends Constructor<AbAttr>>(AttrType: T, ...args: ConstructorParameters<T>): Ability {
-    const attr = new AttrType(...args);
-    attr.source = this;
-    this.attrs.push(attr);
-
-    return this;
-  }
-
-  conditionalAttr<T extends Constructor<AbAttr>>(
-    condition: AbAttrCondition,
-    AttrType: T,
-    ...args: ConstructorParameters<T>
-  ): Ability {
-    const attr = new AttrType(...args);
-    attr.source = this;
-    attr.setCondition(condition);
-    this.attrs.push(attr);
-
-    return this;
-  }
-
-  /** Marks the ability as able to activate even if the ability holder faints. */
-  bypassFaint(): Ability {
-    this.isBypassFaint = true;
-    return this;
-  }
-
-  /** Marks the ability as able to be ignored by effects like {@linkcode AbilityId.MOLD_BREAKER | Mold Breaker} */
-  ignorable(): Ability {
-    this.isIgnorable = true;
-    return this;
-  }
-
-  /** Marks the ability as unable to be suppressed by effects like {@linkcode AbilityId.NEUTRALIZING_GAS | Neutralizing Gas} */
-  unsuppressable(): Ability {
-    this.isSuppressable = false;
-    return this;
-  }
-
-  /** Marks the ability as unable to be copied by effects like {@linkcode MoveId.ROLE_PLAY | Role Play} */
-  uncopiable(): Ability {
-    this.isCopiable = false;
-    return this;
-  }
-
-  /** Marks the ability as unable to be replaced by effects like {@linkcode MoveId.SIMPLE_BEAM | Simple Beam} */
-  unreplaceable(): Ability {
-    this.isReplaceable = false;
-    return this;
-  }
-
-  /**
-   * Marks the ability as unable to activate if the user is transformed (such as from {@linkcode MoveId.TRANSFORM | Transform}).
-   * @todo Implement the effects of this flag
-   */
-  noTransform(): Ability {
-    this.worksWhenTransformed = false;
-    return this;
-  }
-
-  condition(condition: AbAttrCondition): Ability {
-    this.conditions.push(condition);
-
-    return this;
-  }
-
-  /** Marks the ability as being incomplete (missing functionality) in some way */
-  partial(): this {
-    this.nameAppend += " (P)";
-    return this;
-  }
-
-  /** Marks the ability as being unimplemented (no functionality) */
-  unimplemented(): this {
-    this.nameAppend += " (N)";
-    return this;
-  }
-
-  /**
-   * Internal flag used for developers to document edge cases. When using this, please be sure to document the edge case.
-   * @returns the ability
-   */
-  edgeCase(): this {
-    return this;
-  }
-
-  // #endregion
 }
-
-/**
- * The complete list of referable {@linkcode AbAttr} types.
- * All calls to look up and/or apply attributes of a specific type
- * use an {@linkcode AbAttrKey} based on this object.
- */
-const AbilityAttrs = {
-  AccuracyMultiplierAbAttr,
-  AddSecondStrikeAbAttr,
-  AllyMoveCategoryPowerBoostAbAttr,
-  AlliedFieldDamageReductionAbAttr,
-  AlwaysHitAbAttr,
-  ArenaTrapAbAttr,
-  BadDreamsAbAttr,
-  BattlerTagImmunityAbAttr,
-  BlockCritAbAttr,
-  BlockItemTheftAbAttr,
-  BlockNonDirectDamageAbAttr,
-  BlockOneHitKOAbAttr,
-  BlockRecoilDamageAbAttr,
-  BlockRedirectAbAttr,
-  BlockStatusDamageAbAttr,
-  BonusCritAbAttr,
-  BypassBurnDamageReductionAbAttr,
-  BypassParaSpeedReductionAbAttr,
-  BypassSpeedChanceAbAttr,
-  ChangeMovePriorityAbAttr,
-  CommanderAbAttr,
-  ConfusionOnStatusEffectAbAttr,
-  ConditionalCritAbAttr,
-  DamageBoostAbAttr,
-  DoubleBattleChanceAbAttr,
-  DoubleBerryEffectAbAttr,
-  EffectSporeAbAttr,
-  EffectiveStatMultiplierAbAttr,
-  EvasivenessMultiplierAbAttr,
-  FieldAccuracyMultiplierAbAttr,
-  FieldMoveTypePowerBoostAbAttr,
-  FieldPreventExplosionLikeAbAttr,
-  FieldPriorityMoveImmunityAbAttr,
-  FieldStatMultiplierAbAttr,
-  FlinchEffectAbAttr,
-  ForceSwitchOutImmunityAbAttr,
-  FullHpResistTypeAbAttr,
-  HealFromBerryUseAbAttr,
-  IgnoreContactAbAttr,
-  IgnoreMoveEffectsAbAttr,
-  IgnoreOpponentStatStagesAbAttr,
-  IgnoreProtectOnContactAbAttr,
-  IgnoreTypeImmunityAbAttr,
-  IgnoreTypeStatusEffectImmunityAbAttr,
-  IncreasePpAbAttr,
-  InfiltratorAbAttr,
-  IntimidateImmunityAbAttr,
-  MaxMultiHitAbAttr,
-  MockStatusEffectAbAttr,
-  MoveAbilityBypassAbAttr,
-  MoveEffectChanceMultiplierAbAttr,
-  MoveImmunityAbAttr,
-  MoveTypeChangeAbAttr,
-  PokemonTypeChangeAbAttr,
-  MultCritAbAttr,
-  PostAttackAbAttr,
-  PostAttackApplyBattlerTagAbAttr,
-  PostAttackApplyStatusEffectAbAttr,
-  PostBattleAbAttr,
-  PostBattleInitAbAttr,
-  PostDamageAbAttr,
-  PostDamageForceSwitchAbAttr,
-  PostDefendAbAttr,
-  PostDefendAbilityGiveAbAttr,
-  PostDefendContactApplyStatusEffectAbAttr,
-  PostFaintAbAttr,
-  PostIntimidateStatStageChangeAbAttr,
-  PostItemLostAbAttr,
-  PostKnockOutAbAttr,
-  PostMoveUsedAbAttr,
-  PostStatStageChangeAbAttr,
-  PostSummonAbAttr,
-  PostTeraFormChangeClearWeatherTerrainAbAttr,
-  PostTeraFormChangeStatChangeAbAttr,
-  PostTerrainChangeAbAttr,
-  PostTurnAbAttr,
-  PostVictoryAbAttr,
-  PostWeatherChangeAbAttr,
-  PostWeatherLapseAbAttr,
-  PreLeaveFieldAbAttr,
-  PreSwitchOutAbAttr,
-  PreWeatherDamageAbAttr,
-  PreventBerryUseAbAttr,
-  PreventBypassSpeedChanceAbAttr,
-  ProtectStatAbAttr,
-  ReceivedMoveDamageMultiplierAbAttr,
-  RedirectMoveAbAttr,
-  RecoveryBoostAbAttr,
-  ReduceBerryUseThresholdAbAttr,
-  ReduceBurnDamageAbAttr,
-  ReduceSleepDurationAbAttr,
-  ReflectMovesAbAttr,
-  ReflectStatStageChangeAbAttr,
-  ReverseDrainAbAttr,
-  RunSuccessAbAttr,
-  StabBoostAbAttr,
-  StatStageChangeCopyAbAttr,
-  StatStageChangeMultiplierAbAttr,
-  StatusEffectImmunityAbAttr,
-  SturdyAbAttr,
-  SuppressFieldAbilitiesAbAttr,
-  SuppressWeatherEffectAbAttr,
-  SynchronizeStatusAbAttr,
-  SyncEncounterNatureAbAttr,
-  TerrainEventTypeChangeAbAttr,
-  TypeImmunityAbAttr,
-  UserFieldBattlerTagImmunityAbAttr,
-  UserFieldMoveTypePowerBoostAbAttr,
-  UserFieldStatusEffectImmunityAbAttr,
-  VariableMovePowerAbAttr,
-  WeightMultiplierAbAttr,
-  WonderSkinAbAttr,
-} as const;
-
-/**
- * A map of all {@linkcode AbAttr} constructors.
- * @see {@linkcode AbilityAttrs}
- */
-export type AbAttrConstructorMap = typeof AbilityAttrs;

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -1,4 +1,4 @@
-import { Ability } from "#abilities/ability";
+import { AbBuilder } from "#abilities/ab-builder";
 import { AccuracyMultiplierAbAttr } from "#abilities/accuracy-multiplier-ab-attr";
 import { AddSecondStrikeAbAttr } from "#abilities/add-second-strike-ab-attr";
 import { AlliedFieldDamageReductionAbAttr } from "#abilities/allied-field-damage-reduction-ab-attr";
@@ -206,149 +206,191 @@ import i18next from "i18next";
 
 export function initAbilities(): void {
   allAbilities.push(
-    new Ability(AbilityId.NONE, 3), //
-    new Ability(AbilityId.STENCH, 3) //
+    new AbBuilder(AbilityId.NONE, 3) //
+      .build(),
+    new AbBuilder(AbilityId.STENCH, 3) //
       .attr(
         PostAttackApplyBattlerTagAbAttr,
         false,
         (_user, target, move) =>
           !move.hasAttr(FlinchAttr) && !target.turnData.acted && move.category !== MoveCategory.STATUS ? 10 : 0,
         BattlerTagType.FLINCHED,
-      ),
-    new Ability(AbilityId.DRIZZLE, 3) //
-      .attr(PostSummonWeatherChangeAbAttr, WeatherType.RAIN),
-    new Ability(AbilityId.SPEED_BOOST, 3) //
-      .attr(SpeedBoostAbAttr),
-    new Ability(AbilityId.BATTLE_ARMOR, 3) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.DRIZZLE, 3) //
+      .attr(PostSummonWeatherChangeAbAttr, WeatherType.RAIN)
+      .build(),
+    new AbBuilder(AbilityId.SPEED_BOOST, 3) //
+      .attr(SpeedBoostAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.BATTLE_ARMOR, 3) //
       .attr(BlockCritAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.STURDY, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.STURDY, 3) //
       .attr(SturdyAbAttr)
       .attr(BlockOneHitKOAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.DAMP, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.DAMP, 3) //
       .attr(FieldPreventExplosionLikeAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.LIMBER, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.LIMBER, 3) //
       .attr(StatusEffectImmunityAbAttr, StatusEffect.PARALYSIS)
-      .ignorable(),
-    new Ability(AbilityId.SAND_VEIL, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SAND_VEIL, 3) //
       .attr(EvasivenessMultiplierAbAttr, 1.2)
       .attr(BlockWeatherDamageAbAttr, WeatherType.SANDSTORM)
       .condition(getWeatherCondition(WeatherType.SANDSTORM))
-      .ignorable(),
-    new Ability(AbilityId.STATIC, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.STATIC, 3) //
       .attr(PostDefendContactApplyStatusEffectAbAttr, 30, StatusEffect.PARALYSIS)
-      .bypassFaint(),
-    new Ability(AbilityId.VOLT_ABSORB, 3) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.VOLT_ABSORB, 3) //
       .attr(TypeImmunityHealAbAttr, ElementalType.ELECTRIC)
-      .ignorable(),
-    new Ability(AbilityId.WATER_ABSORB, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.WATER_ABSORB, 3) //
       .attr(TypeImmunityHealAbAttr, ElementalType.WATER)
-      .ignorable(),
-    new Ability(AbilityId.OBLIVIOUS, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.OBLIVIOUS, 3) //
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.INFATUATED, BattlerTagType.TAUNT)
       .attr(IntimidateImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.CLOUD_NINE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.CLOUD_NINE, 3) //
       .attr(SuppressWeatherEffectAbAttr)
       .attr(PostSummonUnnamedMessageAbAttr, i18next.t("abilityTriggers:weatherEffectDisappeared"))
       .attr(PostSummonWeatherSuppressedFormChangeAbAttr)
       .attr(PostFaintUnsuppressedWeatherFormChangeAbAttr)
-      .bypassFaint(),
-    new Ability(AbilityId.COMPOUND_EYES, 3) //
-      .attr(AccuracyMultiplierAbAttr, 1.3),
-    new Ability(AbilityId.INSOMNIA, 3) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.COMPOUND_EYES, 3) //
+      .attr(AccuracyMultiplierAbAttr, 1.3)
+      .build(),
+    new AbBuilder(AbilityId.INSOMNIA, 3) //
       .attr(StatusEffectImmunityAbAttr, StatusEffect.SLEEP)
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
-      .ignorable(),
-    new Ability(AbilityId.COLOR_CHANGE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.COLOR_CHANGE, 3) //
       .attr(PostDefendTypeChangeAbAttr)
-      .condition(getSheerForceHitDisableAbCondition()),
-    new Ability(AbilityId.IMMUNITY, 3) //
+      .condition(getSheerForceHitDisableAbCondition())
+      .build(),
+    new AbBuilder(AbilityId.IMMUNITY, 3) //
       .attr(StatusEffectImmunityAbAttr, StatusEffect.POISON, StatusEffect.TOXIC)
-      .ignorable(),
-    new Ability(AbilityId.FLASH_FIRE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.FLASH_FIRE, 3) //
       .attr(TypeImmunityAddBattlerTagAbAttr, ElementalType.FIRE, BattlerTagType.FIRE_BOOST, 1)
-      .ignorable(),
-    new Ability(AbilityId.SHIELD_DUST, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SHIELD_DUST, 3) //
       .attr(IgnoreMoveEffectsAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.OWN_TEMPO, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.OWN_TEMPO, 3) //
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.CONFUSED)
       .attr(IntimidateImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.SUCTION_CUPS, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SUCTION_CUPS, 3) //
       .attr(ForceSwitchOutImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.INTIMIDATE, 3) //
-      .attr(PostSummonStatStageChangeAbAttr, [Stat.ATK], -1, false, true),
-    new Ability(AbilityId.SHADOW_TAG, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.INTIMIDATE, 3) //
+      .attr(PostSummonStatStageChangeAbAttr, [Stat.ATK], -1, false, true)
+      .build(),
+    new AbBuilder(AbilityId.SHADOW_TAG, 3) //
       .attr(ArenaTrapAbAttr, (_user, target) => {
         if (target.hasAbility(AbilityId.SHADOW_TAG)) {
           return false;
         }
         return true;
-      }),
-    new Ability(AbilityId.ROUGH_SKIN, 3) //
+      })
+      .build(),
+    new AbBuilder(AbilityId.ROUGH_SKIN, 3) //
       .attr(PostDefendContactDamageAbAttr, 8)
-      .bypassFaint(),
-    new Ability(AbilityId.WONDER_GUARD, 3) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.WONDER_GUARD, 3) //
       .attr(NonSuperEffectiveImmunityAbAttr)
       .uncopiable()
-      .ignorable(),
-    new Ability(AbilityId.LEVITATE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.LEVITATE, 3) //
       .attr(
         LevitateImmunityAbAttr,
         ElementalType.GROUND,
         (pokemon: Pokemon) =>
           !pokemon.hasTag(BattlerTagType.IGNORE_FLYING) && !globalScene.arena.hasTag(ArenaTagType.GRAVITY),
       )
-      .ignorable(),
-    new Ability(AbilityId.EFFECT_SPORE, 3) //
-      .attr(EffectSporeAbAttr),
-    new Ability(AbilityId.SYNCHRONIZE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.EFFECT_SPORE, 3) //
+      .attr(EffectSporeAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.SYNCHRONIZE, 3) //
       .attr(SyncEncounterNatureAbAttr)
-      .attr(SynchronizeStatusAbAttr),
-    new Ability(AbilityId.CLEAR_BODY, 3) //
+      .attr(SynchronizeStatusAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.CLEAR_BODY, 3) //
       .attr(ProtectStatAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.NATURAL_CURE, 3) //
-      .attr(PreSwitchOutResetStatusAbAttr),
-    new Ability(AbilityId.LIGHTNING_ROD, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.NATURAL_CURE, 3) //
+      .attr(PreSwitchOutResetStatusAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.LIGHTNING_ROD, 3) //
       .attr(RedirectTypeMoveAbAttr, ElementalType.ELECTRIC)
       .attr(TypeImmunityStatStageChangeAbAttr, ElementalType.ELECTRIC, Stat.SPATK, 1)
-      .ignorable(),
-    new Ability(AbilityId.SERENE_GRACE, 3) //
-      .attr(MoveEffectChanceMultiplierAbAttr, 2),
-    new Ability(AbilityId.SWIFT_SWIM, 3) //
-      .attr(WeatherBasedSpeedDoublerAbAttr, ...RAINY_WEATHER_TYPES),
-    new Ability(AbilityId.CHLOROPHYLL, 3) //
-      .attr(WeatherBasedSpeedDoublerAbAttr, ...SUNNY_WEATHER_TYPES),
-    new Ability(AbilityId.ILLUMINATE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SERENE_GRACE, 3) //
+      .attr(MoveEffectChanceMultiplierAbAttr, 2)
+      .build(),
+    new AbBuilder(AbilityId.SWIFT_SWIM, 3) //
+      .attr(WeatherBasedSpeedDoublerAbAttr, ...RAINY_WEATHER_TYPES)
+      .build(),
+    new AbBuilder(AbilityId.CHLOROPHYLL, 3) //
+      .attr(WeatherBasedSpeedDoublerAbAttr, ...SUNNY_WEATHER_TYPES)
+      .build(),
+    new AbBuilder(AbilityId.ILLUMINATE, 3) //
       .attr(ProtectStatAbAttr, Stat.ACC)
       .attr(DoubleBattleChanceAbAttr)
       .attr(IgnoreOpponentStatStagesAbAttr, [Stat.EVA])
-      .ignorable(),
-    new Ability(AbilityId.TRACE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.TRACE, 3) //
       .attr(PostSummonCopyAbilityAbAttr)
-      .uncopiable(),
-    new Ability(AbilityId.HUGE_POWER, 3) //
-      .attr(EffectiveStatMultiplierAbAttr, Stat.ATK, 2),
-    new Ability(AbilityId.POISON_POINT, 3) //
+      .uncopiable()
+      .build(),
+    new AbBuilder(AbilityId.HUGE_POWER, 3) //
+      .attr(EffectiveStatMultiplierAbAttr, Stat.ATK, 2)
+      .build(),
+    new AbBuilder(AbilityId.POISON_POINT, 3) //
       .attr(PostDefendContactApplyStatusEffectAbAttr, 30, StatusEffect.POISON)
-      .bypassFaint(),
-    new Ability(AbilityId.INNER_FOCUS, 3) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.INNER_FOCUS, 3) //
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.FLINCHED)
       .attr(IntimidateImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.MAGMA_ARMOR, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.MAGMA_ARMOR, 3) //
       .attr(StatusEffectImmunityAbAttr, StatusEffect.FREEZE)
-      .ignorable(),
-    new Ability(AbilityId.WATER_VEIL, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.WATER_VEIL, 3) //
       .attr(StatusEffectImmunityAbAttr, StatusEffect.BURN)
-      .ignorable(),
-    new Ability(AbilityId.MAGNET_PULL, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.MAGNET_PULL, 3) //
       .attr(ArenaTrapAbAttr, (_user, target) => {
         if (
           target.getTypes(true).includes(ElementalType.STEEL)
@@ -357,64 +399,81 @@ export function initAbilities(): void {
           return true;
         }
         return false;
-      }),
-    new Ability(AbilityId.SOUNDPROOF, 3) //
+      })
+      .build(),
+    new AbBuilder(AbilityId.SOUNDPROOF, 3) //
       .attr(MoveFlagImmunityAbAttr, MoveFlags.SOUND_MOVE)
-      .ignorable(),
-    new Ability(AbilityId.RAIN_DISH, 3) //
-      .attr(PostWeatherLapseHealAbAttr, 1 / 16, ...RAINY_WEATHER_TYPES),
-    new Ability(AbilityId.SAND_STREAM, 3) //
-      .attr(PostSummonWeatherChangeAbAttr, WeatherType.SANDSTORM),
-    new Ability(AbilityId.PRESSURE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.RAIN_DISH, 3) //
+      .attr(PostWeatherLapseHealAbAttr, 1 / 16, ...RAINY_WEATHER_TYPES)
+      .build(),
+    new AbBuilder(AbilityId.SAND_STREAM, 3) //
+      .attr(PostSummonWeatherChangeAbAttr, WeatherType.SANDSTORM)
+      .build(),
+    new AbBuilder(AbilityId.PRESSURE, 3) //
       .attr(IncreasePpAbAttr)
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonPressure", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       )
       // Does not affect PP cost for field-targeting moves or Snatch
-      .partial(),
-    new Ability(AbilityId.THICK_FAT, 3) //
+      .partial()
+      .build(),
+    new AbBuilder(AbilityId.THICK_FAT, 3) //
       .attr(ReceivedTypeDamageMultiplierAbAttr, ElementalType.FIRE, 0.5)
       .attr(ReceivedTypeDamageMultiplierAbAttr, ElementalType.ICE, 0.5)
-      .ignorable(),
-    new Ability(AbilityId.EARLY_BIRD, 3) //
-      .attr(ReduceSleepDurationAbAttr),
-    new Ability(AbilityId.FLAME_BODY, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.EARLY_BIRD, 3) //
+      .attr(ReduceSleepDurationAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.FLAME_BODY, 3) //
       .attr(PostDefendContactApplyStatusEffectAbAttr, 30, StatusEffect.BURN)
-      .bypassFaint(),
-    new Ability(AbilityId.RUN_AWAY, 3) //
-      .attr(RunSuccessAbAttr),
-    new Ability(AbilityId.KEEN_EYE, 3) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.RUN_AWAY, 3) //
+      .attr(RunSuccessAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.KEEN_EYE, 3) //
       .attr(ProtectStatAbAttr, Stat.ACC)
-      .ignorable(),
-    new Ability(AbilityId.HYPER_CUTTER, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.HYPER_CUTTER, 3) //
       .attr(ProtectStatAbAttr, Stat.ATK)
-      .ignorable(),
-    new Ability(AbilityId.PICKUP, 3) //
-      .attr(PostBattleLootAbAttr),
-    new Ability(AbilityId.TRUANT, 3) //
-      .attr(PostSummonAddBattlerTagAbAttr, BattlerTagType.TRUANT, 1, false),
-    new Ability(AbilityId.HUSTLE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.PICKUP, 3) //
+      .attr(PostBattleLootAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.TRUANT, 3) //
+      .attr(PostSummonAddBattlerTagAbAttr, BattlerTagType.TRUANT, 1, false)
+      .build(),
+    new AbBuilder(AbilityId.HUSTLE, 3) //
       .attr(EffectiveStatMultiplierAbAttr, Stat.ATK, 1.5)
-      .attr(AccuracyMultiplierAbAttr, 0.8, (_user, move) => move?.category === MoveCategory.PHYSICAL),
-    new Ability(AbilityId.CUTE_CHARM, 3) //
-      .attr(PostDefendContactApplyTagChanceAbAttr, 30, BattlerTagType.INFATUATED),
-    new Ability(AbilityId.PLUS, 3) //
+      .attr(AccuracyMultiplierAbAttr, 0.8, (_user, move) => move?.category === MoveCategory.PHYSICAL)
+      .build(),
+    new AbBuilder(AbilityId.CUTE_CHARM, 3) //
+      .attr(PostDefendContactApplyTagChanceAbAttr, 30, BattlerTagType.INFATUATED)
+      .build(),
+    new AbBuilder(AbilityId.PLUS, 3) //
       .conditionalAttr(
         (p) =>
           globalScene.currentBattle.double && [AbilityId.PLUS, AbilityId.MINUS].some((a) => p.getAlly()?.hasAbility(a)),
         EffectiveStatMultiplierAbAttr,
         Stat.SPATK,
         1.5,
-      ),
-    new Ability(AbilityId.MINUS, 3) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.MINUS, 3) //
       .conditionalAttr(
         (p) =>
           globalScene.currentBattle.double && [AbilityId.PLUS, AbilityId.MINUS].some((a) => p.getAlly()?.hasAbility(a)),
         EffectiveStatMultiplierAbAttr,
         Stat.SPATK,
         1.5,
-      ),
-    new Ability(AbilityId.FORECAST, 3, -2) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.FORECAST, 3, -2) //
       .uncopiable()
       .unreplaceable()
       .attr(PostSummonFormChangeByWeatherAbAttr)
@@ -424,61 +483,81 @@ export function initAbilities(): void {
         WeatherType.SANDSTORM,
         WeatherType.STRONG_WINDS,
         WeatherType.FOG,
-      ),
-    new Ability(AbilityId.STICKY_HOLD, 3) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.STICKY_HOLD, 3) //
       .attr(BlockItemTheftAbAttr)
       .bypassFaint()
-      .ignorable(),
-    new Ability(AbilityId.SHED_SKIN, 3) //
-      .conditionalAttr((pokemon) => !pokemon.randSeedInt(3), PostTurnResetStatusAbAttr),
-    new Ability(AbilityId.GUTS, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SHED_SKIN, 3) //
+      .conditionalAttr((pokemon) => !pokemon.randSeedInt(3), PostTurnResetStatusAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.GUTS, 3) //
       .attr(BypassBurnDamageReductionAbAttr)
-      .conditionalAttr((pokemon) => pokemon.hasNonVolatileStatusEffect(), EffectiveStatMultiplierAbAttr, Stat.ATK, 1.5),
-    new Ability(AbilityId.MARVEL_SCALE, 3) //
+      .conditionalAttr((pokemon) => pokemon.hasNonVolatileStatusEffect(), EffectiveStatMultiplierAbAttr, Stat.ATK, 1.5)
+      .build(),
+    new AbBuilder(AbilityId.MARVEL_SCALE, 3) //
       .conditionalAttr((pokemon) => pokemon.hasNonVolatileStatusEffect(), EffectiveStatMultiplierAbAttr, Stat.DEF, 1.5)
-      .ignorable(),
-    new Ability(AbilityId.LIQUID_OOZE, 3) //
-      .attr(ReverseDrainAbAttr),
-    new Ability(AbilityId.OVERGROW, 3) //
-      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.GRASS),
-    new Ability(AbilityId.BLAZE, 3) //
-      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.FIRE),
-    new Ability(AbilityId.TORRENT, 3) //
-      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.WATER),
-    new Ability(AbilityId.SWARM, 3) //
-      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.BUG),
-    new Ability(AbilityId.ROCK_HEAD, 3) //
-      .attr(BlockRecoilDamageAbAttr),
-    new Ability(AbilityId.DROUGHT, 3) //
-      .attr(PostSummonWeatherChangeAbAttr, WeatherType.SUNNY),
-    new Ability(AbilityId.ARENA_TRAP, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.LIQUID_OOZE, 3) //
+      .attr(ReverseDrainAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.OVERGROW, 3) //
+      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.GRASS)
+      .build(),
+    new AbBuilder(AbilityId.BLAZE, 3) //
+      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.FIRE)
+      .build(),
+    new AbBuilder(AbilityId.TORRENT, 3) //
+      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.WATER)
+      .build(),
+    new AbBuilder(AbilityId.SWARM, 3) //
+      .attr(LowHpMoveTypeAttackMultiplierAbAttr, ElementalType.BUG)
+      .build(),
+    new AbBuilder(AbilityId.ROCK_HEAD, 3) //
+      .attr(BlockRecoilDamageAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.DROUGHT, 3) //
+      .attr(PostSummonWeatherChangeAbAttr, WeatherType.SUNNY)
+      .build(),
+    new AbBuilder(AbilityId.ARENA_TRAP, 3) //
       .attr(ArenaTrapAbAttr, (_user, target) => target.isGrounded())
-      .attr(DoubleBattleChanceAbAttr),
-    new Ability(AbilityId.VITAL_SPIRIT, 3) //
+      .attr(DoubleBattleChanceAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.VITAL_SPIRIT, 3) //
       .attr(StatusEffectImmunityAbAttr, StatusEffect.SLEEP)
       .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
-      .ignorable(),
-    new Ability(AbilityId.WHITE_SMOKE, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.WHITE_SMOKE, 3) //
       .attr(ProtectStatAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.PURE_POWER, 3) //
-      .attr(EffectiveStatMultiplierAbAttr, Stat.ATK, 2),
-    new Ability(AbilityId.SHELL_ARMOR, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.PURE_POWER, 3) //
+      .attr(EffectiveStatMultiplierAbAttr, Stat.ATK, 2)
+      .build(),
+    new AbBuilder(AbilityId.SHELL_ARMOR, 3) //
       .attr(BlockCritAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.AIR_LOCK, 3) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.AIR_LOCK, 3) //
       .attr(SuppressWeatherEffectAbAttr)
       .attr(PostSummonUnnamedMessageAbAttr, i18next.t("abilityTriggers:weatherEffectDisappeared"))
       .attr(PostSummonWeatherSuppressedFormChangeAbAttr)
       .attr(PostFaintUnsuppressedWeatherFormChangeAbAttr)
-      .bypassFaint(),
-    new Ability(AbilityId.TANGLED_FEET, 4) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.TANGLED_FEET, 4) //
       .conditionalAttr((pokemon) => pokemon.hasTag(BattlerTagType.CONFUSED), EvasivenessMultiplierAbAttr, 2)
-      .ignorable(),
-    new Ability(AbilityId.MOTOR_DRIVE, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.MOTOR_DRIVE, 4) //
       .attr(TypeImmunityStatStageChangeAbAttr, ElementalType.ELECTRIC, Stat.SPD, 1)
-      .ignorable(),
-    new Ability(AbilityId.RIVALRY, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.RIVALRY, 4) //
       .attr(
         MovePowerBoostAbAttr,
         (user, target, _move) =>
@@ -490,69 +569,91 @@ export function initAbilities(): void {
         (user, target, _move) =>
           user?.gender !== Gender.GENDERLESS && target?.gender !== Gender.GENDERLESS && user?.gender !== target?.gender,
         0.75,
-      ),
-    new Ability(AbilityId.STEADFAST, 4) //
-      .attr(FlinchStatStageChangeAbAttr, [Stat.SPD], 1),
-    new Ability(AbilityId.SNOW_CLOAK, 4) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.STEADFAST, 4) //
+      .attr(FlinchStatStageChangeAbAttr, [Stat.SPD], 1)
+      .build(),
+    new AbBuilder(AbilityId.SNOW_CLOAK, 4) //
       .attr(EvasivenessMultiplierAbAttr, 1.2)
       .attr(BlockWeatherDamageAbAttr, WeatherType.HAIL)
       .condition(getWeatherCondition(...SNOWY_WEATHER_TYPES))
-      .ignorable(),
-    new Ability(AbilityId.GLUTTONY, 4) //
-      .attr(ReduceBerryUseThresholdAbAttr),
-    new Ability(AbilityId.ANGER_POINT, 4) //
-      .attr(PostDefendCritStatStageChangeAbAttr, Stat.ATK, 12),
-    new Ability(AbilityId.UNBURDEN, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.GLUTTONY, 4) //
+      .attr(ReduceBerryUseThresholdAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.ANGER_POINT, 4) //
+      .attr(PostDefendCritStatStageChangeAbAttr, Stat.ATK, 12)
+      .build(),
+    new AbBuilder(AbilityId.UNBURDEN, 4) //
       .attr(PostItemLostApplyBattlerTagAbAttr, BattlerTagType.UNBURDEN)
       // Allows reviver seed to activate Unburden
       .bypassFaint()
       // Should not restore Unburden boost if Pokemon loses then regains Unburden ability
-      .edgeCase(),
-    new Ability(AbilityId.HEATPROOF, 4) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.HEATPROOF, 4) //
       .attr(ReceivedTypeDamageMultiplierAbAttr, ElementalType.FIRE, 0.5)
       .attr(ReduceBurnDamageAbAttr, 0.5)
-      .ignorable(),
-    new Ability(AbilityId.SIMPLE, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SIMPLE, 4) //
       .attr(StatStageChangeMultiplierAbAttr, 2)
-      .ignorable(),
-    new Ability(AbilityId.DRY_SKIN, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.DRY_SKIN, 4) //
       .attr(PostWeatherLapseDamageAbAttr, 1 / 8, ...SUNNY_WEATHER_TYPES)
       .attr(PostWeatherLapseHealAbAttr, 1 / 8, ...RAINY_WEATHER_TYPES)
       .attr(ReceivedTypeDamageMultiplierAbAttr, ElementalType.FIRE, 1.25)
       .attr(TypeImmunityHealAbAttr, ElementalType.WATER)
-      .ignorable(),
-    new Ability(AbilityId.DOWNLOAD, 4) //
-      .attr(DownloadAbAttr),
-    new Ability(AbilityId.IRON_FIST, 4) //
-      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.PUNCHING_MOVE, 1.2),
-    new Ability(AbilityId.POISON_HEAL, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.DOWNLOAD, 4) //
+      .attr(DownloadAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.IRON_FIST, 4) //
+      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.PUNCHING_MOVE, 1.2)
+      .build(),
+    new AbBuilder(AbilityId.POISON_HEAL, 4) //
       .attr(PostTurnStatusHealAbAttr, StatusEffect.TOXIC, StatusEffect.POISON)
-      .attr(BlockStatusDamageAbAttr, StatusEffect.TOXIC, StatusEffect.POISON),
-    new Ability(AbilityId.ADAPTABILITY, 4) //
-      .attr(StabBoostAbAttr),
-    new Ability(AbilityId.SKILL_LINK, 4) //
-      .attr(MaxMultiHitAbAttr),
-    new Ability(AbilityId.HYDRATION, 4) //
+      .attr(BlockStatusDamageAbAttr, StatusEffect.TOXIC, StatusEffect.POISON)
+      .build(),
+    new AbBuilder(AbilityId.ADAPTABILITY, 4) //
+      .attr(StabBoostAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.SKILL_LINK, 4) //
+      .attr(MaxMultiHitAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.HYDRATION, 4) //
       .attr(PostTurnResetStatusAbAttr)
-      .condition(getWeatherCondition(...RAINY_WEATHER_TYPES)),
-    new Ability(AbilityId.SOLAR_POWER, 4) //
+      .condition(getWeatherCondition(...RAINY_WEATHER_TYPES))
+      .build(),
+    new AbBuilder(AbilityId.SOLAR_POWER, 4) //
       .attr(PostWeatherLapseDamageAbAttr, 1 / 8, ...SUNNY_WEATHER_TYPES)
-      .attr(EffectiveStatMultiplierAbAttr, Stat.SPATK, 1.5, getWeatherCondition(...SUNNY_WEATHER_TYPES)),
-    new Ability(AbilityId.QUICK_FEET, 4) //
+      .attr(EffectiveStatMultiplierAbAttr, Stat.SPATK, 1.5, getWeatherCondition(...SUNNY_WEATHER_TYPES))
+      .build(),
+    new AbBuilder(AbilityId.QUICK_FEET, 4) //
       .attr(BypassParaSpeedReductionAbAttr)
-      .conditionalAttr((pokemon) => pokemon.hasNonVolatileStatusEffect(), EffectiveStatMultiplierAbAttr, Stat.SPD, 1.5),
-    new Ability(AbilityId.NORMALIZE, 4) //
-      .attr(MoveTypeChangeAbAttr, ElementalType.NORMAL, 1.2, anyTypeMoveConversionCondition),
-    new Ability(AbilityId.SNIPER, 4) //
-      .attr(MultCritAbAttr, 1.5),
-    new Ability(AbilityId.MAGIC_GUARD, 4) //
-      .attr(BlockNonDirectDamageAbAttr),
-    new Ability(AbilityId.NO_GUARD, 4) //
+      .conditionalAttr((pokemon) => pokemon.hasNonVolatileStatusEffect(), EffectiveStatMultiplierAbAttr, Stat.SPD, 1.5)
+      .build(),
+    new AbBuilder(AbilityId.NORMALIZE, 4) //
+      .attr(MoveTypeChangeAbAttr, ElementalType.NORMAL, 1.2, anyTypeMoveConversionCondition)
+      .build(),
+    new AbBuilder(AbilityId.SNIPER, 4) //
+      .attr(MultCritAbAttr, 1.5)
+      .build(),
+    new AbBuilder(AbilityId.MAGIC_GUARD, 4) //
+      .attr(BlockNonDirectDamageAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.NO_GUARD, 4) //
       .attr(AlwaysHitAbAttr)
-      .attr(DoubleBattleChanceAbAttr),
-    new Ability(AbilityId.STALL, 4) //
-      .attr(ChangeMovePriorityAbAttr, (_pokemon, _move: Move) => true, -0.2),
-    new Ability(AbilityId.TECHNICIAN, 4) //
+      .attr(DoubleBattleChanceAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.STALL, 4) //
+      .attr(ChangeMovePriorityAbAttr, (_pokemon, _move: Move) => true, -0.2)
+      .build(),
+    new AbBuilder(AbilityId.TECHNICIAN, 4) //
       .attr(
         MovePowerBoostAbAttr,
         (user, target, move) => {
@@ -564,78 +665,99 @@ export function initAbilities(): void {
           return power.value <= 60;
         },
         1.5,
-      ),
-    new Ability(AbilityId.LEAF_GUARD, 4) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.LEAF_GUARD, 4) //
       .attr(StatusEffectImmunityAbAttr)
       .condition(getWeatherCondition(...SUNNY_WEATHER_TYPES))
-      .ignorable(),
-    new Ability(AbilityId.KLUTZ, 4, 1) //
-      .unimplemented(),
-    new Ability(AbilityId.MOLD_BREAKER, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.KLUTZ, 4, 1) //
+      .unimplemented()
+      .build(),
+    new AbBuilder(AbilityId.MOLD_BREAKER, 4) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonMoldBreaker", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       )
-      .attr(MoveAbilityBypassAbAttr),
-    new Ability(AbilityId.SUPER_LUCK, 4) //
-      .attr(BonusCritAbAttr, 1),
-    new Ability(AbilityId.AFTERMATH, 4) //
+      .attr(MoveAbilityBypassAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.SUPER_LUCK, 4) //
+      .attr(BonusCritAbAttr, 1)
+      .build(),
+    new AbBuilder(AbilityId.AFTERMATH, 4) //
       .attr(PostFaintContactDamageAbAttr, 4)
-      .bypassFaint(),
-    new Ability(AbilityId.ANTICIPATION, 4) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.ANTICIPATION, 4) //
       .attr(AnticipationAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonAnticipation", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
-      ),
-    new Ability(AbilityId.FOREWARN, 4) //
-      .attr(ForewarnAbAttr),
-    new Ability(AbilityId.UNAWARE, 4) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.FOREWARN, 4) //
+      .attr(ForewarnAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.UNAWARE, 4) //
       .attr(IgnoreOpponentStatStagesAbAttr, [Stat.ATK, Stat.DEF, Stat.SPATK, Stat.SPDEF, Stat.ACC, Stat.EVA])
-      .ignorable(),
-    new Ability(AbilityId.TINTED_LENS, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.TINTED_LENS, 4) //
       .attr(DamageBoostAbAttr, 2, (user, target, move) => {
         if (!user || !target || !move) {
           return false;
         }
         return target.getMoveEffectiveness(user, move) <= 0.5;
-      }),
-    new Ability(AbilityId.FILTER, 4) //
+      })
+      .build(),
+    new AbBuilder(AbilityId.FILTER, 4) //
       .attr(
         ReceivedMoveDamageMultiplierAbAttr,
         (target, user, move) => target.getMoveEffectiveness(user, move) >= 2,
         0.75,
       )
-      .ignorable(),
-    new Ability(AbilityId.SLOW_START, 4) //
-      .attr(PostSummonAddBattlerTagAbAttr, BattlerTagType.SLOW_START, 5, false),
-    new Ability(AbilityId.SCRAPPY, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SLOW_START, 4) //
+      .attr(PostSummonAddBattlerTagAbAttr, BattlerTagType.SLOW_START, 5, false)
+      .build(),
+    new AbBuilder(AbilityId.SCRAPPY, 4) //
       .attr(IgnoreTypeImmunityAbAttr, ElementalType.GHOST, [ElementalType.NORMAL, ElementalType.FIGHTING])
-      .attr(IntimidateImmunityAbAttr),
-    new Ability(AbilityId.STORM_DRAIN, 4) //
+      .attr(IntimidateImmunityAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.STORM_DRAIN, 4) //
       .attr(RedirectTypeMoveAbAttr, ElementalType.WATER)
       .attr(TypeImmunityStatStageChangeAbAttr, ElementalType.WATER, Stat.SPATK, 1)
-      .ignorable(),
-    new Ability(AbilityId.ICE_BODY, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.ICE_BODY, 4) //
       .attr(BlockWeatherDamageAbAttr, WeatherType.HAIL)
-      .attr(PostWeatherLapseHealAbAttr, 1 / 16, ...SNOWY_WEATHER_TYPES),
-    new Ability(AbilityId.SOLID_ROCK, 4) //
+      .attr(PostWeatherLapseHealAbAttr, 1 / 16, ...SNOWY_WEATHER_TYPES)
+      .build(),
+    new AbBuilder(AbilityId.SOLID_ROCK, 4) //
       .attr(
         ReceivedMoveDamageMultiplierAbAttr,
         (target, user, move) => target.getMoveEffectiveness(user, move) >= 2,
         0.75,
       )
-      .ignorable(),
-    new Ability(AbilityId.SNOW_WARNING, 4) //
-      .attr(PostSummonWeatherChangeAbAttr, WeatherType.SNOW),
-    new Ability(AbilityId.HONEY_GATHER, 4) //
-      .attr(MoneyAbAttr),
-    new Ability(AbilityId.FRISK, 4) //
-      .attr(FriskAbAttr),
-    new Ability(AbilityId.RECKLESS, 4) //
-      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.RECKLESS_MOVE, 1.2),
-    new Ability(AbilityId.MULTITYPE, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SNOW_WARNING, 4) //
+      .attr(PostSummonWeatherChangeAbAttr, WeatherType.SNOW)
+      .build(),
+    new AbBuilder(AbilityId.HONEY_GATHER, 4) //
+      .attr(MoneyAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.FRISK, 4) //
+      .attr(FriskAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.RECKLESS, 4) //
+      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.RECKLESS_MOVE, 1.2)
+      .build(),
+    new AbBuilder(AbilityId.MULTITYPE, 4) //
       .uncopiable()
       .unsuppressable()
-      .unreplaceable(),
-    new Ability(AbilityId.FLOWER_GIFT, 4, -2) //
+      .unreplaceable()
+      .build(),
+    new AbBuilder(AbilityId.FLOWER_GIFT, 4, -2) //
       .conditionalAttr(getWeatherCondition(...SUNNY_WEATHER_TYPES), EffectiveStatMultiplierAbAttr, Stat.ATK, 1.5)
       .conditionalAttr(getWeatherCondition(...SUNNY_WEATHER_TYPES), EffectiveStatMultiplierAbAttr, Stat.SPDEF, 1.5)
       .uncopiable()
@@ -652,44 +774,55 @@ export function initAbilities(): void {
       )
       // Should also boosts stats of ally
       .partial()
-      .ignorable(),
-    new Ability(AbilityId.BAD_DREAMS, 4) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.BAD_DREAMS, 4) //
       .attr(BadDreamsAbAttr)
       // When falling asleep, due to being drowsy, the ability flyout appears BEFORE the pokemon falls asleep
-      .edgeCase(),
-    new Ability(AbilityId.PICKPOCKET, 5) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.PICKPOCKET, 5) //
       .attr(PostDefendStealHeldItemAbAttr, (target, user, move) =>
         move.checkFlag(MoveFlags.MAKES_CONTACT, user, target),
       )
-      .condition(getSheerForceHitDisableAbCondition()),
-    new Ability(AbilityId.SHEER_FORCE, 5) //
+      .condition(getSheerForceHitDisableAbCondition())
+      .build(),
+    new AbBuilder(AbilityId.SHEER_FORCE, 5) //
       .attr(MovePowerBoostAbAttr, (_user, _target, move) => !!move && move.chance >= 1, 1.3)
       // Should disable life orb, eject button, red card, kee/maranga berry if they get implemented
-      .attr(MoveEffectChanceMultiplierAbAttr, 0),
-    new Ability(AbilityId.CONTRARY, 5) //
+      .attr(MoveEffectChanceMultiplierAbAttr, 0)
+      .build(),
+    new AbBuilder(AbilityId.CONTRARY, 5) //
       .attr(StatStageChangeMultiplierAbAttr, -1)
-      .ignorable(),
-    new Ability(AbilityId.UNNERVE, 5, 1) //
-      .attr(PreventBerryUseAbAttr),
-    new Ability(AbilityId.DEFIANT, 5) //
-      .attr(DefiantCompetitiveAbAttr, [Stat.ATK], 2),
-    new Ability(AbilityId.DEFEATIST, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.UNNERVE, 5, 1) //
+      .attr(PreventBerryUseAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.DEFIANT, 5) //
+      .attr(DefiantCompetitiveAbAttr, [Stat.ATK], 2)
+      .build(),
+    new AbBuilder(AbilityId.DEFEATIST, 5) //
       .attr(EffectiveStatMultiplierAbAttr, Stat.ATK, 0.5)
       .attr(EffectiveStatMultiplierAbAttr, Stat.SPATK, 0.5)
-      .condition((pokemon) => pokemon.getHpRatio() <= 0.5),
-    new Ability(AbilityId.CURSED_BODY, 5) //
+      .condition((pokemon) => pokemon.getHpRatio() <= 0.5)
+      .build(),
+    new AbBuilder(AbilityId.CURSED_BODY, 5) //
       .attr(PostDefendMoveDisableAbAttr, 30)
-      .bypassFaint(),
-    new Ability(AbilityId.HEALER, 5) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.HEALER, 5) //
       .conditionalAttr(
         (pokemon) => pokemon.getAlly() !== undefined && pokemon.randSeedInt(10) < 3,
         PostTurnResetStatusAbAttr,
         true,
-      ),
-    new Ability(AbilityId.FRIEND_GUARD, 5) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.FRIEND_GUARD, 5) //
       .attr(AlliedFieldDamageReductionAbAttr, 0.75)
-      .ignorable(),
-    new Ability(AbilityId.WEAK_ARMOR, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.WEAK_ARMOR, 5) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, _user, move) => move.category === MoveCategory.PHYSICAL,
@@ -701,31 +834,37 @@ export function initAbilities(): void {
         (_target, _user, move) => move.category === MoveCategory.PHYSICAL,
         Stat.SPD,
         2,
-      ),
-    new Ability(AbilityId.HEAVY_METAL, 5) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.HEAVY_METAL, 5) //
       .attr(WeightMultiplierAbAttr, 2)
-      .ignorable(),
-    new Ability(AbilityId.LIGHT_METAL, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.LIGHT_METAL, 5) //
       .attr(WeightMultiplierAbAttr, 0.5)
-      .ignorable(),
-    new Ability(AbilityId.MULTISCALE, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.MULTISCALE, 5) //
       .attr(ReceivedMoveDamageMultiplierAbAttr, (target, _user, _move) => target.isFullHp(), 0.5)
-      .ignorable(),
-    new Ability(AbilityId.TOXIC_BOOST, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.TOXIC_BOOST, 5) //
       .attr(
         MovePowerBoostAbAttr,
         (user, _target, move) =>
           move?.category === MoveCategory.PHYSICAL
           && !!user?.hasStatusEffect([StatusEffect.TOXIC, StatusEffect.POISON]),
         1.5,
-      ),
-    new Ability(AbilityId.FLARE_BOOST, 5) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.FLARE_BOOST, 5) //
       .attr(
         MovePowerBoostAbAttr,
         (user, _target, move) => move?.category === MoveCategory.SPECIAL && !!user?.hasStatusEffect(StatusEffect.BURN),
         1.5,
-      ),
-    new Ability(AbilityId.HARVEST, 5) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.HARVEST, 5) //
       .attr(
         PostTurnLootAbAttr,
         "EATEN_BERRIES",
@@ -733,56 +872,72 @@ export function initAbilities(): void {
         (pokemon) => (getWeatherCondition(...SUNNY_WEATHER_TYPES)(pokemon) ? 1 : 0.5),
       )
       // Cannot recover berries used up by fling or natural gift (unimplemented)
-      .edgeCase(),
-    new Ability(AbilityId.TELEPATHY, 5) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.TELEPATHY, 5) //
       .attr(MoveImmunityAbAttr, (pokemon, attacker, move) => pokemon.getAlly() === attacker && move.isAttackMove())
-      .ignorable(),
-    new Ability(AbilityId.MOODY, 5) //
-      .attr(MoodyAbAttr),
-    new Ability(AbilityId.OVERCOAT, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.MOODY, 5) //
+      .attr(MoodyAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.OVERCOAT, 5) //
       .attr(BlockWeatherDamageAbAttr, WeatherType.HAIL, WeatherType.SANDSTORM)
       .attr(MoveFlagImmunityAbAttr, MoveFlags.POWDER_MOVE)
-      .ignorable(),
-    new Ability(AbilityId.POISON_TOUCH, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.POISON_TOUCH, 5) //
       .attr(PostAttackApplyStatusEffectAbAttr, true, 30, StatusEffect.POISON)
       // Does not inflict poison if user gets inflicted with target's Mummy
-      .edgeCase(),
-    new Ability(AbilityId.REGENERATOR, 5) //
-      .attr(PreSwitchOutHealAbAttr),
-    new Ability(AbilityId.BIG_PECKS, 5) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.REGENERATOR, 5) //
+      .attr(PreSwitchOutHealAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.BIG_PECKS, 5) //
       .attr(ProtectStatAbAttr, Stat.DEF)
-      .ignorable(),
-    new Ability(AbilityId.SAND_RUSH, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SAND_RUSH, 5) //
       .attr(WeatherBasedSpeedDoublerAbAttr, WeatherType.SANDSTORM)
-      .attr(BlockWeatherDamageAbAttr, WeatherType.SANDSTORM),
-    new Ability(AbilityId.WONDER_SKIN, 5) //
+      .attr(BlockWeatherDamageAbAttr, WeatherType.SANDSTORM)
+      .build(),
+    new AbBuilder(AbilityId.WONDER_SKIN, 5) //
       .attr(WonderSkinAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.ANALYTIC, 5) //
-      .attr(MovePowerBoostAbAttr, () => globalScene.currentBattle.turnManager.isEmpty(), 1.3),
-    new Ability(AbilityId.ILLUSION, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.ANALYTIC, 5) //
+      .attr(MovePowerBoostAbAttr, () => globalScene.currentBattle.turnManager.isEmpty(), 1.3)
+      .build(),
+    new AbBuilder(AbilityId.ILLUSION, 5) //
       .uncopiable()
-      .unimplemented(),
-    new Ability(AbilityId.IMPOSTER, 5) //
+      .unimplemented()
+      .build(),
+    new AbBuilder(AbilityId.IMPOSTER, 5) //
       .attr(PostSummonTransformAbAttr)
-      .uncopiable(),
-    new Ability(AbilityId.INFILTRATOR, 5) //
+      .uncopiable()
+      .build(),
+    new AbBuilder(AbilityId.INFILTRATOR, 5) //
       .attr(InfiltratorAbAttr)
       // does not bypass Mist
-      .partial(),
-    new Ability(AbilityId.MUMMY, 5) //
+      .partial()
+      .build(),
+    new AbBuilder(AbilityId.MUMMY, 5) //
       .attr(PostDefendAbilityGiveAbAttr, AbilityId.MUMMY)
-      .bypassFaint(),
-    new Ability(AbilityId.MOXIE, 5) //
-      .attr(PostVictoryStatStageChangeAbAttr, Stat.ATK, 1),
-    new Ability(AbilityId.JUSTIFIED, 5) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.MOXIE, 5) //
+      .attr(PostVictoryStatStageChangeAbAttr, Stat.ATK, 1)
+      .build(),
+    new AbBuilder(AbilityId.JUSTIFIED, 5) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, user, move) => user.getMoveType(move) === ElementalType.DARK && move.category !== MoveCategory.STATUS,
         Stat.ATK,
         1,
-      ),
-    new Ability(AbilityId.RATTLED, 5) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.RATTLED, 5) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, user, move) => {
@@ -792,45 +947,55 @@ export function initAbilities(): void {
         Stat.SPD,
         1,
       )
-      .attr(PostIntimidateStatStageChangeAbAttr, [Stat.SPD], 1),
-    new Ability(AbilityId.MAGIC_BOUNCE, 5) //
+      .attr(PostIntimidateStatStageChangeAbAttr, [Stat.SPD], 1)
+      .build(),
+    new AbBuilder(AbilityId.MAGIC_BOUNCE, 5) //
       .attr(ReflectMovesAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.SAP_SIPPER, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SAP_SIPPER, 5) //
       .attr(TypeImmunityStatStageChangeAbAttr, ElementalType.GRASS, Stat.ATK, 1)
-      .ignorable(),
-    new Ability(AbilityId.PRANKSTER, 5) //
-      .attr(ChangeMovePriorityAbAttr, (_pokemon, move: Move) => move.category === MoveCategory.STATUS, 1),
-    new Ability(AbilityId.SAND_FORCE, 5) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.PRANKSTER, 5) //
+      .attr(ChangeMovePriorityAbAttr, (_pokemon, move: Move) => move.category === MoveCategory.STATUS, 1)
+      .build(),
+    new AbBuilder(AbilityId.SAND_FORCE, 5) //
       .attr(MoveTypePowerBoostAbAttr, ElementalType.ROCK, 1.3)
       .attr(MoveTypePowerBoostAbAttr, ElementalType.GROUND, 1.3)
       .attr(MoveTypePowerBoostAbAttr, ElementalType.STEEL, 1.3)
       .attr(BlockWeatherDamageAbAttr, WeatherType.SANDSTORM)
-      .condition(getWeatherCondition(WeatherType.SANDSTORM)),
-    new Ability(AbilityId.IRON_BARBS, 5) //
+      .condition(getWeatherCondition(WeatherType.SANDSTORM))
+      .build(),
+    new AbBuilder(AbilityId.IRON_BARBS, 5) //
       .attr(PostDefendContactDamageAbAttr, 8)
-      .bypassFaint(),
-    new Ability(AbilityId.ZEN_MODE, 5) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.ZEN_MODE, 5) //
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .attr(PostSummonFormChangeAbAttr, (p) => (p.getHpRatio() <= 0.5 ? 1 : 0))
       .attr(PostTurnFormChangeAbAttr, (p) => (p.getHpRatio() <= 0.5 ? 1 : 0))
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
-      .bypassFaint(),
-    new Ability(AbilityId.VICTORY_STAR, 5) //
-      .attr(FieldAccuracyMultiplierAbAttr, 1.1, (source, target) => !source.isOpponent(target)),
-    new Ability(AbilityId.TURBOBLAZE, 5) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.VICTORY_STAR, 5) //
+      .attr(FieldAccuracyMultiplierAbAttr, 1.1, (source, target) => !source.isOpponent(target))
+      .build(),
+    new AbBuilder(AbilityId.TURBOBLAZE, 5) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonTurboblaze", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       )
-      .attr(MoveAbilityBypassAbAttr),
-    new Ability(AbilityId.TERAVOLT, 5) //
+      .attr(MoveAbilityBypassAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.TERAVOLT, 5) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonTeravolt", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       )
-      .attr(MoveAbilityBypassAbAttr),
-    new Ability(AbilityId.AROMA_VEIL, 6) //
+      .attr(MoveAbilityBypassAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.AROMA_VEIL, 6) //
       .attr(
         UserFieldBattlerTagImmunityAbAttr,
         BattlerTagType.INFATUATED,
@@ -839,80 +1004,103 @@ export function initAbilities(): void {
         BattlerTagType.TORMENT,
         BattlerTagType.HEAL_BLOCK,
       )
-      .ignorable(),
-    new Ability(AbilityId.FLOWER_VEIL, 6) //
       .ignorable()
-      .unimplemented(),
-    new Ability(AbilityId.CHEEK_POUCH, 6) //
-      .attr(HealFromBerryUseAbAttr, 1 / 3),
-    new Ability(AbilityId.PROTEAN, 6) //
-      .attr(PokemonTypeChangeAbAttr),
-    new Ability(AbilityId.FUR_COAT, 6) //
+      .build(),
+    new AbBuilder(AbilityId.FLOWER_VEIL, 6) //
+      .ignorable()
+      .unimplemented()
+      .build(),
+    new AbBuilder(AbilityId.CHEEK_POUCH, 6) //
+      .attr(HealFromBerryUseAbAttr, 1 / 3)
+      .build(),
+    new AbBuilder(AbilityId.PROTEAN, 6) //
+      .attr(PokemonTypeChangeAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.FUR_COAT, 6) //
       // Doesn't boost defense on self inflicted confusion damage
       .attr(EffectiveStatMultiplierAbAttr, Stat.DEF, 2, (_user, target) => !!target)
-      .ignorable(),
-    new Ability(AbilityId.MAGICIAN, 6) //
-      .attr(PostAttackStealHeldItemAbAttr),
-    new Ability(AbilityId.BULLETPROOF, 6) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.MAGICIAN, 6) //
+      .attr(PostAttackStealHeldItemAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.BULLETPROOF, 6) //
       .attr(MoveFlagImmunityAbAttr, MoveFlags.BULLET_MOVE)
-      .ignorable(),
-    new Ability(AbilityId.COMPETITIVE, 6) //
-      .attr(DefiantCompetitiveAbAttr, [Stat.SPATK], 2),
-    new Ability(AbilityId.STRONG_JAW, 6) //
-      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.BITING_MOVE, 1.5),
-    new Ability(AbilityId.REFRIGERATE, 6) //
-      .attr(MoveTypeChangeAbAttr, ElementalType.ICE, 1.2, normalTypeMoveConversionCondition),
-    new Ability(AbilityId.SWEET_VEIL, 6) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.COMPETITIVE, 6) //
+      .attr(DefiantCompetitiveAbAttr, [Stat.SPATK], 2)
+      .build(),
+    new AbBuilder(AbilityId.STRONG_JAW, 6) //
+      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.BITING_MOVE, 1.5)
+      .build(),
+    new AbBuilder(AbilityId.REFRIGERATE, 6) //
+      .attr(MoveTypeChangeAbAttr, ElementalType.ICE, 1.2, normalTypeMoveConversionCondition)
+      .build(),
+    new AbBuilder(AbilityId.SWEET_VEIL, 6) //
       .attr(UserFieldStatusEffectImmunityAbAttr, StatusEffect.SLEEP)
       .attr(UserFieldBattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
       .ignorable()
       // Mold Breaker ally should not be affected by Sweet Veil
-      .partial(),
-    new Ability(AbilityId.STANCE_CHANGE, 6) //
+      .partial()
+      .build(),
+    new AbBuilder(AbilityId.STANCE_CHANGE, 6) //
       .uncopiable()
       .unsuppressable()
-      .unreplaceable(),
-    new Ability(AbilityId.GALE_WINGS, 6) //
-      .attr(ChangeMovePriorityAbAttr, (pokemon, move) => pokemon.isFullHp() && move.type === ElementalType.FLYING, 1),
-    new Ability(AbilityId.MEGA_LAUNCHER, 6) //
+      .unreplaceable()
+      .build(),
+    new AbBuilder(AbilityId.GALE_WINGS, 6) //
+      .attr(ChangeMovePriorityAbAttr, (pokemon, move) => pokemon.isFullHp() && move.type === ElementalType.FLYING, 1)
+      .build(),
+    new AbBuilder(AbilityId.MEGA_LAUNCHER, 6) //
       .attr(MoveFlagPowerBoostAbAttr, MoveFlags.PULSE_MOVE, 1.5)
       .attr(
         RecoveryBoostAbAttr,
         (pokemon, _target, move) => !!pokemon && !!move?.checkFlag(MoveFlags.PULSE_MOVE, pokemon),
         1.5,
-      ),
-    new Ability(AbilityId.GRASS_PELT, 6) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.GRASS_PELT, 6) //
       .conditionalAttr(getTerrainCondition(TerrainType.GRASSY), EffectiveStatMultiplierAbAttr, Stat.DEF, 1.5)
-      .ignorable(),
-    new Ability(AbilityId.SYMBIOSIS, 6) //
-      .unimplemented(),
-    new Ability(AbilityId.TOUGH_CLAWS, 6) //
-      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.MAKES_CONTACT, 1.3),
-    new Ability(AbilityId.PIXILATE, 6) //
-      .attr(MoveTypeChangeAbAttr, ElementalType.FAIRY, 1.2, normalTypeMoveConversionCondition),
-    new Ability(AbilityId.GOOEY, 6) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SYMBIOSIS, 6) //
+      .unimplemented()
+      .build(),
+    new AbBuilder(AbilityId.TOUGH_CLAWS, 6) //
+      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.MAKES_CONTACT, 1.3)
+      .build(),
+    new AbBuilder(AbilityId.PIXILATE, 6) //
+      .attr(MoveTypeChangeAbAttr, ElementalType.FAIRY, 1.2, normalTypeMoveConversionCondition)
+      .build(),
+    new AbBuilder(AbilityId.GOOEY, 6) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (target, user, move) => move.checkFlag(MoveFlags.MAKES_CONTACT, user, target),
         Stat.SPD,
         -1,
         false,
-      ),
-    new Ability(AbilityId.AERILATE, 6) //
-      .attr(MoveTypeChangeAbAttr, ElementalType.FLYING, 1.2, normalTypeMoveConversionCondition),
-    new Ability(AbilityId.PARENTAL_BOND, 6) //
-      .attr(AddSecondStrikeAbAttr, 0.25),
-    new Ability(AbilityId.DARK_AURA, 6) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.AERILATE, 6) //
+      .attr(MoveTypeChangeAbAttr, ElementalType.FLYING, 1.2, normalTypeMoveConversionCondition)
+      .build(),
+    new AbBuilder(AbilityId.PARENTAL_BOND, 6) //
+      .attr(AddSecondStrikeAbAttr, 0.25)
+      .build(),
+    new AbBuilder(AbilityId.DARK_AURA, 6) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonDarkAura", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       )
-      .attr(FieldMoveTypePowerBoostAbAttr, ElementalType.DARK, 4 / 3),
-    new Ability(AbilityId.FAIRY_AURA, 6) //
+      .attr(FieldMoveTypePowerBoostAbAttr, ElementalType.DARK, 4 / 3)
+      .build(),
+    new AbBuilder(AbilityId.FAIRY_AURA, 6) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonFairyAura", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       )
-      .attr(FieldMoveTypePowerBoostAbAttr, ElementalType.FAIRY, 4 / 3),
-    new Ability(AbilityId.AURA_BREAK, 6) //
+      .attr(FieldMoveTypePowerBoostAbAttr, ElementalType.FAIRY, 4 / 3)
+      .build(),
+    new AbBuilder(AbilityId.AURA_BREAK, 6) //
       .ignorable()
       .conditionalAttr(
         (_pokemon) => globalScene.getField(true).some((p) => p.hasAbility(AbilityId.DARK_AURA)),
@@ -934,48 +1122,57 @@ export function initAbilities(): void {
         PostSummonMessageAbAttr,
         (pokemon: Pokemon) =>
           i18next.t("abilityTriggers:postSummonAuraBreak", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
-      ),
-    new Ability(AbilityId.PRIMORDIAL_SEA, 6) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.PRIMORDIAL_SEA, 6) //
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.HEAVY_RAIN)
       .attr(PreLeaveFieldClearWeatherAbAttr)
-      .bypassFaint(),
-    new Ability(AbilityId.DESOLATE_LAND, 6) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.DESOLATE_LAND, 6) //
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.HARSH_SUN)
       .attr(PreLeaveFieldClearWeatherAbAttr)
-      .bypassFaint(),
-    new Ability(AbilityId.DELTA_STREAM, 6) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.DELTA_STREAM, 6) //
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.STRONG_WINDS)
       .attr(PreLeaveFieldClearWeatherAbAttr)
-      .bypassFaint(),
-    new Ability(AbilityId.STAMINA, 7) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.STAMINA, 7) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, _user, move) => move.category !== MoveCategory.STATUS,
         Stat.DEF,
         1,
-      ),
-    new Ability(AbilityId.WIMP_OUT, 7) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.WIMP_OUT, 7) //
       .attr(PostDamageForceSwitchAbAttr)
       // Should not trigger when hurting itself in confusion
-      .edgeCase(),
-    new Ability(AbilityId.EMERGENCY_EXIT, 7) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.EMERGENCY_EXIT, 7) //
       .attr(PostDamageForceSwitchAbAttr)
       // Should not trigger when hurting itself in confusion
-      .edgeCase(),
-    new Ability(AbilityId.WATER_COMPACTION, 7) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.WATER_COMPACTION, 7) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, user, move) =>
           user.getMoveType(move) === ElementalType.WATER && move.category !== MoveCategory.STATUS,
         Stat.DEF,
         2,
-      ),
-    new Ability(AbilityId.MERCILESS, 7) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.MERCILESS, 7) //
       .attr(
         ConditionalCritAbAttr,
         (_user, target, _move) => !!target?.hasStatusEffect([StatusEffect.POISON, StatusEffect.TOXIC]),
-      ),
-    new Ability(AbilityId.SHIELDS_DOWN, 7, -1) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.SHIELDS_DOWN, 7, -1) //
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .attr(PostSummonFormChangeAbAttr, (p) => (p.formIndex % 7) + (p.getHpRatio() <= 0.5 ? 7 : 0))
       .attr(PostTurnFormChangeAbAttr, (p) => (p.formIndex % 7) + (p.getHpRatio() <= 0.5 ? 7 : 0))
@@ -984,17 +1181,21 @@ export function initAbilities(): void {
       .unreplaceable()
       .bypassFaint()
       // Meteor form should protect against status effects and yawn
-      .partial(),
-    new Ability(AbilityId.STAKEOUT, 7) //
-      .attr(MovePowerBoostAbAttr, (_user, target, _move) => !!target?.turnData.switchedInThisTurn, 2),
-    new Ability(AbilityId.WATER_BUBBLE, 7) //
+      .partial()
+      .build(),
+    new AbBuilder(AbilityId.STAKEOUT, 7) //
+      .attr(MovePowerBoostAbAttr, (_user, target, _move) => !!target?.turnData.switchedInThisTurn, 2)
+      .build(),
+    new AbBuilder(AbilityId.WATER_BUBBLE, 7) //
       .attr(ReceivedTypeDamageMultiplierAbAttr, ElementalType.FIRE, 0.5)
       .attr(MoveTypePowerBoostAbAttr, ElementalType.WATER, 2)
       .attr(StatusEffectImmunityAbAttr, StatusEffect.BURN)
-      .ignorable(),
-    new Ability(AbilityId.STEELWORKER, 7) //
-      .attr(MoveTypePowerBoostAbAttr, ElementalType.STEEL),
-    new Ability(AbilityId.BERSERK, 7) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.STEELWORKER, 7) //
+      .attr(MoveTypePowerBoostAbAttr, ElementalType.STEEL)
+      .build(),
+    new AbBuilder(AbilityId.BERSERK, 7) //
       .attr(
         PostDefendHpGatedStatStageChangeAbAttr,
         (_target, _user, move) => move.category !== MoveCategory.STATUS,
@@ -1002,33 +1203,41 @@ export function initAbilities(): void {
         [Stat.SPATK],
         1,
       )
-      .condition(getSheerForceHitDisableAbCondition()),
-    new Ability(AbilityId.SLUSH_RUSH, 7) //
-      .attr(WeatherBasedSpeedDoublerAbAttr, ...SNOWY_WEATHER_TYPES),
-    new Ability(AbilityId.LONG_REACH, 7) //
-      .attr(IgnoreContactAbAttr),
-    new Ability(AbilityId.LIQUID_VOICE, 7) //
+      .condition(getSheerForceHitDisableAbCondition())
+      .build(),
+    new AbBuilder(AbilityId.SLUSH_RUSH, 7) //
+      .attr(WeatherBasedSpeedDoublerAbAttr, ...SNOWY_WEATHER_TYPES)
+      .build(),
+    new AbBuilder(AbilityId.LONG_REACH, 7) //
+      .attr(IgnoreContactAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.LIQUID_VOICE, 7) //
       .attr(
         MoveTypeChangeAbAttr,
         ElementalType.WATER,
         1,
         (user, target, move) => !!user && !!move?.checkFlag(MoveFlags.SOUND_MOVE, user, target),
-      ),
-    new Ability(AbilityId.TRIAGE, 7) //
-      .attr(ChangeMovePriorityAbAttr, (pokemon, move) => move.checkFlag(MoveFlags.TRIAGE_MOVE, pokemon), 3),
-    new Ability(AbilityId.GALVANIZE, 7) //
-      .attr(MoveTypeChangeAbAttr, ElementalType.ELECTRIC, 1.2, normalTypeMoveConversionCondition),
-    new Ability(AbilityId.SURGE_SURFER, 7) //
-      .conditionalAttr(getTerrainCondition(TerrainType.ELECTRIC), EffectiveStatMultiplierAbAttr, Stat.SPD, 2),
-    new Ability(AbilityId.SCHOOLING, 7, -1) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.TRIAGE, 7) //
+      .attr(ChangeMovePriorityAbAttr, (pokemon, move) => move.checkFlag(MoveFlags.TRIAGE_MOVE, pokemon), 3)
+      .build(),
+    new AbBuilder(AbilityId.GALVANIZE, 7) //
+      .attr(MoveTypeChangeAbAttr, ElementalType.ELECTRIC, 1.2, normalTypeMoveConversionCondition)
+      .build(),
+    new AbBuilder(AbilityId.SURGE_SURFER, 7) //
+      .conditionalAttr(getTerrainCondition(TerrainType.ELECTRIC), EffectiveStatMultiplierAbAttr, Stat.SPD, 2)
+      .build(),
+    new AbBuilder(AbilityId.SCHOOLING, 7, -1) //
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .attr(PostSummonFormChangeAbAttr, (p) => (p.level < 20 || p.getHpRatio() <= 0.25 ? 0 : 1))
       .attr(PostTurnFormChangeAbAttr, (p) => (p.level < 20 || p.getHpRatio() <= 0.25 ? 0 : 1))
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
-      .bypassFaint(),
-    new Ability(AbilityId.DISGUISE, 7) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.DISGUISE, 7) //
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
@@ -1055,15 +1264,17 @@ export function initAbilities(): void {
       )
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .bypassFaint()
-      .ignorable(),
-    new Ability(AbilityId.BATTLE_BOND, 7) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.BATTLE_BOND, 7) //
       .attr(PostVictoryFormChangeAbAttr, () => 2)
       .attr(PostBattleInitFormChangeAbAttr, () => 1)
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
-      .bypassFaint(),
-    new Ability(AbilityId.POWER_CONSTRUCT, 7) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.POWER_CONSTRUCT, 7) //
       .conditionalAttr(
         (pokemon) => pokemon.formIndex === 2 || pokemon.formIndex === 4,
         PostBattleInitFormChangeAbAttr,
@@ -1097,60 +1308,73 @@ export function initAbilities(): void {
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
-      .bypassFaint(),
-    new Ability(AbilityId.CORROSION, 7) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.CORROSION, 7) //
       .attr(
         IgnoreTypeStatusEffectImmunityAbAttr,
         [StatusEffect.POISON, StatusEffect.TOXIC],
         [ElementalType.STEEL, ElementalType.POISON],
       )
       // fling with toxic orb (not implemented yet)
-      .edgeCase(),
-    new Ability(AbilityId.COMATOSE, 7) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.COMATOSE, 7) //
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
       .attr(MockStatusEffectAbAttr, StatusEffect.SLEEP)
       .attr(StatusEffectImmunityAbAttr, ...NON_VOLATILE_STATUS_EFFECTS)
-      .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY),
-    new Ability(AbilityId.QUEENLY_MAJESTY, 7) //
+      .attr(BattlerTagImmunityAbAttr, BattlerTagType.DROWSY)
+      .build(),
+    new AbBuilder(AbilityId.QUEENLY_MAJESTY, 7) //
       .attr(FieldPriorityMoveImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.INNARDS_OUT, 7) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.INNARDS_OUT, 7) //
       .attr(PostFaintHPDamageAbAttr)
-      .bypassFaint(),
-    new Ability(AbilityId.DANCER, 7) //
-      .attr(PostDancingMoveAbAttr),
-    new Ability(AbilityId.BATTERY, 7) //
-      .attr(AllyMoveCategoryPowerBoostAbAttr, [MoveCategory.SPECIAL], 1.3),
-    new Ability(AbilityId.FLUFFY, 7) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.DANCER, 7) //
+      .attr(PostDancingMoveAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.BATTERY, 7) //
+      .attr(AllyMoveCategoryPowerBoostAbAttr, [MoveCategory.SPECIAL], 1.3)
+      .build(),
+    new AbBuilder(AbilityId.FLUFFY, 7) //
       .attr(
         ReceivedMoveDamageMultiplierAbAttr,
         (target, user, move) => move.checkFlag(MoveFlags.MAKES_CONTACT, user, target),
         0.5,
       )
       .attr(ReceivedTypeDamageMultiplierAbAttr, ElementalType.FIRE, 2)
-      .ignorable(),
-    new Ability(AbilityId.DAZZLING, 7) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.DAZZLING, 7) //
       .attr(FieldPriorityMoveImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.SOUL_HEART, 7) //
-      .attr(PostKnockOutStatStageChangeAbAttr, Stat.SPATK, 1),
-    new Ability(AbilityId.TANGLING_HAIR, 7) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SOUL_HEART, 7) //
+      .attr(PostKnockOutStatStageChangeAbAttr, Stat.SPATK, 1)
+      .build(),
+    new AbBuilder(AbilityId.TANGLING_HAIR, 7) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (target, user, move) => move.checkFlag(MoveFlags.MAKES_CONTACT, user, target),
         Stat.SPD,
         -1,
         false,
-      ),
-    new Ability(AbilityId.RECEIVER, 7) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.RECEIVER, 7) //
       .attr(CopyFaintedAllyAbilityAbAttr)
-      .uncopiable(),
-    new Ability(AbilityId.POWER_OF_ALCHEMY, 7) //
+      .uncopiable()
+      .build(),
+    new AbBuilder(AbilityId.POWER_OF_ALCHEMY, 7) //
       .attr(CopyFaintedAllyAbilityAbAttr)
-      .uncopiable(),
-    new Ability(AbilityId.BEAST_BOOST, 7) //
+      .uncopiable()
+      .build(),
+    new AbBuilder(AbilityId.BEAST_BOOST, 7) //
       .attr(
         PostVictoryStatStageChangeAbAttr,
         (p) => {
@@ -1166,24 +1390,32 @@ export function initAbilities(): void {
           return highestStat!;
         },
         1,
-      ),
-    new Ability(AbilityId.RKS_SYSTEM, 7) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.RKS_SYSTEM, 7) //
       .uncopiable()
       .unsuppressable()
-      .unreplaceable(),
-    new Ability(AbilityId.ELECTRIC_SURGE, 7) //
-      .attr(PostSummonTerrainChangeAbAttr, TerrainType.ELECTRIC),
-    new Ability(AbilityId.PSYCHIC_SURGE, 7) //
-      .attr(PostSummonTerrainChangeAbAttr, TerrainType.PSYCHIC),
-    new Ability(AbilityId.MISTY_SURGE, 7) //
-      .attr(PostSummonTerrainChangeAbAttr, TerrainType.MISTY),
-    new Ability(AbilityId.GRASSY_SURGE, 7) //
-      .attr(PostSummonTerrainChangeAbAttr, TerrainType.GRASSY),
-    new Ability(AbilityId.FULL_METAL_BODY, 7) //
-      .attr(ProtectStatAbAttr),
-    new Ability(AbilityId.SHADOW_SHIELD, 7) //
-      .attr(ReceivedMoveDamageMultiplierAbAttr, (target, _user, _move) => target.isFullHp(), 0.5),
-    new Ability(AbilityId.PRISM_ARMOR, 7) //
+      .unreplaceable()
+      .build(),
+    new AbBuilder(AbilityId.ELECTRIC_SURGE, 7) //
+      .attr(PostSummonTerrainChangeAbAttr, TerrainType.ELECTRIC)
+      .build(),
+    new AbBuilder(AbilityId.PSYCHIC_SURGE, 7) //
+      .attr(PostSummonTerrainChangeAbAttr, TerrainType.PSYCHIC)
+      .build(),
+    new AbBuilder(AbilityId.MISTY_SURGE, 7) //
+      .attr(PostSummonTerrainChangeAbAttr, TerrainType.MISTY)
+      .build(),
+    new AbBuilder(AbilityId.GRASSY_SURGE, 7) //
+      .attr(PostSummonTerrainChangeAbAttr, TerrainType.GRASSY)
+      .build(),
+    new AbBuilder(AbilityId.FULL_METAL_BODY, 7) //
+      .attr(ProtectStatAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.SHADOW_SHIELD, 7) //
+      .attr(ReceivedMoveDamageMultiplierAbAttr, (target, _user, _move) => target.isFullHp(), 0.5)
+      .build(),
+    new AbBuilder(AbilityId.PRISM_ARMOR, 7) //
       .attr(
         ReceivedMoveDamageMultiplierAbAttr,
         (user, target, move) => {
@@ -1193,8 +1425,9 @@ export function initAbilities(): void {
           return target.getMoveEffectiveness(user, move) >= 2;
         },
         0.75,
-      ),
-    new Ability(AbilityId.NEUROFORCE, 7) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.NEUROFORCE, 7) //
       .attr(
         MovePowerBoostAbAttr,
         (user, target, move) => {
@@ -1204,17 +1437,22 @@ export function initAbilities(): void {
           return target.getMoveEffectiveness(user, move) >= 2;
         },
         1.25,
-      ),
-    new Ability(AbilityId.INTREPID_SWORD, 8) //
-      .attr(PostSummonStatStageChangeAbAttr, [Stat.ATK], 1, true),
-    new Ability(AbilityId.DAUNTLESS_SHIELD, 8) //
-      .attr(PostSummonStatStageChangeAbAttr, [Stat.DEF], 1, true),
-    new Ability(AbilityId.LIBERO, 8) //
-      .attr(PokemonTypeChangeAbAttr),
-    new Ability(AbilityId.BALL_FETCH, 8) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.INTREPID_SWORD, 8) //
+      .attr(PostSummonStatStageChangeAbAttr, [Stat.ATK], 1, true)
+      .build(),
+    new AbBuilder(AbilityId.DAUNTLESS_SHIELD, 8) //
+      .attr(PostSummonStatStageChangeAbAttr, [Stat.DEF], 1, true)
+      .build(),
+    new AbBuilder(AbilityId.LIBERO, 8) //
+      .attr(PokemonTypeChangeAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.BALL_FETCH, 8) //
       .attr(FetchBallAbAttr)
-      .condition(getOncePerBattleCondition(AbilityId.BALL_FETCH)),
-    new Ability(AbilityId.COTTON_DOWN, 8) //
+      .condition(getOncePerBattleCondition(AbilityId.BALL_FETCH))
+      .build(),
+    new AbBuilder(AbilityId.COTTON_DOWN, 8) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, _user, move) => move.category !== MoveCategory.STATUS,
@@ -1223,12 +1461,15 @@ export function initAbilities(): void {
         false,
         true,
       )
-      .bypassFaint(),
-    new Ability(AbilityId.PROPELLER_TAIL, 8) //
-      .attr(BlockRedirectAbAttr),
-    new Ability(AbilityId.MIRROR_ARMOR, 8) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.PROPELLER_TAIL, 8) //
+      .attr(BlockRedirectAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.MIRROR_ARMOR, 8) //
       .attr(ReflectStatStageChangeAbAttr)
-      .ignorable(),
+      .ignorable()
+      .build(),
     /*
      * Right now, the logic is attached to Surf and Dive. Ideally, the post-defend/hit should be an
      * ability attribute but the current implementation of move effects for BattlerTag does not support this
@@ -1236,15 +1477,17 @@ export function initAbilities(): void {
      *
      * See `GulpMissileTagAttr` and `GulpMissileTag` for Gulp Missile implementation
      */
-    new Ability(AbilityId.GULP_MISSILE, 8) //
+    new AbBuilder(AbilityId.GULP_MISSILE, 8) //
       .noTransform()
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
-      .bypassFaint(),
-    new Ability(AbilityId.STALWART, 8) //
-      .attr(BlockRedirectAbAttr),
-    new Ability(AbilityId.STEAM_ENGINE, 8) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.STALWART, 8) //
+      .attr(BlockRedirectAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.STEAM_ENGINE, 8) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, user, move) => {
@@ -1253,28 +1496,33 @@ export function initAbilities(): void {
         },
         Stat.SPD,
         6,
-      ),
-    new Ability(AbilityId.PUNK_ROCK, 8) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.PUNK_ROCK, 8) //
       .attr(MoveFlagPowerBoostAbAttr, MoveFlags.SOUND_MOVE, 1.3)
       .attr(
         ReceivedMoveDamageMultiplierAbAttr,
         (target, user, move) => move.checkFlag(MoveFlags.SOUND_MOVE, user, target),
         0.5,
       )
-      .ignorable(),
-    new Ability(AbilityId.SAND_SPIT, 8) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SAND_SPIT, 8) //
       .bypassFaint()
       .attr(
         PostDefendWeatherChangeAbAttr,
         WeatherType.SANDSTORM,
         (_target, _user, move) => move.category !== MoveCategory.STATUS,
-      ),
-    new Ability(AbilityId.ICE_SCALES, 8) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.ICE_SCALES, 8) //
       .attr(ReceivedMoveDamageMultiplierAbAttr, (_target, _user, move) => move.category === MoveCategory.SPECIAL, 0.5)
-      .ignorable(),
-    new Ability(AbilityId.RIPEN, 8) //
-      .attr(DoubleBerryEffectAbAttr),
-    new Ability(AbilityId.ICE_FACE, 8, -2) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.RIPEN, 8) //
+      .attr(DoubleBerryEffectAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.ICE_FACE, 8, -2) //
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
@@ -1310,32 +1558,36 @@ export function initAbilities(): void {
       )
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .bypassFaint()
-      .ignorable(),
-    new Ability(AbilityId.POWER_SPOT, 8) //
-      .attr(AllyMoveCategoryPowerBoostAbAttr, [MoveCategory.SPECIAL, MoveCategory.PHYSICAL], 1.3),
-    new Ability(AbilityId.MIMICRY, 8, -1) //
-      .attr(TerrainEventTypeChangeAbAttr),
-    new Ability(AbilityId.SCREEN_CLEANER, 8) //
-      .attr(PostSummonRemoveArenaTagAbAttr, [
-        ArenaTagType.AURORA_VEIL,
-        ArenaTagType.LIGHT_SCREEN,
-        ArenaTagType.REFLECT,
-      ]),
-    new Ability(AbilityId.STEELY_SPIRIT, 8) //
-      .attr(UserFieldMoveTypePowerBoostAbAttr, ElementalType.STEEL),
-    new Ability(AbilityId.PERISH_BODY, 8) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.POWER_SPOT, 8) //
+      .attr(AllyMoveCategoryPowerBoostAbAttr, [MoveCategory.SPECIAL, MoveCategory.PHYSICAL], 1.3)
+      .build(),
+    new AbBuilder(AbilityId.MIMICRY, 8, -1) //
+      .attr(TerrainEventTypeChangeAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.SCREEN_CLEANER, 8) //
+      .attr(PostSummonRemoveArenaTagAbAttr, [ArenaTagType.AURORA_VEIL, ArenaTagType.LIGHT_SCREEN, ArenaTagType.REFLECT])
+      .build(),
+    new AbBuilder(AbilityId.STEELY_SPIRIT, 8) //
+      .attr(UserFieldMoveTypePowerBoostAbAttr, ElementalType.STEEL)
+      .build(),
+    new AbBuilder(AbilityId.PERISH_BODY, 8) //
       .attr(PostDefendPerishSongAbAttr)
-      .bypassFaint(),
-    new Ability(AbilityId.WANDERING_SPIRIT, 8) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.WANDERING_SPIRIT, 8) //
       .attr(PostDefendAbilitySwapAbAttr)
       .bypassFaint()
       // Interacts incorrectly with rock head.
       // It's meant to switch abilities before recoil would apply so that a pokemon with rock head
       // would lose rock head first and still take the recoil
-      .edgeCase(),
-    new Ability(AbilityId.GORILLA_TACTICS, 8) //
-      .attr(GorillaTacticsAbAttr),
-    new Ability(AbilityId.NEUTRALIZING_GAS, 8, 2) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.GORILLA_TACTICS, 8) //
+      .attr(GorillaTacticsAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.NEUTRALIZING_GAS, 8, 2) //
       .attr(SuppressFieldAbilitiesAbAttr)
       .uncopiable()
       .noTransform()
@@ -1345,33 +1597,43 @@ export function initAbilities(): void {
         }),
       )
       // A bunch of weird interactions with other abilities being suppressed then unsuppressed
-      .partial(),
-    new Ability(AbilityId.PASTEL_VEIL, 8) //
+      .partial()
+      .build(),
+    new AbBuilder(AbilityId.PASTEL_VEIL, 8) //
       .attr(PostSummonUserFieldRemoveStatusEffectAbAttr, StatusEffect.POISON, StatusEffect.TOXIC)
       .attr(UserFieldStatusEffectImmunityAbAttr, StatusEffect.POISON, StatusEffect.TOXIC)
-      .ignorable(),
-    new Ability(AbilityId.HUNGER_SWITCH, 8) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.HUNGER_SWITCH, 8) //
       .attr(PostTurnFormChangeAbAttr, (p) => (p.getFormKey() ? 0 : 1))
       .attr(PostTurnFormChangeAbAttr, (p) => (p.getFormKey() ? 1 : 0))
       .uncopiable()
       .unreplaceable()
       .noTransform()
-      .condition((pokemon) => !pokemon.isTerastallized),
-    new Ability(AbilityId.QUICK_DRAW, 8) //
-      .attr(BypassSpeedChanceAbAttr, 30),
-    new Ability(AbilityId.UNSEEN_FIST, 8) //
-      .attr(IgnoreProtectOnContactAbAttr),
-    new Ability(AbilityId.CURIOUS_MEDICINE, 8) //
-      .attr(PostSummonClearAllyStatStagesAbAttr),
-    new Ability(AbilityId.TRANSISTOR, 8) //
-      .attr(MoveTypePowerBoostAbAttr, ElementalType.ELECTRIC, 1.3),
-    new Ability(AbilityId.DRAGONS_MAW, 8) //
-      .attr(MoveTypePowerBoostAbAttr, ElementalType.DRAGON),
-    new Ability(AbilityId.CHILLING_NEIGH, 8) //
-      .attr(PostVictoryStatStageChangeAbAttr, Stat.ATK, 1),
-    new Ability(AbilityId.GRIM_NEIGH, 8) //
-      .attr(PostVictoryStatStageChangeAbAttr, Stat.SPATK, 1),
-    new Ability(AbilityId.AS_ONE_GLASTRIER, 8, 1) //
+      .condition((pokemon) => !pokemon.isTerastallized)
+      .build(),
+    new AbBuilder(AbilityId.QUICK_DRAW, 8) //
+      .attr(BypassSpeedChanceAbAttr, 30)
+      .build(),
+    new AbBuilder(AbilityId.UNSEEN_FIST, 8) //
+      .attr(IgnoreProtectOnContactAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.CURIOUS_MEDICINE, 8) //
+      .attr(PostSummonClearAllyStatStagesAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.TRANSISTOR, 8) //
+      .attr(MoveTypePowerBoostAbAttr, ElementalType.ELECTRIC, 1.3)
+      .build(),
+    new AbBuilder(AbilityId.DRAGONS_MAW, 8) //
+      .attr(MoveTypePowerBoostAbAttr, ElementalType.DRAGON)
+      .build(),
+    new AbBuilder(AbilityId.CHILLING_NEIGH, 8) //
+      .attr(PostVictoryStatStageChangeAbAttr, Stat.ATK, 1)
+      .build(),
+    new AbBuilder(AbilityId.GRIM_NEIGH, 8) //
+      .attr(PostVictoryStatStageChangeAbAttr, Stat.SPATK, 1)
+      .build(),
+    new AbBuilder(AbilityId.AS_ONE_GLASTRIER, 8, 1) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonAsOneGlastrier", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
@@ -1381,8 +1643,9 @@ export function initAbilities(): void {
       .attr(PostVictoryStatStageChangeAbAttr, Stat.ATK, 1)
       .uncopiable()
       .unsuppressable()
-      .unreplaceable(),
-    new Ability(AbilityId.AS_ONE_SPECTRIER, 8, 1) //
+      .unreplaceable()
+      .build(),
+    new AbBuilder(AbilityId.AS_ONE_SPECTRIER, 8, 1) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>
         i18next.t("abilityTriggers:postSummonAsOneSpectrier", {
           pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
@@ -1392,14 +1655,17 @@ export function initAbilities(): void {
       .attr(PostVictoryStatStageChangeAbAttr, Stat.SPATK, 1)
       .uncopiable()
       .unsuppressable()
-      .unreplaceable(),
-    new Ability(AbilityId.LINGERING_AROMA, 9) //
+      .unreplaceable()
+      .build(),
+    new AbBuilder(AbilityId.LINGERING_AROMA, 9) //
       .attr(PostDefendAbilityGiveAbAttr, AbilityId.LINGERING_AROMA)
-      .bypassFaint(),
-    new Ability(AbilityId.SEED_SOWER, 9) //
       .bypassFaint()
-      .attr(PostDefendTerrainChangeAbAttr, TerrainType.GRASSY),
-    new Ability(AbilityId.THERMAL_EXCHANGE, 9) //
+      .build(),
+    new AbBuilder(AbilityId.SEED_SOWER, 9) //
+      .bypassFaint()
+      .attr(PostDefendTerrainChangeAbAttr, TerrainType.GRASSY)
+      .build(),
+    new AbBuilder(AbilityId.THERMAL_EXCHANGE, 9) //
       .attr(
         PostDefendStatStageChangeAbAttr,
         (_target, user, move) => user.getMoveType(move) === ElementalType.FIRE && move.category !== MoveCategory.STATUS,
@@ -1407,8 +1673,9 @@ export function initAbilities(): void {
         1,
       )
       .attr(StatusEffectImmunityAbAttr, StatusEffect.BURN)
-      .ignorable(),
-    new Ability(AbilityId.ANGER_SHELL, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.ANGER_SHELL, 9) //
       .attr(
         PostDefendHpGatedStatStageChangeAbAttr,
         (_target, _user, move) => move.category !== MoveCategory.STATUS,
@@ -1423,15 +1690,18 @@ export function initAbilities(): void {
         [Stat.DEF, Stat.SPDEF],
         -1,
       )
-      .condition(getSheerForceHitDisableAbCondition()),
-    new Ability(AbilityId.PURIFYING_SALT, 9) //
+      .condition(getSheerForceHitDisableAbCondition())
+      .build(),
+    new AbBuilder(AbilityId.PURIFYING_SALT, 9) //
       .attr(StatusEffectImmunityAbAttr)
       .attr(ReceivedTypeDamageMultiplierAbAttr, ElementalType.GHOST, 0.5)
-      .ignorable(),
-    new Ability(AbilityId.WELL_BAKED_BODY, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.WELL_BAKED_BODY, 9) //
       .attr(TypeImmunityStatStageChangeAbAttr, ElementalType.FIRE, Stat.DEF, 2)
-      .ignorable(),
-    new Ability(AbilityId.WIND_RIDER, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.WIND_RIDER, 9) //
       .attr(
         MoveImmunityStatStageChangeAbAttr,
         (pokemon, attacker, move) =>
@@ -1442,43 +1712,50 @@ export function initAbilities(): void {
         1,
       )
       .attr(PostSummonStatStageChangeOnArenaAbAttr, ArenaTagType.TAILWIND)
-      .ignorable(),
-    new Ability(AbilityId.GUARD_DOG, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.GUARD_DOG, 9) //
       .attr(IntimidateImmunityAbAttr, false)
       .attr(PostIntimidateStatStageChangeAbAttr, [Stat.ATK], 1)
       .attr(ForceSwitchOutImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.ROCKY_PAYLOAD, 9) //
-      .attr(MoveTypePowerBoostAbAttr, ElementalType.ROCK),
-    new Ability(AbilityId.WIND_POWER, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.ROCKY_PAYLOAD, 9) //
+      .attr(MoveTypePowerBoostAbAttr, ElementalType.ROCK)
+      .build(),
+    new AbBuilder(AbilityId.WIND_POWER, 9) //
       .attr(
         PostDefendApplyBattlerTagAbAttr,
         (target, user, move) => move.checkFlag(MoveFlags.WIND_MOVE, user, target),
         BattlerTagType.CHARGED,
-      ),
-    new Ability(AbilityId.ZERO_TO_HERO, 9) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.ZERO_TO_HERO, 9) //
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
       .noTransform()
       .attr(PostBattleInitFormChangeAbAttr, () => 0)
       .attr(PreSwitchOutFormChangeAbAttr, (pokemon) => (pokemon.isFainted() ? pokemon.formIndex : 1))
-      .bypassFaint(),
-    new Ability(AbilityId.COMMANDER, 9) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.COMMANDER, 9) //
       .attr(CommanderAbAttr)
       // Custom implementation to allow more double battles
       .attr(DoubleBattleChanceAbAttr)
       .uncopiable()
       .unreplaceable()
       // Encore, Frenzy, and other non-`TURN_END` tags don't lapse correctly on the commanding Pokemon.
-      .edgeCase(),
-    new Ability(AbilityId.ELECTROMORPHOSIS, 9) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.ELECTROMORPHOSIS, 9) //
       .attr(
         PostDefendApplyBattlerTagAbAttr,
         (_target, _user, move) => move.category !== MoveCategory.STATUS,
         BattlerTagType.CHARGED,
-      ),
-    new Ability(AbilityId.PROTOSYNTHESIS, 9, -2) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.PROTOSYNTHESIS, 9, -2) //
       .conditionalAttr(
         getWeatherCondition(...SUNNY_WEATHER_TYPES),
         PostSummonAddBattlerTagAbAttr,
@@ -1487,8 +1764,9 @@ export function initAbilities(): void {
       )
       .attr(PostWeatherChangeAddBattlerTagAbAttr, BattlerTagType.PROTOSYNTHESIS, 0, ...SUNNY_WEATHER_TYPES)
       .uncopiable()
-      .noTransform(),
-    new Ability(AbilityId.QUARK_DRIVE, 9, -2) //
+      .noTransform()
+      .build(),
+    new AbBuilder(AbilityId.QUARK_DRIVE, 9, -2) //
       .conditionalAttr(
         getTerrainCondition(TerrainType.ELECTRIC),
         PostSummonAddBattlerTagAbAttr,
@@ -1497,14 +1775,16 @@ export function initAbilities(): void {
       )
       .attr(PostTerrainChangeAddBattlerTagAbAttr, BattlerTagType.QUARK_DRIVE, 0, TerrainType.ELECTRIC)
       .uncopiable()
-      .noTransform(),
-    new Ability(AbilityId.GOOD_AS_GOLD, 9) //
+      .noTransform()
+      .build(),
+    new AbBuilder(AbilityId.GOOD_AS_GOLD, 9) //
       .attr(
         MoveImmunityAbAttr,
         (pokemon, attacker, move) => pokemon !== attacker && move.category === MoveCategory.STATUS,
       )
-      .ignorable(),
-    new Ability(AbilityId.VESSEL_OF_RUIN, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.VESSEL_OF_RUIN, 9) //
       .attr(TreasureOfRuinAbAttr, Stat.SPATK)
       .attr(PostSummonMessageAbAttr, (user) =>
         i18next.t("abilityTriggers:postSummonVesselOfRuin", {
@@ -1512,16 +1792,18 @@ export function initAbilities(): void {
           statName: i18next.t(getStatKey(Stat.SPATK)),
         }),
       )
-      .ignorable(),
-    new Ability(AbilityId.SWORD_OF_RUIN, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SWORD_OF_RUIN, 9) //
       .attr(TreasureOfRuinAbAttr, Stat.DEF)
       .attr(PostSummonMessageAbAttr, (user) =>
         i18next.t("abilityTriggers:postSummonSwordOfRuin", {
           pokemonNameWithAffix: getPokemonNameWithAffix(user),
           statName: i18next.t(getStatKey(Stat.DEF)),
         }),
-      ),
-    new Ability(AbilityId.TABLETS_OF_RUIN, 9) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.TABLETS_OF_RUIN, 9) //
       .attr(TreasureOfRuinAbAttr, Stat.ATK)
       .attr(PostSummonMessageAbAttr, (user) =>
         i18next.t("abilityTriggers:postSummonTabletsOfRuin", {
@@ -1529,114 +1811,139 @@ export function initAbilities(): void {
           statName: i18next.t(getStatKey(Stat.ATK)),
         }),
       )
-      .ignorable(),
-    new Ability(AbilityId.BEADS_OF_RUIN, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.BEADS_OF_RUIN, 9) //
       .attr(TreasureOfRuinAbAttr, Stat.SPDEF)
       .attr(PostSummonMessageAbAttr, (user) =>
         i18next.t("abilityTriggers:postSummonBeadsOfRuin", {
           pokemonNameWithAffix: getPokemonNameWithAffix(user),
           statName: i18next.t(getStatKey(Stat.SPDEF)),
         }),
-      ),
-    new Ability(AbilityId.ORICHALCUM_PULSE, 9) //
+      )
+      .build(),
+    new AbBuilder(AbilityId.ORICHALCUM_PULSE, 9) //
       .attr(PostSummonWeatherChangeAbAttr, WeatherType.SUNNY)
-      .conditionalAttr(getWeatherCondition(...SUNNY_WEATHER_TYPES), EffectiveStatMultiplierAbAttr, Stat.ATK, 4 / 3),
-    new Ability(AbilityId.HADRON_ENGINE, 9) //
+      .conditionalAttr(getWeatherCondition(...SUNNY_WEATHER_TYPES), EffectiveStatMultiplierAbAttr, Stat.ATK, 4 / 3)
+      .build(),
+    new AbBuilder(AbilityId.HADRON_ENGINE, 9) //
       .attr(PostSummonTerrainChangeAbAttr, TerrainType.ELECTRIC)
-      .conditionalAttr(getTerrainCondition(TerrainType.ELECTRIC), EffectiveStatMultiplierAbAttr, Stat.SPATK, 4 / 3),
-    new Ability(AbilityId.OPPORTUNIST, 9) //
-      .attr(StatStageChangeCopyAbAttr),
-    new Ability(AbilityId.CUD_CHEW, 9) //
-      .unimplemented(),
-    new Ability(AbilityId.SHARPNESS, 9) //
-      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.SLICING_MOVE, 1.5),
-    new Ability(AbilityId.SUPREME_OVERLORD, 9) //
+      .conditionalAttr(getTerrainCondition(TerrainType.ELECTRIC), EffectiveStatMultiplierAbAttr, Stat.SPATK, 4 / 3)
+      .build(),
+    new AbBuilder(AbilityId.OPPORTUNIST, 9) //
+      .attr(StatStageChangeCopyAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.CUD_CHEW, 9) //
+      .unimplemented()
+      .build(),
+    new AbBuilder(AbilityId.SHARPNESS, 9) //
+      .attr(MoveFlagPowerBoostAbAttr, MoveFlags.SLICING_MOVE, 1.5)
+      .build(),
+    new AbBuilder(AbilityId.SUPREME_OVERLORD, 9) //
       .attr(VariableMovePowerBoostAbAttr, (user, _target, _move) => {
         const { playerFaints, enemyFaints } = globalScene.currentBattle;
         return 1 + 0.1 * Math.min(user.isPlayer() ? playerFaints : enemyFaints, 5);
       })
       // Counter resets every wave instead of on arena reset
-      .partial(),
-    new Ability(AbilityId.COSTAR, 9, -2) //
-      .attr(PostSummonCopyAllyStatsAbAttr),
-    new Ability(AbilityId.TOXIC_DEBRIS, 9) //
+      .partial()
+      .build(),
+    new AbBuilder(AbilityId.COSTAR, 9, -2) //
+      .attr(PostSummonCopyAllyStatsAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.TOXIC_DEBRIS, 9) //
       .attr(
         PostDefendApplyEntryHazardTagAbAttr,
         (_target, _user, move) => move.category === MoveCategory.PHYSICAL,
         ArenaTagType.TOXIC_SPIKES,
       )
-      .bypassFaint(),
-    new Ability(AbilityId.ARMOR_TAIL, 9) //
+      .bypassFaint()
+      .build(),
+    new AbBuilder(AbilityId.ARMOR_TAIL, 9) //
       .attr(FieldPriorityMoveImmunityAbAttr)
-      .ignorable(),
-    new Ability(AbilityId.EARTH_EATER, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.EARTH_EATER, 9) //
       .attr(TypeImmunityHealAbAttr, ElementalType.GROUND)
-      .ignorable(),
-    new Ability(AbilityId.MYCELIUM_MIGHT, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.MYCELIUM_MIGHT, 9) //
       .attr(ChangeMovePriorityAbAttr, (_pokemon, move) => move.category === MoveCategory.STATUS, -0.2)
       .attr(PreventBypassSpeedChanceAbAttr, (_pokemon, move) => move.category === MoveCategory.STATUS)
-      .attr(MoveAbilityBypassAbAttr, (_pokemon, move: Move) => move.category === MoveCategory.STATUS),
-    new Ability(AbilityId.MINDS_EYE, 9) //
+      .attr(MoveAbilityBypassAbAttr, (_pokemon, move: Move) => move.category === MoveCategory.STATUS)
+      .build(),
+    new AbBuilder(AbilityId.MINDS_EYE, 9) //
       .attr(IgnoreTypeImmunityAbAttr, ElementalType.GHOST, [ElementalType.NORMAL, ElementalType.FIGHTING])
       .attr(ProtectStatAbAttr, Stat.ACC)
       .attr(IgnoreOpponentStatStagesAbAttr, [Stat.EVA])
-      .ignorable(),
-    new Ability(AbilityId.SUPERSWEET_SYRUP, 9) //
-      .attr(PostSummonStatStageChangeAbAttr, [Stat.EVA], -1),
-    new Ability(AbilityId.HOSPITALITY, 9, -2) //
-      .attr(PostSummonAllyHealAbAttr, 4, true),
-    new Ability(AbilityId.TOXIC_CHAIN, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.SUPERSWEET_SYRUP, 9) //
+      .attr(PostSummonStatStageChangeAbAttr, [Stat.EVA], -1)
+      .build(),
+    new AbBuilder(AbilityId.HOSPITALITY, 9, -2) //
+      .attr(PostSummonAllyHealAbAttr, 4, true)
+      .build(),
+    new AbBuilder(AbilityId.TOXIC_CHAIN, 9) //
       .attr(PostAttackApplyStatusEffectAbAttr, false, 30, StatusEffect.TOXIC)
       // Does not inflict poison if user gets inflicted with target's Mummy
-      .edgeCase(),
-    new Ability(AbilityId.EMBODY_ASPECT_TEAL, 9) //
+      .edgeCase()
+      .build(),
+    new AbBuilder(AbilityId.EMBODY_ASPECT_TEAL, 9) //
       .attr(PostTeraFormChangeStatChangeAbAttr, [Stat.SPD], 1)
       .attr(PostSummonStatStageChangeAbAttr, [Stat.SPD], 1, true)
       .uncopiable()
       // TODO: confirm if this is true
       .unreplaceable()
-      .noTransform(),
-    new Ability(AbilityId.EMBODY_ASPECT_WELLSPRING, 9) //
+      .noTransform()
+      .build(),
+    new AbBuilder(AbilityId.EMBODY_ASPECT_WELLSPRING, 9) //
       .attr(PostTeraFormChangeStatChangeAbAttr, [Stat.SPDEF], 1)
       .attr(PostSummonStatStageChangeAbAttr, [Stat.SPDEF], 1, true)
       .uncopiable()
       // TODO: confirm if this is true
       .unreplaceable()
-      .noTransform(),
-    new Ability(AbilityId.EMBODY_ASPECT_HEARTHFLAME, 9) //
+      .noTransform()
+      .build(),
+    new AbBuilder(AbilityId.EMBODY_ASPECT_HEARTHFLAME, 9) //
       .attr(PostTeraFormChangeStatChangeAbAttr, [Stat.ATK], 1)
       .attr(PostSummonStatStageChangeAbAttr, [Stat.ATK], 1, true)
       .uncopiable()
       // TODO: confirm if this is true
       .unreplaceable()
-      .noTransform(),
-    new Ability(AbilityId.EMBODY_ASPECT_CORNERSTONE, 9) //
+      .noTransform()
+      .build(),
+    new AbBuilder(AbilityId.EMBODY_ASPECT_CORNERSTONE, 9) //
       .attr(PostTeraFormChangeStatChangeAbAttr, [Stat.DEF], 1)
       .attr(PostSummonStatStageChangeAbAttr, [Stat.DEF], 1, true)
       .uncopiable()
       // TODO: confirm if this is true
       .unreplaceable()
-      .noTransform(),
-    new Ability(AbilityId.TERA_SHIFT, 9, 2) //
+      .noTransform()
+      .build(),
+    new AbBuilder(AbilityId.TERA_SHIFT, 9, 2) //
       .attr(PostSummonFormChangeAbAttr, (p) => (p.getFormKey() ? 0 : 1))
       .uncopiable()
       .unsuppressable()
       .unreplaceable()
-      .noTransform(),
-    new Ability(AbilityId.TERA_SHELL, 9) //
+      .noTransform()
+      .build(),
+    new AbBuilder(AbilityId.TERA_SHELL, 9) //
       .attr(FullHpResistTypeAbAttr)
       .uncopiable()
       .unreplaceable()
-      .ignorable(),
-    new Ability(AbilityId.TERAFORM_ZERO, 9) //
+      .ignorable()
+      .build(),
+    new AbBuilder(AbilityId.TERAFORM_ZERO, 9) //
       .uncopiable()
       .unreplaceable()
-      .attr(PostTeraFormChangeClearWeatherTerrainAbAttr),
-    new Ability(AbilityId.POISON_PUPPETEER, 9) //
+      .attr(PostTeraFormChangeClearWeatherTerrainAbAttr)
+      .build(),
+    new AbBuilder(AbilityId.POISON_PUPPETEER, 9) //
       .uncopiable()
       // TODO: confirm if this is true
       .unreplaceable()
-      .attr(ConfusionOnStatusEffectAbAttr, StatusEffect.POISON, StatusEffect.TOXIC),
+      .attr(ConfusionOnStatusEffectAbAttr, StatusEffect.POISON, StatusEffect.TOXIC)
+      .build(),
   );
 }
 

--- a/src/data/moves/move-attrs/ability-change-attr.ts
+++ b/src/data/moves/move-attrs/ability-change-attr.ts
@@ -42,7 +42,7 @@ export class AbilityChangeAttr extends MoveEffectAttr {
 
   override getCondition(): MoveConditionFunc {
     return (user, target, _move) =>
-      (this.selfTarget ? user : target).getAbility().isReplaceable
+      (this.selfTarget ? user : target).getAbility().replaceable
       && (this.selfTarget ? user : target).getAbility().id !== this.ability;
   }
 }

--- a/src/data/moves/move-attrs/ability-copy-attr.ts
+++ b/src/data/moves/move-attrs/ability-copy-attr.ts
@@ -51,9 +51,9 @@ export class AbilityCopyAttr extends MoveEffectAttr {
 
   override getCondition(): MoveConditionFunc {
     return (user, target, _move) => {
-      let ret = target.getAbility().isCopiable && user.getAbility().isReplaceable;
+      let ret = target.getAbility().copiable && user.getAbility().replaceable;
       if (this.copyToPartner && globalScene.currentBattle?.double) {
-        ret = ret && (user.getAlly()?.hp === 0 || !!user.getAlly()?.getAbility().isReplaceable);
+        ret = ret && (user.getAlly()?.hp === 0 || !!user.getAlly()?.getAbility().replaceable);
       } else {
         ret = ret && user.getAbility().id !== target.getAbility().id;
       }

--- a/src/data/moves/move-attrs/ability-give-attr.ts
+++ b/src/data/moves/move-attrs/ability-give-attr.ts
@@ -28,8 +28,6 @@ export class AbilityGiveAttr extends MoveEffectAttr {
 
   override getCondition(): MoveConditionFunc {
     return (user, target, _move) =>
-      user.getAbility().isCopiable
-      && target.getAbility().isReplaceable
-      && user.getAbility().id !== target.getAbility().id;
+      user.getAbility().copiable && target.getAbility().replaceable && user.getAbility().id !== target.getAbility().id;
   }
 }

--- a/src/data/moves/move-attrs/suppress-abilities-attr.ts
+++ b/src/data/moves/move-attrs/suppress-abilities-attr.ts
@@ -26,6 +26,6 @@ export class SuppressAbilitiesAttr extends MoveEffectAttr {
 
   /** Causes the effect to fail when the target's ability is unsupressable or already suppressed. */
   override getCondition(): MoveConditionFunc {
-    return (_user, target, _move) => target.getAbility().isSuppressable && !target.summonData.abilitySuppressed;
+    return (_user, target, _move) => target.getAbility().suppressable && !target.summonData.abilitySuppressed;
   }
 }

--- a/src/data/moves/move-attrs/switch-abilities-attr.ts
+++ b/src/data/moves/move-attrs/switch-abilities-attr.ts
@@ -29,6 +29,6 @@ export class SwitchAbilitiesAttr extends MoveEffectAttr {
   }
 
   override getCondition(): MoveConditionFunc {
-    return (user, target, _move) => [user, target].every((pkmn) => pkmn.getAbility().isSwappable);
+    return (user, target, _move) => [user, target].every((pkmn) => pkmn.getAbility().swappable);
   }
 }

--- a/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
+++ b/src/data/mystery-encounters/encounters/clowning-around-encounter.ts
@@ -1,7 +1,7 @@
-import { Ability } from "#abilities/ability";
 import { EncounterBattleAnim } from "#animations/encounter-battle-anim";
 import { globalScene } from "#app/global-scene";
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#constants/mystery-encounter-constants";
+import { allAbilities } from "#data/data-lists";
 import { TrainerPartyCompoundTemplate, TrainerPartyTemplate } from "#data/trainer-config";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
@@ -135,7 +135,7 @@ export const ClowningAroundEncounter: MysteryEncounter = MysteryEncounterBuilder
 
     // Generate random ability for Blacephalon from pool
     const ability = RANDOM_ABILITY_POOL[randSeedInt(RANDOM_ABILITY_POOL.length)];
-    encounter.setDialogueToken("ability", new Ability(ability, 3).name);
+    encounter.setDialogueToken("ability", allAbilities[ability].name);
     encounter.misc = { ability };
 
     encounter.enemyPartyConfigs.push({

--- a/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
+++ b/src/data/mystery-encounters/encounters/fiery-fallout-encounter.ts
@@ -1,7 +1,7 @@
-import { Ability } from "#abilities/ability";
 import { EncounterBattleAnim } from "#animations/encounter-battle-anim";
 import { globalScene } from "#app/global-scene";
 import { CLASSIC_MODE_MYSTERY_ENCOUNTER_WAVES } from "#constants/mystery-encounter-constants";
+import { allAbilities } from "#data/data-lists";
 import { AbilityId } from "#enums/ability-id";
 import { BattlerIndex } from "#enums/battler-index";
 import { BattlerTagType } from "#enums/battler-tag-type";
@@ -241,7 +241,7 @@ export const FieryFalloutEncounter: MysteryEncounter = MysteryEncounterBuilder.w
         if (chosenPokemon.trySetStatus(StatusEffect.BURN)) {
           // Burn applied
           encounter.setDialogueToken("burnedPokemon", chosenPokemon.getNameToRender());
-          encounter.setDialogueToken("abilityName", new Ability(AbilityId.HEATPROOF, 3).name);
+          encounter.setDialogueToken("abilityName", allAbilities[AbilityId.HEATPROOF].name);
           queueEncounterMessage(`${namespace}:option.2.target_burned`);
 
           // Also permanently change the burned Pokemon's ability to Heatproof

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1728,10 +1728,10 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     }
     const ability = passive ? this.getPassiveAbility() : this.getAbility();
     const arena = globalScene?.arena;
-    if (arena.ignoreAbilities && arena.ignoringEffectSource !== this.getBattlerIndex() && ability.isIgnorable) {
+    if (arena.ignoreAbilities && arena.ignoringEffectSource !== this.getBattlerIndex() && ability.ignorable) {
       return false;
     }
-    if (this.summonData.abilitySuppressed && ability.isSuppressable) {
+    if (this.summonData.abilitySuppressed && ability.suppressable) {
       return false;
     }
     if (this.isOnField() && !ability.hasAttr("SuppressFieldAbilitiesAbAttr")) {
@@ -1753,7 +1753,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
         return false;
       }
     }
-    return (this.hp > 0 || ability.isBypassFaint) && !ability.conditions.find((condition) => !condition(this));
+    return (this.hp > 0 || ability.bypassFaint) && !ability.conditions.find((condition) => !condition(this));
   }
 
   /**


### PR DESCRIPTION
- This is a port of https://github.com/pagefaultgames/pokerogue/pull/6534

## What are the changes the user will see?
N/A

## Why am I making these changes?
Methods that are only used when initializing abilities will no longer show up as intellisense suggestions on the `Ability` class.

## What are the changes from a developer perspective?
- Split the `Ability` class into a second `AbBuilder` class.
- Ability flags now use a new `flags` field and are a bitfield instead of individual boolean fields.
- Renamed the `is[...]` properties to discard the "is", and use getters that check a new flags field on the ability class.
- Abilities are now initialized with `AbBuilder#build` and the constructor of the `Ability` class is made private, meaning new `Ability` instances can only be created with `AbBuilder#build`.
- Replaced `Ability#name` and `#description` getters with `readonly` fields, and removed `#i18nKey` field since it was only used to set `name` and `description` and was now no longer needed to be accessible across scopes.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?