### PR TITLE
refactor: convert `abilitiesApplied` and `abilitiesRevealed` to `Set`s

### DIFF
--- a/src/@types/pokemon-types.ts
+++ b/src/@types/pokemon-types.ts
@@ -56,7 +56,7 @@ export interface PokemonSummonData {
   /** Whether the pokemon's abilities are being suppressed by a move like {@linkcode MoveId.GASTRO_ACID | Gastro Acid} */
   abilitySuppressed: boolean;
   /** List of abilities that have been activated */
-  abilitiesApplied: AbilityId[];
+  abilitiesApplied: Set<AbilityId>;
   /** The {@linkcode PokemonSpeciesForm | species} this pokemon has transformed into */
   speciesForm: PokemonSpeciesForm | null;
   ability: AbilityId;
@@ -119,14 +119,14 @@ export interface PokemonWaveData {
   /** The berries eaten by the Pokemon */
   berriesEaten: BerryType[];
   /** The abilities this Pokemon has applied */
-  abilitiesApplied: AbilityId[];
+  abilitiesApplied: Set<AbilityId>;
   /**
    * The abilities revealed from this Pokemon.
    * This differs from {@linkcode abilitiesApplied} in that
    * effects such as Frisk and Trace can reveal abilities
    * without applying them.
    */
-  abilitiesRevealed: AbilityId[];
+  abilitiesRevealed: Set<AbilityId>;
 }
 
 /**

--- a/src/data/abilities/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/copy-fainted-ally-ability-ab-attr.ts
@@ -10,7 +10,7 @@ export class CopyFaintedAllyAbilityAbAttr extends PostKnockOutAbAttr {
     if (!simulated) {
       const knockedOutAllyAb = knockedOutPokemon.getAbility().id;
       pokemon.summonData.ability = knockedOutAllyAb;
-      pokemon.waveData.abilitiesRevealed.push(knockedOutAllyAb);
+      pokemon.waveData.abilitiesRevealed.add(knockedOutAllyAb);
       globalScene.phaseManager.createAndUnshiftPhase(
         "MessagePhase",
         i18next.t("abilityTriggers:copyFaintedAllyAbility", {

--- a/src/data/abilities/ab-attrs/frisk-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/frisk-ab-attr.ts
@@ -17,7 +17,7 @@ export class FriskAbAttr extends PostSummonAbAttr {
             opponentAbilityName: opponent.getAbility().name,
           }),
         );
-        opponent.waveData.abilitiesRevealed.push(opponent.getAbility().id);
+        opponent.waveData.abilitiesRevealed.add(opponent.getAbility().id);
       }
     }
   }

--- a/src/data/abilities/ab-attrs/post-defend-ability-give-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-ability-give-ab-attr.ts
@@ -23,7 +23,7 @@ export class PostDefendAbilityGiveAbAttr extends PostDefendAbAttr {
   public override apply(_pokemon: Pokemon, simulated: boolean, attacker: Pokemon, _move: Move): void {
     if (!simulated) {
       attacker.summonData.ability = this.ability;
-      attacker.waveData.abilitiesRevealed.push(this.ability);
+      attacker.waveData.abilitiesRevealed.add(this.ability);
     }
   }
 

--- a/src/data/abilities/ab-attrs/post-defend-ability-swap-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-ability-swap-ab-attr.ts
@@ -12,10 +12,10 @@ export class PostDefendAbilitySwapAbAttr extends PostDefendAbAttr {
       const attackerAbilityId = attacker.getAbility().id;
 
       attacker.summonData.ability = sourceAbilityId;
-      attacker.waveData.abilitiesRevealed.push(sourceAbilityId);
+      attacker.waveData.abilitiesRevealed.add(sourceAbilityId);
 
       pokemon.summonData.ability = attackerAbilityId;
-      pokemon.waveData.abilitiesRevealed.push(attackerAbilityId);
+      pokemon.waveData.abilitiesRevealed.add(attackerAbilityId);
     }
   }
 

--- a/src/data/abilities/ab-attrs/post-summon-copy-ability-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-summon-copy-ability-ab-attr.ts
@@ -20,7 +20,7 @@ export class PostSummonCopyAbilityAbAttr extends PostSummonAbAttr {
     const targetAbility = this.target.getAbility();
     this.targetAbilityName = targetAbility.name;
     pokemon.summonData.ability = targetAbility.id;
-    this.target.waveData.abilitiesRevealed.push(targetAbility.id);
+    this.target.waveData.abilitiesRevealed.add(targetAbility.id);
     pokemon.updateInfo();
   }
 

--- a/src/data/abilities/apply-ab-attrs.ts
+++ b/src/data/abilities/apply-ab-attrs.ts
@@ -111,14 +111,10 @@ function applyAbAttrsInternal<K extends AbAttrKey>(
       // @ts-expect-error: TS doesn't narrow `args` correctly (See above)
       attr.apply(pokemon, simulated, ...args);
 
-      if (!pokemon.summonData.abilitiesApplied.includes(ability.id)) {
-        pokemon.summonData.abilitiesApplied.push(ability.id);
-      }
+      pokemon.summonData.abilitiesApplied.add(ability.id);
 
-      if (!pokemon.waveData.abilitiesApplied.includes(ability.id)) {
-        pokemon.waveData.abilitiesApplied.push(ability.id);
-        pokemon.waveData.abilitiesRevealed.push(ability.id);
-      }
+      pokemon.waveData.abilitiesApplied.add(ability.id);
+      pokemon.waveData.abilitiesRevealed.add(ability.id);
 
       if (attr.showAbility && !simulated) {
         globalScene.phaseManager.createAndUnshiftPhase("HideAbilityPhase", pokemon);

--- a/src/data/init/init-abilities.ts
+++ b/src/data/init/init-abilities.ts
@@ -1992,7 +1992,7 @@ function getSheerForceHitDisableAbCondition(): AbAttrCondition {
  */
 function getOncePerBattleCondition(ability: AbilityId): AbAttrCondition {
   return (pokemon: Pokemon) => {
-    return !pokemon.waveData.abilitiesApplied.includes(ability);
+    return !pokemon.waveData.abilitiesApplied.has(ability);
   };
 }
 

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -1618,7 +1618,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   }
 
   public hasRevealedAbility(abilityId: AbilityId) {
-    return this.waveData.abilitiesRevealed.includes(abilityId);
+    return this.waveData.abilitiesRevealed.has(abilityId);
   }
 
   /**
@@ -4163,7 +4163,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
       moveQueue: [],
       tags: [],
       abilitySuppressed: false,
-      abilitiesApplied: [],
+      abilitiesApplied: new Set(),
       speciesForm: null,
       ability: AbilityId.NONE,
       passiveAbility: AbilityId.NONE,
@@ -4214,8 +4214,8 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
     this.waveData = {
       hitCount: 0,
       berriesEaten: [],
-      abilitiesApplied: [],
-      abilitiesRevealed: [],
+      abilitiesApplied: new Set(),
+      abilitiesRevealed: new Set(),
     };
   }
 

--- a/src/system/pokemon-data.ts
+++ b/src/system/pokemon-data.ts
@@ -14,7 +14,13 @@ import type { SpeciesId } from "#enums/species-id";
 import { TrainerSlot } from "#enums/trainer-slot";
 import type { Pokemon, PokemonOptions } from "#field/pokemon";
 import { PokemonMove } from "#field/pokemon-move";
-import type { CustomPokemonData, PokemonSummonData, SerializedSpeciesForm, Status } from "#types/pokemon-types";
+import type {
+  CustomPokemonData,
+  PokemonSummonData,
+  SerializedPokemonSummonData,
+  SerializedSpeciesForm,
+  Status,
+} from "#types/pokemon-types";
 import { clamp, isPokemon } from "#utils/common-utils";
 import { getPokemonSpecies, getPokemonSpeciesForm, summonDataToJSON } from "#utils/pokemon-utils";
 
@@ -130,29 +136,34 @@ export class PokemonData implements PokemonOptions {
       return;
     }
 
-    // This is required because the full class object doesn't exist in save data
+    // #region Class reconstruction
+    // This is required because the full class/function data is not serialized to the save data
+
     this.moveset = source.moveset.map((m) => PokemonMove.loadMove(m)) ?? [
       new PokemonMove(MoveId.TACKLE),
       new PokemonMove(MoveId.GROWL),
     ];
 
     this.summonData = source.summonData;
+
+    const sourceSummonData = source.summonData as unknown as SerializedPokemonSummonData;
+
     this.summonData.toJSON = summonDataToJSON;
-    // This is required because the full class object doesn't exist in save data
-    this.summonData.moveset = source.summonData.moveset?.map((m) => PokemonMove.loadMove(m)) ?? [];
-    // This is required because the full class object doesn't exist in save data
-    this.summonData.tags = source.summonData.tags?.map((t) => loadBattlerTag(t)) ?? [];
-    if (source.summonData.speciesForm) {
-      this.summonData.speciesForm = deserializePokemonSpeciesForm(source.summonData.speciesForm);
+    this.summonData.moveset = sourceSummonData.moveset?.map((m) => PokemonMove.loadMove(m)) ?? [];
+    this.summonData.tags = sourceSummonData.tags?.map((t) => loadBattlerTag(t)) ?? [];
+    if (sourceSummonData.speciesForm) {
+      this.summonData.speciesForm = deserializePokemonSpeciesForm(sourceSummonData.speciesForm);
     }
+    this.summonData.abilitiesApplied = new Set(sourceSummonData.abilitiesApplied);
+
     for (const turnMove of this.summonData.moveHistory) {
-      // This is required because the full class object doesn't exist in save data
       turnMove.move = allMoves.get(turnMove.move.id);
     }
     for (const turnMove of this.summonData.moveQueue) {
-      // This is required because the full class object doesn't exist in save data
       turnMove.move = allMoves.get(turnMove.move.id);
     }
+
+    // #endregion
   }
 
   toPokemon(battleType?: BattleType, partyMemberIndex: number = 0, double: boolean = false): Pokemon {

--- a/src/utils/pokemon-utils.ts
+++ b/src/utils/pokemon-utils.ts
@@ -113,12 +113,13 @@ export function getPokemonMoveName(pokemon: Pokemon, moveId: MoveId, bypassSummo
 export function summonDataToJSON(this: PokemonSummonData): SerializedPokemonSummonData {
   // Pokemon species forms are never saved, only the species ID.
   const speciesForm = this.speciesForm;
-  const t = {
+  const t: SerializedPokemonSummonData = {
     // the "as omit" is required to avoid TS resolving the overwritten properties to `never`
     // We coerce `null` to `undefined` in the type, as the for loop below replaces `null` with `undefined`
     ...(this as Omit<CoerceNullPropertiesToUndefined<PokemonSummonData>, "speciesForm">),
     speciesForm:
       speciesForm == null ? undefined : { speciesId: speciesForm.speciesId, formIndex: speciesForm.formIndex },
+    abilitiesApplied: [...this.abilitiesApplied.values()],
   };
   // Replace `null` with `undefined`, as `undefined` never gets serialized
   for (const [key, value] of Object.entries(t)) {

--- a/test/abilities/anticipation.test.ts
+++ b/test/abilities/anticipation.test.ts
@@ -36,7 +36,7 @@ describe("Abilities - Anticipation", () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(playerPokemon.waveData.abilitiesApplied[0]).toBe(AbilityId.ANTICIPATION);
+    expect(playerPokemon).toHaveAbilityApplied(AbilityId.ANTICIPATION);
   });
 
   it("should activate when the opponent has a 1HKO move", async () => {
@@ -44,7 +44,7 @@ describe("Abilities - Anticipation", () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(playerPokemon.waveData.abilitiesApplied[0]).toBe(AbilityId.ANTICIPATION);
+    expect(playerPokemon).toHaveAbilityApplied(AbilityId.ANTICIPATION);
   });
 
   it("should not activate when the opponent does not have a super-effective or 1HKO move", async () => {
@@ -52,7 +52,7 @@ describe("Abilities - Anticipation", () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(playerPokemon.waveData.abilitiesApplied.length).toBe(0);
+    expect(playerPokemon.waveData.abilitiesApplied.size).toBe(0);
   });
 
   it("should not activate against status moves", async () => {
@@ -60,7 +60,7 @@ describe("Abilities - Anticipation", () => {
     await game.classicMode.startBattle(SpeciesId.FEEBAS);
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(playerPokemon.waveData.abilitiesApplied.length).toBe(0);
+    expect(playerPokemon.waveData.abilitiesApplied.size).toBe(0);
   });
 
   it("should work correctly in Inverse Battles", async () => {
@@ -69,7 +69,7 @@ describe("Abilities - Anticipation", () => {
     await game.challengeMode.startBattle(SpeciesId.FEEBAS);
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
-    expect(playerPokemon.waveData.abilitiesApplied[0]).toBe(AbilityId.ANTICIPATION);
+    expect(playerPokemon).toHaveAbilityApplied(AbilityId.ANTICIPATION);
   });
 
   it("should ignore Gravity when evaluating move effectiveness", async () => {
@@ -86,7 +86,7 @@ describe("Abilities - Anticipation", () => {
 
     // Should not have activated Anticipation despite taking super-effective damage
     expect(playerPokemon.getMoveEffectiveness).toHaveLastReturnedWith(2);
-    expect(playerPokemon.waveData.abilitiesApplied.length).toBe(0);
+    expect(playerPokemon.waveData.abilitiesApplied.size).toBe(0);
   });
 
   it("should consider Hidden Power's calculated type, not its default Normal type", async () => {
@@ -97,7 +97,7 @@ describe("Abilities - Anticipation", () => {
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
     expect(enemyPokemon.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
-    expect(playerPokemon.waveData.abilitiesApplied[0]).toBe(AbilityId.ANTICIPATION);
+    expect(playerPokemon).toHaveAbilityApplied(AbilityId.ANTICIPATION);
   });
 
   it("should not consider most variable-type moves' calculated type", async () => {
@@ -108,6 +108,6 @@ describe("Abilities - Anticipation", () => {
     const playerPokemon = game.scene.getPlayerPokemon()!;
 
     expect(enemyPokemon.getMoveType(enemyPokemon.getMoveset()[0].getMove())).toBe(ElementalType.ELECTRIC);
-    expect(playerPokemon.waveData.abilitiesApplied.length).toBe(0);
+    expect(playerPokemon.waveData.abilitiesApplied.size).toBe(0);
   });
 });

--- a/test/abilities/infiltrator.test.ts
+++ b/test/abilities/infiltrator.test.ts
@@ -69,7 +69,7 @@ describe("Abilities - Infiltrator", () => {
     ).damage;
 
     expect(postScreenDmg).toBe(preScreenDmg);
-    expect(player.waveData.abilitiesApplied[0]).toBe(AbilityId.INFILTRATOR);
+    expect(player).toHaveAbilityApplied(AbilityId.INFILTRATOR);
   });
 
   it("should bypass the target's Safeguard", async () => {
@@ -84,7 +84,7 @@ describe("Abilities - Infiltrator", () => {
 
     await game.toEndOfTurn();
     expect(enemy.getStatusEffect(true)).toBe(StatusEffect.SLEEP);
-    expect(player.waveData.abilitiesApplied[0]).toBe(AbilityId.INFILTRATOR);
+    expect(player).toHaveAbilityApplied(AbilityId.INFILTRATOR);
   });
 
   it("should bypass the target's Mist", async () => {
@@ -99,7 +99,7 @@ describe("Abilities - Infiltrator", () => {
 
     await game.phaseInterceptor.to("PostActionPhase");
     expect(enemy.getStatStage(Stat.ATK)).toBe(-1);
-    expect(player.waveData.abilitiesApplied[0]).toBe(AbilityId.INFILTRATOR);
+    expect(player).toHaveAbilityApplied(AbilityId.INFILTRATOR);
   });
 
   it("should bypass the target's Substitute", async () => {
@@ -114,6 +114,6 @@ describe("Abilities - Infiltrator", () => {
 
     await game.phaseInterceptor.to("PostActionPhase");
     expect(enemy.getStatStage(Stat.ATK)).toBe(-1);
-    expect(player.waveData.abilitiesApplied[0]).toBe(AbilityId.INFILTRATOR);
+    expect(player).toHaveAbilityApplied(AbilityId.INFILTRATOR);
   });
 });

--- a/test/abilities/libero.test.ts
+++ b/test/abilities/libero.test.ts
@@ -66,7 +66,8 @@ describe.each([
     game.move.use(MoveId.AGILITY);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied.filter((a) => a === ability)).toHaveLength(1);
+    // can't use custom matcher as it checks `waveData` and this needs to check `summonData` (if it's ever re-enabled)
+    expect(leadPokemon.summonData.abilitiesApplied).toContain(ability);
     const leadPokemonType = enumValueToKey(ElementalType, leadPokemon.getTypes()[0]);
     const moveType = enumValueToKey(ElementalType, allMoves.get(MoveId.AGILITY).type);
     expect(leadPokemonType).not.toBe(moveType);
@@ -94,7 +95,7 @@ describe.each([
     game.move.use(MoveId.WEATHER_BALL);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied).toContain(ability);
+    expect(leadPokemon).toHaveAbilityApplied(ability);
     expect(leadPokemon.getTypes()).toHaveLength(1);
     const leadPokemonType = enumValueToKey(ElementalType, leadPokemon.getTypes()[0]);
     const moveType = enumValueToKey(ElementalType, ElementalType.FIRE);
@@ -111,7 +112,7 @@ describe.each([
     game.move.use(MoveId.TACKLE);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied).toContain(ability);
+    expect(leadPokemon).toHaveAbilityApplied(ability);
     expect(leadPokemon.getTypes()).toHaveLength(1);
     const leadPokemonType = enumValueToKey(ElementalType, leadPokemon.getTypes()[0]);
     const moveType = enumValueToKey(ElementalType, ElementalType.ICE);
@@ -191,7 +192,7 @@ describe.each([
     game.move.use(MoveId.SPLASH);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied).not.toContain(ability);
+    expect(leadPokemon).not.toHaveAbilityApplied(ability);
   });
 
   it("is not applied if pokemon's modified type is the same as the move's type", async () => {
@@ -203,7 +204,7 @@ describe.each([
     game.move.use(MoveId.SPLASH);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied).not.toContain(ability);
+    expect(leadPokemon).not.toHaveAbilityApplied(ability);
   });
 
   it("is not applied if pokemon is terastallized", async () => {
@@ -215,7 +216,7 @@ describe.each([
     game.move.use(MoveId.SPLASH);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied).not.toContain(ability);
+    expect(leadPokemon).not.toHaveAbilityApplied(ability);
   });
 
   it("is not applied if pokemon uses struggle", async () => {
@@ -226,7 +227,7 @@ describe.each([
     game.move.use(MoveId.STRUGGLE);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied).not.toContain(ability);
+    expect(leadPokemon).not.toHaveAbilityApplied(ability);
   });
 
   it("is not applied if the pokemon's move fails", async () => {
@@ -237,7 +238,7 @@ describe.each([
     game.move.use(MoveId.BURN_UP);
     await game.toEndOfTurn();
 
-    expect(leadPokemon.summonData.abilitiesApplied).not.toContain(ability);
+    expect(leadPokemon).not.toHaveAbilityApplied(ability);
   });
 
   it("applies correctly even if the pokemon's Trick-or-Treat fails", async () => {
@@ -266,7 +267,7 @@ describe.each([
   });
 
   function testPokemonTypeMatchesDefaultMoveType(pokemon: PlayerPokemon, moveId: MoveId) {
-    expect(pokemon.summonData.abilitiesApplied).toContain(ability);
+    expect(pokemon).toHaveAbilityApplied(ability);
     expect(pokemon.getTypes()).toHaveLength(1);
     const pokemonType = enumValueToKey(ElementalType, pokemon.getTypes()[0]);
     const moveType = enumValueToKey(ElementalType, allMoves.get(moveId).type);

--- a/test/abilities/mirror-armor.test.ts
+++ b/test/abilities/mirror-armor.test.ts
@@ -239,7 +239,7 @@ describe("Abilities - Mirror Armor", () => {
     game.move.use(MoveId.GROWL);
     await game.toEndOfTurn();
 
-    expect(player.waveData.abilitiesApplied).toContain(AbilityId.CLEAR_BODY);
+    expect(player).toHaveAbilityApplied(AbilityId.CLEAR_BODY);
     expect(player.getStatStage(Stat.ATK)).toBe(0);
     expect(enemy.getStatStage(Stat.ATK)).toBe(0);
   });

--- a/test/abilities/quick-draw.test.ts
+++ b/test/abilities/quick-draw.test.ts
@@ -48,7 +48,7 @@ describe("Abilities - Quick Draw", () => {
     await game.toEndOfTurn();
 
     expect(player.turnData.order).toBeLessThan(enemy.turnData.order);
-    expect(player.waveData.abilitiesApplied).toContain(AbilityId.QUICK_DRAW);
+    expect(player).toHaveAbilityApplied(AbilityId.QUICK_DRAW);
   });
 
   test("should not apply when the source uses a status move", async () => {
@@ -61,7 +61,7 @@ describe("Abilities - Quick Draw", () => {
     await game.toEndOfTurn();
 
     expect(player.turnData.order).toBeGreaterThan(enemy.turnData.order);
-    expect(player.waveData.abilitiesApplied).not.toContain(AbilityId.QUICK_DRAW);
+    expect(player).not.toHaveAbilityApplied(AbilityId.QUICK_DRAW);
   });
 
   test("should not cause the source to move before higher-priority moves", async () => {
@@ -75,6 +75,6 @@ describe("Abilities - Quick Draw", () => {
     await game.toEndOfTurn();
 
     expect(player.turnData.order).toBeGreaterThan(enemy.turnData.order);
-    expect(player.waveData.abilitiesApplied).contain(AbilityId.QUICK_DRAW);
+    expect(player).toHaveAbilityApplied(AbilityId.QUICK_DRAW);
   });
 });

--- a/test/abilities/wimp-out.test.ts
+++ b/test/abilities/wimp-out.test.ts
@@ -184,7 +184,7 @@ describe("Abilities - Wimp Out", () => {
     game.selectPartyPokemon(1);
     await game.phaseInterceptor.to("SwitchPhase", false);
 
-    expect(wimpod.summonData.abilitiesApplied).not.toContain(AbilityId.WIMP_OUT);
+    expect(wimpod).not.toHaveAbilityApplied(AbilityId.WIMP_OUT);
 
     await game.toEndOfTurn();
 
@@ -562,6 +562,6 @@ describe("Abilities - Wimp Out", () => {
     expect(enemy1.getHpRatio()).toBeLessThanOrEqual(0.5);
     expect(enemy1).not.toHaveFainted();
     expect(enemy1.isOnField()).toBeTruthy();
-    expect(enemy1.waveData.abilitiesApplied.includes(AbilityId.WIMP_OUT)).toBeFalsy();
+    expect(enemy1).not.toHaveAbilityApplied(AbilityId.WIMP_OUT);
   });
 });

--- a/test/challenges/inverse-battle.test.ts
+++ b/test/challenges/inverse-battle.test.ts
@@ -183,7 +183,7 @@ describe("Inverse Battle", () => {
 
     await game.challengeMode.startBattle(SpeciesId.FEEBAS);
 
-    expect(game.scene.getEnemyPokemon()?.summonData.abilitiesApplied[0]).toBe(AbilityId.ANTICIPATION);
+    expect(game.field.getEnemyPokemon()).toHaveAbilityApplied(AbilityId.ANTICIPATION);
   });
 
   it("Conversion 2 should change the type to the resistive type - Conversion 2 against Dragonite", async () => {

--- a/test/moves/dive.test.ts
+++ b/test/moves/dive.test.ts
@@ -106,7 +106,7 @@ describe("Moves - Dive", () => {
 
     await game.phaseInterceptor.to("PostActionPhase");
     expect(playerPokemon.hp).toBeLessThan(playerPokemon.getMaxHp());
-    expect(enemyPokemon.waveData.abilitiesApplied[0]).toBe(AbilityId.ROUGH_SKIN);
+    expect(enemyPokemon).toHaveAbilityApplied(AbilityId.ROUGH_SKIN);
   });
 
   it("should cancel attack after Harsh Sunlight is set", async () => {

--- a/test/moves/order-up.test.ts
+++ b/test/moves/order-up.test.ts
@@ -90,7 +90,7 @@ describe("Moves - Order Up", () => {
 
     await game.toEndOfTurn();
 
-    expect(dondozo.waveData.abilitiesApplied.includes(AbilityId.SHEER_FORCE)).toBeTruthy();
+    expect(dondozo).toHaveAbilityApplied(AbilityId.SHEER_FORCE);
     expect(dondozo.getStatStage(Stat.ATK)).toBe(3);
   });
 });

--- a/test/moves/psyshock.test.ts
+++ b/test/moves/psyshock.test.ts
@@ -41,7 +41,7 @@ describe("Moves - Psyshock", () => {
     game.move.use(MoveId.PSYSHOCK);
     await game.toEndOfTurn();
 
-    expect(enemy.waveData.abilitiesApplied).toContain(AbilityId.FUR_COAT);
+    expect(enemy).toHaveAbilityApplied(AbilityId.FUR_COAT);
   });
 
   it("should use the user's Sp. Atk stat stages during damage calculation", async () => {

--- a/test/moves/spectral-thief.test.ts
+++ b/test/moves/spectral-thief.test.ts
@@ -98,7 +98,7 @@ describe("Moves - Spectral Thief", () => {
 
     expect(player.getStatStage(Stat.DEF)).toBe(2);
     expect(enemy.getStatStage(Stat.DEF)).toBe(0);
-    expect(enemy.waveData.abilitiesApplied.includes(AbilityId.CLEAR_BODY)).toBeFalsy();
+    expect(enemy).not.toHaveAbilityApplied(AbilityId.CLEAR_BODY);
   });
 
   // biome-ignore format: prefer pre-2.3.6 formatting
@@ -143,6 +143,6 @@ describe("Moves - Spectral Thief", () => {
     expect(player.getStatStage(Stat.DEF)).toBe(2);
     expect(enemy.getStatStage(Stat.DEF)).toBe(0);
     expect(enemy.getStatStage(Stat.ATK)).toBe(0);
-    expect(enemy.waveData.abilitiesApplied.includes(AbilityId.DEFIANT)).toBeFalsy();
+    expect(enemy).not.toHaveAbilityApplied(AbilityId.DEFIANT);
   });
 });

--- a/test/moves/tera-blast.test.ts
+++ b/test/moves/tera-blast.test.ts
@@ -95,7 +95,7 @@ describe("Moves - Tera Blast", () => {
 
     game.move.select(MoveId.TERA_BLAST);
     await game.toEndOfTurn();
-    expect(game.field.getEnemyPokemon().waveData.abilitiesApplied).toContain(AbilityId.TOXIC_DEBRIS);
+    expect(game.field.getEnemyPokemon()).toHaveAbilityApplied(AbilityId.TOXIC_DEBRIS);
   });
 
   it("causes stat drops if user is Stellar tera type", async () => {

--- a/test/test-utils/matchers/to-have-ability-applied-matcher.ts
+++ b/test/test-utils/matchers/to-have-ability-applied-matcher.ts
@@ -5,9 +5,9 @@ import { isPokemonInstance, receivedStr } from "#test/test-utils/test-utils";
 import type { MatcherState, SyncExpectationResult } from "@vitest/expect";
 
 /**
- * Matcher to check if a {@linkcode Pokemon} had a specific {@linkcode AbilityId} applied.
- * @param received - The object to check. Should be a {@linkcode Pokemon}.
- * @param expectedAbility - The {@linkcode AbilityId} to check for.
+ * Matcher that checks if a {@linkcode Pokemon} has applied a specific {@linkcode AbilityId}.
+ * @param received - The object to check. Should be a {@linkcode Pokemon}
+ * @param expectedAbility - The {@linkcode AbilityId} to check for
  * @returns Whether the matcher passed
  */
 export function toHaveAbilityAppliedMatcher(
@@ -18,11 +18,11 @@ export function toHaveAbilityAppliedMatcher(
   if (!isPokemonInstance(received)) {
     return {
       pass: this.isNot,
-      message: () => `Expected Pokemon, but got ${receivedStr(received)}!`,
+      message: () => `Expected to receive a Pokemon, but got ${receivedStr(received)}!`,
     };
   }
 
-  const pass = received.summonData.abilitiesApplied.includes(expectedAbilityId);
+  const pass = received.waveData.abilitiesApplied.has(expectedAbilityId);
 
   const pkmName = getPokemonNameWithAffix(received);
   const expectedAbilityStr = `${AbilityId[expectedAbilityId]} (=${expectedAbilityId})`;
@@ -31,7 +31,9 @@ export function toHaveAbilityAppliedMatcher(
     pass,
     message: () =>
       pass
-        ? `Expected ${pkmName} to NOT have ${expectedAbilityStr} ability applied, but it did!`
-        : `Expected ${pkmName} to have ${expectedAbilityStr} ability applied, but it did not.`,
+        ? `Expected ${pkmName} to NOT have applied ${expectedAbilityStr}, but it did!`
+        : `Expected ${pkmName} to have applied ${expectedAbilityStr}, but it didn't!`,
+    expected: expectedAbilityId,
+    actual: received.waveData.abilitiesApplied,
   };
 }


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
These fields are used as if they're `Set`s, so now they actually are.

## What are the changes from a developer perspective?
Converted `PokemonSummonData#abilitiesApplied`, `PokemonWaveData#abilitiesApplied` and `PokemonWaveData#abilitiesRevealed` from `Array`s to `Set`s.

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?