### PR TITLE
fix(ability): Parental Bond no longer reduces damage improperly

### DIFF
--- a/src/data/abilities/ab-attrs/add-second-strike-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/add-second-strike-ab-attr.ts
@@ -10,13 +10,6 @@ import type { ValueHolder } from "#utils/common-utils";
  */
 export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
   protected override readonly abAttrKey = "AddSecondStrikeAbAttr";
-  private readonly damageMultiplier: number;
-
-  constructor(damageMultiplier: number) {
-    super();
-
-    this.damageMultiplier = damageMultiplier;
-  }
 
   /**
    * If conditions are met, this increases the move's hit count (via args[0])
@@ -30,27 +23,20 @@ export class AddSecondStrikeAbAttr extends PreAttackAbAttr {
    * @returns `true` if the given move is modified by this effect
    */
   public override apply(
-    pokemon: Pokemon,
+    _pokemon: Pokemon,
     _simulated: boolean,
     _move: Move,
     _defender: Pokemon,
-    hitCount?: ValueHolder<number>,
-    multiplier?: ValueHolder<number>,
+    hitCount: ValueHolder<number>,
   ): void {
-    if (hitCount?.value) {
-      hitCount.value += 1;
-    }
-
-    if (multiplier?.value && pokemon.turnData.hitsLeft === 1) {
-      multiplier.value = this.damageMultiplier;
-    }
+    hitCount.value += 1;
   }
 
   /**
    * @returns `true` if the move being used satisfies {@linkcode Move.canBeMultiStrikeEnhanced | conditions}
    * to be multi-strike-enhanced.
    */
-  public override canApply(...[pokemon, , move]: Parameters<this["apply"]>): boolean {
-    return move.canBeMultiStrikeEnhanced(pokemon);
+  public override canApply(...[pokemon, , move, defender]: Parameters<this["apply"]>): boolean {
+    return move.canBeMultiStrikeEnhanced(pokemon, defender);
   }
 }

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -1086,7 +1086,16 @@ export function initAbilities(): void {
       .attr(MoveTypeChangeAbAttr, ElementalType.FLYING, 1.2, normalTypeMoveConversionCondition)
       .build(),
     new AbBuilder(AbilityId.PARENTAL_BOND, 6) //
-      .attr(AddSecondStrikeAbAttr, 0.25)
+      .attr(AddSecondStrikeAbAttr)
+      .attr(
+        DamageBoostAbAttr,
+        0.25,
+        (user, target, move) =>
+          !!user
+          && user.turnData.hitCount > 1 // move was originally multi hit
+          && user.turnData.hitsLeft === 1 // move is on its final strike
+          && !!move?.canBeMultiStrikeEnhanced(user, target),
+      )
       .build(),
     new AbBuilder(AbilityId.DARK_AURA, 6) //
       .attr(PostSummonMessageAbAttr, (pokemon: Pokemon) =>

--- a/src/data/moves/move.ts
+++ b/src/data/moves/move.ts
@@ -859,32 +859,41 @@ export abstract class Move {
   }
 
   /**
-   * Returns `true` if this move can be given additional strikes
-   * by enhancing effects.
+   * Check whether this Move can be given additional strikes from enhancing effects.
    * Currently used for {@link https://bulbapedia.bulbagarden.net/wiki/Parental_Bond_(Ability) | Parental Bond}
-   * and {@linkcode PokemonMultiHitModifier | Multi-Lens}.
-   * @param user The {@linkcode Pokemon} using the move
+   * and {@linkcode PokemonMultiHitModifier | Multi Lens}.
+   * @param user - The {@linkcode Pokemon} using the move
+   * @param target - The `target` of the move. Used for Pollen Puff
+   * @returns Whether this Move can be given additional strikes.
    */
-  canBeMultiStrikeEnhanced(user: Pokemon): boolean {
-    // Multi-strike enhancers...
+  public canBeMultiStrikeEnhanced(user: Pokemon, target?: Pokemon): boolean {
+    if (this.isChargingMove()) {
+      return false;
+    }
 
-    // ...cannot enhance moves that hit multiple targets
     const { targets, multiple } = getMoveTargets(user, this.id);
-    const isMultiTarget = multiple && targets.length > 1;
+    if (multiple && targets.length > 1) {
+      return false;
+    }
 
-    // ...cannot enhance multi-hit or sacrificial moves
+    if (
+      this.category === MoveCategory.STATUS
+      || (target != null && user.getMoveCategory(target, this) === MoveCategory.STATUS) // Pollen Puff check
+    ) {
+      return false;
+    }
+
     const exceptAttrs: AbstractConstructor<MoveAttr>[] = [MultiHitAttr, SacrificialAttr];
+    if (exceptAttrs.some((attr) => this.hasAttr(attr))) {
+      return false;
+    }
 
-    // ...and cannot enhance these specific moves.
     const exceptMoves: MoveId[] = [MoveId.FLING, MoveId.UPROAR, MoveId.ROLLOUT, MoveId.ICE_BALL, MoveId.ENDEAVOR];
+    if (exceptMoves.includes(this.id)) {
+      return false;
+    }
 
-    return (
-      !isMultiTarget
-      && !this.isChargingMove()
-      && !exceptAttrs.some((attr) => this.hasAttr(attr))
-      && !exceptMoves.some((id) => this.id === id)
-      && this.category !== MoveCategory.STATUS
-    );
+    return true;
   }
 
   /**

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -3117,10 +3117,9 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     const numTargets = multiple ? targets.length : 1;
     const targetMultiplier = numTargets > 1 ? 0.75 : 1;
 
-    /** Multiplier for moves enhanced by Multi-Lens and/or Parental Bond */
-    const multiStrikeEnhancementMultiplier = new NumberHolder(1);
-    // TODO: re-add multi-lens calculation
-    applyAbFunc("AddSecondStrikeAbAttr", source, simulated, move, this, undefined, multiStrikeEnhancementMultiplier);
+    /** Multiplier for moves enhanced by Multi-Lens */
+    const multiLensDamageMultiplier = new ValueHolder(1);
+    // TODO: re-add multi-lens calculation here
 
     /** Doubles damage if this Pokemon's last move was Glaive Rush */
     const glaiveRushMultiplier = new NumberHolder(1);
@@ -3215,7 +3214,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       baseDamage
       * targetMultiplier
       * gmaxBonusDamageMultiplier.value
-      * multiStrikeEnhancementMultiplier.value
+      * multiLensDamageMultiplier.value
       * weatherDamageMultiplier.value
       * terrainDamageMultiplier
       * glaiveRushMultiplier.value

--- a/test/abilities/parental-bond.test.ts
+++ b/test/abilities/parental-bond.test.ts
@@ -449,4 +449,24 @@ describe("Abilities - Parental Bond", () => {
     expect(enemyPokemon.getStatStage(Stat.SPATK)).toBe(-1);
     expect(playerPokemon.turnData.hitCount).toBe(2);
   });
+
+  it("should not reduce damage against the remaining target if the first one faints", async () => {
+    game.override.battleType("double");
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    const player = game.field.getPlayerPokemon();
+    const [enemy1, enemy2] = game.scene.getEnemyField();
+
+    // Mock base damage for both mons for consistent results
+    vi.spyOn(enemy1, "getBaseDamage").mockReturnValue(100);
+    vi.spyOn(enemy2, "getBaseDamage").mockReturnValue(100);
+    enemy1.hp = 1;
+
+    game.move.use(MoveId.HYPER_VOICE);
+    await game.toEndOfTurn();
+
+    expect(enemy1).toHaveFainted();
+    expect(player).not.toHaveAbilityApplied(AbilityId.PARENTAL_BOND);
+    expect(enemy2).toHaveTakenDamage(100);
+  });
 });


### PR DESCRIPTION
Port of https://github.com/pagefaultgames/pokerogue/pull/6743

## What are the changes the user will see?
Parental Bond will no longer erroneously consider hitting the second Pokémon on the field as the second strike of a move when using a spread move (meaning the damage will no longer be improperly reduced).

## Why am I making these changes?
Fixing a bug.

## What are the changes from a developer perspective?
The damage reduction of the second strike from Parental Bond is no longer handled by `AddSecondStrikeAbAttr`. Instead, Parental Bond uses the existing `DamageBoostAbAttr` with a multiplier of `0.25` with a condition function that checks if it's the second hit of the move.

## How to test the changes?
`pnpm test:silent parental-bond`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?