### PR TITLE
dev: update handling of dev and beta modes

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: pnpm build:beta
         env:
-          NODE_ENV: production
+          NODE_ENV: beta
 
       - name: Set up SSH
         run: |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "start": "vite",
+    "start:prod": "vite --mode production",
+    "start:beta": "vite --mode beta",
     "start:dev": "vite --mode development",
     "build": "vite build",
     "build:beta": "vite build --mode beta",

--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -64,8 +64,19 @@ export const RUN_HISTORY_LIMIT: number = 25;
 /** The number of save slots available to players. */
 export const SAVE_SLOT_LIMIT: number = 5;
 
-/** Whether the app is running in beta (or development) mode. */
+/**
+ * `true` if running in "beta" mode via either of:
+ * - `pnpm start:beta` (which runs `vite --mode beta`)
+ * - A build created via `pnpm build:beta`
+ */
 export const IS_BETA = import.meta.env.MODE === "beta";
+
+/**
+ * `true` if running in "development" mode via either of:
+ * - `pnpm start:dev` (which runs `vite --mode development`)
+ * - A build created via `pnpm build:dev`
+ */
+export const IS_DEV = import.meta.env.MODE === "development";
 
 /** Whether the app is running in a test environment */
 export const IS_TEST = import.meta.env.NODE_ENV === "test";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,20 @@
 import "#app/polyfills"; // polyfills must be first
 import "#app/phaser-extensions";
 
-// Catch global errors and display them in an alert so users can report the issue.
+import { IS_BETA, IS_DEV } from "#constants/app-constants";
+
+if (IS_DEV || IS_BETA) {
+  document.title += " (Beta)";
+}
+
 window.onerror = (_message, _source, _lineno, _colno, error) => {
   console.error(error);
-  // const errorString = `Received unhandled error. Open browser console and click OK to see details.\nError: ${message}\nSource: ${source}\nLine: ${lineno}\nColumn: ${colno}\nStack: ${error.stack}`;
-  //alert(errorString);
   // Avoids logging the error a second time.
   return true;
 };
 
-// Catch global promise rejections and display them in an alert so users can report the issue.
 window.addEventListener("unhandledrejection", (event) => {
-  // const errorString = `Received unhandled promise rejection. Open browser console and click OK to see details.\nReason: ${event.reason}`;
   console.error(event.reason);
-  //alert(errorString);
 });
 
 document.fonts.load("16px emerald").then(() => document.fonts.load("10px pkmnems"));
@@ -36,17 +36,14 @@ const startGame = async (manifest?: any) => {
   }
 };
 
-fetch("/manifest.json")
-  .then((res) => res.json())
-  .then((jsonResponse) => {
-    startGame(jsonResponse.manifest);
-  })
-  .catch(() => {
-    // Manifest not found (likely local build)
-    startGame();
-  })
-  .finally(() => {
-    if (import.meta.env.MODE === "development") {
-      import("./dev");
-    }
-  });
+try {
+  const json = await (await fetch("/manifest.json")).json();
+  await startGame(json.manifest);
+} catch {
+  // The manifest wasn't found, likely due to running locally
+  await startGame();
+}
+
+if (IS_DEV) {
+  await import("./dev");
+}

--- a/src/phases/game-over-phase.ts
+++ b/src/phases/game-over-phase.ts
@@ -1,6 +1,7 @@
 import { api } from "#api/api";
 import { clientSessionId } from "#app/account";
 import { globalScene } from "#app/global-scene";
+import { BYPASS_LOGIN } from "#constants/app-constants";
 import { getCharVariantFromDialogue } from "#data/dialogue";
 import type { PokemonSpecies } from "#data/pokemon-species";
 import { AchvCategory } from "#enums/achv-category";
@@ -200,12 +201,9 @@ export class GameOverPhase extends BattlePhase {
       });
     };
 
-    /**
-     * Check to see if the game is running offline
-     * If Online, execute apiFetch as intended
-     * If Offline, execute offlineNewClear() only for victory, a localStorage implementation of newClear daily run checks
-     */
-    if (!api.isLocal || api.isConnected) {
+    // If Online, execute `apiFetch` as intended
+    // If Offline, execute `offlineNewClear()` only for victory, a localStorage implementation of `newClear` daily run checks
+    if (!BYPASS_LOGIN || api.isConnected) {
       api.savedata.session
         .newclear({ slot: globalScene.sessionSlotId, isVictory: this.isVictory, clientSessionId })
         .then((success) => doGameOver(success));

--- a/src/phases/title-phase.ts
+++ b/src/phases/title-phase.ts
@@ -3,6 +3,7 @@ import { loggedInUser } from "#app/account";
 import { getGameMode, getModeName } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
 import { Phase } from "#app/phase";
+import { BYPASS_LOGIN } from "#constants/app-constants";
 import { fetchDailyRunSeed, getDailyRunStarters } from "#data/daily-run";
 import { GameModes } from "#enums/game-modes";
 import { ModifierPoolType } from "#enums/modifier-pool-type";
@@ -247,8 +248,9 @@ export class TitlePhase extends Phase {
         });
       };
 
-      // If Online, calls seed fetch from db to generate daily run. If Offline, generates a daily run based on current date.
-      if (!api.isLocal || api.isConnected) {
+      // If Online, calls seed fetch from db to generate daily run.
+      // If Offline, generates a daily run based on current date.
+      if (!BYPASS_LOGIN || api.isConnected) {
         fetchDailyRunSeed()
           .then((seed) => {
             if (seed) {

--- a/src/plugins/api/account-api.ts
+++ b/src/plugins/api/account-api.ts
@@ -8,9 +8,7 @@ import type {
 } from "#types/api-types";
 import { removeCookie, setCookie } from "#utils/app-utils";
 
-/**
- * A wrapper for the account API requests.
- */
+/** A wrapper for the account API requests. */
 export class AccountApi extends ApiBase {
   //#region Public
 
@@ -39,7 +37,7 @@ export class AccountApi extends ApiBase {
    * @param registerData The {@linkcode AccountRegisterRequest} to send
    * @returns An error message if something went wrong
    */
-  public async register(registerData: AccountRegisterRequest) {
+  public async register(registerData: AccountRegisterRequest): Promise<string | null> {
     try {
       const response = await this.doPost("/account/register", registerData, "form-urlencoded");
 
@@ -60,7 +58,7 @@ export class AccountApi extends ApiBase {
    * @param loginData The {@linkcode AccountLoginRequest} to send
    * @returns An error message if something went wrong
    */
-  public async login(loginData: AccountLoginRequest) {
+  public async login(loginData: AccountLoginRequest): Promise<string | null> {
     try {
       const response = await this.doPost("/account/login", loginData, "form-urlencoded");
 
@@ -82,7 +80,7 @@ export class AccountApi extends ApiBase {
    * Send a logout request.
    * **Always** (no matter if failed or not) removes the session cookie.
    */
-  public async logout() {
+  public async logout(): Promise<void> {
     try {
       const response = await this.doGet("/account/logout");
 
@@ -95,4 +93,6 @@ export class AccountApi extends ApiBase {
 
     removeCookie(SESSION_ID_COOKIE); // we are always clearing the cookie.
   }
+
+  //#endregion
 }

--- a/src/plugins/api/admin-api.ts
+++ b/src/plugins/api/admin-api.ts
@@ -16,7 +16,7 @@ export class AdminApi extends ApiBase {
    * @param params The {@linkcode LinkAccountToDiscordIdRequest} to send
    * @returns `null` if successful, error message if not
    */
-  public async linkAccountToDiscord(params: LinkAccountToDiscordIdRequest) {
+  public async linkAccountToDiscord(params: LinkAccountToDiscordIdRequest): Promise<string | null> {
     try {
       const response = await this.doPost("/admin/account/discordLink", params, "form-urlencoded");
 
@@ -40,7 +40,7 @@ export class AdminApi extends ApiBase {
    * @param params The {@linkcode UnlinkAccountFromDiscordIdRequest} to send
    * @returns `null` if successful, error message if not
    */
-  public async unlinkAccountFromDiscord(params: UnlinkAccountFromDiscordIdRequest) {
+  public async unlinkAccountFromDiscord(params: UnlinkAccountFromDiscordIdRequest): Promise<string | null> {
     try {
       const response = await this.doPost("/admin/account/discordUnlink", params, "form-urlencoded");
 
@@ -64,7 +64,7 @@ export class AdminApi extends ApiBase {
    * @param params The {@linkcode LinkAccountToGoogledIdRequest} to send
    * @returns `null` if successful, error message if not
    */
-  public async linkAccountToGoogleId(params: LinkAccountToGoogledIdRequest) {
+  public async linkAccountToGoogleId(params: LinkAccountToGoogledIdRequest): Promise<string | null> {
     try {
       const response = await this.doPost("/admin/account/googleLink", params, "form-urlencoded");
 
@@ -88,7 +88,7 @@ export class AdminApi extends ApiBase {
    * @param params The {@linkcode UnlinkAccountFromGoogledIdRequest} to send
    * @returns `null` if successful, error message if not
    */
-  public async unlinkAccountFromGoogleId(params: UnlinkAccountFromGoogledIdRequest) {
+  public async unlinkAccountFromGoogleId(params: UnlinkAccountFromGoogledIdRequest): Promise<string | null> {
     try {
       const response = await this.doPost("/admin/account/googleUnlink", params, "form-urlencoded");
 

--- a/src/plugins/api/api-base.ts
+++ b/src/plugins/api/api-base.ts
@@ -10,19 +10,21 @@ export abstract class ApiBase {
 
   protected readonly base: string;
 
+  //#endregion
   //#region Public
 
   constructor(base: string) {
     this.base = base;
   }
 
+  //#endregion
   //#region Protected
 
   /**
    * Send a GET request.
    * @param path The path to send the request to.
    */
-  protected async doGet(path: string) {
+  protected async doGet(path: string): Promise<Response> {
     return this.doFetch(path, { method: "GET" });
   }
 
@@ -32,7 +34,7 @@ export abstract class ApiBase {
    * @param bodyData The body-data to send.
    * @param dataType The data-type of the {@linkcode bodyData}.
    */
-  protected async doPost<D = undefined>(path: string, bodyData?: D, dataType: DataType = "json") {
+  protected async doPost<D = undefined>(path: string, bodyData?: D, dataType: DataType = "json"): Promise<Response> {
     let body: string | undefined;
     const headers: HeadersInit = {};
 
@@ -83,11 +85,13 @@ export abstract class ApiBase {
    * @param data the data to transform to {@linkcode URLSearchParams}
    * @returns a {@linkcode URLSearchParams} representaton of {@linkcode data}
    */
-  protected toUrlSearchParams<D extends Record<string, any>>(data: D) {
+  protected toUrlSearchParams<D extends Record<string, any>>(data: D): URLSearchParams {
     const arr = Object.entries(data)
       .map(([key, value]) => [key, String(value ?? "")])
       .filter(([, value]) => value !== "");
 
     return new URLSearchParams(arr);
   }
+
+  //#endregion
 }

--- a/src/plugins/api/api.ts
+++ b/src/plugins/api/api.ts
@@ -5,9 +5,7 @@ import { DailyApi } from "#api/daily-api";
 import { SavedataApi } from "#api/savedata-api";
 import type { TitleStatsResponse } from "#types/api-types";
 
-/**
- * A wrapper for API requests.
- */
+/** A wrapper for API requests. */
 class Api extends ApiBase {
   //#region Fields
 
@@ -21,6 +19,7 @@ class Api extends ApiBase {
   /** Whether the server/api is connected. By default we assume `true`. */
   private _isConnected: boolean;
 
+  //#endregion
   //#region Public
 
   constructor(base: string) {
@@ -32,14 +31,14 @@ class Api extends ApiBase {
   }
 
   /** Whether the server/api is connected. By default we assume `true`. */
-  public get isConnected() {
+  public get isConnected(): boolean {
     return this._isConnected;
   }
 
   /**
    * Request game title-stats.
    */
-  public async getGameTitleStats() {
+  public async getGameTitleStats(): Promise<TitleStatsResponse | null> {
     if (!this.isConnected) {
       this.printServerNotConnectedWarning();
       return null;
@@ -58,7 +57,7 @@ class Api extends ApiBase {
    * Unlink the currently logged in user from Discord.
    * @returns `true` if unlinking was successful, `false` if not
    */
-  public async unlinkDiscord() {
+  public async unlinkDiscord(): Promise<boolean> {
     if (!this.isConnected) {
       this.printServerNotConnectedWarning();
       return false;
@@ -81,7 +80,7 @@ class Api extends ApiBase {
    * Unlink the currently logged in user from Google.
    * @returns `true` if unlinking was successful, `false` if not
    */
-  public async unlinkGoogle() {
+  public async unlinkGoogle(): Promise<boolean> {
     if (!this.isConnected) {
       this.printServerNotConnectedWarning();
       return false;
@@ -105,7 +104,7 @@ class Api extends ApiBase {
    * @remarks
    * We have no dedicated ping/status endpoint yet, so we ping the game title stats endpoint, but without printing any errors by default.
    */
-  async ping() {
+  public async ping(): Promise<void> {
     try {
       const response = await this.doGet("/game/titlestats");
       const data = await response.json();
@@ -125,7 +124,7 @@ class Api extends ApiBase {
   //#endregion
   //#region Private
 
-  private printServerNotConnectedWarning() {
+  private printServerNotConnectedWarning(): void {
     if (import.meta.env.VITE_API_DEBUG === "1") {
       console.warn(this.ERR_SERVER_NOT_CONNECTED);
     }

--- a/src/plugins/api/api.ts
+++ b/src/plugins/api/api.ts
@@ -18,8 +18,6 @@ class Api extends ApiBase {
   public readonly admin: AdminApi;
   public readonly savedata: SavedataApi;
 
-  /** Wheter the hostname is 'localhost' or an IP address, and ensure a port is specified. */
-  private readonly _isLocal: boolean;
   /** Whether the server/api is connected. By default we assume `true`. */
   private _isConnected: boolean;
 
@@ -31,20 +29,11 @@ class Api extends ApiBase {
     this.daily = new DailyApi(base);
     this.admin = new AdminApi(base);
     this.savedata = new SavedataApi(base);
-    this._isLocal =
-      ((window.location.hostname === "localhost" || /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/.test(window.location.hostname))
-        && window.location.port !== "")
-      || window.location.hostname === "";
   }
 
   /** Whether the server/api is connected. By default we assume `true`. */
   public get isConnected() {
     return this._isConnected;
-  }
-
-  /** Wheter the hostname is 'localhost' or an IP address, and ensure a port is specified. */
-  public get isLocal() {
-    return this._isLocal;
   }
 
   /**
@@ -129,7 +118,7 @@ class Api extends ApiBase {
       }
     }
     if (import.meta.env.VITE_API_DEBUG === "1") {
-      console.log("isLocalServerConnected:", this.isConnected);
+      console.log("`Api#isConnected`:", this.isConnected);
     }
   }
 

--- a/src/plugins/api/daily-api.ts
+++ b/src/plugins/api/daily-api.ts
@@ -1,8 +1,6 @@
 import { ApiBase } from "#api/api-base";
 
-/**
- * A wrapper for daily-run API requests.
- */
+/** A wrapper for daily-run API requests. */
 export class DailyApi extends ApiBase {
   //#region Public
 
@@ -10,7 +8,7 @@ export class DailyApi extends ApiBase {
    * Request the daily-run seed.
    * @returns The active daily-run seed as `string`.
    */
-  public async getSeed() {
+  public async getSeed(): Promise<string | null> {
     try {
       const response = await this.doGet("/daily/seed");
       return response.text();
@@ -19,4 +17,6 @@ export class DailyApi extends ApiBase {
       return null;
     }
   }
+
+  //#endregion
 }

--- a/src/plugins/api/savedata-api.ts
+++ b/src/plugins/api/savedata-api.ts
@@ -4,15 +4,14 @@ import { SystemSavedataApi } from "#api/system-savedata-api";
 import { MAX_INT_ATTR_VALUE } from "#constants/game-constants";
 import type { UpdateAllSavedataRequest } from "#types/api-types";
 
-/**
- * A wrapper for savedata API requests.
- */
+/** A wrapper for savedata API requests. */
 export class SavedataApi extends ApiBase {
   //#region Fields
 
   public readonly system: SystemSavedataApi;
   public readonly session: SessionSavedataApi;
 
+  //#endregion
   //#region Public
 
   constructor(base: string) {
@@ -26,7 +25,7 @@ export class SavedataApi extends ApiBase {
    * @param bodyData The {@linkcode UpdateAllSavedataRequest | request data} to send
    * @returns An error message if something went wrong
    */
-  public async updateAll(bodyData: UpdateAllSavedataRequest) {
+  public async updateAll(bodyData: UpdateAllSavedataRequest): Promise<string> {
     try {
       const rawBodyData = JSON.stringify(bodyData, (_k: any, v: any) => {
         if (typeof v === "bigint") {
@@ -41,4 +40,6 @@ export class SavedataApi extends ApiBase {
       return "Unknown error";
     }
   }
+
+  //#endregion
 }

--- a/src/plugins/api/session-savedata-api.ts
+++ b/src/plugins/api/session-savedata-api.ts
@@ -9,9 +9,7 @@ import type {
 } from "#types/api-types";
 import type { SessionSaveData } from "#types/session-data";
 
-/**
- * A wrapper for session savedata API requests.
- */
+/** A wrapper for session savedata API requests. */
 export class SessionSavedataApi extends ApiBase {
   //#region Public
 
@@ -40,7 +38,7 @@ export class SessionSavedataApi extends ApiBase {
    * @param params The {@linkcode GetSessionSavedataRequest} to send
    * @returns The session as `string`
    */
-  public async get(params: GetSessionSavedataRequest) {
+  public async get(params: GetSessionSavedataRequest): Promise<string | null> {
     try {
       const urlSearchParams = this.toUrlSearchParams(params);
       const response = await this.doGet(`/savedata/session/get?${urlSearchParams}`);
@@ -58,7 +56,7 @@ export class SessionSavedataApi extends ApiBase {
    * @param rawSavedata The raw savedata (as `string`)
    * @returns An error message if something went wrong
    */
-  public async update(params: UpdateSessionSavedataRequest, rawSavedata: string) {
+  public async update(params: UpdateSessionSavedataRequest, rawSavedata: string): Promise<string> {
     try {
       const urlSearchParams = this.toUrlSearchParams(params);
       const response = await this.doPost(`/savedata/session/update?${urlSearchParams}`, rawSavedata);
@@ -76,7 +74,7 @@ export class SessionSavedataApi extends ApiBase {
    * @param params The {@linkcode DeleteSessionSavedataRequest} to send
    * @returns An error message if something went wrong
    */
-  public async delete(params: DeleteSessionSavedataRequest) {
+  public async delete(params: DeleteSessionSavedataRequest): Promise<string | null> {
     try {
       const urlSearchParams = this.toUrlSearchParams(params);
       const response = await this.doGet(`/savedata/session/delete?${urlSearchParams}`);
@@ -98,7 +96,10 @@ export class SessionSavedataApi extends ApiBase {
    * @param params The {@linkcode ClearSessionSavedataRequest} to send
    * @param sessionData The {@linkcode SessionSaveData} object
    */
-  public async clear(params: ClearSessionSavedataRequest, sessionData: SessionSaveData) {
+  public async clear(
+    params: ClearSessionSavedataRequest,
+    sessionData: SessionSaveData,
+  ): Promise<ClearSessionSavedataResponse> {
     try {
       const urlSearchParams = this.toUrlSearchParams(params);
       const response = await this.doPost(`/savedata/session/clear?${urlSearchParams}`, sessionData);
@@ -113,4 +114,6 @@ export class SessionSavedataApi extends ApiBase {
       success: false,
     } as ClearSessionSavedataResponse;
   }
+
+  //#endregion
 }

--- a/src/plugins/api/system-savedata-api.ts
+++ b/src/plugins/api/system-savedata-api.ts
@@ -5,19 +5,18 @@ import type {
   VerifySystemSavedataRequest,
   VerifySystemSavedataResponse,
 } from "#types/api-types";
+import type { SystemSaveData } from "#types/system-data";
 
-/**
- * A wrapper for system savedata API requests.
- */
+/** A wrapper for system savedata API requests. */
 export class SystemSavedataApi extends ApiBase {
   //#region Public
 
   /**
-   * Get a system savedata.
-   * @param params The {@linkcode GetSystemSavedataRequest} to send
-   * @returns The system savedata as `string` or `null` on error
+   * Get the system savedata.
+   * @param params - The {@linkcode GetSystemSavedataRequest} to send
+   * @returns The system savedata as `string`, or `null` on error
    */
-  public async get(params: GetSystemSavedataRequest) {
+  public async get(params: GetSystemSavedataRequest): Promise<string | null> {
     try {
       const urlSearchParams = this.toUrlSearchParams(params);
       const response = await this.doGet(`/savedata/system/get?${urlSearchParams}`);
@@ -32,13 +31,12 @@ export class SystemSavedataApi extends ApiBase {
 
   /**
    * Verify if the session is valid.
-   * If not the {@linkcode SystemSaveData} is returned.
-   * @param params The {@linkcode VerifySystemSavedataRequest} to send
+   * If not, the `SystemSaveData` is returned.
+   * @param params - The {@linkcode VerifySystemSavedataRequest} to send
    * @returns A {@linkcode SystemSaveData} if **NOT** valid, otherwise `null`.
-   *
-   * TODO: add handling for errors
    */
-  public async verify(params: VerifySystemSavedataRequest) {
+  // TODO: add handling for errors
+  public async verify(params: VerifySystemSavedataRequest): Promise<SystemSaveData | null> {
     const urlSearchParams = this.toUrlSearchParams(params);
     const response = await this.doGet(`/savedata/system/verify?${urlSearchParams}`);
 
@@ -57,12 +55,12 @@ export class SystemSavedataApi extends ApiBase {
   }
 
   /**
-   * Update a system savedata.
-   * @param params The {@linkcode UpdateSystemSavedataRequest} to send
-   * @param rawSystemData The raw {@linkcode SystemSaveData}
+   * Update the system savedata.
+   * @param params - The {@linkcode UpdateSystemSavedataRequest} to send
+   * @param rawSystemData - The raw {@linkcode SystemSaveData}
    * @returns An error message if something went wrong
    */
-  public async update(params: UpdateSystemSavedataRequest, rawSystemData: string) {
+  public async update(params: UpdateSystemSavedataRequest, rawSystemData: string): Promise<string> {
     try {
       const urSearchParams = this.toUrlSearchParams(params);
       const response = await this.doPost(`/savedata/system/update?${urSearchParams}`, rawSystemData);
@@ -74,4 +72,6 @@ export class SystemSavedataApi extends ApiBase {
 
     return "Unknown Error";
   }
+
+  //#endregion
 }

--- a/src/system/game-data.ts
+++ b/src/system/game-data.ts
@@ -88,7 +88,7 @@ import { randInt } from "#utils/random-utils";
 import { AES, enc } from "crypto-js";
 import i18next from "i18next";
 
-const saveKey = "x0i2O7WRiANTqPmZ"; // Temporary; secure encryption is not yet necessary
+const saveKey = "x0i2O7WRiANTqPmZ";
 
 function encrypt(data: string, bypassLogin: boolean): string {
   if (bypassLogin) {
@@ -415,42 +415,12 @@ export class GameData {
    * At the moment, only retrievable from locale cache
    */
   async getRunHistoryData(): Promise<RunHistoryData> {
-    if (!api.isLocal) {
-      /**
-       * Networking Code DO NOT DELETE!
-       * Note: Might have to be migrated to `api.ts`
-       *
-      const response = await Utils.apiFetch("savedata/runHistory", true);
-      const data = await response.json();
-      */
-      const lsItemKey = getLocalStorageKey(GameDataType.RUN_HISTORY);
-      const lsItem = localStorage.getItem(lsItemKey);
-      if (lsItem) {
-        const cachedResponse = lsItem;
-        if (cachedResponse) {
-          const runHistory = JSON.parse(decrypt(cachedResponse, BYPASS_LOGIN));
-          return runHistory;
-        }
-        return {};
-        // check to see whether cachedData or serverData is more up-to-date
-        /**
-       * Networking Code DO NOT DELETE!
-       *
-        if ( Object.keys(cachedRHData).length >= Object.keys(data).length ) {
-          return cachedRHData;
-        }
-        */
-      }
-      localStorage.setItem(lsItemKey, "");
-      return {};
-    }
     const lsItemKey = getLocalStorageKey(GameDataType.RUN_HISTORY);
     const lsItem = localStorage.getItem(lsItemKey);
     if (lsItem) {
       const cachedResponse = lsItem;
       if (cachedResponse) {
-        const runHistory: RunHistoryData = JSON.parse(decrypt(cachedResponse, BYPASS_LOGIN));
-        return runHistory;
+        return JSON.parse(decrypt(cachedResponse, BYPASS_LOGIN));
       }
       return {};
     }
@@ -460,9 +430,10 @@ export class GameData {
 
   /**
    * Saves a new entry to Run History
-   * @param runEntry: most recent SessionSaveData of the run
-   * @param isVictory: result of the run
-   * Arbitrary limit of 25 runs per player - Will delete runs, starting with the oldest one, if needed
+   * @param runEntry - Most recent SessionSaveData of the run
+   * @param isVictory - Result of the run
+   * @remarks
+   * Currently limited to 25 runs. If a 26th run would be saved, the oldest is deleted.
    */
   async saveRunHistory(runEntry: SessionSaveData, isVictory: boolean): Promise<boolean> {
     const runHistoryData = await this.getRunHistoryData();
@@ -487,20 +458,6 @@ export class GameData {
       getLocalStorageKey(GameDataType.RUN_HISTORY),
       encrypt(JSON.stringify(runHistoryData), BYPASS_LOGIN),
     );
-    /**
-     * Networking Code DO NOT DELETE
-     *
-    if (!Utils.isLocal) {
-      try {
-        await Utils.apiPost("savedata/runHistory", JSON.stringify(runHistoryData), undefined, true);
-        return true;
-      } catch (err) {
-        console.log("savedata/runHistory POST failed : ", err);
-        return false;
-      }
-    }
-    NOTE: should be adopted to `api.ts`
-    */
     return true;
   }
 

--- a/src/ui/handlers/menu-ui-handler.ts
+++ b/src/ui/handlers/menu-ui-handler.ts
@@ -2,7 +2,7 @@ import { api } from "#api/api";
 import { loggedInUser, updateUserInfo } from "#app/account";
 import { globalScene } from "#app/global-scene";
 import { handleTutorial } from "#app/tutorial";
-import { BYPASS_LOGIN, IS_BETA, SAVE_SLOT_LIMIT, SESSION_ID_COOKIE } from "#constants/app-constants";
+import { BYPASS_LOGIN, IS_BETA, IS_DEV, SAVE_SLOT_LIMIT, SESSION_ID_COOKIE } from "#constants/app-constants";
 import { GAME_HEIGHT, GAME_WIDTH } from "#constants/ui-constants";
 import { AdminMode } from "#enums/admin-mode";
 import { Button } from "#enums/button";
@@ -223,7 +223,7 @@ export class MenuUiHandler extends OptionSelectUiHandler {
       });
     };
     // Import Session
-    if (api.isLocal || IS_BETA) {
+    if (IS_DEV || IS_BETA) {
       manageDataOptions.push({
         label: i18next.t("menuUiHandler:importSession"),
         handler: () => {
@@ -281,7 +281,7 @@ export class MenuUiHandler extends OptionSelectUiHandler {
       keepOpen: true,
     });
     // Import Data
-    if (api.isLocal || IS_BETA) {
+    if (IS_DEV || IS_BETA) {
       manageDataOptions.push({
         label: i18next.t("menuUiHandler:importData"),
         handler: () => {
@@ -320,8 +320,7 @@ export class MenuUiHandler extends OptionSelectUiHandler {
     );
 
     // TODO: fully remove test dialogue option and related handlers
-    if (api.isLocal || IS_BETA) {
-      // this should make sure we don't have this option in live
+    if (IS_DEV || IS_BETA) {
       manageDataOptions.push({
         label: "Test Dialogue",
         handler: () => {

--- a/src/ui/handlers/save-slot-select-ui-handler.ts
+++ b/src/ui/handlers/save-slot-select-ui-handler.ts
@@ -1,6 +1,6 @@
 import { getModeName } from "#app/game-mode";
 import { globalScene } from "#app/global-scene";
-import { SAVE_SLOT_LIMIT } from "#constants/app-constants";
+import { IS_BETA, IS_DEV, SAVE_SLOT_LIMIT } from "#constants/app-constants";
 import { GAME_HEIGHT, GAME_WIDTH } from "#constants/ui-constants";
 import { Button } from "#enums/button";
 import { RunDisplayMode } from "#enums/run-display-mode";
@@ -138,7 +138,7 @@ export class SaveSlotSelectUiHandler extends MessageUiHandler {
                   },
                   canBypassInputDelay: true,
                   yOffset: 28,
-                  inputDelay: import.meta.env.DEV ? 300 : 2000,
+                  inputDelay: IS_DEV || IS_BETA ? 300 : 2000,
                 };
                 ui.showText(i18next.t("saveSlotSelectUiHandler:overwriteData"), {
                   callback: () => ui.setOverlayMode<ConfirmUiHandler>(UiMode.CONFIRM, overwriteDataOptions),

--- a/src/ui/handlers/title-ui-handler.ts
+++ b/src/ui/handlers/title-ui-handler.ts
@@ -1,6 +1,7 @@
 import { api } from "#api/api";
 import { globalScene } from "#app/global-scene";
 import { timedEventManager } from "#app/timed-event-manager";
+import { IS_BETA, IS_DEV } from "#constants/app-constants";
 import { GAME_HEIGHT, GAME_WIDTH } from "#constants/ui-constants";
 import { getSplashMessages } from "#data/splash-messages";
 import { TextStyle } from "#enums/text-style";
@@ -110,7 +111,8 @@ export class TitleUiHandler extends OptionSelectUiHandler {
       this.splashMessage = randItem(getSplashMessages());
       this.splashMessageText.setText(i18next.t(this.splashMessage, { count: TitleUiHandler.BATTLES_WON_FALLBACK }));
 
-      this.appVersionText.setText("v" + version);
+      const betaText = IS_DEV || IS_BETA ? " (Beta)" : "";
+      this.appVersionText.setText("v" + version + betaText);
 
       const ui = this.getUi();
 


### PR DESCRIPTION
## What are the changes the user will see?
The title of the webpage and the version string displayed on the title screen will have " (Beta)" appended to them when running in "beta" (e.g. some sort of beta website) or "development" mode (e.g. locally).

## Why am I making these changes?
General code simplification and cleanup.

## What are the changes from a developer perspective?
- Replaced the `start` command in `package.json` with `start:prod` and `start:beta`, which run the game in "production" and "beta" mode respectively.
  Previously, `start` would run the game in "development" mode just like `start:dev` due to the `vite` command running in "development" mode by default if no `--mode` arg is passed.

- Added `IS_DEV` global constant that checks for "development" mode.

- Removed `Api#isLocal` and replace its uses with `BYPASS_LOGIN`.

- Added " (Beta)" to window title and game version displayed on the title screen when in "development" or "beta" mode.

- Replaced `.then()` pattern with `await` in `main.ts`.

- Removed obsolete commented code in `game-data.ts`.

- Added return types to api methods.

- Updated `deploy-beta.yml` workflow to use "beta" mode when building (though the workflow is currently disabled anyway).

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?