### PR TITLE
refactor: remove `null` from `PhaseManager#currentPhase` typing

### DIFF
--- a/src/battle-scene.ts
+++ b/src/battle-scene.ts
@@ -1420,8 +1420,8 @@ export class BattleScene extends SceneBase {
     }
 
     const isEggPhase: boolean =
-      !!this.phaseManager.getCurrentPhase()?.is("EggHatchPhase")
-      || !!this.phaseManager.getCurrentPhase()?.is("EggLapsePhase");
+      this.phaseManager.getCurrentPhase().is("EggHatchPhase")
+      || this.phaseManager.getCurrentPhase().is("EggLapsePhase");
 
     switch (species.speciesId) {
       case SpeciesId.UNOWN:

--- a/src/data/arena-tags/quick-guard-tag.ts
+++ b/src/data/arena-tags/quick-guard-tag.ts
@@ -17,7 +17,7 @@ const QuickGuardConditionFunc: ProtectConditionFunc = (moveId) => {
   const move = allMoves.get(moveId);
   const effectPhase = globalScene.phaseManager.getCurrentPhase();
 
-  if (effectPhase?.is("MoveEffectPhase")) {
+  if (effectPhase.is("MoveEffectPhase")) {
     const attacker = effectPhase.getUserPokemon();
     if (attacker) {
       return move.getPriority(attacker) > 0;

--- a/src/data/battler-tags/beak-blast-charging-tag.ts
+++ b/src/data/battler-tags/beak-blast-charging-tag.ts
@@ -47,7 +47,7 @@ export class BeakBlastChargingTag extends BattlerTag {
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.AFTER_HIT) {
-      const phaseData = getMoveEffectPhaseData(pokemon);
+      const phaseData = getMoveEffectPhaseData();
       if (phaseData?.move.checkFlag(MoveFlags.MAKES_CONTACT, pokemon)) {
         phaseData.attacker.trySetStatus(StatusEffect.BURN, true, pokemon);
       }

--- a/src/data/battler-tags/confused-tag.ts
+++ b/src/data/battler-tags/confused-tag.ts
@@ -104,7 +104,7 @@ export class ConfusedTag extends BattlerTag {
 
         pokemon.damageAndUpdate(damageHolder.value);
         pokemon.waveData.hitCount++;
-        globalScene.phaseManager.getCurrentPhase<MovePhase>()?.cancel();
+        globalScene.phaseManager.getCurrentPhase<MovePhase>().cancel();
       }
     }
 

--- a/src/data/battler-tags/flinched-tag.ts
+++ b/src/data/battler-tags/flinched-tag.ts
@@ -33,7 +33,7 @@ export class FlinchedTag extends BattlerTag {
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.PRE_MOVE) {
-      globalScene.phaseManager.getCurrentPhase<MovePhase>()?.cancel();
+      globalScene.phaseManager.getCurrentPhase<MovePhase>().cancel();
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",
         i18next.t("battlerTags:flinchedLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),

--- a/src/data/battler-tags/gulp-missile-tag.ts
+++ b/src/data/battler-tags/gulp-missile-tag.ts
@@ -11,11 +11,9 @@ import { Stat } from "#enums/stat";
 import { StatusEffect } from "#enums/status-effect";
 import type { Pokemon } from "#field/pokemon";
 import { SpeciesFormChangeManualTrigger } from "#form-change-triggers/species-form-change-manual-trigger";
-import { BooleanHolder, toDmgValue } from "#utils/common-utils";
+import { toDmgValue, ValueHolder } from "#utils/common-utils";
 
-/**
- * Battler tag for Gulp Missile used by Cramorant.
- */
+/** Battler tag for Gulp Missile used by Cramorant. */
 export class GulpMissileTag extends BattlerTag {
   constructor(tagType: BattlerTagType, sourceMoveId: MoveId) {
     super(tagType, BattlerTagLapseType.HIT, 0, sourceMoveId);
@@ -27,38 +25,41 @@ export class GulpMissileTag extends BattlerTag {
     }
 
     const moveEffectPhase = globalScene.phaseManager.getCurrentPhase();
-    if (moveEffectPhase?.is("MoveEffectPhase")) {
-      const attacker = moveEffectPhase.getUserPokemon();
-
-      if (!attacker) {
-        return false;
-      }
-
-      if (moveEffectPhase.move.getMove().hitsSubstitute(attacker, pokemon)) {
-        return true;
-      }
-
-      const cancelled = new BooleanHolder(false);
-      applyAbAttrs("BlockNonDirectDamageAbAttr", attacker, false, cancelled);
-
-      if (!cancelled.value) {
-        attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() / 4), {
-          result: HitResult.OTHER,
-        });
-      }
-
-      if (this.tagType === BattlerTagType.GULP_MISSILE_ARROKUDA) {
-        globalScene.phaseManager.createAndUnshiftPhase(
-          "StatStageChangePhase",
-          attacker.getBattlerIndex(),
-          pokemon,
-          [Stat.DEF],
-          -1,
-        );
-      } else {
-        attacker.trySetStatus(StatusEffect.PARALYSIS, true, pokemon);
-      }
+    if (!moveEffectPhase.is("MoveEffectPhase")) {
+      return false;
     }
+
+    const attacker = moveEffectPhase.getUserPokemon();
+
+    if (!attacker) {
+      return false;
+    }
+
+    if (moveEffectPhase.move.getMove().hitsSubstitute(attacker, pokemon)) {
+      return true;
+    }
+
+    const cancelled = new ValueHolder(false);
+    applyAbAttrs("BlockNonDirectDamageAbAttr", attacker, false, cancelled);
+
+    if (!cancelled.value) {
+      attacker.damageAndUpdate(toDmgValue(attacker.getMaxHp() / 4), {
+        result: HitResult.OTHER,
+      });
+    }
+
+    if (this.tagType === BattlerTagType.GULP_MISSILE_ARROKUDA) {
+      globalScene.phaseManager.createAndUnshiftPhase(
+        "StatStageChangePhase",
+        attacker.getBattlerIndex(),
+        pokemon,
+        [Stat.DEF],
+        -1,
+      );
+    } else {
+      attacker.trySetStatus(StatusEffect.PARALYSIS, true, pokemon);
+    }
+
     return false;
   }
 

--- a/src/data/battler-tags/infatuated-tag.ts
+++ b/src/data/battler-tags/infatuated-tag.ts
@@ -77,7 +77,7 @@ export class InfatuatedTag extends BattlerTag {
             pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
           }),
         );
-        (globalScene.phaseManager.getCurrentPhase() as MovePhase).cancel();
+        globalScene.phaseManager.getCurrentPhase<MovePhase>().cancel();
       }
     }
 

--- a/src/data/battler-tags/interrupted-tag.ts
+++ b/src/data/battler-tags/interrupted-tag.ts
@@ -35,7 +35,7 @@ export class InterruptedTag extends BattlerTag {
   }
 
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    (globalScene.phaseManager.getCurrentPhase() as MovePhase).cancel();
+    globalScene.phaseManager.getCurrentPhase<MovePhase>().cancel();
     return super.lapse(pokemon, lapseType);
   }
 }

--- a/src/data/battler-tags/move-restriction-battler-tag.ts
+++ b/src/data/battler-tags/move-restriction-battler-tag.ts
@@ -9,11 +9,11 @@ import type { Move } from "#moves/move";
 import type { MovePhase } from "#phases/move-phase";
 
 /**
- * Base class for tags that restrict the usage of moves.
- * This effect is generally referred to as "disabling" a move in-game.
+ * Base class for tags that restrict the usage of moves. \
+ * This effect is generally referred to as "disabling" a move in-game. \
  * This is not to be confused with {@linkcode MoveId.DISABLE}.
  *
- * Descendants can override {@linkcode isMoveRestricted} to restrict moves that match a condition.
+ * Descendants can override {@linkcode isMoveRestricted} to restrict moves that match a condition. \
  * A restricted move gets cancelled before it is used.
  *
  * Players and enemies should not be allowed to select restricted moves.
@@ -22,25 +22,24 @@ import type { MovePhase } from "#phases/move-phase";
  * Tags that use or subclass this should be added to {@linkcode RESTRICTING_TAG_TYPES}
  */
 export abstract class MoveRestrictionBattlerTag extends BattlerTag implements RestrictingBattlerTag {
-  /** @override */
-  override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    if (lapseType === BattlerTagLapseType.PRE_MOVE) {
-      // Cancel the affected pokemon's selected move
-      const phase = globalScene.phaseManager.getCurrentPhase() as MovePhase;
-      const { pokemonMove } = phase;
-
-      if (this.isMoveRestricted(pokemonMove.moveId, pokemon)) {
-        const interruptedText = this.getInterruptedText(pokemon, pokemonMove.moveId);
-        if (interruptedText) {
-          globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", interruptedText);
-        }
-        phase.cancel();
-      }
-
-      return true;
+  public override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
+    if (lapseType !== BattlerTagLapseType.PRE_MOVE) {
+      return super.lapse(pokemon, lapseType);
     }
 
-    return super.lapse(pokemon, lapseType);
+    // Cancel the affected pokemon's selected move
+    const phase = globalScene.phaseManager.getCurrentPhase<MovePhase>();
+    const { pokemonMove } = phase;
+
+    if (this.isMoveRestricted(pokemonMove.moveId, pokemon)) {
+      const interruptedText = this.getInterruptedText(pokemon, pokemonMove.moveId);
+      if (interruptedText) {
+        globalScene.phaseManager.createAndUnshiftPhase("MessagePhase", interruptedText);
+      }
+      phase.cancel();
+    }
+
+    return true;
   }
 
   /**
@@ -70,7 +69,7 @@ export abstract class MoveRestrictionBattlerTag extends BattlerTag implements Re
    * @param moveId - {@linkcode MoveId | move} that is having its selection denied
    * @returns text to display when the player attempts to select the restricted move
    */
-  abstract getSelectionDeniedText(pokemon: Pokemon, moveId: MoveId): string;
+  public abstract getSelectionDeniedText(pokemon: Pokemon, moveId: MoveId): string;
 
   /**
    * Gets the text to display when a move's execution is prevented as a result of the restriction.
@@ -81,7 +80,7 @@ export abstract class MoveRestrictionBattlerTag extends BattlerTag implements Re
    * @param _moveId - The {@linkcode MoveId | move} being interrupted
    * @returns text to display when the move is interrupted
    */
-  abstract getInterruptedText(_pokemon: Pokemon, _moveId: MoveId): string;
+  public abstract getInterruptedText(_pokemon: Pokemon, _moveId: MoveId): string;
 
   /**
    * Gets the last valid move from the pokemon's move history.

--- a/src/data/battler-tags/powder-tag.ts
+++ b/src/data/battler-tags/powder-tag.ts
@@ -9,7 +9,7 @@ import { ElementalType } from "#enums/elemental-type";
 import { HitResult } from "#enums/hit-result";
 import { WeatherType } from "#enums/weather-type";
 import type { Pokemon } from "#field/pokemon";
-import { BooleanHolder } from "#utils/common-utils";
+import { ValueHolder } from "#utils/common-utils";
 import i18next from "i18next";
 
 /**
@@ -40,41 +40,40 @@ export class PowderTag extends BattlerTag {
    * @returns `true` if the tag should not expire after this lapse; `false` otherwise.
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
-    if (lapseType === BattlerTagLapseType.PRE_MOVE) {
-      const currPhase = globalScene.phaseManager.getCurrentPhase();
-      if (currPhase?.is("MovePhase")) {
-        const move = currPhase.pokemonMove.getMove();
-        const weather = globalScene.arena.weather;
-        if (
-          pokemon.getMoveType(move) === ElementalType.FIRE
-          && !(weather && weather.weatherType === WeatherType.HEAVY_RAIN && !weather.isEffectSuppressed())
-        ) {
-          currPhase.fail();
-          currPhase.showMoveText();
+    if (lapseType !== BattlerTagLapseType.PRE_MOVE) {
+      return super.lapse(pokemon, lapseType);
+    }
 
-          globalScene.phaseManager.createAndUnshiftPhase(
-            "CommonAnimPhase",
-            CommonAnim.POWDER,
-            pokemon.getBattlerIndex(),
-          );
-
-          const cancelDamage = new BooleanHolder(false);
-          applyAbAttrs("BlockNonDirectDamageAbAttr", pokemon, false, cancelDamage);
-          if (!cancelDamage.value) {
-            pokemon.damageAndUpdate(Math.floor(pokemon.getMaxHp() / 4), {
-              result: HitResult.OTHER,
-            });
-          }
-
-          // "When the flame touched the powder\non the Pokémon, it exploded!"
-          globalScene.phaseManager.createAndUnshiftPhase(
-            "MessagePhase",
-            i18next.t("battlerTags:powderLapse", { moveName: currPhase.pokemonMove.name }),
-          );
-        }
-      }
+    const currPhase = globalScene.phaseManager.getCurrentPhase();
+    if (!currPhase.is("MovePhase")) {
       return true;
     }
-    return super.lapse(pokemon, lapseType);
+
+    const move = currPhase.pokemonMove.getMove();
+    const weather = globalScene.arena.weather;
+    if (
+      pokemon.getMoveType(move) === ElementalType.FIRE
+      && !(weather && weather.weatherType === WeatherType.HEAVY_RAIN && !weather.isEffectSuppressed())
+    ) {
+      currPhase.fail();
+      currPhase.showMoveText();
+
+      globalScene.phaseManager.createAndUnshiftPhase("CommonAnimPhase", CommonAnim.POWDER, pokemon.getBattlerIndex());
+
+      const cancelDamage = new ValueHolder(false);
+      applyAbAttrs("BlockNonDirectDamageAbAttr", pokemon, false, cancelDamage);
+      if (!cancelDamage.value) {
+        pokemon.damageAndUpdate(Math.floor(pokemon.getMaxHp() / 4), {
+          result: HitResult.OTHER,
+        });
+      }
+
+      // "When the flame touched the powder\non the Pokémon, it exploded!"
+      globalScene.phaseManager.createAndUnshiftPhase(
+        "MessagePhase",
+        i18next.t("battlerTags:powderLapse", { moveName: currPhase.pokemonMove.name }),
+      );
+    }
+    return true;
   }
 }

--- a/src/data/battler-tags/recharging-tag.ts
+++ b/src/data/battler-tags/recharging-tag.ts
@@ -33,7 +33,7 @@ export class RechargingTag extends BattlerTag {
         "MessagePhase",
         i18next.t("battlerTags:rechargingLapse", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
       );
-      (globalScene.phaseManager.getCurrentPhase() as MovePhase).cancel();
+      globalScene.phaseManager.getCurrentPhase<MovePhase>().cancel();
       pokemon.getMoveQueue().shift();
     }
     return super.lapse(pokemon, lapseType);

--- a/src/data/battler-tags/shell-trap-tag.ts
+++ b/src/data/battler-tags/shell-trap-tag.ts
@@ -35,7 +35,7 @@ export class ShellTrapTag extends BattlerTag {
    */
   override lapse(pokemon: Pokemon, lapseType: BattlerTagLapseType): boolean {
     if (lapseType === BattlerTagLapseType.AFTER_HIT) {
-      const phaseData = getMoveEffectPhaseData(pokemon);
+      const phaseData = getMoveEffectPhaseData();
 
       // Trap should only be triggered by opponent's Physical moves
       if (phaseData?.move.category === MoveCategory.PHYSICAL && pokemon.isOpponent(phaseData.attacker)) {

--- a/src/data/battler-tags/substitute-tag.ts
+++ b/src/data/battler-tags/substitute-tag.ts
@@ -102,20 +102,22 @@ export class SubstituteTag extends BattlerTag {
   /** If the Substitute redirects damage, queue a message to indicate it. */
   onHit(pokemon: Pokemon): void {
     const moveEffectPhase = globalScene.phaseManager.getCurrentPhase();
-    if (moveEffectPhase?.is("MoveEffectPhase")) {
-      const attacker = moveEffectPhase.getUserPokemon();
-      if (!attacker) {
-        return;
-      }
-      const move = moveEffectPhase.move.getMove();
-      const firstHit = attacker.turnData.hitCount === attacker.turnData.hitsLeft;
+    if (!moveEffectPhase.is("MoveEffectPhase")) {
+      return;
+    }
 
-      if (firstHit && move.hitsSubstitute(attacker, pokemon)) {
-        globalScene.phaseManager.createAndUnshiftPhase(
-          "MessagePhase",
-          i18next.t("battlerTags:substituteOnHit", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
-        );
-      }
+    const attacker = moveEffectPhase.getUserPokemon();
+    if (!attacker) {
+      return;
+    }
+    const move = moveEffectPhase.move.getMove();
+    const firstHit = attacker.turnData.hitCount === attacker.turnData.hitsLeft;
+
+    if (firstHit && move.hitsSubstitute(attacker, pokemon)) {
+      globalScene.phaseManager.createAndUnshiftPhase(
+        "MessagePhase",
+        i18next.t("battlerTags:substituteOnHit", { pokemonNameWithAffix: getPokemonNameWithAffix(pokemon) }),
+      );
     }
   }
 

--- a/src/data/battler-tags/truant-tag.ts
+++ b/src/data/battler-tags/truant-tag.ts
@@ -28,7 +28,7 @@ export class TruantTag extends AbilityBattlerTag {
 
     if (lastMove && lastMove.move.id !== MoveId.NONE) {
       const { phaseManager } = globalScene;
-      phaseManager.getCurrentPhase<MovePhase>()?.cancel();
+      phaseManager.getCurrentPhase<MovePhase>().cancel();
       phaseManager.unshiftPhase(
         phaseManager.createPhase("ShowAbilityPhase", pokemon, passive),
         phaseManager.createPhase(

--- a/src/data/battler-tags/utils/get-move-effect-phase-data.ts
+++ b/src/data/battler-tags/utils/get-move-effect-phase-data.ts
@@ -3,23 +3,18 @@ import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import type { MoveEffectPhase } from "#phases/move-effect-phase";
 
+type MoveEffectPhaseData = { phase: MoveEffectPhase; attacker: Pokemon; move: Move };
+
 /**
  * Helper function to verify that the current phase is a MoveEffectPhase and provide quick access to commonly used fields
  *
- * @param pokemon {@linkcode Pokemon} The Pokémon used to access the current phase
  * @returns null if current phase is not MoveEffectPhase, otherwise Object containing the {@linkcode MoveEffectPhase}, and its
  * corresponding {@linkcode Move} and user {@linkcode Pokemon}
  */
-export function getMoveEffectPhaseData(
-  _pokemon: Pokemon,
-): { phase: MoveEffectPhase; attacker: Pokemon; move: Move } | null {
+export function getMoveEffectPhaseData(): MoveEffectPhaseData | null {
   const phase = globalScene.phaseManager.getCurrentPhase();
-  if (phase?.is("MoveEffectPhase")) {
-    return {
-      phase,
-      attacker: phase.getPokemon(),
-      move: phase.move.getMove(),
-    };
+  if (phase.is("MoveEffectPhase")) {
+    return { phase, attacker: phase.getPokemon(), move: phase.move.getMove() };
   }
   return null;
 }

--- a/src/data/moves/move-conditions/has-stockpile-stacks-condition.ts
+++ b/src/data/moves/move-conditions/has-stockpile-stacks-condition.ts
@@ -5,7 +5,7 @@ import type { MovePhase } from "#phases/move-phase";
 import type { MoveConditionFunc } from "#types/move-types";
 
 export const hasStockpileStacksCondition: MoveConditionFunc = (user) => {
-  const snatched = globalScene.phaseManager.getCurrentPhase<MovePhase>()?.snatched;
-  const hasStockpilingTag = user.getTag<StockpilingTag>(BattlerTagType.STOCKPILING);
-  return !!snatched || (!!hasStockpilingTag && hasStockpilingTag.stockpiledCount > 0);
+  const { snatched } = globalScene.phaseManager.getCurrentPhase<MovePhase>();
+  const stockpilingTag = user.getTag<StockpilingTag>(BattlerTagType.STOCKPILING);
+  return snatched || (!!stockpilingTag && stockpilingTag.stockpiledCount > 0);
 };

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -945,7 +945,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
 
       // During the Pokemon's MoveEffect phase, the offset is removed to put the Pokemon "in focus"
       const currentPhase = globalScene.phaseManager.getCurrentPhase();
-      if (currentPhase?.is("MoveEffectPhase") && currentPhase.getPokemon() === this) {
+      if (currentPhase.is("MoveEffectPhase") && currentPhase.getPokemon() === this) {
         return false;
       }
       return true;
@@ -4020,7 +4020,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
      */
     if (effect === StatusEffect.SLEEP || effect === StatusEffect.FREEZE) {
       const currentPhase = globalScene.phaseManager.getCurrentPhase();
-      if (currentPhase?.is("MoveEffectPhase") && currentPhase.getUserPokemon() === this) {
+      if (currentPhase.is("MoveEffectPhase") && currentPhase.getUserPokemon() === this) {
         this.stopMultiHit();
       }
     }

--- a/src/phase-manager.ts
+++ b/src/phase-manager.ts
@@ -243,7 +243,7 @@ export class PhaseManager {
    */
   private standbyPhase: Phase | null = null;
 
-  public getCurrentPhase<P extends Phase = Phase>(): P | null {
+  public getCurrentPhase<P extends Phase = Phase>(): P {
     return this.currentPhase as P;
   }
 
@@ -393,8 +393,7 @@ export class PhaseManager {
     if (phaseEntry == null) {
       this.dynamicPhaseManager.clearQueues();
       this.currentPhase = this.createPhase("TurnInitPhase");
-      console.log(`%cStart Phase ${this.currentPhase.constructor.name}`, "color:green;");
-      this.currentPhase.start();
+      this.startCurrentPhase();
       return;
     }
 
@@ -403,6 +402,10 @@ export class PhaseManager {
       : (this.dynamicPhaseManager.popNextPhase(phaseEntry.phaseType) ?? this.createPhase("TurnInitPhase"));
 
     this.currentPhase = phase;
+    this.startCurrentPhase();
+  }
+
+  private startCurrentPhase(): void {
     console.log(`%cStart Phase ${this.currentPhase.constructor.name}`, "color:green;");
     this.currentPhase.start();
   }
@@ -421,8 +424,7 @@ export class PhaseManager {
 
     this.standbyPhase = this.currentPhase;
     this.currentPhase = phase;
-    console.log(`%cStart Phase ${phase.constructor.name}`, "color:green;");
-    phase.start();
+    this.startCurrentPhase();
 
     return true;
   }

--- a/src/ui/handlers/ball-ui-handler.ts
+++ b/src/ui/handlers/ball-ui-handler.ts
@@ -85,7 +85,7 @@ export class BallUiHandler extends UiHandler {
     const pokeballTypeCount = Object.keys(globalScene.pokeballCounts).length;
 
     if (button === Button.ACTION || button === Button.CANCEL) {
-      const commandPhase = globalScene.phaseManager.getCurrentPhase() as CommandPhase;
+      const commandPhase = globalScene.phaseManager.getCurrentPhase<CommandPhase>();
       success = true;
       if (button === Button.ACTION && this.cursor < pokeballTypeCount) {
         if (globalScene.pokeballCounts[this.cursor]) {

--- a/src/ui/handlers/challenges-select-ui-handler.ts
+++ b/src/ui/handlers/challenges-select-ui-handler.ts
@@ -369,14 +369,14 @@ export class ChallengeSelectUiHandler extends UiHandler {
         this.updateChallengeArrows(this.startCursor.visible);
       } else {
         globalScene.phaseManager.toTitleScreen({ clearPhaseQueue: true });
-        globalScene.phaseManager.getCurrentPhase()?.end();
+        globalScene.phaseManager.getCurrentPhase().end();
       }
       success = true;
     } else if (button === Button.SUBMIT || button === Button.ACTION) {
       if (this.hasSelectedChallenge) {
         if (this.startCursor.visible) {
           globalScene.phaseManager.createAndUnshiftPhase("SelectStarterPhase");
-          globalScene.phaseManager.getCurrentPhase()?.end();
+          globalScene.phaseManager.getCurrentPhase().end();
         } else {
           this.startCursor.setVisible(true);
           this.cursorObj?.setVisible(false);

--- a/src/ui/handlers/command-ui-handler.ts
+++ b/src/ui/handlers/command-ui-handler.ts
@@ -127,7 +127,7 @@ export class CommandUiHandler extends UiHandler {
           case BattleCommand.FIGHT:
             ui.setMode<FightUiHandler>(
               UiMode.FIGHT,
-              globalScene.phaseManager.getCurrentPhase<CommandPhase>()?.getFieldIndex(),
+              globalScene.phaseManager.getCurrentPhase<CommandPhase>().getFieldIndex(),
             );
             success = true;
             break;
@@ -139,27 +139,27 @@ export class CommandUiHandler extends UiHandler {
             ui.setMode<PartyUiHandler>(
               UiMode.PARTY,
               PartyUiMode.SWITCH,
-              globalScene.phaseManager.getCurrentPhase<CommandPhase>()?.getPokemon().getFieldIndex(),
+              globalScene.phaseManager.getCurrentPhase<CommandPhase>().getPokemon().getFieldIndex(),
               null,
               PartyFilterNonFainted,
             );
             success = true;
             break;
           case BattleCommand.RUN:
-            globalScene.phaseManager.getCurrentPhase<CommandPhase>()?.handleCommand(BattleCommand.RUN, 0);
+            globalScene.phaseManager.getCurrentPhase<CommandPhase>().handleCommand(BattleCommand.RUN, 0);
             success = true;
             break;
           case BattleCommand.TERA:
             ui.setMode<FightUiHandler>(
               UiMode.FIGHT,
-              globalScene.phaseManager.getCurrentPhase<CommandPhase>()?.getFieldIndex(),
+              globalScene.phaseManager.getCurrentPhase<CommandPhase>().getFieldIndex(),
               BattleCommand.TERA,
             );
             success = true;
             break;
         }
       } else {
-        (globalScene.phaseManager.getCurrentPhase() as CommandPhase).cancel();
+        globalScene.phaseManager.getCurrentPhase<CommandPhase>().cancel();
       }
     } else {
       switch (button) {
@@ -285,9 +285,10 @@ export class CommandUiHandler extends UiHandler {
   private getCommandPhase(): CommandPhase {
     let commandPhase: CommandPhase;
     const currentPhase = globalScene.phaseManager.getCurrentPhase();
-    if (currentPhase?.is("CommandPhase")) {
+    if (currentPhase.is("CommandPhase")) {
       commandPhase = currentPhase;
     } else {
+      console.log("Got standby phase in `CommandUiHandler#getCommandPhase`");
       commandPhase = globalScene.phaseManager.getStandbyPhase() as CommandPhase;
     }
     return commandPhase;

--- a/src/ui/handlers/egg-hatch-scene-ui-handler.ts
+++ b/src/ui/handlers/egg-hatch-scene-ui-handler.ts
@@ -2,7 +2,6 @@ import { globalScene } from "#app/global-scene";
 import { GAME_HEIGHT } from "#constants/ui-constants";
 import { Button } from "#enums/button";
 import { UiMode } from "#enums/ui-mode";
-import { EggHatchPhase } from "#phases/egg-hatch-phase";
 import { UiHandler } from "#ui/ui-handler";
 
 export class EggHatchSceneUiHandler extends UiHandler {
@@ -55,7 +54,7 @@ export class EggHatchSceneUiHandler extends UiHandler {
   public override processInput(button: Button): boolean {
     if (button === Button.ACTION || button === Button.CANCEL) {
       const phase = globalScene.phaseManager.getCurrentPhase();
-      if (phase instanceof EggHatchPhase && phase.trySkip()) {
+      if (phase.is("EggHatchPhase") && phase.trySkip()) {
         return true;
       }
     }

--- a/src/ui/handlers/egg-hatch-summary-ui-handler.ts
+++ b/src/ui/handlers/egg-hatch-summary-ui-handler.ts
@@ -233,7 +233,7 @@ export class EggHatchSummaryUiHandler extends MessageUiHandler {
         error = true;
       } else {
         const phase = globalScene.phaseManager.getCurrentPhase();
-        if (phase?.is("EggSummaryPhase")) {
+        if (phase.is("EggSummaryPhase")) {
           phase.end();
         }
         success = true;

--- a/src/ui/handlers/fight-ui-handler.ts
+++ b/src/ui/handlers/fight-ui-handler.ts
@@ -140,7 +140,7 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
       messageHandler.movesWindowContainer.setVisible(true);
     }
 
-    const pokemon = (globalScene.phaseManager.getCurrentPhase() as CommandPhase).getPokemon();
+    const pokemon = globalScene.phaseManager.getCurrentPhase<CommandPhase>().getPokemon();
     if (pokemon.summonData.turnCount > 1) {
       this.setCursor(this.getCursor());
     } else {
@@ -158,7 +158,7 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
     let success = false;
 
     if (button === Button.ACTION) {
-      if (globalScene.phaseManager.getCurrentPhase<CommandPhase>()?.handleCommand(this.fromCommand, cursor, false)) {
+      if (globalScene.phaseManager.getCurrentPhase<CommandPhase>().handleCommand(this.fromCommand, cursor, false)) {
         success = true;
       } else {
         ui.playError();
@@ -248,7 +248,7 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
       ui.add(this.cursorObj);
     }
 
-    const pokemon = (globalScene.phaseManager.getCurrentPhase() as CommandPhase).getPokemon();
+    const pokemon = globalScene.phaseManager.getCurrentPhase<CommandPhase>().getPokemon();
     const moveset = pokemon.getMoveset();
 
     const hasMove = cursor < moveset.length;
@@ -322,7 +322,7 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
   }
 
   displayMoves() {
-    const pokemon = (globalScene.phaseManager.getCurrentPhase() as CommandPhase).getPokemon();
+    const pokemon = globalScene.phaseManager.getCurrentPhase<CommandPhase>().getPokemon();
     const moveset = pokemon.getMoveset();
 
     for (let moveIndex = 0; moveIndex < 4; moveIndex++) {
@@ -382,10 +382,10 @@ export class FightUiHandler extends UiHandler implements InfoToggle {
   clearMoves() {
     this.movesContainer.removeAll(true);
 
-    const opponents = (globalScene.phaseManager.getCurrentPhase() as CommandPhase).getPokemon().getOpponents();
-    opponents.forEach((opponent) => {
+    const opponents = globalScene.phaseManager.getCurrentPhase<CommandPhase>().getPokemon().getOpponents();
+    for (const opponent of opponents) {
       opponent.updateEffectiveness(undefined);
-    });
+    }
   }
 
   eraseCursor() {

--- a/src/ui/handlers/form-change-scene-ui-handler.ts
+++ b/src/ui/handlers/form-change-scene-ui-handler.ts
@@ -72,7 +72,7 @@ export class FormChangeSceneUiHandler extends MessageUiHandler {
     if (this.canCancel && button === Button.CANCEL) {
       this.canCancel = false;
       const currentPhase = globalScene.phaseManager.getCurrentPhase();
-      if (currentPhase?.is("EvolutionPhase")) {
+      if (currentPhase.is("EvolutionPhase")) {
         currentPhase.cancelEvolution();
       }
       return true;

--- a/src/ui/handlers/menu-ui-handler.ts
+++ b/src/ui/handlers/menu-ui-handler.ts
@@ -69,7 +69,7 @@ export class MenuUiHandler extends OptionSelectUiHandler {
 
     this.excludedMenus = () => [
       {
-        excluded: globalScene.phaseManager.getCurrentPhase()?.is("SelectModifierPhase") ?? false,
+        excluded: globalScene.phaseManager.getCurrentPhase().is("SelectModifierPhase"),
         options: [MenuOptions.EGG_GACHA, MenuOptions.EGG_LIST],
       },
       { excluded: BYPASS_LOGIN, options: [MenuOptions.LOG_OUT] },

--- a/src/ui/handlers/mystery-encounter-ui-handler.ts
+++ b/src/ui/handlers/mystery-encounter-ui-handler.ts
@@ -190,7 +190,7 @@ export class MysteryEncounterUiHandler extends UiHandler {
         ) {
           success = false;
         } else if (
-          (globalScene.phaseManager.getCurrentPhase() as MysteryEncounterPhase).handleOptionSelect(selected, cursor)
+          globalScene.phaseManager.getCurrentPhase<MysteryEncounterPhase>().handleOptionSelect(selected, cursor)
         ) {
           success = true;
         } else {

--- a/src/ui/handlers/party-ui-handler.ts
+++ b/src/ui/handlers/party-ui-handler.ts
@@ -398,7 +398,7 @@ export class PartyUiHandler extends MessageUiHandler {
               }
             } else if (
               option >= PartyOption.FORM_CHANGE_ITEM
-              && globalScene.phaseManager.getCurrentPhase()?.is("SelectModifierPhase")
+              && globalScene.phaseManager.getCurrentPhase().is("SelectModifierPhase")
             ) {
               if (this.partyUiMode === PartyUiMode.CHECK) {
                 const formChangeItemModifiers = this.getFormChangeItemsModifiers(pokemon);
@@ -407,11 +407,9 @@ export class PartyUiHandler extends MessageUiHandler {
                 globalScene.triggerPokemonFormChange(pokemon, SpeciesFormChangeItemTrigger, false, true);
               }
             } else if (this.cursor) {
-              (globalScene.phaseManager.getCurrentPhase() as CommandPhase).handleCommand(
-                BattleCommand.POKEMON,
-                this.cursor,
-                option === PartyOption.PASS_BATON,
-              );
+              globalScene.phaseManager
+                .getCurrentPhase<CommandPhase>()
+                .handleCommand(BattleCommand.POKEMON, this.cursor, option === PartyOption.PASS_BATON);
             }
             if (
               this.partyUiMode !== PartyUiMode.MODIFIER
@@ -877,7 +875,7 @@ export class PartyUiHandler extends MessageUiHandler {
           this.options.push(PartyOption.RELEASE);
           break;
         case PartyUiMode.CHECK:
-          if (globalScene.phaseManager.getCurrentPhase()?.is("SelectModifierPhase")) {
+          if (globalScene.phaseManager.getCurrentPhase().is("SelectModifierPhase")) {
             formChangeItemModifiers = this.getFormChangeItemsModifiers(pokemon);
             for (let i = 0; i < formChangeItemModifiers.length; i++) {
               this.options.push(PartyOption.FORM_CHANGE_ITEM + i);

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -3956,7 +3956,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         globalScene.phaseManager.toTitleScreen();
       }
       this.clearText();
-      globalScene.phaseManager.getCurrentPhase()?.end();
+      globalScene.phaseManager.getCurrentPhase().end();
     };
     const cancelExit = () => {
       ui.setMode<StarterSelectUiHandler>(UiMode.STARTER_SELECT);

--- a/test/abilities/dancer.test.ts
+++ b/test/abilities/dancer.test.ts
@@ -44,7 +44,7 @@ describe("Abilities - Dancer", () => {
     await game.phaseInterceptor.to("MovePhase");
     // immediately copies ally move Feather Dance, and uses it on opponent
     await game.phaseInterceptor.to("MovePhase", false);
-    let currentPhase = game.scene.phaseManager.getCurrentPhase() as MovePhase;
+    let currentPhase = game.scene.phaseManager.getCurrentPhase<MovePhase>();
     expect(currentPhase.pokemon).toBe(oricorio);
     expect(currentPhase.targets).toEqual([BattlerIndex.ENEMY]);
     expect(currentPhase.pokemonMove.moveId).toBe(MoveId.FEATHER_DANCE);
@@ -52,7 +52,7 @@ describe("Abilities - Dancer", () => {
     await game.phaseInterceptor.to("MovePhase");
     // immediately copies enemy move Victory Dance, and uses it on itself
     await game.phaseInterceptor.to("MovePhase", false);
-    currentPhase = game.scene.phaseManager.getCurrentPhase() as MovePhase;
+    currentPhase = game.scene.phaseManager.getCurrentPhase<MovePhase>();
     expect(currentPhase.pokemon).toBe(oricorio);
     expect(currentPhase.targets).toEqual([BattlerIndex.PLAYER]);
     expect(currentPhase.pokemonMove.moveId).toBe(MoveId.VICTORY_DANCE);

--- a/test/abilities/disguise.test.ts
+++ b/test/abilities/disguise.test.ts
@@ -194,7 +194,7 @@ describe("Abilities - Disguise", () => {
     game.move.select(MoveId.SHADOW_SNEAK);
     await game.toNextWave();
 
-    expect(game.scene.phaseManager.getCurrentPhase()?.constructor.name).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().constructor.name).toBe("CommandPhase");
     expect(game.scene.currentBattle.waveIndex).toBe(2);
   });
 

--- a/test/abilities/honey-gather.test.ts
+++ b/test/abilities/honey-gather.test.ts
@@ -64,7 +64,7 @@ describe("Abilities - Honey Gather", () => {
     const enemy = game.scene.getEnemyPokemon()!;
     vi.spyOn(enemy, "scene", "get").mockReturnValue(game.scene);
 
-    const commandPhase = game.scene.phaseManager.getCurrentPhase() as CommandPhase;
+    const commandPhase = game.scene.phaseManager.getCurrentPhase<CommandPhase>();
     commandPhase.handleCommand(BattleCommand.RUN, 0);
     await game.toNextTurn();
 

--- a/test/abilities/imposter.test.ts
+++ b/test/abilities/imposter.test.ts
@@ -126,7 +126,7 @@ describe("Abilities - Imposter", () => {
     await game.move.forceEnemyMove(MoveId.MEMENTO);
     await game.toNextWave();
 
-    expect(game.scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
     expect(game.scene.currentBattle.waveIndex).toBe(2);
 
     await game.reload.reloadSession();

--- a/test/abilities/neutralizing-gas.test.ts
+++ b/test/abilities/neutralizing-gas.test.ts
@@ -168,8 +168,8 @@ describe.todo("Abilities - Neutralizing Gas", () => {
 
     // TODO: add currentphase helper that `expect`s the correct phase
     const commandPhase = game.scene.phaseManager.getCurrentPhase<CommandPhase>();
-    expect(commandPhase?.phaseName).toBe("CommandPhase");
-    commandPhase!.handleCommand(BattleCommand.RUN, 0);
+    expect(commandPhase.phaseName).toBe("CommandPhase");
+    commandPhase.handleCommand(BattleCommand.RUN, 0);
     await game.toEndOfTurn();
 
     // expect(game.scene.arena.getTag(ArenaTagType.NEUTRALIZING_GAS)).toBeUndefined();

--- a/test/battle/battle.test.ts
+++ b/test/battle/battle.test.ts
@@ -79,7 +79,7 @@ describe("Test Phase Interceptor", () => {
   it("newGame one-liner", async () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.phaseManager.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().constructor.name).toBe("CommandPhase");
   });
 
   it("wrong phase", async () => {
@@ -227,7 +227,7 @@ describe("Test Battle Phase", () => {
     game.override.ability(AbilityId.HYDRATION);
     await game.classicMode.startBattle(SpeciesId.BLASTOISE, SpeciesId.CHARIZARD);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.phaseManager.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().constructor.name).toBe("CommandPhase");
   });
 
   it("1vs1", async () => {
@@ -237,7 +237,7 @@ describe("Test Battle Phase", () => {
     game.override.ability(AbilityId.HYDRATION);
     await game.classicMode.startBattle(SpeciesId.BLASTOISE);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.phaseManager.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().constructor.name).toBe("CommandPhase");
   });
 
   it("2vs2", async () => {
@@ -248,7 +248,7 @@ describe("Test Battle Phase", () => {
     game.override.startingWave(3);
     await game.classicMode.startBattle(SpeciesId.BLASTOISE, SpeciesId.CHARIZARD);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.phaseManager.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().constructor.name).toBe("CommandPhase");
   });
 
   it("4vs2", async () => {
@@ -259,7 +259,7 @@ describe("Test Battle Phase", () => {
     game.override.startingWave(3);
     await game.classicMode.startBattle(SpeciesId.BLASTOISE, SpeciesId.CHARIZARD, SpeciesId.DARKRAI, SpeciesId.GABITE);
     expect(game.scene.ui?.getMode()).toBe(UiMode.COMMAND);
-    expect(game.scene.phaseManager.getCurrentPhase()!.constructor.name).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().constructor.name).toBe("CommandPhase");
   });
 
   it("kill opponent pokemon", async () => {

--- a/test/moves/focus-punch.test.ts
+++ b/test/moves/focus-punch.test.ts
@@ -105,10 +105,10 @@ describe("Moves - Focus Punch", () => {
 
     await game.phaseInterceptor.to("TurnStartPhase");
 
-    expect(game.scene.phaseManager.getCurrentPhase()?.phaseName).toBe("RecallPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().phaseName).toBe("RecallPhase");
 
     await game.phaseInterceptor.to("PostActionPhase");
 
-    expect(game.scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MoveHeaderPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().phaseName).toBe("MoveHeaderPhase");
   });
 });

--- a/test/moves/shell-trap.test.ts
+++ b/test/moves/shell-trap.test.ts
@@ -48,9 +48,9 @@ describe("Moves - Shell Trap", () => {
 
     await game.phaseInterceptor.to("PostActionPhase");
 
-    const movePhase = game.scene.phaseManager.getCurrentPhase();
-    expect(movePhase?.phaseName).toBe("MovePhase");
-    expect((movePhase as MovePhase).pokemon).toBe(playerPokemon[1]);
+    const movePhase = game.scene.phaseManager.getCurrentPhase<MovePhase>();
+    expect(movePhase.phaseName).toBe("MovePhase");
+    expect(movePhase.pokemon).toBe(playerPokemon[1]);
 
     await game.phaseInterceptor.to("PostActionPhase");
     enemyPokemon.forEach((p) => expect(p.hp).toBeLessThan(p.getMaxHp()));
@@ -71,9 +71,9 @@ describe("Moves - Shell Trap", () => {
 
     await game.phaseInterceptor.to("PostActionPhase");
 
-    const movePhase = game.scene.phaseManager.getCurrentPhase();
-    expect(movePhase?.phaseName).toBe("MovePhase");
-    expect((movePhase as MovePhase).pokemon).not.toBe(playerPokemon[1]);
+    const movePhase = game.scene.phaseManager.getCurrentPhase<MovePhase>();
+    expect(movePhase.phaseName).toBe("MovePhase");
+    expect(movePhase.pokemon).not.toBe(playerPokemon[1]);
 
     await game.toEndOfTurn();
     enemyPokemon.forEach((p) => expect(p.hp).toBe(p.getMaxHp()));
@@ -94,9 +94,9 @@ describe("Moves - Shell Trap", () => {
 
     await game.phaseInterceptor.to("PostActionPhase");
 
-    const movePhase = game.scene.phaseManager.getCurrentPhase();
-    expect(movePhase?.phaseName).toBe("MovePhase");
-    expect((movePhase as MovePhase).pokemon).not.toBe(playerPokemon[1]);
+    const movePhase = game.scene.phaseManager.getCurrentPhase<MovePhase>();
+    expect(movePhase.phaseName).toBe("MovePhase");
+    expect(movePhase.pokemon).not.toBe(playerPokemon[1]);
 
     await game.toEndOfTurn();
     enemyPokemon.forEach((p) => expect(p.hp).toBe(p.getMaxHp()));
@@ -115,9 +115,9 @@ describe("Moves - Shell Trap", () => {
 
     await game.phaseInterceptor.to("PostActionPhase");
 
-    const movePhase = game.scene.phaseManager.getCurrentPhase();
-    expect(movePhase?.phaseName).toBe("MovePhase");
-    expect((movePhase as MovePhase).pokemon).not.toBe(playerPokemon[1]);
+    const movePhase = game.scene.phaseManager.getCurrentPhase<MovePhase>();
+    expect(movePhase.phaseName).toBe("MovePhase");
+    expect(movePhase.pokemon).not.toBe(playerPokemon[1]);
 
     const enemyStartingHp = enemyPokemon.map((p) => p.hp);
 

--- a/test/moves/transform.test.ts
+++ b/test/moves/transform.test.ts
@@ -135,7 +135,7 @@ describe("Moves - Transform", () => {
     await game.move.selectEnemyMove(MoveId.MEMENTO);
     await game.toNextWave();
 
-    expect(game.scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+    expect(game.scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
     expect(game.scene.currentBattle.waveIndex).toBe(2);
 
     await game.reload.reloadSession();

--- a/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
+++ b/test/mystery-encounter/encounters/a-trainers-test-encounter.test.ts
@@ -104,7 +104,7 @@ describe("A Trainer's Test - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(scene.currentBattle.trainer).toBeDefined();
       expect([TrainerType.BUCK, TrainerType.CHERYL, TrainerType.MARLEY, TrainerType.MIRA, TrainerType.RILEY]).toContain(
@@ -123,7 +123,7 @@ describe("A Trainer's Test - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const eggsAfter = scene.gameData.eggs;
       expect(eggsAfter).toBeDefined();
@@ -171,7 +171,7 @@ describe("A Trainer's Test - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 2);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const eggsAfter = scene.gameData.eggs;
       expect(eggsAfter).toBeDefined();

--- a/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
+++ b/test/mystery-encounter/encounters/absolute-avarice-encounter.test.ts
@@ -131,7 +131,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(SpeciesId.GREEDENT);
       const moveset = enemyField[0].getMoveset(true).map((m) => m.moveId);
@@ -148,7 +148,7 @@ describe("Absolute Avarice - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       for (const partyPokemon of scene.getPlayerParty()) {
         const pokemonId = partyPokemon.id;

--- a/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
+++ b/test/mystery-encounter/encounters/berries-abound-encounter.test.ts
@@ -114,7 +114,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
     });
@@ -132,7 +132,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const berriesAfter = scene.findModifiers((m) => m.isBerryModifier()) as BerryModifier[];
       const berriesAfterCount = berriesAfter.reduce((a, b) => a + b.stackCount, 0);
@@ -145,7 +145,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -183,7 +183,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
 
@@ -207,7 +207,7 @@ describe("Berries Abound - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
 
@@ -228,7 +228,7 @@ describe("Berries Abound - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 2);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
+++ b/test/mystery-encounter/encounters/bug-type-superfan-encounter.test.ts
@@ -229,7 +229,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(2);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -242,7 +242,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(3);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -256,7 +256,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(4);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -271,7 +271,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(5);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -287,7 +287,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(5);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -305,7 +305,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(5);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -323,7 +323,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(5);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -341,7 +341,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyParty = scene.getEnemyParty();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyParty.length).toBe(5);
       expect(scene.currentBattle.trainer?.config.trainerType).toBe(TrainerType.BUG_TYPE_SUPERFAN);
       expect(enemyParty[0].species.speciesId).toBe(SpeciesId.BEEDRILL);
@@ -363,7 +363,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game, false);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterRewardsPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterRewardsPhase");
 
       // Clear out prompt handlers created by `runMysteryEncounterToEnd`.
       // TODO: refactor the prompt handler queue to add this handler at the front of the queue instead.
@@ -398,26 +398,25 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.BUG_TYPE_SUPERFAN, [SpeciesId.ABRA]);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should proceed to rewards screen with 0-1 Bug Types reward options", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.BUG_TYPE_SUPERFAN, defaultParty);
       await runMysteryEncounterToEnd(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -434,7 +433,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       ]);
       await runMysteryEncounterToEnd(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -454,7 +453,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       ]);
       await runMysteryEncounterToEnd(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -476,7 +475,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       ]);
       await runMysteryEncounterToEnd(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -526,19 +525,18 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
       game.scene.modifiers = [];
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 3);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should remove the gifted item and proceed to rewards screen", async () => {
@@ -550,7 +548,7 @@ describe("Bug-Type Superfan - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 3, { partySlot: 1, optionNumber: 1 });
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
+++ b/test/mystery-encounter/encounters/clowning-around-encounter.test.ts
@@ -167,7 +167,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       expect(scene.currentBattle.double).toBeTruthy();
       const [enemy1, enemy2] = scene.getEnemyField();
       [enemy1, enemy2].forEach((p) => expect(p).toBeDefined());
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemy1.species.speciesId).toBe(SpeciesId.MR_MIME);
       expect(enemy1.getMoveset(true).map((m) => m.moveId)).toEqual([
         MoveId.TEETER_DANCE,
@@ -208,7 +208,7 @@ describe("Clowning Around - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
       const abilityToTrain = scene.currentBattle.mysteryEncounter?.misc.ability;
 
@@ -229,7 +229,7 @@ describe("Clowning Around - Mystery Encounter", () => {
 
       game.endPhase();
       await game.phaseInterceptor.to("PostMysteryEncounterPhase");
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("PostMysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("PostMysteryEncounterPhase");
 
       await game.phaseInterceptor.to("NewBattlePhase", false);
 

--- a/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
+++ b/test/mystery-encounter/encounters/dancing-lessons-encounter.test.ts
@@ -102,7 +102,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(SpeciesId.ORICORIO);
       expect(enemyField[0].summonData.statStages).toEqual([1, 1, 1, 1, 0, 0, 0]);
@@ -123,7 +123,7 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -214,20 +214,19 @@ describe("Dancing Lessons - Mystery Encounter", () => {
       });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 3);
       const partyCountAfter = scene.getPlayerParty().length;
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
       expect(partyCountBefore).toBe(partyCountAfter);
     });
 

--- a/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
+++ b/test/mystery-encounter/encounters/delibirdy-encounter.test.ts
@@ -149,19 +149,18 @@ describe("Delibird-y - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DELIBIRDY, defaultParty);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 1);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should leave encounter without battle", async () => {
@@ -304,19 +303,18 @@ describe("Delibird-y - Mystery Encounter", () => {
 
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should leave encounter without battle", async () => {
@@ -437,19 +435,18 @@ describe("Delibird-y - Mystery Encounter", () => {
 
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 3);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should leave encounter without battle", async () => {

--- a/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
+++ b/test/mystery-encounter/encounters/department-store-sale-encounter.test.ts
@@ -91,7 +91,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
     it("should have shop with only TMs", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 1);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -126,7 +126,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
     it("should have shop with only Vitamins", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 2);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -164,7 +164,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
     it("should have shop with only X Items", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 3);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -202,7 +202,7 @@ describe("Department Store Sale - Mystery Encounter", () => {
     it("should have shop with only Pokeballs", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.DEPARTMENT_STORE_SALE, defaultParty);
       await runMysteryEncounterToEnd(game, 4);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fiery-fallout-encounter.test.ts
@@ -161,7 +161,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(2);
       expect(enemyField[0].species.speciesId).toBe(SpeciesId.VOLCARONA);
       expect(enemyField[1].species.speciesId).toBe(SpeciesId.VOLCARONA);
@@ -177,7 +177,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const leadPokemonId = scene.getPlayerParty()?.[0].id;
       const leadPokemonItems = scene.findModifiers<PokemonHeldItemModifier>(
@@ -267,7 +267,7 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIERY_FALLOUT, defaultParty);
       await runMysteryEncounterToEnd(game, 3);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const leadPokemonItems = scene.getPlayerParty()?.[0].getHeldItems();
       const item = leadPokemonItems.find((i) => i.isAttackTypeBoosterModifier());
@@ -287,13 +287,13 @@ describe("Fiery Fallout - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FIERY_FALLOUT, [SpeciesId.MAGIKARP]);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const continueEncounterSpy = vi.spyOn(encounterPhase as MysteryEncounterPhase, "continueEncounter");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      const continueEncounterSpy = vi.spyOn(encounterPhase, "continueEncounter");
 
       await runSelectMysteryEncounterOption(game, 3);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(continueEncounterSpy).not.toHaveBeenCalled();
     });
   });

--- a/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fight-or-flight-encounter.test.ts
@@ -105,7 +105,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
     });
@@ -118,7 +118,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
 
@@ -152,19 +152,18 @@ describe("Fight or Flight - Mystery Encounter", () => {
       });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("Should skip fight when player meets requirements", async () => {
@@ -179,7 +178,7 @@ describe("Fight or Flight - Mystery Encounter", () => {
 
       await runMysteryEncounterToEnd(game, 2);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
 

--- a/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
+++ b/test/mystery-encounter/encounters/fun-and-games-encounter.test.ts
@@ -119,19 +119,18 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FUN_AND_GAMES, defaultParty);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 1);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should get 3 turns to attack the Wobbuffet for a reward", async () => {
@@ -140,7 +139,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FUN_AND_GAMES, defaultParty);
       await runMysteryEncounterToEnd(game, 1, { partySlot: 1 }, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.getEnemyPokemon()?.species.speciesId).toBe(SpeciesId.WOBBUFFET);
       expect(scene.getEnemyPokemon()?.ivs).toEqual([0, 0, 0, 0, 0, 0]);
       expect(scene.getEnemyPokemon()?.nature).toBe(Nature.MILD);
@@ -162,7 +161,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
     });
 
     it("should have no items in rewards if Wubboffet doesn't take enough damage", async () => {
@@ -170,7 +169,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FUN_AND_GAMES, defaultParty);
       await runMysteryEncounterToEnd(game, 1, { partySlot: 1 }, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       game.onNextPrompt("MessagePhase", UiMode.MESSAGE, () => {
         game.endPhase();
       });
@@ -181,7 +180,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -196,7 +195,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FUN_AND_GAMES, defaultParty);
       await runMysteryEncounterToEnd(game, 1, { partySlot: 1 }, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       game.onNextPrompt("MessagePhase", UiMode.MESSAGE, () => {
         game.endPhase();
       });
@@ -209,7 +208,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -225,7 +224,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FUN_AND_GAMES, defaultParty);
       await runMysteryEncounterToEnd(game, 1, { partySlot: 1 }, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       game.onNextPrompt("MessagePhase", UiMode.MESSAGE, () => {
         game.endPhase();
       });
@@ -238,7 +237,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -254,7 +253,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.FUN_AND_GAMES, defaultParty);
       await runMysteryEncounterToEnd(game, 1, { partySlot: 1 }, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       game.onNextPrompt("MessagePhase", UiMode.MESSAGE, () => {
         game.endPhase();
       });
@@ -267,7 +266,7 @@ describe("Fun And Games! - Mystery Encounter", () => {
       await game.phaseInterceptor.to("SelectModifierPhase", false);
 
       // Rewards
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
+++ b/test/mystery-encounter/encounters/global-trade-system-encounter.test.ts
@@ -223,7 +223,7 @@ describe("Global Trade System - Mystery Encounter", () => {
       scene.updateModifiers(true);
 
       await runMysteryEncounterToEnd(game, 3, { partySlot: 1, optionNumber: 1 });
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
+++ b/test/mystery-encounter/encounters/lost-at-sea-encounter.test.ts
@@ -137,19 +137,18 @@ describe("Lost at Sea - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.LOST_AT_SEA, [SpeciesId.ARCANINE]);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 1);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
   });
 
@@ -203,19 +202,18 @@ describe("Lost at Sea - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.LOST_AT_SEA, [SpeciesId.ARCANINE]);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
   });
 

--- a/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
+++ b/test/mystery-encounter/encounters/mysterious-challengers-encounter.test.ts
@@ -148,7 +148,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.MYSTERIOUS_CHALLENGERS, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.currentBattle.trainer).toBeDefined();
       expect(scene.currentBattle.mysteryEncounter?.encounterMode).toBe(MysteryEncounterMode.TRAINER_BATTLE);
     });
@@ -158,7 +158,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -190,7 +190,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.MYSTERIOUS_CHALLENGERS, defaultParty);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.currentBattle.trainer).toBeDefined();
       expect(scene.currentBattle.mysteryEncounter?.encounterMode).toBe(MysteryEncounterMode.TRAINER_BATTLE);
     });
@@ -200,7 +200,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -245,7 +245,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.MYSTERIOUS_CHALLENGERS, defaultParty);
       await runMysteryEncounterToEnd(game, 3, undefined, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.currentBattle.trainer).toBeDefined();
       expect(scene.currentBattle.mysteryEncounter?.encounterMode).toBe(MysteryEncounterMode.TRAINER_BATTLE);
     });
@@ -255,7 +255,7 @@ describe("Mysterious Challengers - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 3, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/part-timer-encounter.test.ts
+++ b/test/mystery-encounter/encounters/part-timer-encounter.test.ts
@@ -236,19 +236,18 @@ describe("Part-Timer - Mystery Encounter", () => {
       });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 3);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
       expect(EncounterPhaseUtils.updatePlayerMoney).not.toHaveBeenCalled();
     });
 

--- a/test/mystery-encounter/encounters/safari-zone.test.ts
+++ b/test/mystery-encounter/encounters/safari-zone.test.ts
@@ -110,19 +110,18 @@ describe("Safari Zone - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.SAFARI_ZONE, defaultParty);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 1);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should not spawn any Paradox Pokemon", async () => {

--- a/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
+++ b/test/mystery-encounter/encounters/teleporting-hijinks-encounter.test.ts
@@ -151,26 +151,25 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TELEPORTING_HIJINKS, defaultParty);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 1);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should be selectable if the player has enough money", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TELEPORTING_HIJINKS, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
     });
 
     it("should transport to a new area", async () => {
@@ -223,26 +222,25 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TELEPORTING_HIJINKS, [SpeciesId.BLASTOISE]);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should be selectable if the player has the right type pokemon", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TELEPORTING_HIJINKS, [SpeciesId.METAGROSS]);
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
     });
 
     it("should transport to a new area", async () => {
@@ -303,7 +301,7 @@ describe("Teleporting Hijinks - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 3, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-expert-breeder-encounter.test.ts
@@ -154,7 +154,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
       expect(successfullyLoaded).toBe(true);
 
       // Check usual battle stuff
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.currentBattle.trainer).toBeDefined();
       expect(scene.currentBattle.mysteryEncounter?.encounterMode).toBe(MysteryEncounterMode.TRAINER_BATTLE);
       expect(scene.getPlayerParty().length).toBe(1);
@@ -174,7 +174,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const eggsAfter = scene.gameData.eggs;
       const commonEggs = scene.currentBattle.mysteryEncounter!.misc.pokemon1CommonEggs;
@@ -239,7 +239,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
       expect(successfullyLoaded).toBe(true);
 
       // Check usual battle stuff
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.currentBattle.trainer).toBeDefined();
       expect(scene.currentBattle.mysteryEncounter?.encounterMode).toBe(MysteryEncounterMode.TRAINER_BATTLE);
       expect(scene.getPlayerParty().length).toBe(1);
@@ -259,7 +259,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const eggsAfter = scene.gameData.eggs;
       const commonEggs = scene.currentBattle.mysteryEncounter!.misc.pokemon2CommonEggs;
@@ -323,7 +323,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
       expect(successfullyLoaded).toBe(true);
 
       // Check usual battle stuff
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.currentBattle.trainer).toBeDefined();
       expect(scene.currentBattle.mysteryEncounter?.encounterMode).toBe(MysteryEncounterMode.TRAINER_BATTLE);
       expect(scene.getPlayerParty().length).toBe(1);
@@ -343,7 +343,7 @@ describe("The Expert Pokémon Breeder - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 3, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const eggsAfter = scene.gameData.eggs;
       const commonEggs = scene.currentBattle.mysteryEncounter!.misc.pokemon3CommonEggs;

--- a/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-pokemon-salesman-encounter.test.ts
@@ -174,19 +174,18 @@ describe("The Pokemon Salesman - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.THE_POKEMON_SALESMAN, defaultParty);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 1);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("should not offer any Paradox Pokemon", async () => {

--- a/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-strong-stuff-encounter.test.ts
@@ -192,7 +192,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
       const enemy = game.field.getEnemyPokemon();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemy.species.speciesId).toBe(SpeciesId.SHUCKLE);
       expect(enemy.summonData.statStages).toEqual([0, 2, 0, 2, 0, 0, 0]);
       const shuckleItems = enemy.getHeldItems();
@@ -221,7 +221,7 @@ describe("The Strong Stuff - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
+++ b/test/mystery-encounter/encounters/the-winstrate-challenge-encounter.test.ts
@@ -256,7 +256,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.THE_WINSTRATE_CHALLENGE, defaultParty);
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(scene.currentBattle.trainer).toBeDefined();
       expect(scene.currentBattle.trainer!.config.trainerType).toBe(TrainerType.VICTOR);
       expect(scene.currentBattle.mysteryEncounter?.enemyPartyConfigs.length).toBe(4);
@@ -289,7 +289,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
       // Should have Macho Brace in the rewards
       await skipBattleToNextBattle(game, true);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -329,7 +329,7 @@ describe("The Winstrate Challenge - Mystery Encounter", () => {
     it("should have a Rarer Candy in the rewards", async () => {
       await game.runToMysteryEncounter(MysteryEncounterType.THE_WINSTRATE_CHALLENGE, defaultParty);
       await runMysteryEncounterToEnd(game, 2);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
+++ b/test/mystery-encounter/encounters/trash-to-treasure-encounter.test.ts
@@ -120,7 +120,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.TRASH_TO_TREASURE, defaultParty);
       await runMysteryEncounterToEnd(game, 1);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const leftovers = scene.findModifier((m) => m.isTurnHealModifier());
       expect(leftovers).toBeDefined();
@@ -168,7 +168,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
       const enemy = game.field.getEnemyPokemon();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemy.species.speciesId).toBe(SpeciesId.GARBODOR);
       expect(enemy.getMoveset(true).map((m) => m.moveId)).toEqual([
         MoveId.PAYBACK,
@@ -189,7 +189,7 @@ describe("Trash to Treasure - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
+++ b/test/mystery-encounter/encounters/uncommon-breed-encounter.test.ts
@@ -120,7 +120,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
 
@@ -147,7 +147,7 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(enemyField[0].species.speciesId).toBe(speciesToSpawn);
 
@@ -190,19 +190,18 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       await scene.updateModifiers(true);
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 2);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     // TODO: there is some severe test flakiness occurring for this file, needs to be looked at/addressed in separate issue
@@ -252,19 +251,18 @@ describe("Uncommon Breed - Mystery Encounter", () => {
       });
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
 
-      const encounterPhase = scene.phaseManager.getCurrentPhase();
-      expect(encounterPhase?.phaseName).toBe("MysteryEncounterPhase");
-      const mysteryEncounterPhase = encounterPhase as MysteryEncounterPhase;
-      vi.spyOn(mysteryEncounterPhase, "continueEncounter");
-      vi.spyOn(mysteryEncounterPhase, "handleOptionSelect");
+      const encounterPhase = scene.phaseManager.getCurrentPhase<MysteryEncounterPhase>();
+      expect(encounterPhase.phaseName).toBe("MysteryEncounterPhase");
+      vi.spyOn(encounterPhase, "continueEncounter");
+      vi.spyOn(encounterPhase, "handleOptionSelect");
       vi.spyOn(scene.ui, "playError");
 
       await runSelectMysteryEncounterOption(game, 3);
 
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
       expect(scene.ui.playError).not.toHaveBeenCalled(); // No error sfx, option is disabled
-      expect(mysteryEncounterPhase.handleOptionSelect).not.toHaveBeenCalled();
-      expect(mysteryEncounterPhase.continueEncounter).not.toHaveBeenCalled();
+      expect(encounterPhase.handleOptionSelect).not.toHaveBeenCalled();
+      expect(encounterPhase.continueEncounter).not.toHaveBeenCalled();
     });
 
     it("Should skip fight when player meets requirements", async () => {

--- a/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
+++ b/test/mystery-encounter/encounters/weird-dream-encounter.test.ts
@@ -121,7 +121,7 @@ describe("Weird Dream - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 1);
       clearInterval(pressCancelInterval);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
 
       const pokemonAfter = scene.getPlayerParty();
       const bstsAfter = pokemonAfter.map((pokemon) => pokemon.getSpeciesForm().getBaseStatTotal());
@@ -144,7 +144,7 @@ describe("Weird Dream - Mystery Encounter", () => {
       await game.runToMysteryEncounter(MysteryEncounterType.WEIRD_DREAM, defaultParty);
       await runMysteryEncounterToEnd(game, 1);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);
@@ -187,7 +187,7 @@ describe("Weird Dream - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
 
       const enemyField = scene.getEnemyField();
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("CommandPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("CommandPhase");
       expect(enemyField.length).toBe(1);
       expect(scene.getEnemyParty().length).toBe(scene.getPlayerParty().length);
     });
@@ -197,7 +197,7 @@ describe("Weird Dream - Mystery Encounter", () => {
       await runMysteryEncounterToEnd(game, 2, undefined, true);
       await skipBattleRunMysteryEncounterRewardsPhase(game);
       await game.phaseInterceptor.to("SelectModifierPhase", false);
-      expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("SelectModifierPhase");
+      expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("SelectModifierPhase");
       await game.phaseInterceptor.to("SelectModifierPhase");
 
       expect(scene.ui.getMode()).to.equal(UiMode.MODIFIER_SELECT);

--- a/test/mystery-encounter/mystery-encounter.test.ts
+++ b/test/mystery-encounter/mystery-encounter.test.ts
@@ -34,7 +34,7 @@ describe("Mystery Encounters", () => {
     ]);
 
     await game.phaseInterceptor.to("MysteryEncounterPhase", false);
-    expect(scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+    expect(scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
   });
 
   it("Encounters should not run below wave 10", async () => {

--- a/test/phases/mystery-encounter-phase.test.ts
+++ b/test/phases/mystery-encounter-phase.test.ts
@@ -40,7 +40,7 @@ describe("Mystery Encounter Phases", () => {
       ]);
 
       await game.phaseInterceptor.to("MysteryEncounterPhase", false);
-      expect(game.scene.phaseManager.getCurrentPhase()?.phaseName).toBe("MysteryEncounterPhase");
+      expect(game.scene.phaseManager.getCurrentPhase().phaseName).toBe("MysteryEncounterPhase");
     });
 
     it("Runs MysteryEncounterPhase", async () => {

--- a/test/test-utils/game-manager.ts
+++ b/test/test-utils/game-manager.ts
@@ -151,7 +151,7 @@ export class GameManager {
    * Ends the current phase.
    */
   endPhase() {
-    this.scene.phaseManager.getCurrentPhase()?.end();
+    this.scene.phaseManager.getCurrentPhase().end();
   }
 
   /**
@@ -367,7 +367,7 @@ export class GameManager {
    * @returns True if the current phase matches the target phase, otherwise false.
    */
   isCurrentPhase(phaseTarget: PhaseKey) {
-    return this.scene.phaseManager.getCurrentPhase()?.is(phaseTarget);
+    return this.scene.phaseManager.getCurrentPhase().is(phaseTarget);
   }
 
   /**
@@ -529,7 +529,7 @@ export class GameManager {
    * **Must** be called during the {@linkcode CommandPhase}.
    */
   public tryToRunAway() {
-    const commandPhase = this.scene.phaseManager.getCurrentPhase<CommandPhase>()!;
+    const commandPhase = this.scene.phaseManager.getCurrentPhase<CommandPhase>();
     expect(commandPhase.phaseName).toBe("CommandPhase");
 
     commandPhase.handleCommand(BattleCommand.RUN, 0);
@@ -543,7 +543,7 @@ export class GameManager {
    * @see {@linkcode PokeballType}
    */
   public throwPokeball(ballType: PokeballType) {
-    const commandPhase = this.scene.phaseManager.getCurrentPhase<CommandPhase>()!;
+    const commandPhase = this.scene.phaseManager.getCurrentPhase<CommandPhase>();
     expect(commandPhase.phaseName).toBe("CommandPhase");
 
     commandPhase.handleCommand(BattleCommand.BALL, ballType);

--- a/test/test-utils/game-wrapper.ts
+++ b/test/test-utils/game-wrapper.ts
@@ -53,13 +53,13 @@ export class GameWrapper {
       const currentPhase = globalScene.phaseManager.getCurrentPhase();
       let moveName = "N/A";
       let moveId = MoveId.NONE;
-      if (currentPhase?.is("MoveEffectPhase")) {
+      if (currentPhase.is("MoveEffectPhase")) {
         const move = currentPhase.move;
         moveName = move.name;
         moveId = move.moveId;
       }
       const isLowHpMove = lowHpMoves.includes(moveId);
-      /**
+      /*
        * Warn about Pokemon reaching low HP, as a measure to prevent flaky tests from Pokemon randomly fainting.
        *
        * The list of conditions required for the warning to show up are:

--- a/test/test-utils/helpers/move-helper.ts
+++ b/test/test-utils/helpers/move-helper.ts
@@ -34,8 +34,7 @@ export class MoveHelper extends GameManagerHelper {
   public async forceHit(): Promise<void> {
     await this.game.phaseInterceptor.to("MoveEffectPhase", false);
     const moveEffectPhase = this.game.scene.phaseManager.getCurrentPhase<MoveEffectPhase>();
-    expect(moveEffectPhase).toBeDefined();
-    const move = moveEffectPhase!.move.getMove();
+    const move = moveEffectPhase.move.getMove();
     vi.spyOn(move, "calculateBattleAccuracy").mockImplementation((user, _target, _simulated) => {
       console.log(chalk.gray(`- Forcing hit on ${getPokemonNameWithAffix(user)}'s ${move.name}! - `));
       return -1;
@@ -168,7 +167,7 @@ export class MoveHelper extends GameManagerHelper {
     // Wait for the next EnemyCommandPhase to start
     await this.game.phaseInterceptor.to("EnemyCommandPhase", false);
     const enemy =
-      this.game.scene.getEnemyField()[this.game.scene.phaseManager.getCurrentPhase<EnemyCommandPhase>()!.fieldIndex];
+      this.game.scene.getEnemyField()[this.game.scene.phaseManager.getCurrentPhase<EnemyCommandPhase>().fieldIndex];
     const legalTargets = getMoveTargets(enemy, moveId);
 
     vi.spyOn(enemy, "getNextMove").mockReturnValueOnce({
@@ -202,7 +201,7 @@ export class MoveHelper extends GameManagerHelper {
     // Wait for the next EnemyCommandPhase to start
     await this.game.phaseInterceptor.to("EnemyCommandPhase", false);
     const enemy =
-      this.game.scene.getEnemyField()[this.game.scene.phaseManager.getCurrentPhase<EnemyCommandPhase>()!.fieldIndex];
+      this.game.scene.getEnemyField()[this.game.scene.phaseManager.getCurrentPhase<EnemyCommandPhase>().fieldIndex];
 
     if (coerceArray(activeOverrides.ENEMY_MOVESET_OVERRIDE).length > 0) {
       vi.spyOn(activeOverrides, "ENEMY_MOVESET_OVERRIDE", "get").mockReturnValue([]);
@@ -243,7 +242,7 @@ export class MoveHelper extends GameManagerHelper {
       UiMode.TARGET_SELECT,
       () => {
         const handler = this.game.scene.ui.getCurrentHandler<TargetSelectUiHandler>();
-        const phase = this.game.scene.phaseManager.getCurrentPhase<SelectTargetPhase>()!;
+        const phase = this.game.scene.phaseManager.getCurrentPhase<SelectTargetPhase>();
         const move = phase.getPokemon().getMoveset()[movePosition].getMove();
         if (!move.isMultiTarget()) {
           handler.setCursor(targetIndex ?? BattlerIndex.ENEMY);

--- a/test/test-utils/phase-interceptor.ts
+++ b/test/test-utils/phase-interceptor.ts
@@ -361,12 +361,12 @@ export class PhaseInterceptor {
     const instance = this.scene.ui;
     // @ts-expect-error: TypeScript doesn't like the `= never` from `UI#setMode`
     const ret = this.originalSetMode.apply(instance, [mode, ...args]);
-    if (currentPhase && !this.phases[currentPhase.constructor.name]) {
+    if (!this.phases[currentPhase.constructor.name]) {
       throw new Error(
         `missing ${currentPhase.constructor.name} in phaseInterceptor PHASES list  ---  Add it to PHASES inside of /test/utils/phaseInterceptor.ts`,
       );
     }
-    if (currentPhase && this.phases[currentPhase.constructor.name].endBySetMode) {
+    if (this.phases[currentPhase.constructor.name].endBySetMode) {
       this.inProgress?.callback();
       this.inProgress = undefined;
     }
@@ -378,11 +378,11 @@ export class PhaseInterceptor {
    */
   startPromptHandler() {
     this.promptInterval = setInterval(() => {
-      if (this.prompts.length) {
+      if (this.prompts.length > 0) {
         const actionForNextPrompt = this.prompts[0];
         const expireFn = actionForNextPrompt.expireFn?.();
         const currentMode = this.scene.ui.getMode();
-        const currentPhase = this.scene.phaseManager.getCurrentPhase()?.constructor.name;
+        const currentPhase = this.scene.phaseManager.getCurrentPhase().constructor.name;
         const currentHandler = this.scene.ui.getCurrentHandler();
         if (expireFn) {
           this.prompts.shift();


### PR DESCRIPTION
- Port of https://github.com/pagefaultgames/pokerogue/pull/6243 (though not the new matcher, that'll be in another PR)

## What are the changes the user will see?
N/A

## Why am I making these changes?
`PhaseManager#getCurrentPhase` can never return `null` any more (though technically `| null` was already removed from `PhaseManager#currentPhase` earlier so perhaps it already couldn't before #1406).

## What are the changes from a developer perspective?
Removed `| null` from return signature of `PhaseManager#getCurrentPhase`.
Removed a bunch of obsolete optional chaining/etc.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?