### PR TITLE
refactor: move asset initialization from `launchBattle` to `preload`

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -335,7 +335,7 @@ export class BattleScene extends SceneBase {
     );
   }
 
-  async preload() {
+  public async preload() {
     // TODO: Move all RNG-related code outside of `battle-scene.ts`.
     if (DEBUG_RNG) {
       /**
@@ -381,7 +381,21 @@ export class BattleScene extends SceneBase {
       };
     }
 
-    await this.initVariantData();
+    /**
+     * These moves serve as fallback animations for other moves without loaded animations,
+     * and must be loaded prior to game start.
+     */
+    const defaultMoves = [MoveId.TACKLE, MoveId.TAIL_WHIP, MoveId.FOCUS_ENERGY, MoveId.STRUGGLE];
+    try {
+      await Promise.all([
+        this.initVariantData(),
+        initCommonAnims().then(() => loadCommonAnimAssets(true)),
+        Promise.all(defaultMoves.map((m) => initMoveAnim(m))).then(() => loadMoveAnimAssets(defaultMoves, true)),
+        this.initStarterColors(),
+      ]);
+    } catch (err) {
+      throw new Error(`Unexpected error during \`BattleScene#preLoad\`!\nReason: ${err}`);
+    }
   }
 
   create() {
@@ -646,20 +660,10 @@ export class BattleScene extends SceneBase {
 
     ui.setup();
 
-    const defaultMoves = [MoveId.TACKLE, MoveId.TAIL_WHIP, MoveId.FOCUS_ENERGY, MoveId.STRUGGLE];
+    this.phaseManager.createAndPushPhase("LoginPhase");
+    this.phaseManager.toTitleScreen();
 
-    Promise.all([
-      initCommonAnims().then(() => loadCommonAnimAssets(true)),
-      Promise.all(
-        [MoveId.TACKLE, MoveId.TAIL_WHIP, MoveId.FOCUS_ENERGY, MoveId.STRUGGLE].map((m) => initMoveAnim(m)),
-      ).then(() => loadMoveAnimAssets(defaultMoves, true)),
-      this.initStarterColors(),
-    ]).then(() => {
-      this.phaseManager.createAndPushPhase("LoginPhase");
-      this.phaseManager.toTitleScreen();
-
-      this.phaseManager.shiftPhase();
-    });
+    this.phaseManager.shiftPhase();
   }
 
   initSession(): void {

--- a/test/test-utils/game-manager-utils.ts
+++ b/test/test-utils/game-manager-utils.ts
@@ -81,17 +81,6 @@ function getTestRunStarters(species: SpeciesId[]): StarterConfig[] {
   return starters;
 }
 
-export function waitUntil(truth): Promise<unknown> {
-  return new Promise((resolve) => {
-    const interval = setInterval(() => {
-      if (truth()) {
-        clearInterval(interval);
-        resolve(true);
-      }
-    }, 1000);
-  });
-}
-
 /** Get the index of `move` from the moveset of the pokemon on the player's field at location `pokemonIndex` */
 export function getMovePosition(scene: BattleScene, pokemonIndex: 0 | 1, moveId: MoveId): number {
   const playerPokemon = scene.getPlayerField()[pokemonIndex];

--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -26,7 +26,7 @@ import type { CommandPhase } from "#phases/command-phase";
 import type { TurnEndPhase } from "#phases/turn-end-phase";
 import { settings } from "#system/settings-manager";
 import { ErrorInterceptor } from "#test/test-utils/error-interceptor";
-import { generateStarter, waitUntil } from "#test/test-utils/game-manager-utils";
+import { generateStarter } from "#test/test-utils/game-manager-utils";
 import { GameWrapper } from "#test/test-utils/game-wrapper";
 import { ChallengeModeHelper } from "#test/test-utils/helpers/challenge-mode-helper";
 import { ClassicModeHelper } from "#test/test-utils/helpers/classic-mode-helper";
@@ -83,30 +83,16 @@ export class GameManager {
     BattleScene.prototype.randBattleSeedInt = (range, min: number = 0) => min + range - 1; // This simulates a max roll
     this.gameWrapper = new GameWrapper(phaserGame, bypassLogin);
 
-    let firstTimeScene = false;
     if (globalScene) {
       this.scene = globalScene;
+      this.phaseInterceptor = new PhaseInterceptor(this.scene);
+      this.resetScene();
     } else {
       this.scene = new BattleScene();
+      this.phaseInterceptor = new PhaseInterceptor(this.scene);
       this.gameWrapper.setScene(this.scene);
-      firstTimeScene = true;
     }
 
-    this.phaseInterceptor = new PhaseInterceptor(this.scene);
-
-    if (!firstTimeScene) {
-      this.scene.reset(false, true);
-
-      this.scene.phaseManager.clear();
-      this.scene.ui.resetHandlers(); // reset ui state
-
-      // This part, in particular, must not be run before the PhaseInterceptor has been initialized.
-      this.scene.phaseManager.createAndPushPhase("LoginPhase");
-      this.scene.phaseManager.toTitleScreen();
-      this.scene.phaseManager.shiftPhase();
-
-      this.gameWrapper.scene = this.scene;
-    }
     this.textInterceptor = new TextInterceptor(this.scene);
     this.override = new OverridesHelper(this);
     this.move = new MoveHelper(this);
@@ -129,6 +115,20 @@ export class GameManager {
     global.fetch = vi.fn(MockFetch) as any;
   }
 
+  private resetScene(): void {
+    this.scene.reset(false, true);
+
+    this.scene.phaseManager.clear();
+    this.scene.ui.resetHandlers(); // reset ui state
+
+    // This part, in particular, must not be run before the PhaseInterceptor has been initialized.
+    this.scene.phaseManager.createAndPushPhase("LoginPhase");
+    this.scene.phaseManager.toTitleScreen();
+    this.scene.phaseManager.shiftPhase();
+
+    this.gameWrapper.scene = this.scene;
+  }
+
   /**
    * Sets the game mode.
    * @param mode - The mode to set.
@@ -143,11 +143,8 @@ export class GameManager {
    * @param mode - The mode to wait for.
    * @returns A promise that resolves when the mode is set.
    */
-  waitMode(mode: UiMode): Promise<void> {
-    return new Promise(async (resolve) => {
-      await waitUntil(() => this.scene.ui?.getMode() === mode);
-      return resolve();
-    });
+  public async waitMode(mode: UiMode): Promise<void> {
+    await vi.waitUntil(() => this.scene.ui?.getMode() === mode);
   }
 
   /**

--- a/test/test-utils/helpers/move-helper.ts
+++ b/test/test-utils/helpers/move-helper.ts
@@ -247,9 +247,8 @@ export class MoveHelper extends GameManagerHelper {
         const move = phase.getPokemon().getMoveset()[movePosition].getMove();
         if (!move.isMultiTarget()) {
           handler.setCursor(targetIndex ?? BattlerIndex.ENEMY);
-        }
-        if (move.isMultiTarget() && targetIndex !== undefined) {
-          throw new Error(`targetIndex was passed to selectMove() but move ("${move.name}") is not targetted`);
+        } else if (targetIndex !== undefined) {
+          expect.fail(`\`targetIndex\` was passed to \`selectMove()\` but move ("${move.name}") is not targeted`);
         }
         handler.processInput(Button.ACTION);
       },


### PR DESCRIPTION
- Port of https://github.com/pagefaultgames/pokerogue/pull/6109

## What are the changes the user will see?
N/A

## Why am I making these changes?
Asset initialization should be done in the `preload` step and not after launching the game.

## What are the changes from a developer perspective?
Moved asset initialization from `BattleScene#launchBattle` to `#preload`.
Removed utility function `waitUntil` in `game-manager-utils.ts` and replaced its use with `vi.waitUntil`.
Replaced `firstTimeScene` variable in `GameManager` with `private resetScene` method.
Simplified `if/elseif` in `MoveHelper#selectTarget`.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [-] The PR is self-contained and cannot be split into smaller PRs?
  - It could, but it's just a collection of small changes so w/e, might as well just port the whole thing at once.
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?