### PR TITLE
github: update PR title linting script and workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,64 +3,29 @@
 <!-- Feel free to look at other PRs for examples -->
 
 <!--
-The PR title must match this format (and is ideally less than or equal to 72 characters):
+Make sure your title matches the https://www.conventionalcommits.org/en/v1.0.0/ format.
+
+Ideally the title is less than or equal to 72 characters (GitHub cuts off commit titles longer than this length).
+
+See https://github.com/pagefaultgames/pokerogue/blob/beta/PULL_REQUESTS.md for more information on the allowed scopes and prefixes.
+
+Example:
 
 fix(move): Future Sight no longer crashes
 ^   ^      ^
 |   |      |__ Subject
 |   |_________ Scope (optional)
 |_____________ Prefix
-
-You should add a `!` before the `:` if the PR includes a version increase / save migrator. Example:
-refactor!: change Tera mechanic to match mainline
-
-List of valid prefixes:
-  balance - Primarily a balance change
-  deps - Primarily adding/updating/removing dependencies
-  dev - Improving the developer experience (such as by modifying lint rules or creating cli scripts)
-  docs - Primarily adding/updating documentation
-  feat - Adding a new feature (e.g. adding a new implementation of a move) or redesigning an existing feature
-  fix - Fixing a bug
-  github - Updating the CI pipeline or otherwise modifying something in the `./github/` directory
-  i18n - Updating the localization submodule, adding new translatable text, etc
-  misc - A change that doesn't fit any other category
-  refactor - A change that doesn't impact functionality or fix any bugs (except incidentally)
-  revert - Reverting a previous commit
-  test - Primarily adding/updating tests or modifying the test framework
-
-List of valid scopes:
-  ability
-  ai
-  anomaly - Formerly "Mystery Encounters"
-  audio
-  battle - Relating to the general battle engine
-  biomes
-  challenge
-  data - Data not covered by other scopes, such as TM lists
-  event
-  graphics - Anything related to art/graphics (adding new sprites, fixing a sprite that isn't displaying, etc)
-  item
-  move
-  ui - UI/UX
-
-List of valid "prefix(scope)" combinations:
-  balance - ability, ai, anomaly, biomes, challenge, item, move
-  deps - N/A
-  dev - N/A
-  docs - N/A
-  feat - All
-  fix - All
-  github - N/A
-  i18n - N/A
-  misc - N/A
-  refactor - All
-  revert - N/A
-  test - N/A
 -->
 
 <!--
-Make sure that this PR is not overlapping with someone else's work
-Please try to keep the PR self-contained (and small)
+Make sure that this PR is not overlapping with someone else's work.
+Please try to keep the PR self-contained (don't change a bunch of unrelated things).
+-->
+<!--
+The first section is mandatory if there are user-facing changes (it will be used as the base for a changelog entry).
+The second and third section are mandatory.
+The screenshot/video section is mandatory if you made any visual changes (such as to UI elements).
 -->
 
 ## What are the changes the user will see?
@@ -70,29 +35,41 @@ Please try to keep the PR self-contained (and small)
 ## Why am I making these changes?
 
 <!--
-Explain why you decided to introduce these changes
-Does it come from an issue or another PR? Please link it
-Explain why you believe this can enhance user experience
+Explain why you decided to introduce these changes.
+Does it come from an issue or another PR? Link to them if possible.
+Explain why you believe this can enhance user experience.
 -->
 <!--
 If there are existing GitHub issues related to the PR that would be fixed,
-you can add "Fixes #[issue number]" (ie: "Fixes #1234") to link an issue to your PR
+you can add "Fixes #[issue number]" (e.g.: "Fixes #1234") to link an issue to your PR
 so that it will automatically be closed when the PR is merged.
 -->
 
 ## What are the changes from a developer perspective?
 
 <!--
-Explicitly state what are the changes introduced by the PR
-You can make use of a comparison between what was the state before and after your PR changes
+Describe the codebase changes introduced by the PR.
+You can make use of a comparison between the state of the code before and after your changes.
 Ex: What files have been changed? What classes/functions/variables/etc have been added or changed?
 -->
 
 ## Screenshots/Videos
 
 <!--
-If your changes are changing anything on the user experience, please provide visual proofs of it
-Please take screenshots/videos before and after your changes, to show what is brought by this PR
+If you are changing anything visual (such as UI/UX), put screenshot(s) and/or video(s) showing the changes here.
+
+Please use one or more collapsible blocks, e.g.:
+
+<details><summary>Before</summary>
+
+[before screenshot here]
+
+</details>
+<details><summary>After</summary>
+
+[after screenshot here]
+
+</details>
 -->
 
 ## How to test the changes?
@@ -106,32 +83,44 @@ Do the reviewers need to do something special in order to test your changes?
 
 ## Checklist
 
-- [ ] ⚠️ If this is a PR for `main` (such as a hotfix), has the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`?
-- [ ] Otherwise: **I'm using `beta` as my base branch**
-- [ ] There is no overlap with another PR?
-- [ ] The PR is self-contained and cannot be split into smaller PRs?
-- [ ] Have I provided a clear explanation of the changes?
-- [ ] Have I tested the changes manually?
-- [ ] Are all unit tests still passing? (`pnpm test:silent`)
-  - [ ] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?
-- [ ] Have I provided screenshots/videos of the changes (if applicable)?
-  - [ ] Have I made sure that any UI change works for both UI themes (dark and light)?
+<!--
+If an item isn't valid (for example, you didn't make any locales changes)
+you can cross it out using the tilde character (~), e.g.:
+- ~[ ] A locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo~
+-->
+<!-- - [ ] ⚠️ If this is a PR for `main` (such as a hotfix), the game version been updated (`pnpm update-version:patch` / `pnpm update-version:minor`) -->
+- [ ] <!--Otherwise: -->**I'm using `beta` as my base branch**
+- [ ] There is no overlap with another PR
+- [ ] The PR is self-contained and cannot be split into smaller PRs
+- [ ] I have provided a clear explanation of the changes
+- [ ] The PR title matches the format described in [PULL_REQUESTS.md](https://github.com/pagefaultgames/pokerogue/blob/beta/PULL_REQUESTS.md)
+- [ ] I have tested the changes manually
+- [ ] The full test suite still passes (`pnpm test:silent`)
+  - [ ] I have created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes
+- [ ] I have provided screenshots/videos of the changes (if applicable)
+  - [ ] I have made sure that any UI change works for both the dark and light UI themes (if applicable)
 
 #### Are there any localization additions or changes? If so:
 
-- [ ] Has a locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo?
-  - [ ] If so, please leave a link to it here:
-- [ ] Have I added the `Localization` tag to this PR?
-<!-- not relevant for now - [ ] Has the translation team been contacted for proofreading/translation? -->
-<!-- You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself. For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md) -->
+- [ ] A locales PR been created on the [locales](https://github.com/despair-games/poketernity-locales) repo
+  - [ ] Link to locales PR: 
+- [ ] I have added the `Localization` tag to this PR
+<!--
+You can find a summarized version of the merging process surrounding locale PRs in your locale PR itself.
+For full instructions, check [localization.md](https://github.com/Despair-Games/poketernity/blob/beta/docs/localization.md)
+-->
 
 #### If there are no locale changes:
-- [ ] Have I made sure **not** to commit any changes to the locale repo on this branch?
-<!-- check the `Files Changed` tab on the PR to be sure. 
-`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta. -->
+- [ ] I have made sure **not** to commit any changes to the locales repo on this branch
+<!--
+check the `Files Changed` tab on the PR to be sure. 
+`public/locales` should not appear here, or it will create needless conflicts for future PRs and could potentially roll back changes already merged to beta.
+-->
 
-<!-- How to fix it if no: -->
-<!-- #### Using the Command Line:
+<!--
+How to fix it if no:
+
+#### Using the Command Line:
 - Go to https://github.com/Despair-Games/poketernity/tree/beta/public and copy the hash of the current locale commit beta is pointing to
 - If the hash corresponds to the latest commit in the locale repo:
   - `pnpm update-locales:remote`
@@ -147,4 +136,5 @@ Do the reviewers need to do something special in order to test your changes?
  /!\ anyone using another tool, feel free to add instructions there /!\
 
 You may have to do this again later and fix conflicts if beta keeps updating the locale repo.
-**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.** -->
+**When fixing conflicts, make sure you prioritize the latest commit between the one on beta and this branch, to avoid any rollbacks.**
+-->

--- a/.github/scripts/pr-title.mts
+++ b/.github/scripts/pr-title.mts
@@ -4,18 +4,21 @@ import * as github from "@actions/github";
 
 const PREFIXES = [
   "balance", // Primarily a balance change
-  "deps", // Primarily adding/updating/removing dependencies
+  "chore", // Misc project upkeep (e.g. updating submodules, updating dependencies) not covered by other prefixes
   "dev", // Improving the developer experience (such as by modifying lint rules or creating cli scripts)
   "docs", // Primarily adding/updating documentation
   "feat", // Adding a new feature (e.g. adding a new implementation of a move) or redesigning an existing feature
   "fix", // Fixing a bug
-  "github", // Updating the CI pipeline or otherwise modifying something in the `./github/` directory
-  "i18n", // Updating the localization submodule, adding new translatable text, etc
-  "misc", // A change that doesn't fit any other category
+  "github", // Updating the CI pipeline or otherwise modifying something in the `./github/**` directory
+  "i18n", // Adding/modifying translation keys, etc
+  "misc", // A change that doesn't fit any other prefix
+  "perf", // A refactor aimed at improving performance
   "refactor", // A change that doesn't impact functionality or fix any bugs (except incidentally)
-  "revert", // Reverting a previous commit
+  "revert", // Reverting a bad commit
   "test", // Primarily adding/updating tests or modifying the test framework
 ] as const;
+
+type Prefixes = (typeof PREFIXES)[number];
 
 const ALL_SCOPES = [
   "ability",
@@ -25,50 +28,39 @@ const ALL_SCOPES = [
   "battle", // Relating to the general battle engine
   "biomes",
   "challenge",
-  "data", // Data not covered by other scopes, such as TM lists
-  "event",
-  "graphics", // Anything related to art/graphics (adding new sprites, fixing a sprite that isn't displaying, etc)
+  "event", // e.g. adding a Christmas event to the game
+  "graphics", // Anything related to art/graphics (adding new sprites, fixing a sprite that isn't displaying properly, etc)
   "item",
   "move",
   "ui", // UI/UX
 ] as const;
 
+type AllScopes = (typeof ALL_SCOPES)[number];
+
 const PREFIX_SCOPE_MAP = {
-  balance: ["ability", "ai", "anomaly", "biomes", "challenge", "item", "move"],
-  deps: [],
+  balance: ["ability", "ai", "anomaly", "biomes", "challenge", "event", "item", "move"],
+  chore: [],
   dev: [],
-  docs: [],
+  docs: ALL_SCOPES,
   feat: ALL_SCOPES,
   fix: ALL_SCOPES,
   github: [],
   i18n: [],
   misc: [],
+  perf: [],
   refactor: ALL_SCOPES,
   revert: [],
-  test: [],
-} as const;
+  test: ALL_SCOPES,
+} as const satisfies Record<Prefixes, readonly AllScopes[]>;
 
-const validEvent = ["pull_request"];
+// @ts-expect-error: Add special scope for fixing bugs that only existed on the beta branch
+PREFIX_SCOPE_MAP.fix = [...ALL_SCOPES, "beta"];
 
 async function run() {
   try {
-    // Make sure the prefix:scope map stays in sync with the list of prefixes
-    for (const p of PREFIXES) {
-      if (PREFIX_SCOPE_MAP[p] === undefined) {
-        core.setFailed(`Prefix "${p}" missing from prefix map!`);
-        return;
-      }
-    }
-    for (const key in PREFIX_SCOPE_MAP) {
-      if (!([...PREFIXES] as string[]).includes(key)) {
-        core.setFailed(`Prefix "${key}" missing from prefix list: [${PREFIXES}]!`);
-        return;
-      }
-    }
     const authToken = core.getInput("github_token", { required: true });
-    const eventName = github.context.eventName;
-    core.info(`Event name: ${eventName}`);
-    if (!validEvent.includes(eventName)) {
+    const { eventName } = github.context;
+    if (eventName !== "pull_request") {
       core.setFailed(`Invalid event: ${eventName}`);
       return;
     }
@@ -84,7 +76,8 @@ async function run() {
     });
 
     const { title } = pullRequest;
-    core.info(`Pull Request title: "${title}"`);
+    core.info("Info on PR title formatting: https://github.com/Despair-Games/poketernity/blob/beta/PULL_REQUESTS.md");
+    core.info(`Pull Request title: "${title}" (length ${title.length})`);
 
     // if (title.length > 72) {
     //   core.setFailed(`Max title length of 72 exceeded! Current length: ${title.length}`);
@@ -102,9 +95,8 @@ Terminology: fix(move): Future Sight no longer crashes
 
     core.info(info.trim());
 
-    // Check if title passes regex
-    // Example of regex: https://regex101.com/r/FeN8jG/7
-    const regex = /^([a-z]+)!?(\([a-z]+\))?: .+/;
+    // Example usage of regex: https://regex101.com/r/FeN8jG/8
+    const regex = /^([a-z0-9]+)!?(\([a-z]+\))?: .+/;
     if (!regex.test(title)) {
       core.setFailed(`Pull Request title "${title}" failed to match - "Prefix(Scope): Subject"`);
       return;
@@ -114,14 +106,12 @@ Terminology: fix(move): Future Sight no longer crashes
     const prefix = regexResult[1];
     const scope = regexResult[2]?.replace(/[()]/g, "");
 
-    // Check if title starts with an allowed prefix
     core.info(`Allowed prefixes: ${PREFIXES}`);
     if (!PREFIXES.some((p) => p === prefix)) {
       core.setFailed(`Pull Request title "${title}" did not match any of the prefixes: [${PREFIXES}]`);
       return;
     }
 
-    // Check if title has an allowed scope
     // biome-ignore lint/style/useExplicitLengthCheck: doubles as a nullish check for `scope`
     if (scope?.length && !PREFIX_SCOPE_MAP[prefix].includes(scope)) {
       core.setFailed(`Pull Request title "${title}" has an invalid prefix (${prefix}) + scope (${scope}) combination!`);

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -6,6 +6,12 @@ on:
       - beta
     types: [opened, edited, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   lint-pr:
     name: Lint PR title
@@ -13,6 +19,13 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
+        with:
+          submodules: false
+          sparse-checkout: |
+            pnpm-lock.yaml
+            .nvmrc
+            .github/scripts/pr-title.mts
+          sparse-checkout-cone-mode: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -20,15 +33,15 @@ jobs:
           version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: Install Node.js dependencies
-        run: pnpm add @actions/core @actions/github tsx
+        run: pnpm add @actions/core @actions/github
 
       - name: Lint PR title
-        run: pnpm exec tsx ./.github/scripts/pr-title.ts
+        run: node ./.github/scripts/pr-title.mts
         env:
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -1,0 +1,75 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 Despair Games
+SPDX-FileContributor: NightKev <https://github.com/DayKev>
+SPDX-FileContributor: Bertie690 <https://github.com/Bertie690>
+
+SPDX-License-Identifier: CC-BY-NC-SA-4.0
+-->
+
+## ✅ Submitting a Pull Request
+
+Most information related to submitting a pull request is contained within comments inside the [default pull request template](./.github/pull_request_template.md). \
+This section serves to elaborate on particular parts of the PR creation workflow that cannot fit fully inside the margins.
+
+### PR Title Format
+This repository follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR titles, enforced by an automated GitHub Actions workflow.
+
+Each PR must contain a valid prefix (and optionally a valid scope), followed by a colon and then the PR's subject line. \
+```
+fix(move): Future Sight no longer crashes
+^   ^      ^
+|   |      |__ Subject
+|   |_________ Scope (optional)
+|_____________ Prefix
+```
+
+> [!IMPORTANT]
+> If a save migrator, version increase or other breaking change is part of the PR, a `!` must be added before the `:`.
+
+Try to keep the title under 72 characters, as GitHub cuts off commit titles longer than this length.
+
+#### Examples
+```
+refactor(data)!: improve serialization of Pokemon save data
+balance: update TM compatibility lists
+fix(move): Retaliate now saves power boost between waves
+test: preserve text output of original shards
+```
+
+#### List of valid prefixes
+
+- "balance" - Changes primarily related to game balance
+- "chore" - Misc project upkeep (e.g. updating submodules, updating dependencies) not covered by other prefixes
+- "dev" - Improving the developer experience (such as by modifying lint rules or creating cli scripts)
+- "docs" - Primarily adding/updating documentation
+- "feat" - Adding a new feature (e.g. adding a new implementation of a move) or redesigning an existing feature
+- "fix" - Fixing a bug
+- "github" - Updating the CI pipeline or otherwise modifying something in the `./github/**` directory
+- "i18n" - Adding/modifying translation keys, etc
+- "misc" - A change that doesn't fit any other prefix
+- "perf" - A refactor aimed at improving performance
+- "refactor" - A change that doesn't impact functionality or fix any bugs (except incidentally)
+- "test" - Primarily adding/updating tests or modifying the test framework
+
+#### List of valid scopes
+
+- "ability"
+- "ai"
+- "anomaly" - Formerly "Mystery Encounters"
+- "audio"
+- "battle" - Relating to the general battle engine
+- "biomes"
+- "challenge"
+- "event" - e.g. adding a Christmas event to the game
+- "graphics" - Anything related to art/graphics (adding new sprites, fixing a sprite that isn't displaying properly, etc)
+- "item"
+- "move"
+- "ui" - UI/UX
+
+> [!IMPORTANT]
+> All scopes are valid when using the "docs", "feat", "fix", "refactor" and "test" prefixes. \
+> All scopes except "audio", "battle", "graphics", and "ui" are valid when using the "balance" prefix. \
+> No other prefixes have valid scopes.
+>
+> There is a special "beta" scope for the "fix" prefix,
+> for fixing bugs that only existed on the `beta` branch that never made it onto `main`.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -20,14 +20,15 @@
     // and having to verify whether each individual file is ignored
     "includes": [
       "**",
-      "!.github/**/*.*", // workaround due to bug, should be `"!.github"`
+      "!.github/**/*.*", // workaround due to bug/design limitation, should be `"!.github"`
       ".github/**/*.ts",
+      ".github/**/*.mts",
       "!!.vscode",
       "!!build",
       "!!coverage",
       "!!dist",
       "!!docs",
-      "!public/**/*.*", // workaround due to bug, should be `"!public"`
+      "!public/**/*.*", // workaround due to bug/design limitation, should be `"!public"`
       "public/service-worker.js",
       "!!typedoc",
       "!pnpm-lock.yml",


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
Optimizing the workflow and script.
Fixing a bug where `i18n:` wouldn't be accepted in PR titles due to an incorrect regex.
Making the PR template more readable.

## What are the changes from a developer perspective?
Optimized the workflow and script:
- The workflow only checks out the minimum files required to run the script.
- The workflow only installs the `@actions` deps instead of all deps.
- The workflow will now automatically cancel stale runs.
- The workflow's permissions have been minimized.
- The script now uses type safety instead of runtime checks to confirm that the scopes and prefixes are correct.

Fixed a bug where `i18n:` wouldn't be accepted in PR titles due to an incorrect regex.

Updated the pull request template and moved detailed information on the title format to a new `PULL_REQUESTS.md` file (for now).

## Checklist
- [x] **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [PULL_REQUESTS.md](https://github.com/pagefaultgames/pokerogue/blob/beta/PULL_REQUESTS.md)
- [x] I have tested the changes manually