### PR TITLE
dev: reconfigure Typedoc and adjust Pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           sparse-checkout: |
             .nvmrc
-          sparse-checkout-cone-mode: false
 
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,7 +3,8 @@ name: "Github Pages"
 on:
   push:
     branches:
-      - main
+      # - main
+      - beta
   pull_request:
     branches:
       - main
@@ -11,62 +12,95 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
+  gh-pages-path-filter:
+    name: GitHub Pages path filter
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      all: ${{ steps.filter.outputs.all }}
+    steps:
+      # ensure the correct commit is detected on push workflow
+      - name: Checkout GitHub repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .nvmrc
+          sparse-checkout-cone-mode: false
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            all:
+              - "src/**/*.ts"
+              - "test/test-utils/*.ts"
+              - "typedoc.config.js"
+              - "tsdoc.json"
+              - "tsconfig.json"
+
   pages:
     name: Github Pages
-    if: github.repository == 'despair-games/poketernity'
+    needs: gh-pages-path-filter
+    if: github.repository == 'despair-games/poketernity' && needs.gh-pages-path-filter.outputs.all == 'true'
+    timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
-      api-dir: ./
-
-    strategy:
-      fail-fast: false
+      docs-dir: ./poketernity_docs
+      # Only push docs when running on pushes to main/beta
+      DRY_RUN: ${{ github.event_name != 'push' || (github.ref_name != 'beta' && github.ref_name != 'main') }}
 
     steps:
       - name: Checkout repository for Typedoc
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          submodules: "recursive"
           path: poketernity_docs
-
+          
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10
 
-      - name: Setup Node 22
-        uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
-          node-version-file: 'poketernity_docs/.nvmrc'
+          node-version-file: "poketernity_docs/.nvmrc"
 
       - name: Checkout repository for Github Pages
-        if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        if: ${{ env.DRY_RUN == 'false' }}
+        uses: actions/checkout@v6
         with:
           path: poketernity_gh
           ref: gh-pages
 
       - name: Install Node.js dependencies
-        working-directory: ${{env.api-dir}}
-        run: |
-          cd poketernity_docs
-          pnpm i
+        working-directory: ${{ env.docs-dir }}
+        run: pnpm i
 
       - name: Generate Typedoc docs
-        working-directory: ${{env.api-dir}}
-        run: |
-          cd poketernity_docs
-          pnpm run docs --out /tmp/docs --githubPages false --entryPoints ./src/
+        working-directory: ${{ env.docs-dir }}
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+        run: pnpm typedoc
 
       - name: Commit & Push docs
-        if: github.event_name == 'push'
+        if: ${{ env.DRY_RUN == 'false'}}
         run: |
           cd poketernity_gh
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          mkdir -p $GITHUB_REF_NAME
-          rm -rf $GITHUB_REF_NAME/*
-          cp -r /tmp/docs/. $GITHUB_REF_NAME
+          rsync -rd --delete /tmp/docs/ $GITHUB_REF_NAME
           git add $GITHUB_REF_NAME
-          git commit --allow-empty -m "[skip ci] Deploy docs"
+          git commit -m "[skip ci] Deploy docs"
           git push

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,3 @@
-import type { AnyFn } from "#types/utility-types";
 import type { SetupServerApi } from "msw/node";
 
 declare global {
@@ -10,11 +9,16 @@ declare global {
    * To set up your own server in a test see `game_data.test.ts`
    */
   var server: SetupServerApi;
+}
 
-  // Overloads for `Function.apply` and `Function.call` to add type safety on matching argument types
-  interface Function {
-    apply<T extends AnyFn>(this: T, thisArg: ThisParameterType<T>, argArray: Parameters<T>): ReturnType<T>;
-
-    call<T extends AnyFn>(this: T, thisArg: ThisParameterType<T>, ...argArray: Parameters<T>): ReturnType<T>;
+// Global augments for `typedoc` to prevent TS from erroring when editing the config JS file
+// TODO: This should be provided by the extensions in question, so why isn't TypeScript picking it up?
+declare module "typedoc" {
+  export interface TypeDocOptionMap {
+    // typedoc-plugin-missing-exports
+    internalModule: string;
+    placeInternalsInOwningModule: boolean;
+    collapseInternalModule: boolean;
+    includeDocCommentReferences: boolean;
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "biome-ci": "biome ci --diagnostic-level=error --reporter=github --no-errors-on-unmatched",
     "biome-all": "biome check --write --no-errors-on-unmatched",
     "biome-all:unsafe": "biome check --write --unsafe --no-errors-on-unmatched",
-    "docs": "typedoc",
+    "typedoc": "typedoc",
     "depcruise": "depcruise src test",
     "postinstall": "lefthook install; git submodule update --init --recursive",
     "update-version:patch": "pnpm version patch --force --no-git-tag-version",
@@ -63,7 +63,10 @@
     "i18next-korean-postposition-processor": "^1.0.0",
     "jszip": "^3.10.1",
     "phaser": "^3.90.0",
-    "phaser3-rex-plugins": "^1.80.18"
+    "phaser3-rex-plugins": "^1.80.18",
+    "typedoc-github-theme": "^0.3.1",
+    "typedoc-plugin-mdn-links": "^5.1.1",
+    "typedoc-plugin-missing-exports": "^4.1.2"
   },
   "engines": {
     "node": ">=24.9.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,15 @@ importers:
       phaser3-rex-plugins:
         specifier: ^1.80.18
         version: 1.80.18(graphology-types@0.24.8)
+      typedoc-github-theme:
+        specifier: ^0.3.1
+        version: 0.3.1(typedoc@0.28.17(typescript@5.9.3))
+      typedoc-plugin-mdn-links:
+        specifier: ^5.1.1
+        version: 5.1.1(typedoc@0.28.17(typescript@5.9.3))
+      typedoc-plugin-missing-exports:
+        specifier: ^4.1.2
+        version: 4.1.2(typedoc@0.28.17(typescript@5.9.3))
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.0
@@ -1762,6 +1771,22 @@ packages:
   type-fest@5.4.4:
     resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
     engines: {node: '>=20'}
+
+  typedoc-github-theme@0.3.1:
+    resolution: {integrity: sha512-j6PmkAGmf/MGCzYjQcUH6jS9djPsNl/IoTXooxC+MoeMkBhbmPyKJlpR6Lw12BLoe2OYpYA2J1KMktUJXp/8Sw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      typedoc: ~0.28.0
+
+  typedoc-plugin-mdn-links@5.1.1:
+    resolution: {integrity: sha512-fLlYudnlGkE9uspOEm/SBXwr+G0RbxoDZiHAVsCg+5NwKe2aUxjZK1YyQfleNZydImanzkX2oUJF29xbEeOSWw==}
+    peerDependencies:
+      typedoc: 0.27.x || 0.28.x
+
+  typedoc-plugin-missing-exports@4.1.2:
+    resolution: {integrity: sha512-WNoeWX9+8X3E3riuYPduilUTFefl1K+Z+5bmYqNeH5qcWjtnTRMbRzGdEQ4XXn1WEO4WCIlU0vf46Ca2y/mspg==}
+    peerDependencies:
+      typedoc: ^0.28.1
 
   typedoc@0.28.17:
     resolution: {integrity: sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==}
@@ -3531,6 +3556,18 @@ snapshots:
   type-fest@5.4.4:
     dependencies:
       tagged-tag: 1.0.0
+
+  typedoc-github-theme@0.3.1(typedoc@0.28.17(typescript@5.9.3)):
+    dependencies:
+      typedoc: 0.28.17(typescript@5.9.3)
+
+  typedoc-plugin-mdn-links@5.1.1(typedoc@0.28.17(typescript@5.9.3)):
+    dependencies:
+      typedoc: 0.28.17(typescript@5.9.3)
+
+  typedoc-plugin-missing-exports@4.1.2(typedoc@0.28.17(typescript@5.9.3)):
+    dependencies:
+      typedoc: 0.28.17(typescript@5.9.3)
 
   typedoc@0.28.17(typescript@5.9.3):
     dependencies:

--- a/src/@types/ability-types.ts
+++ b/src/@types/ability-types.ts
@@ -6,10 +6,12 @@ import type { PokemonWaveData } from "#types/pokemon-types";
 /** Union type of all referable ability attribute class names as strings */
 export type AbAttrKey = keyof AbAttrConstructorMap;
 
+/** @interface */
 export type AbAttrMap = {
   [K in keyof AbAttrConstructorMap]: InstanceType<AbAttrConstructorMap[K]>;
 };
 
+/** @interface */
 export type AbAttrParamMap = {
   [K in keyof AbAttrMap]: Parameters<AbAttrMap[K]["apply"]>;
 };

--- a/test/test-utils/helpers/overrides-helper.ts
+++ b/test/test-utils/helpers/overrides-helper.ts
@@ -59,7 +59,8 @@ export class OverridesHelper extends GameManagerHelper {
 
   /**
    * Override the starting biome
-   * @warning Any event listeners that are attached to {@linkcode NewArenaEvent} may need to be handled down the line
+   * @privateRemarks
+   * Any event listeners that are attached to {@linkcode NewArenaEvent} may need to be handled down the line
    * @param biome the biome to set
    */
   public startingBiome(biome: BiomeId): this {

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -16,7 +16,7 @@
     },
     {
       "tagName": "@interface",
-      "syntaxKind": "block"
+      "syntaxKind": "modifier"
     }
   ]
 }

--- a/typedoc.config.js
+++ b/typedoc.config.js
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Pagefault Games
+ * SPDX-FileCopyrightText: 2026 Despair Games
+ * SPDX-FileContributor: Bertie690
+ * SPDX-FileContributor: NightKev
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/// <reference path="./global.d.ts" />
+
+const dryRun = process.env.DRY_RUN === "true";
+const currentYear = new Date().getFullYear();
+
+/**
+ * <!-- @satisfies {Partial<import("typedoc").TypeDocOptions>} -->
+ */
+const config = {
+  entryPoints: ["./src", "./test/test-utils"],
+  entryPointStrategy: "expand",
+  exclude: [
+    "src/polyfills.ts",
+    "src/phaser-extensions.ts",
+    "src/vite.env.d.ts",
+    "**/*+.test.ts",
+    "**/*+.test-d.ts",
+    "test/test-utils/setup",
+    "test/test-utils/reporters",
+    "test/@types/matcher-helpers.ts",
+    "test/@types/vitest.d.ts",
+  ],
+  excludePrivate: false, // Private members are useful in the docs for contributors
+  excludeReferences: true, // prevent documenting re-exports
+  requiredToBeDocumented: [
+    "Enum",
+    "EnumMember",
+    "Variable",
+    "Function",
+    "Class",
+    "Interface",
+    "Property",
+    "Method",
+    "Accessor",
+    "TypeAlias",
+  ],
+  highlightLanguages: ["javascript", "json", "jsonc", "json5", "tsx", "typescript", "markdown"],
+  plugin: ["typedoc-github-theme", "typedoc-plugin-mdn-links", "typedoc-plugin-missing-exports"],
+  // Avoid emitting docs for branches other than main/beta
+  emit: dryRun ? "none" : "docs",
+  out: process.env.CI ? "/tmp/docs" : "./typedoc",
+  name: "Pokéternity",
+  readme: "./README.md",
+  projectDocuments: ["docs/*.md"],
+  favicon: "./favicon.ico",
+  theme: "typedoc-github-theme",
+  customFooterHtml: `<p>Copyright <strong>Despair Games</strong> ${currentYear === 2026 ? "2026" : "2026 - " + currentYear}</p>`,
+  customFooterHtmlDisableWrapper: true,
+  navigationLinks: {
+    GitHub: "https://github.com/despair-games/poketernity",
+  },
+  includeDocCommentReferences: true,
+  placeInternalsInOwningModule: true,
+};
+
+// If generating docs for main/beta, check the ref name and add an appropriate navigation header
+//! Note: disabled while there is no `main` branch
+/*
+if (!dryRun && process.env.REF_NAME) {
+  const otherRefName = process.env.REF_NAME === "main" ? "beta" : "main";
+  config.navigationLinks = {
+    ...config.navigationLinks,
+    // This will be "Switch to Beta" when on main, and vice versa
+    [`Switch to ${otherRefName.charAt(0).toUpperCase() + otherRefName.slice(1).toLowerCase()}`]: `https://despair-games.github.io/poketernity/${otherRefName}`,
+  };
+}
+*/
+
+// biome-ignore lint/style/noDefaultExport: required by TypeDoc
+export default config;

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,0 @@
-{
-  "entryPoints": ["./src"],
-  "entryPointStrategy": "expand",
-  "exclude": ["**/*+.test.ts"],
-  "out": "typedoc",
-  "highlightLanguages": ["javascript", "json", "jsonc", "json5", "tsx", "typescript", "markdown"]
-}


### PR DESCRIPTION
## What are the changes the user will see?
The Typedoc site will be re-enabled.

## Why am I making these changes?
Typedoc can be useful for examining project structure.

## What are the changes from a developer perspective?
Replaced `typedoc.json` config file with `typedoc.config.js` and filled out many settings.

Updated the workflow:
- Stale runs will be automatically cancelled.
- Permissions were minimized.
- The workflow will only run if relevant files were changed (e.g. `*.ts` files).

3 Typedoc plugins were added as dev deps:
- `typedoc-github-theme`: makes the docs site look similar to GitHub's default theme
- `typedoc-plugin-mdn-links`: replaces `{@link[code] <some built-in, like Array>}` with links to the MDN docs site (though we shouldn't be using `@link[code]` on built-ins anyway, but some do exist already)
- `typedoc-plugin-missing-exports`: "[Automatically document symbols which aren't exported but are referenced](https://www.npmjs.com/package/typedoc-plugin-missing-exports)"

The command to run Typedoc was changed from `docs` to `typedoc` in `package.json` to fix the issue where `pnpm docs` wouldn't run the command, which required using `pnpm run docs` instead.

## Screenshots/Videos

<details><summary>Details</summary>

<img width="1734" height="1270" alt="image" src="https://github.com/user-attachments/assets/586990cc-5723-4b97-9cb0-ab6418b54350" />

</details> 

## How to test the changes?
`pnpm typedoc`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Have I tested the changes manually?