### PR TITLE
fix(move): Magnitude power values and thresholds set to correct values

### DIFF
--- a/src/data/moves/move-attrs/magnitude-power-attr.ts
+++ b/src/data/moves/move-attrs/magnitude-power-attr.ts
@@ -2,14 +2,13 @@ import { globalScene } from "#app/global-scene";
 import type { Pokemon } from "#field/pokemon";
 import type { Move } from "#moves/move";
 import { VariablePowerAttr } from "#moves/variable-power-attr";
-import type { NumberHolder } from "#utils/common-utils";
+import type { ValueHolder } from "#utils/common-utils";
 import { randSeedInt } from "#utils/random-utils";
 import i18next from "i18next";
 
-// TODO: this is not correct, fix later
-const magnitudeThresholds = [5, 15, 35, 65, 75, 95];
+const magnitudeThresholds = [5, 15, 35, 65, 85, 95];
 
-export const magnitudeMessageFunc = (_user: Pokemon, _target: Pokemon, _move: Move): string => {
+export const magnitudeMessageFunc = (): string => {
   let message!: string;
 
   globalScene.executeWithSeedOffset(
@@ -37,8 +36,8 @@ export const magnitudeMessageFunc = (_user: Pokemon, _target: Pokemon, _move: Mo
  * {@link https://bulbapedia.bulbagarden.net/wiki/Magnitude_(move) | Magnitude} level.
  */
 export class MagnitudePowerAttr extends VariablePowerAttr {
-  override apply(_user: Pokemon, _target: Pokemon, _move: Move, power: NumberHolder): boolean {
-    const magnitudePowers = [10, 30, 50, 70, 90, 100, 110, 150];
+  override apply(_user: Pokemon, _target: Pokemon, _move: Move, power: ValueHolder<number>): boolean {
+    const magnitudePowers = [10, 30, 50, 70, 90, 110, 150];
 
     globalScene.executeWithSeedOffset(
       () => {

--- a/test/moves/magnitude.test.ts
+++ b/test/moves/magnitude.test.ts
@@ -1,0 +1,53 @@
+import { allMoves } from "#data/data-lists";
+import { AbilityId } from "#enums/ability-id";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { MagnitudePowerAttr } from "#moves/magnitude-power-attr";
+import { GameManager } from "#test/test-utils/game-manager";
+import { ValueHolder } from "#utils/common-utils";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Move - Magnitude", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.BALL_FETCH)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  it("should have the correct rng thresholds and power values", async () => {
+    await game.classicMode.runToSummon(SpeciesId.FEEBAS);
+
+    const magnitudeAttr = allMoves.get(MoveId.MAGNITUDE).getAttrs(MagnitudePowerAttr)[0];
+    const movePower = new ValueHolder(0);
+    const results = { [0]: 0, [10]: 0, [30]: 0, [50]: 0, [70]: 0, [90]: 0, [110]: 0, [150]: 0 };
+
+    await game.rng.equalSample(100, () => {
+      movePower.value = 0;
+      magnitudeAttr.apply(null!, null!, null!, movePower);
+      results[movePower.value]++;
+    });
+
+    expect(results).toMatchObject({ [0]: 0, [10]: 5, [30]: 10, [50]: 20, [70]: 30, [90]: 20, [110]: 10, [150]: 5 });
+  });
+});

--- a/test/test-utils/helpers/rng-helper.ts
+++ b/test/test-utils/helpers/rng-helper.ts
@@ -6,12 +6,12 @@ export class RngHelper extends GameManagerHelper {
    * Performs the RNG experiment dictated by `fn` while sampling uniformly n times from
    * the full range of possible RNG values, where n is the number of trials to perform.
    *
-   * Specifically, this function divides the interval of possible RNG values into
-   * n equal slices, then samples exactly once from the midpoint of each interval, and
-   * rounds down as necessary for integer-based RNG functions.
+   * Specifically, this function divides the interval of possible RNG values into n equal slices,
+   * then samples exactly once from the midpoint of each interval,
+   * and rounds down as necessary for integer-based RNG functions.
    *
-   * @param numTrials The number of trials to perform.
-   * @param fn The function to be called during each trial.
+   * @param numTrials - The number of trials to perform.
+   * @param fn - The function to be called during each trial.
    * @example
    * ```
    * let zeroCounter = 0;


### PR DESCRIPTION
## What are the changes the user will see?
Magnitude will now have the correct move base power values and will output them with the correct frequency.

## Why am I making these changes?
The move is bugged.

## What are the changes from a developer perspective?
Removed the extra incorrect entry from the move power array and fixed the incorrect value in the RNG thresholds array.

## How to test the changes?
`pnpm test:silent magnitude`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?