### PR TITLE
fix(ability): Color Change will now activate in the correct situations

### DIFF
--- a/src/data/abilities/ab-attrs/post-defend-type-change-ab-attr.ts
+++ b/src/data/abilities/ab-attrs/post-defend-type-change-ab-attr.ts
@@ -1,32 +1,54 @@
 import { PostDefendAbAttr } from "#abilities/post-defend-ab-attr";
 import { getPokemonNameWithAffix } from "#app/messages";
 import { ElementalType } from "#enums/elemental-type";
+import { TypelessAttr } from "#moves/typeless-attr";
 import type { PostDefendAbAttrParams } from "#types/ab-attr-param-types";
 import { enumValueToKey } from "#utils/common-utils";
 import i18next from "i18next";
 
 /** @see {@link https://bulbapedia.bulbagarden.net/wiki/Color_Change_(Ability)} */
 export class PostDefendTypeChangeAbAttr extends PostDefendAbAttr {
-  public override apply({ pokemon, simulated, attacker, move }: PostDefendAbAttrParams): void {
+  private type: ElementalType;
+
+  public override canApply({ pokemon, attacker, move }: Parameters<this["apply"]>[0]): boolean {
+    if (pokemon.isTerastallized) {
+      return false;
+    }
+
+    if (!move.isAttackMove(attacker, pokemon)) {
+      return false;
+    }
+
+    if (move.hasAttr(TypelessAttr)) {
+      return false;
+    }
+
+    if (attacker.turnData.hitsLeft > 1) {
+      return false;
+    }
+
+    this.type = attacker.getMoveType(move);
+
+    if (pokemon.isOfType(this.type, true, true)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public override apply({ pokemon, simulated }: PostDefendAbAttrParams): void {
     if (simulated) {
       return;
     }
 
-    pokemon.setTemporaryTypes(attacker.getMoveType(move));
-  }
-
-  public override canApply({ pokemon, attacker, move }: Parameters<this["apply"]>[0]): boolean {
-    const moveType = attacker.getMoveType(move);
-    const pokemonTypes = pokemon.getTypes(true, true);
-
-    return move.isAttackMove(attacker, pokemon) && !pokemon.isTerastallized && !pokemonTypes.includes(moveType);
+    pokemon.setTemporaryTypes(this.type);
   }
 
   public override getTriggerMessage({ pokemon }: Parameters<this["apply"]>[0], abilityName: string): string {
     return i18next.t("abilityTriggers:postDefendTypeChange", {
       pokemonNameWithAffix: getPokemonNameWithAffix(pokemon),
       abilityName,
-      typeName: i18next.t(`pokemonInfo:Type.${enumValueToKey(ElementalType, pokemon.getTypes(true)[0])}`),
+      typeName: i18next.t(`pokemonInfo:Type.${enumValueToKey(ElementalType, this.type)}`),
     });
   }
 }

--- a/test/abilities/color-change.test.ts
+++ b/test/abilities/color-change.test.ts
@@ -1,0 +1,165 @@
+import { AbilityId } from "#enums/ability-id";
+import { BattlerIndex } from "#enums/battler-index";
+import { ElementalType } from "#enums/elemental-type";
+import { MoveId } from "#enums/move-id";
+import { SpeciesId } from "#enums/species-id";
+import { StatusEffect } from "#enums/status-effect";
+import { GameManager } from "#test/test-utils/game-manager";
+import type { NonEmptyArray } from "#types/utility-types";
+import Phaser from "phaser";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+describe("Ability - Color Change", () => {
+  let phaserGame: Phaser.Game;
+  let game: GameManager;
+
+  beforeAll(() => {
+    phaserGame = new Phaser.Game({
+      type: Phaser.HEADLESS,
+    });
+  });
+
+  beforeEach(() => {
+    game = new GameManager(phaserGame);
+    game.override
+      .ability(AbilityId.BALL_FETCH)
+      .battleType("single")
+      .disableCrits()
+      .enemySpecies(SpeciesId.MAGIKARP)
+      .enemyAbility(AbilityId.COLOR_CHANGE)
+      .enemyMoveset(MoveId.SPLASH)
+      .startingLevel(100)
+      .enemyLevel(100);
+  });
+
+  afterEach(() => {
+    game.phaseInterceptor.restoreOg();
+  });
+
+  function checkTypeChange(changed: true, newType: ElementalType): void;
+  function checkTypeChange(changed: false): void;
+  function checkTypeChange(changed: boolean, newType?: ElementalType): void {
+    const enemy = game.field.getEnemyPokemon();
+    if (changed) {
+      expect(enemy).toHaveAbilityApplied(AbilityId.COLOR_CHANGE);
+      expect(enemy).toHaveTypes([newType!]);
+      return;
+    }
+    expect(enemy).not.toHaveAbilityApplied(AbilityId.COLOR_CHANGE);
+    expect(enemy).toHaveTypes(enemy.getTypes(true, true, true) as NonEmptyArray<ElementalType>, { mode: "ordered" });
+  }
+
+  it("should change the pokemon's type to the move's type", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.TACKLE);
+    await game.toEndOfTurn();
+
+    checkTypeChange(true, ElementalType.NORMAL);
+  });
+
+  it("should not change the pokemon's type if their current typing includes the move's type", async () => {
+    game.override.enemySpecies(SpeciesId.TENTACOOL);
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.WATER_GUN);
+    await game.toEndOfTurn();
+
+    checkTypeChange(false);
+  });
+
+  it("should not change the pokemon's type if they are behind a substitute", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.TACKLE);
+    game.setTurnOrder([BattlerIndex.ENEMY, BattlerIndex.PLAYER]);
+    await game.move.forceEnemyMove(MoveId.SUBSTITUTE);
+    await game.toEndOfTurn();
+
+    checkTypeChange(false);
+  });
+
+  // TODO: refactor `trySetStatus`/`ObtainStatusEffectPhase`
+  it.todo.each([
+    { moveId: MoveId.NUZZLE, moveName: "Nuzzle", status: StatusEffect.PARALYSIS, type: ElementalType.ELECTRIC },
+    { moveId: MoveId.MORTAL_SPIN, moveName: "Mortal Spin", status: StatusEffect.POISON, type: ElementalType.POISON },
+  ])("should change the pokemon's type after status effects would be inflicted ($moveName)", async ({
+    moveId,
+    status,
+    type,
+  }) => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(moveId);
+    await game.toEndOfTurn();
+
+    checkTypeChange(true, type);
+    expect(game.field.getEnemyPokemon()).toHaveStatusEffect(status);
+  });
+
+  it("should not change the pokemon's type when hit by pain split", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.PAIN_SPLIT);
+    await game.toEndOfTurn();
+
+    checkTypeChange(false);
+  });
+
+  it("should not change the pokemon's type when hit by typeless moves", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.STRUGGLE);
+    await game.toEndOfTurn();
+
+    checkTypeChange(false);
+  });
+
+  it("should not change the pokemon's type until after the last hit of a multi-hit move", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.DOUBLE_KICK);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    await game.phaseInterceptor.to("MoveEffectPhase");
+    checkTypeChange(false);
+    await game.phaseInterceptor.to("PostActionPhase");
+    checkTypeChange(true, ElementalType.FIGHTING);
+    await game.toEndOfTurn();
+  });
+
+  it("should change the pokemon's type when hit by future sight", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.FUTURE_SIGHT);
+    await game.toNextTurn();
+    game.move.use(MoveId.RECOVER);
+    await game.toNextTurn();
+    game.move.use(MoveId.RECOVER);
+    await game.toNextTurn();
+
+    checkTypeChange(true, ElementalType.PSYCHIC);
+  });
+
+  it("should not change the pokemon's type when the pokemon is terastallized", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.field.forceTera(game.field.getEnemyPokemon());
+
+    game.move.use(MoveId.TACKLE);
+    await game.toEndOfTurn();
+
+    checkTypeChange(false);
+  });
+
+  it.todo("should change the pokemon's type if at least one hit of a multi-hit move connects", async () => {
+    await game.classicMode.startBattle(SpeciesId.FEEBAS);
+
+    game.move.use(MoveId.POPULATION_BOMB);
+    game.setTurnOrder([BattlerIndex.PLAYER, BattlerIndex.ENEMY]);
+    await game.move.forceHit();
+    await game.move.forceMiss();
+    await game.toEndOfTurn();
+
+    checkTypeChange(true, ElementalType.NORMAL);
+  });
+});


### PR DESCRIPTION
## What are the changes the user will see?
Color change will no longer incorrectly activate in the following scenarios:
- The defender's typing includes the move's type
- The move is typeless (Struggle)
- A multi-hit move hasn't finished (only the final hit of a multi-hit should cause the type change)

## Why am I making these changes?
Fix bugs, add tests.

## What are the changes from a developer perspective?
Modified `PostDefendTypeChangeAbAttr` to correctly check the conditions for Color Change.
Added tests for various scenarios.

## How to test the changes?
`pnpm test:silent color-change`

## Checklist
- [x] Otherwise: **I'm using `beta` as my base branch**
- [x] There is no overlap with another PR?
- [x] The PR is self-contained and cannot be split into smaller PRs?
- [x] Have I provided a clear explanation of the changes?
- [x] Are all unit tests still passing? (`pnpm test:silent`)
  - [x] Have I created new automated tests (`pnpm test:create`) or updated existing tests related to the PR's changes?