### PR TITLE
dev: enable `useIterableCallbackReturn` lint rule at "error"

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -155,7 +155,12 @@
         "noDocumentCookie": "off", // Firefox has minimal support for the "Cookie Store API"
         "noConstantBinaryExpressions": "error",
         "noTsIgnore": "error",
-        "useIterableCallbackReturn": "off", // TODO: re-enable if the rule is changed to be type-aware
+        "useIterableCallbackReturn": {
+          "level": "error",
+          "options": {
+            "checkForEach": false
+          }
+        },
         "useErrorMessage": "error",
         "useGuardForIn": "error",
         "useNumberToFixedDigitsArgument": "error",

--- a/src/data/animations/anim-config.ts
+++ b/src/data/animations/anim-config.ts
@@ -204,7 +204,7 @@ export class LegacyAnimConfig {
       this.id = source.id;
       this.graphic = source.graphic;
       const frames: any[][] = source.frames;
-      frames.map((animFrames) => {
+      frames.forEach((animFrames) => {
         for (let f = 0; f < animFrames.length; f++) {
           animFrames[f] = new ImportedAnimFrame(animFrames[f]);
         }

--- a/src/data/moves/move-attrs/last-resort-attr.ts
+++ b/src/data/moves/move-attrs/last-resort-attr.ts
@@ -15,7 +15,7 @@ export class LastResortAttr extends MoveAttr {
     return (user: Pokemon, _target: Pokemon, move: Move) => {
       const uniqueUsedMoveIds = new Set<MoveId>();
       const movesetMoveIds = user.getMoveset().map((m) => m.moveId);
-      user.getMoveHistory().map((m) => {
+      user.getMoveHistory().forEach((m) => {
         if (m.move.id !== move.id && movesetMoveIds.find((mm) => mm === m.move.id)) {
           uniqueUsedMoveIds.add(m.move.id);
         }

--- a/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
+++ b/src/data/mystery-encounters/encounters/global-trade-system-encounter.ts
@@ -602,7 +602,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
     receivedPokemonTintSprite.setVisible(false);
     receivedPokemonTintSprite.setTintFill(getPokeballTintColor(receivedPokemon.pokeball));
 
-    [tradedPokemonSprite, tradedPokemonTintSprite].map((sprite) => {
+    [tradedPokemonSprite, tradedPokemonTintSprite].forEach((sprite) => {
       const spriteKey = tradedPokemon.getSpriteKey(true);
       sprite.play(spriteKey);
 
@@ -621,7 +621,7 @@ function doPokemonTradeSequence(tradedPokemon: PlayerPokemon, receivedPokemon: P
       sprite.pipelineData[key] = tradedPokemon.getSprite().pipelineData[key];
     });
 
-    [receivedPokemonSprite, receivedPokemonTintSprite].map((sprite) => {
+    [receivedPokemonSprite, receivedPokemonTintSprite].forEach((sprite) => {
       const spriteKey = receivedPokemon.getSpriteKey(true);
       sprite.play(spriteKey);
 

--- a/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
+++ b/src/data/mystery-encounters/utils/encounter-transformation-sequence.ts
@@ -55,7 +55,7 @@ export function doPokemonTransformationSequence(
     pokemonEvoTintSprite.setVisible(false);
     pokemonEvoTintSprite.setTintFill(0xffffff);
 
-    [pokemonSprite, pokemonTintSprite, pokemonEvoSprite, pokemonEvoTintSprite].map((sprite) => {
+    [pokemonSprite, pokemonTintSprite, pokemonEvoSprite, pokemonEvoTintSprite].forEach((sprite) => {
       const spriteKey = previousPokemon.getSpriteKey(true);
       sprite.play(spriteKey);
 
@@ -74,7 +74,7 @@ export function doPokemonTransformationSequence(
       sprite.pipelineData[key] = previousPokemon.getSprite().pipelineData[key];
     });
 
-    [pokemonEvoSprite, pokemonEvoTintSprite].map((sprite) => {
+    [pokemonEvoSprite, pokemonEvoTintSprite].forEach((sprite) => {
       const spriteKey = transformPokemon.getSpriteKey(true);
       sprite.play(spriteKey);
 

--- a/src/field/arena.ts
+++ b/src/field/arena.ts
@@ -255,7 +255,7 @@ export class Arena {
     globalScene
       .getField(true)
       .filter((p) => p.isOnField())
-      .map((pokemon) => {
+      .forEach((pokemon) => {
         pokemon.findAndRemoveTags(
           (tag) => "weatherTypes" in tag && !(tag.weatherTypes as WeatherType[]).find((wt) => wt === newWeatherType),
         );
@@ -416,7 +416,7 @@ export class Arena {
     globalScene
       .getField(true)
       .filter((p) => p.isOnField())
-      .map((pokemon) => {
+      .forEach((pokemon) => {
         pokemon.findAndRemoveTags(
           (tag) => "terrainTypes" in tag && !(tag.terrainTypes as TerrainType[]).find((tt) => tt === terrain),
         );

--- a/src/field/mystery-encounter-intro.ts
+++ b/src/field/mystery-encounter-intro.ts
@@ -260,7 +260,7 @@ export class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Container {
       return;
     }
 
-    this.getSprites().map((sprite, i) => {
+    this.getSprites().forEach((sprite, i) => {
       if (!this.spriteConfigs[i].isItem) {
         sprite.setTexture(this.spriteConfigs[i].spriteKey).setFrame(0);
         if (sprite.texture.frameTotal > 1) {
@@ -270,7 +270,7 @@ export class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Container {
         }
       }
     });
-    this.getTintSprites().map((tintSprite, i) => {
+    this.getTintSprites().forEach((tintSprite, i) => {
       if (!this.spriteConfigs[i].isItem) {
         tintSprite.setTexture(this.spriteConfigs[i].spriteKey).setFrame(0);
         if (tintSprite.texture.frameTotal > 1) {
@@ -442,7 +442,7 @@ export class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Container {
    */
   tintAll(color: number, alpha?: number, duration?: number, ease?: string): void {
     const tintSprites = this.getTintSprites();
-    tintSprites.map((tintSprite) => {
+    tintSprites.forEach((tintSprite) => {
       this.tint(tintSprite, color, alpha, duration, ease);
     });
   }
@@ -479,7 +479,7 @@ export class MysteryEncounterIntroVisuals extends Phaser.GameObjects.Container {
    */
   untintAll(duration: number, ease?: string): void {
     const tintSprites = this.getTintSprites();
-    tintSprites.map((tintSprite) => {
+    tintSprites.forEach((tintSprite) => {
       this.untint(tintSprite, duration, ease);
     });
   }

--- a/src/field/pokemon.ts
+++ b/src/field/pokemon.ts
@@ -878,7 +878,7 @@ export abstract class Pokemon extends Phaser.GameObjects.Container {
   updateSpritePipelineData(): void {
     [this.getSprite(), this.getTintSprite()]
       .filter((s) => !!s)
-      .map((s) => {
+      .forEach((s) => {
         s.pipelineData["teraColor"] = getTypeRgb(this.teraType);
         s.pipelineData["isTerastallized"] = this.isTerastallized;
       });

--- a/src/field/trainer.ts
+++ b/src/field/trainer.ts
@@ -565,7 +565,7 @@ export class Trainer extends Phaser.GameObjects.Container {
         if (forSwitch && !pkmn.isOnField()) {
           globalScene.arena
             .getTags<EntryHazardTag>((t) => ENTRY_HAZARD_ARENA_TAG_TYPES.includes(t.tagType), ArenaTagSide.ENEMY)
-            ?.map((t) => {
+            ?.forEach((t) => {
               score *= t.getMatchupScoreMultiplier(pkmn);
             });
         }
@@ -733,7 +733,7 @@ export class Trainer extends Phaser.GameObjects.Container {
 
   tint(color: number, alpha?: number, duration?: number, ease?: string): void {
     const tintSprites = this.getTintSprites();
-    tintSprites.map((tintSprite) => {
+    tintSprites.forEach((tintSprite) => {
       tintSprite.setTintFill(color);
       tintSprite.setVisible(true);
 
@@ -754,7 +754,7 @@ export class Trainer extends Phaser.GameObjects.Container {
 
   untint(duration: number, ease?: string): void {
     const tintSprites = this.getTintSprites();
-    tintSprites.map((tintSprite) => {
+    tintSprites.forEach((tintSprite) => {
       if (duration) {
         globalScene.tweens.add({
           targets: tintSprite,

--- a/src/loading-scene.ts
+++ b/src/loading-scene.ts
@@ -207,7 +207,7 @@ export class LoadingScene extends SceneBase {
 
     // Load arena images
     this.loadImage("default_bg", ImagesFolder.ARENAS);
-    Object.values(BiomeId).map((bt) => {
+    Object.values(BiomeId).forEach((bt) => {
       const btKey = enumValueToKey(BiomeId, bt).toLowerCase();
       const isBaseAnimated = btKey === "end";
       const baseAKey = `${btKey}_a`;

--- a/src/modifier/modifier.ts
+++ b/src/modifier/modifier.ts
@@ -2645,7 +2645,7 @@ export class MoneyRewardModifier extends ConsumableModifier {
 
     globalScene.addMoney(moneyAmount.value);
 
-    globalScene.getPlayerParty().map((p) => {
+    globalScene.getPlayerParty().forEach((p) => {
       if (p.species?.speciesId === SpeciesId.GIMMIGHOUL) {
         if (p.evoCounter) {
           p.evoCounter += Math.min(Math.floor(this.moneyMultiplier), 3);

--- a/src/ui/components/battle-info.ts
+++ b/src/ui/components/battle-info.ts
@@ -228,7 +228,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
     // this tells us whether or not to use the player or enemy battle stat order
     this.statOrder = this.player ? this.statOrderPlayer : this.statOrderEnemy;
 
-    this.statOrder.map((s, i) => {
+    this.statOrder.forEach((s, i) => {
       // we do a check for i > statOverflow to see when the stat labels go onto the next column
       // For enemies, we have HP (i=0) by itself then a new column, so we check for i > 0
       // For players, we don't have HP, so we start with i = 0 and i = 1 for our first column, and so need to check for i > 1
@@ -532,7 +532,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
         this.statusIndicator,
         this.levelContainer,
         this.statValuesContainer,
-      ].map((e) => {
+      ].forEach((e) => {
         e.x += 48 * (isBoss ? -1 : 1);
       });
       this.hpBar.x += 38 * (isBoss ? -1 : 1);
@@ -876,7 +876,7 @@ export class BattleInfo extends Phaser.GameObjects.Container {
   }
 
   updateStats(stats: number[]): void {
-    this.statOrder.map((s, i) => {
+    this.statOrder.forEach((s, i) => {
       if (s !== Stat.HP) {
         this.statNumbers[i].setFrame(stats[s - 1].toString());
       }

--- a/src/ui/components/iv-graph.ts
+++ b/src/ui/components/iv-graph.ts
@@ -129,7 +129,7 @@ export class IVGraph extends Phaser.GameObjects.Container {
     const lastIvChartData = this.statsIvsCache || defaultIvChartData;
     this.statsIvsCache = ivChartData.slice(0);
 
-    this.ivStatValueTexts.map((t: BBCodeText, i: number) => {
+    this.ivStatValueTexts.forEach((t: BBCodeText, i: number) => {
       let label = "";
 
       // Check to see if IVs are 31, if so change the text style to gold, otherwise leave them be.

--- a/src/ui/handlers/starter-select-ui-handler.ts
+++ b/src/ui/handlers/starter-select-ui-handler.ts
@@ -2682,6 +2682,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       const isVariant2Caught: boolean = (caughtAttr & DexAttr.SHINY_RARE_VARIANT) > 0;
       const isVariant3Caught: boolean = (caughtAttr & DexAttr.SHINY_EPIC_VARIANT) > 0;
       const isUncaught = !isNonShinyCaught && !isVariant1Caught && !isVariant2Caught && !isVariant3Caught;
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsCaught = this.filterBar.getVals(DropDownColumn.CAUGHT).some((caught) => {
         if (caught === "SHINY3") {
           return isVariant3Caught;
@@ -2703,6 +2704,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       // Passive Filter
       const isPassiveUnlocked = globalScene.gameData.isPassiveUnlocked(container.species.speciesId);
       const isPassiveUnlockable = this.isPassiveAvailable(container.species.speciesId) && !isPassiveUnlocked;
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsPassive = this.filterBar.getVals(DropDownColumn.UNLOCKS).some((unlocks) => {
         if (unlocks.val === "PASSIVE" && unlocks.state === DropDownState.ON) {
           return isPassiveUnlocked;
@@ -2722,6 +2724,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       const isCostReduced = starterData.valueReduction > 0;
       const isCostFullyReduced = starterData.valueReduction === valueReductionMax;
       const isCostReductionUnlockable = this.isValueReductionAvailable(container.species.speciesId);
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsCostReduction = this.filterBar.getVals(DropDownColumn.UNLOCKS).some((unlocks) => {
         if (unlocks.val === "COST_REDUCTION" && unlocks.state === DropDownState.ON) {
           return isCostFullyReduced;
@@ -2742,6 +2745,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
       // Favorite Filter
       const isFavorite = this.starterPreferences[container.species.speciesId]?.favorite ?? false;
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsFavorite = this.filterBar.getVals(DropDownColumn.MISC).some((misc) => {
         if (misc.val === "FAVORITE" && misc.state === DropDownState.ON) {
           return isFavorite;
@@ -2758,6 +2762,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       const hasWon = starterData.classicWinCount > 0;
       const hasNotWon = starterData.classicWinCount === 0;
       const isUndefined = starterData.classicWinCount === undefined;
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsWin = this.filterBar.getVals(DropDownColumn.MISC).some((misc) => {
         if (misc.val === "WIN" && misc.state === DropDownState.ON) {
           return hasWon;
@@ -2775,6 +2780,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
         container.species.abilityHidden !== container.species.ability1
         && container.species.abilityHidden !== AbilityId.NONE;
       const hasHA = starterData.abilityAttr & AbilityAttr.ABILITY_HIDDEN;
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsHA = this.filterBar.getVals(DropDownColumn.MISC).some((misc) => {
         if (misc.val === "HIDDEN_ABILITY" && misc.state === DropDownState.ON) {
           return hasHA;
@@ -2789,6 +2795,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
 
       // Egg Purchasable Filter
       const isEggPurchasable = this.isSameSpeciesEggAvailable(container.species.speciesId);
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsEgg = this.filterBar.getVals(DropDownColumn.MISC).some((misc) => {
         if (misc.val === "EGG" && misc.state === DropDownState.ON) {
           return isEggPurchasable;
@@ -2802,6 +2809,7 @@ export class StarterSelectUiHandler extends MessageUiHandler {
       });
 
       // Pokerus Filter
+      // biome-ignore lint/suspicious/useIterableCallbackReturn: TODO: refactor SSUI
       const fitsPokerus = this.filterBar.getVals(DropDownColumn.MISC).some((misc) => {
         if (misc.val === "POKERUS" && misc.state === DropDownState.ON) {
           return this.pokerusSpecies.includes(container.species);

--- a/src/ui/handlers/target-select-ui-handler.ts
+++ b/src/ui/handlers/target-select-ui-handler.ts
@@ -191,7 +191,7 @@ export class TargetSelectUiHandler extends UiHandler {
 
     const targetsBattleInfo = this.targetsHighlighted.map((target) => target.getBattleInfo());
 
-    targetsBattleInfo.map((info) => {
+    targetsBattleInfo.forEach((info) => {
       this.targetBattleInfoMoveTween.push(
         globalScene.tweens.add({
           targets: [info],

--- a/src/ui/handlers/test-dialogue-ui-handler.ts
+++ b/src/ui/handlers/test-dialogue-ui-handler.ts
@@ -16,6 +16,7 @@ export class TestDialogueUiHandler extends FormModalUiHandler {
     super.setup();
 
     const flattenKeys = (i18nObject: object = {}, topKey?: string, middleKey?: string[]): any[] => {
+      // biome-ignore-start lint/suspicious/useIterableCallbackReturn: TODO: fix?
       return Object.keys(i18nObject)
         .map((t, i) => {
           const value = Object.values(i18nObject)[i];
@@ -40,6 +41,7 @@ export class TestDialogueUiHandler extends FormModalUiHandler {
           }
         })
         .filter((t) => t);
+      // biome-ignore-end lint/suspicious/useIterableCallbackReturn: TODO: fix?
     };
 
     const keysInArrays = flattenKeys(i18next.getDataByLanguage(String(i18next.resolvedLanguage))).filter(


### PR DESCRIPTION
## What are the changes the user will see?
N/A

## Why am I making these changes?
More lint rules = more good.

## What are the changes from a developer perspective?
Enabled `lint/suspicious/useIterableCallbackReturn` at "error" level with the option "checkForEach" set to `false` due to false positives from the rule being non-type-aware.

## Checklist
- [x] <!--Otherwise: -->**I'm using `beta` as my base branch**
- [x] There is no overlap with another PR
- [x] The PR is self-contained and cannot be split into smaller PRs
- [x] I have provided a clear explanation of the changes
- [x] The PR title matches the format described in [PULL_REQUESTS.md](https://github.com/pagefaultgames/pokerogue/blob/beta/PULL_REQUESTS.md)